### PR TITLE
chore: prepare v0.9.1 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prime-agent",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prime-agent",
-			"version": "0.9.0",
+			"version": "0.9.1",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -15,7 +15,7 @@
 				"packages/coding-agent/examples/extensions/sandbox"
 			],
 			"dependencies": {
-				"@earendil-works/pi-coding-agent": "^0.9.0",
+				"@earendil-works/pi-coding-agent": "^0.9.1",
 				"get-east-asian-width": "^1.6.0"
 			},
 			"devDependencies": {
@@ -5597,10 +5597,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "0.9.0",
+			"version": "0.9.1",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.9.0",
+				"@earendil-works/pi-ai": "^0.9.1",
 				"typebox": "^1.3.9"
 			},
 			"devDependencies": {
@@ -5631,7 +5631,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "0.9.0",
+			"version": "0.9.1",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
@@ -5677,14 +5677,14 @@
 		},
 		"packages/coding-agent": {
 			"name": "@earendil-works/pi-coding-agent",
-			"version": "0.9.0",
+			"version": "0.9.1",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"@agentclientprotocol/sdk": "^1.3.0",
-				"@earendil-works/pi-agent-core": "^0.9.0",
-				"@earendil-works/pi-ai": "^0.9.0",
-				"@earendil-works/pi-tui": "^0.9.0",
+				"@earendil-works/pi-agent-core": "^0.9.1",
+				"@earendil-works/pi-ai": "^0.9.1",
+				"@earendil-works/pi-tui": "^0.9.1",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
@@ -5728,18 +5728,18 @@
 		},
 		"packages/coding-agent/examples/extensions/custom-provider-anthropic": {
 			"name": "pi-extension-custom-provider-anthropic",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.52.0"
 			}
 		},
 		"packages/coding-agent/examples/extensions/custom-provider-gitlab-duo": {
 			"name": "pi-extension-custom-provider-gitlab-duo",
-			"version": "0.1.0"
+			"version": "0.1.1"
 		},
 		"packages/coding-agent/examples/extensions/sandbox": {
 			"name": "pi-extension-sandbox",
-			"version": "1.5.0",
+			"version": "1.5.1",
 			"dependencies": {
 				"@anthropic-ai/sandbox-runtime": "^0.0.55"
 			}
@@ -5779,7 +5779,7 @@
 		},
 		"packages/coding-agent/examples/extensions/with-deps": {
 			"name": "pi-extension-with-deps",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"dependencies": {
 				"ms": "^2.1.3"
 			},
@@ -5813,7 +5813,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "0.9.0",
+			"version": "0.9.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
 	"engines": {
 		"node": ">=22.8.0"
 	},
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "^0.9.0",
+		"@earendil-works/pi-coding-agent": "^0.9.1",
 		"get-east-asian-width": "^1.6.0"
 	},
 	"overrides": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-agent-core",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,7 +17,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-ai": "^0.9.0",
+		"@earendil-works/pi-ai": "^0.9.1",
 		"typebox": "^1.3.9"
 	},
 	"keywords": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-ai",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/.changes/agents-view-inactive-catalog.md
+++ b/packages/coding-agent/.changes/agents-view-inactive-catalog.md
@@ -1,1 +1,0 @@
-- Fixed a v0.9.0 regression: the agents view's Inactive section was empty on a fresh view until a search was typed. The saved-session catalog now loads (progressively) when the view opens; it was previously deferred to search because the roster's boot seed carried the saved corpus, which the seed scoping removed.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.9.1] - 2026-09-01
+
+- Fixed a v0.9.0 regression: the agents view's Inactive section was empty on a fresh view until a search was typed. The saved-session catalog now loads (progressively) when the view opens; it was previously deferred to search because the roster's boot seed carried the saved corpus, which the seed scoping removed.
+
 ## [0.9.0] - 2026-09-01
 
 - Fixed background (unattributed) kernel output missing from the expanded IPython cell view: it is now surfaced in the tool details and rendered under a "background output (unattributed)" label after stdout/stderr/result.

--- a/packages/coding-agent/examples/extensions/custom-provider-anthropic/package-lock.json
+++ b/packages/coding-agent/examples/extensions/custom-provider-anthropic/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-extension-custom-provider",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-extension-custom-provider",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0"
       }

