### PR TITLE
fix(coding-agent): load the saved catalog when the agents view opens

### DIFF
--- a/packages/coding-agent/.changes/agents-view-inactive-catalog.md
+++ b/packages/coding-agent/.changes/agents-view-inactive-catalog.md
@@ -1,0 +1,1 @@
+- Fixed a v0.9.0 regression: the agents view's Inactive section was empty on a fresh view until a search was typed. The saved-session catalog now loads (progressively) when the view opens; it was previously deferred to search because the roster's boot seed carried the saved corpus, which the seed scoping removed.

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1254,11 +1254,9 @@ export class AgentsViewMode implements Component, Focusable {
 	}
 
 	private armSavedSearchFetch(options: { duringReconnect?: boolean } = {}): void {
-		if (
-			this.savedSearchFetchStarted ||
-			this.persistentState.savedCatalogLoaded === true ||
-			this.editor.getText().trim().length === 0
-		) {
+		// No query gate: the inactive section is catalog-fed now that the roster
+		// carries live families only, so the view loads the catalog when it opens.
+		if (this.savedSearchFetchStarted || this.persistentState.savedCatalogLoaded === true) {
 			return;
 		}
 		this.savedSearchFetchStarted = true;

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1254,8 +1254,7 @@ export class AgentsViewMode implements Component, Focusable {
 	}
 
 	private armSavedSearchFetch(options: { duringReconnect?: boolean } = {}): void {
-		// No query gate: the inactive section is catalog-fed now that the roster
-		// carries live families only, so the view loads the catalog when it opens.
+		// The inactive section is catalog-fed, so no query gate: load on view open.
 		if (this.savedSearchFetchStarted || this.persistentState.savedCatalogLoaded === true) {
 			return;
 		}

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -680,10 +680,7 @@ describe("agents view slash commands", () => {
 			return { self, persistentState, request, supersede };
 		};
 
-		// An empty query never arms; an already-loaded shared catalog never refetches.
-		const idle = latchHarness("   ", []);
-		invoke("armSavedSearchFetch", idle.self);
-		expect(idle.self.savedSearchFetchStarted).toBe(false);
+		// An already-loaded shared catalog never refetches.
 		const loaded = latchHarness("needle", []);
 		(loaded.persistentState as { savedCatalogLoaded?: boolean }).savedCatalogLoaded = true;
 		invoke("armSavedSearchFetch", loaded.self);

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -118,6 +118,19 @@ describe("AgentsViewMode", () => {
 		expect(self.selectedIndex).toBe(4);
 	});
 
+	it("loads the saved catalog on view entry without a search query", () => {
+		const self = {
+			savedSearchFetchStarted: false,
+			persistentState: {},
+			refreshSavedSessions: vi.fn(async () => true),
+		};
+
+		invoke("armSavedSearchFetch", self);
+
+		expect(self.refreshSavedSessions).toHaveBeenCalledOnce();
+		expect(self.savedSearchFetchStarted).toBe(true);
+	});
+
 	it("re-resolves subagent state before choosing stop or delete intent", async () => {
 		const child = summary({
 			id: "passive-child-session",


### PR DESCRIPTION
## Regression

Introduced in v0.9.0 by the roster seed scoping (#1951): the agents view's Inactive section is empty on a fresh view. Before v0.9.0 the daemon's boot seed pushed the whole saved-session corpus as inactive roster rows through `roster_subscribe`, and the view rendered those. #1951 scoped the seed to registered workers' families (CLI `list --all` kept full parity), but the agents view's other source — the saved-session catalog — was only loaded once a search query was typed (`armSavedSearchFetch` gates on editor text, a #1900 optimization whose stated premise was that deep catalog data is needed only for search; display rows were assumed to come from the roster seed). Fresh TUI + agents view + no query = no catalog = empty Inactive section.

## Fix

Delete the dead-premise gate: the view loads the saved catalog when it opens, not first at search time. The load path is unchanged and stays progressive (`refreshSavedSessions` streams rows in via `onSession` as the daemon reads them) and once-per-view (`savedSearchFetchStarted` latch plus persisted `savedCatalogLoaded` across view instances). No new load path, no wire change.

## Measured (3051-session corpus, local M-series laptop)

Progressive catalog load after opening the view: first inactive row after ~10 ms, complete after ~6.0 s on a cold daemon (~2.2 s warm), filling in as it loads. For context, v0.8.1 showed all inactive rows immediately at view open, but only because the daemon had spent ~5.2 s at startup seeding and every roster subscriber received the full ~3300-row corpus as one payload; v0.9.0+ daemon startup is ~0.7-1.4 s on the same corpus.

## Tests

New pin in `agents-view-mode.test.ts`: `armSavedSearchFetch` with an empty query starts the catalog fetch (fails on v0.9.0 main: the mock is never called). The `agents-view-inactive-reply.test.ts` latch test drops only its empty-query-never-arms assertion (the reverted behavior); its loaded-catalog one-shot and failure re-arm pins are unchanged. Suites: agents-view + roster/daemon-adjacent files green in a sandbox (10 files, 226 tests), root `npm run check` clean.

Linear: https://linear.app/primeintellect/issue/ENG-5840/v090-regression-agents-view-inactive-section-empty-on-fresh-view

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow agents-view UX fix: earlier progressive catalog load on open, no protocol or auth changes; main tradeoff is extra daemon work when opening the view with many saved sessions.
> 
> **Overview**
> Fixes a **v0.9.0 regression** where the agents view **Inactive** section stayed empty until the user typed a search. Roster seed scoping stopped pre-filling inactive rows from the daemon boot seed, but the saved-session catalog was still only armed when the search box had text.
> 
> **`armSavedSearchFetch`** no longer returns early on an empty trimmed query. The inactive list is catalog-driven, so **`refreshSavedSessions`** still runs progressively on view open (and on reconnect / query changes) with the same once-per-view latch and **`savedCatalogLoaded`** guard.
> 
> Tests add a pin that an empty query starts the catalog fetch; the inactive-reply latch test drops the obsolete “empty query never arms” assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79c9256110d85618417b37106d94f58d20e0ce55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Load saved session catalog on `AgentsViewMode` view open regardless of query
> Fixes a v0.9.0 regression where the agents view Inactive section stayed empty until the user typed a search. `AgentsViewMode.armSavedSearchFetch` no longer gates the fetch on a non-empty editor query — it now returns early only if a fetch already started or `savedCatalogLoaded` is true. Tests in [agents-view-inactive-reply.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1960/files#diff-9b3bff8453954c7464c6306d88f0d09ba13290147a8ed971dd71f685bde5357c) and [agents-view-mode.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1960/files#diff-bbeca49f58d79eef24abf26818a4a4fd8cd2e0d319e8c4629a58dab7af006a3b) are updated to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79c9256.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->