### PR TITLE
docs: add a release process guide with pre-release cross-surface verification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,4 +49,6 @@ line(s) that describe the change, e.g. `- Fixed the frobnicator dropping input o
 script aggregates fragments into the release section and deletes them. PRs that change `packages/<pkg>/src`
 without a fragment fail CI; apply the `no-changelog` label to opt out.
 
+Release preparation and the pre-release verification checklist are documented in [RELEASING.md](RELEASING.md).
+
 Maintainers may close a pull request that changes scope, cannot be validated safely, or no longer fits the project roadmap.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,74 @@
+# Releasing
+
+How to prepare, verify, and publish a Prime Agent release. The mechanical steps
+live in `scripts/release.mjs`; this document adds the verification the scripts
+cannot do.
+
+## Prepare the release PR
+
+1. Branch from fresh `main` (e.g. `chore/release-x.y.z`).
+2. Bump versions in lockstep: `npm run version:<patch|minor|major>`.
+   Known issue: on 0.x minor bumps the script's own `npm install` can fail with
+   ETARGET before `sync-versions.js` runs, because dependent caret ranges
+   (`^0.8.x`) cannot resolve the new minor from the registry. If that happens,
+   run the steps manually: `node scripts/sync-versions.js`, bump the root
+   `package.json` version and its `@earendil-works/pi-coding-agent` range, then
+   reinstall.
+3. Refresh the lockfile minimally: restore `package-lock.json` from `main` and
+   run `npm install`. Do not regenerate the lockfile from scratch for a release
+   PR — a fresh resolve floats every third-party dependency at once and has
+   broken the browser-smoke check before (`@mistralai/mistralai` drifting to a
+   version whose optional otel import esbuild cannot resolve).
+4. Aggregate changelog fragments into the per-package `CHANGELOG.md`s for the
+   new version and `git rm` the consumed fragments (the changelog portion of
+   `scripts/release.mjs`). Check the rendered markdown: every entry must be a
+   `-` list item (a fragment missing its marker merges into the previous entry).
+5. Open the PR with the validation results listed explicitly (see #1794, #1956
+   for the format). Tag and publish only after merge.
+
+## Pre-release verification
+
+### Test gate
+
+Run the full suite in a clean sandbox at the release base, mirroring the CI
+matrix (`npm run build`, root `npm run check`, per-package suites, coding-agent
+`test:ci` shards + `test:process` + `test:kernel`, and the
+`prime-agent-runtime` Python suite). Compare failures by file against the
+documented environmental baseline; any failure outside the baseline blocks the
+release.
+
+### Cross-surface data checks
+
+Motivation: v0.9.0 shipped with an empty Inactive section in the agents view.
+The roster seed had been scoped down (#1951) with byte-for-byte parity proven
+for `list --all` — but the agents view consumed the seeded rows through a
+different surface (`roster_subscribe`), which nobody re-checked. Parity on one
+surface does not cover the others: **when a producer changes what it emits,
+every consumer surface must be re-verified.**
+
+Build one populated fixture agent dir: a few hundred saved sessions including
+finished subagent families with no live worker ("dead families"), plus one live
+session with a running and a completed subagent. Then check every surface that
+displays session or agent data:
+
+- `prime-agent list`: live rows only, correct statuses.
+- `prime-agent list --all`: saved sessions and dead-family subagent rows all
+  present.
+- TUI agents view on a **fresh** view (no search text typed): Running, Idle,
+  and Inactive sections all populate; search narrows without losing sections.
+- Subagents bar in an active chat: counts match the spawned children.
+- Resume a saved session; wake/message a completed subagent by name.
+- `prime-agent update` path: daemon restores sessions after the update and the
+  surfaces above still hold.
+
+### Performance spot checks
+
+On a large session corpus (thousands of saved sessions), time daemon cold boot
+(first command after daemon death) and first/steady `list --all` against the
+previous release. Regressions here are user-visible on every machine with a
+long history; they must be either fixed or called out in the release notes.
+
+## Publish
+
+After merge: `git tag vx.y.z`, push the tag, `npm run publish` (see the tail of
+`scripts/release.mjs`). Announce with the release notes and changelog.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,7 +14,9 @@ How to prepare, verify, and publish a Prime Agent release. The mechanical steps 
 
 ### Test gate
 
-Run the full suite in a clean sandbox at the release base, mirroring the CI matrix (`npm run build`, root `npm run check`, per-package suites, coding-agent `test:ci` shards + `test:process` + `test:kernel`, and the `prime-agent-runtime` Python suite). Compare failures by file against the documented environmental baseline; any failure outside the baseline blocks the release.
+Run the full suite in a clean sandbox at the release base, mirroring the CI matrix (`npm run build`, root `npm run check`, per-package suites, coding-agent `test:ci` shards + `test:process` + `test:kernel`, and the `prime-agent-runtime` Python suite). Compare failures by file against the environmental baseline below; any failure outside the baseline blocks the release.
+
+The environmental baseline is the set of test failures caused by the sandbox environment rather than the code, re-derived by running the same suite at the previous release tag in an identical sandbox: only failures that occur at BOTH refs, in the same files, are baseline. As of v0.9.1 the CI-mirroring baseline is 4 tests across 3 files, all environment-shaped: `tools.test.ts` (2 EACCES failures when running as root), `config.test.ts` (config dir not writable as root), and `4603-worker-recovery.test.ts` (requires `lsof`). A raw full-suite run without CI's environment adds kernel-skill bridge suites (`kernel-agent-message-skill`, `kernel-agent-observe-skill`, `kernel-attach-image-skill`, `kernel-rlm-heartbeat-skill`), `sdk-session-manager`, `agent-session-recursion`, and `4428-cancel-mid-tool` — legitimate in CI, environment-dependent outside it. When the baseline changes, update this paragraph in the same PR that observed the change.
 
 ### Cross-surface data checks
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,74 +1,39 @@
 # Releasing
 
-How to prepare, verify, and publish a Prime Agent release. The mechanical steps
-live in `scripts/release.mjs`; this document adds the verification the scripts
-cannot do.
+How to prepare, verify, and publish a Prime Agent release. The mechanical steps live in `scripts/release.mjs`; this document adds the verification the scripts cannot do.
 
 ## Prepare the release PR
 
 1. Branch from fresh `main` (e.g. `chore/release-x.y.z`).
-2. Bump versions in lockstep: `npm run version:<patch|minor|major>`.
-   Known issue: on 0.x minor bumps the script's own `npm install` can fail with
-   ETARGET before `sync-versions.js` runs, because dependent caret ranges
-   (`^0.8.x`) cannot resolve the new minor from the registry. If that happens,
-   run the steps manually: `node scripts/sync-versions.js`, bump the root
-   `package.json` version and its `@earendil-works/pi-coding-agent` range, then
-   reinstall.
-3. Refresh the lockfile minimally: restore `package-lock.json` from `main` and
-   run `npm install`. Do not regenerate the lockfile from scratch for a release
-   PR — a fresh resolve floats every third-party dependency at once and has
-   broken the browser-smoke check before (`@mistralai/mistralai` drifting to a
-   version whose optional otel import esbuild cannot resolve).
-4. Aggregate changelog fragments into the per-package `CHANGELOG.md`s for the
-   new version and `git rm` the consumed fragments (the changelog portion of
-   `scripts/release.mjs`). Check the rendered markdown: every entry must be a
-   `-` list item (a fragment missing its marker merges into the previous entry).
-5. Open the PR with the validation results listed explicitly (see #1794, #1956
-   for the format). Tag and publish only after merge.
+2. Bump versions in lockstep: `npm run version:<patch|minor|major>`. Known issue: on 0.x minor bumps the script's own `npm install` can fail with ETARGET before `sync-versions.js` runs, because dependent caret ranges (`^0.8.x`) cannot resolve the new minor from the registry. If that happens, run the steps manually: `node scripts/sync-versions.js`, bump the root `package.json` version and its `@earendil-works/pi-coding-agent` range, then reinstall.
+3. Refresh the lockfile minimally: restore `package-lock.json` from `main` and run `npm install`. Do not regenerate the lockfile from scratch for a release PR — a fresh resolve floats every third-party dependency at once and has broken the browser-smoke check before (`@mistralai/mistralai` drifting to a version whose optional otel import esbuild cannot resolve).
+4. Aggregate changelog fragments into the per-package `CHANGELOG.md`s for the new version and `git rm` the consumed fragments (the changelog portion of `scripts/release.mjs`). Check the rendered markdown: every entry must be a `-` list item (a fragment missing its marker merges into the previous entry).
+5. Open the PR with the validation results listed explicitly (see #1794, #1956 for the format). Tag and publish only after merge.
 
 ## Pre-release verification
 
 ### Test gate
 
-Run the full suite in a clean sandbox at the release base, mirroring the CI
-matrix (`npm run build`, root `npm run check`, per-package suites, coding-agent
-`test:ci` shards + `test:process` + `test:kernel`, and the
-`prime-agent-runtime` Python suite). Compare failures by file against the
-documented environmental baseline; any failure outside the baseline blocks the
-release.
+Run the full suite in a clean sandbox at the release base, mirroring the CI matrix (`npm run build`, root `npm run check`, per-package suites, coding-agent `test:ci` shards + `test:process` + `test:kernel`, and the `prime-agent-runtime` Python suite). Compare failures by file against the documented environmental baseline; any failure outside the baseline blocks the release.
 
 ### Cross-surface data checks
 
-Motivation: v0.9.0 shipped with an empty Inactive section in the agents view.
-The roster seed had been scoped down (#1951) with byte-for-byte parity proven
-for `list --all` — but the agents view consumed the seeded rows through a
-different surface (`roster_subscribe`), which nobody re-checked. Parity on one
-surface does not cover the others: **when a producer changes what it emits,
-every consumer surface must be re-verified.**
+Motivation: v0.9.0 shipped with an empty Inactive section in the agents view. The roster seed had been scoped down (#1951) with byte-for-byte parity proven for `list --all` — but the agents view consumed the seeded rows through a different surface (`roster_subscribe`), which nobody re-checked. Parity on one surface does not cover the others: **when a producer changes what it emits, every consumer surface must be re-verified.**
 
-Build one populated fixture agent dir: a few hundred saved sessions including
-finished subagent families with no live worker ("dead families"), plus one live
-session with a running and a completed subagent. Then check every surface that
-displays session or agent data:
+Build one populated fixture agent dir: a few hundred saved sessions including finished subagent families with no live worker ("dead families"), plus one live session with a running and a completed subagent. Then check every surface that displays session or agent data:
 
 - `prime-agent list`: live rows only, correct statuses.
-- `prime-agent list --all`: saved sessions and dead-family subagent rows all
-  present.
-- TUI agents view on a **fresh** view (no search text typed): Running, Idle,
-  and Inactive sections all populate; search narrows without losing sections.
+- `prime-agent list --all`: saved sessions and dead-family subagent rows all present.
+- TUI agents view on a **fresh** view (no search text typed): Running, Idle, and Inactive sections all populate; search narrows without losing sections.
 - Subagents bar in an active chat: counts match the spawned children.
 - Resume a saved session; wake/message a completed subagent by name.
-- `prime-agent update` path: daemon restores sessions after the update and the
-  surfaces above still hold.
+- `prime-agent update` path: daemon restores sessions after the update and the surfaces above still hold.
 
 ### Performance spot checks
 
-On a large session corpus (thousands of saved sessions), time daemon cold boot
-(first command after daemon death) and first/steady `list --all` against the
-previous release. Regressions here are user-visible on every machine with a
-long history; they must be either fixed or called out in the release notes.
+On a large session corpus (thousands of saved sessions), time daemon cold boot (first command after daemon death) and first/steady `list --all` against the previous release. Regressions here are user-visible on every machine with a long history; they must be either fixed or called out in the release notes.
 
 ## Publish
 
-After merge: `git tag vx.y.z`, push the tag, `npm run publish` (see the tail of
-`scripts/release.mjs`). Announce with the release notes and changelog.
+After merge: `git tag vx.y.z`, push the tag, `npm run publish` (see the tail of `scripts/release.mjs`). Announce with the release notes and changelog.
+


### PR DESCRIPTION
v0.9.0 shipped with an empty Inactive section in the agents view (ENG-5840): the roster seed was scoped down with byte-for-byte parity proven for `list --all`, but the agents view consumed the seeded rows through a different surface (`roster_subscribe`) that nobody re-checked. The failure class is general: a producer changes what it emits, one consumer surface is verified, the others silently degrade.

This adds `RELEASING.md`: the release-prep mechanics with the two known traps (the `version:minor` ETARGET failure on 0.x minor bumps, and the from-scratch lockfile regen that floats third-party deps and has broken browser-smoke), the sandbox test gate against the environmental baseline, and a pre-release verification checklist whose core is **cross-surface data checks** — one populated fixture dir (saved sessions, dead subagent families, a live session with children) checked through every surface that displays session/agent data: `list`, `list --all`, a fresh agents view's three sections, the subagents bar, resume/wake by name, and the post-`update` restore path. Plus performance spot checks (cold boot, `list --all`) on a large corpus against the previous release.

`CONTRIBUTING.md` links to it. Docs only; no source changes.

Linear: [RES-1247](https://linear.app/primeintellect/issue/RES-1247/document-release-process-with-pre-release-cross-surface-verification)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, auth, or release automation behavior changes.
> 
> **Overview**
> Adds **`RELEASING.md`** so maintainers have a single place for release prep, verification, and publish—beyond what `scripts/release.mjs` automates.
> 
> The guide covers release PR steps (version bumps, minimal lockfile refresh vs full regen, changelog aggregation), a **test gate** with an environmental baseline, and a **cross-surface data checklist** motivated by v0.9.0’s empty agents-view Inactive section when only `list --all` was checked. It also documents performance spot checks (cold boot, `list --all` on large corpora) and post-merge tag/publish.
> 
> **`CONTRIBUTING.md`** now links to `RELEASING.md` from the changelog-fragments section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae3e8fc80c04af9614c94f9875a8ba3319444eda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add release process guide with pre-release cross-surface verification
> Adds [RELEASING.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1959/files#diff-87d6a57a759f2386bf9caf5309b9aa0b9ff0ca70f5e38696e114a1ccdb0e785d) covering release-PR preparation, version sync with the 0.x minor-bump workaround, minimal lockfile refreshes, changelog aggregation, validation reporting, CI-mirroring test checks, cross-surface session/agent data checks, performance spot checks, and post-merge publishing steps. Also adds a link from [CONTRIBUTING.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1959/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055) to the new guide.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae3e8fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->