--- a/packages/coding-agent/examples/extensions/custom-provider-anthropic/package.json
+++ b/packages/coding-agent/examples/extensions/custom-provider-anthropic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-extension-custom-provider-anthropic",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/examples/extensions/custom-provider-gitlab-duo/package.json
+++ b/packages/coding-agent/examples/extensions/custom-provider-gitlab-duo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-extension-custom-provider-gitlab-duo",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/examples/extensions/sandbox/package-lock.json
+++ b/packages/coding-agent/examples/extensions/sandbox/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-extension-sandbox",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-extension-sandbox",
-			"version": "1.5.0",
+			"version": "1.5.1",
 			"dependencies": {
 				"@anthropic-ai/sandbox-runtime": "^0.0.55"
 			}

--- a/packages/coding-agent/examples/extensions/sandbox/package.json
+++ b/packages/coding-agent/examples/extensions/sandbox/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pi-extension-sandbox",
 	"private": true,
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"type": "module",
 	"scripts": {
 		"clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/examples/extensions/with-deps/package-lock.json
+++ b/packages/coding-agent/examples/extensions/with-deps/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-extension-with-deps",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-extension-with-deps",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "ms": "^2.1.3"
       },

--- a/packages/coding-agent/examples/extensions/with-deps/package.json
+++ b/packages/coding-agent/examples/extensions/with-deps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-extension-with-deps",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-coding-agent",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"description": "Coding agent CLI with a persistent Python REPL kernel and session management",
 	"type": "module",
 	"piConfig": {
@@ -48,9 +48,9 @@
 	},
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^1.3.0",
-		"@earendil-works/pi-agent-core": "^0.9.0",
-		"@earendil-works/pi-ai": "^0.9.0",
-		"@earendil-works/pi-tui": "^0.9.0",
+		"@earendil-works/pi-agent-core": "^0.9.1",
+		"@earendil-works/pi-ai": "^0.9.1",
+		"@earendil-works/pi-tui": "^0.9.1",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-tui",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Prepares the v0.9.1 patch release. Exactly one change on top of v0.9.0: the fix for the empty Inactive section in the agents view (#1960 / ENG-5840) — the saved-session catalog now loads progressively when the view opens instead of only when a search query is typed, restoring the inactive rows that the v0.9.0 roster seed scoping removed from the view's data path.

Version bump 0.9.0 → 0.9.1 in lockstep (root + workspaces, ranges synced per RELEASING.md's manual path), lockfile refreshed minimally from main (15-line diff, no third-party drift), and the single changelog fragment folded into the coding-agent 0.9.1 section.

## Validation

- root `npm run check` (biome, tsgo, installer render, browser smoke) — pass on the release branch after bump + aggregation
- `node scripts/sync-versions.js` — lockstep confirmed
- #1960's own gate: fix pin fails on v0.9.0 main and passes with the fix; 226 tests green across 10 agents-view/roster/catalog files in a sandbox; measured on a 3051-session corpus (first inactive row ~10ms after view open, complete 2.2s warm)
- full-suite sandbox gate at the release base + fresh-agents-view cross-surface check per RELEASING.md: running now, result will be posted as a PR comment before merge

## Release sequencing

Prepare-only: no tag, no publish. After merge: tag `v0.9.1` and `npm run publish`.

Linear: [ENG-5839](https://linear.app/primeintellect/issue/ENG-5839) (release tracking), [ENG-5840](https://linear.app/primeintellect/issue/ENG-5840) (the regression)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only changes with no runtime code edits in this PR.
> 
> **Overview**
> **Prepares the v0.9.1 patch release** with no application code in this diff—only monorepo versioning and release notes.
> 
> Bumps **0.9.0 → 0.9.1** in lockstep across the root `prime-agent` package, `@earendil-works/pi-*` workspaces, example extension packages, and `package-lock.json` dependency ranges. Adds a **`[0.9.1]`** entry to `packages/coding-agent/CHANGELOG.md` documenting the agents view regression fix (Inactive section empty until search; saved-session catalog now loads progressively on open). Removes the folded `.changes/agents-view-inactive-catalog.md` fragment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 194ae62fe8c358b62a5ad60c45d2c66f1189393d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prepare v0.9.1 release across all packages
> - Bumps versions from 0.9.0 to 0.9.1 in the root and packages: `agent`, `ai`, `tui`, and `coding-agent`, plus example extensions
> - Updates internal `@earendil-works/*` dependency ranges to `^0.9.1` accordingly
> - Adds a 0.9.1 section to [CHANGELOG.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1961/files#diff-c6cac40b1364c0a754eeed6b270894091b2fabf42650673820e3b460f0a41d0e) noting a fix for the agents view Inactive section loading on fresh view
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 194ae62.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->