### PR TITLE
ci: default Prime Agent tickets to Research

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,8 @@ https://github.com/PrimeIntellect-ai/prime-agent/discussions
 ## Context
 
 <!-- Link the accepted Issue or Discussion and explain why this change is needed.
-Prime Agent Linear tickets should normally use the Research team and the Prime Agent: Long-Horizon research project. -->
+Prime Agent Linear tickets should normally use the Research team and the Prime Agent: Long-Horizon research project.
+If this change has no ticket, add `No-Ticket: <short reason>` below. -->
 
 ## Changes
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,8 @@ https://github.com/PrimeIntellect-ai/prime-agent/discussions
 
 ## Context
 
-<!-- Link the accepted Issue or Discussion and explain why this change is needed. -->
+<!-- Link the accepted Issue or Discussion and explain why this change is needed.
+Prime Agent Linear tickets should normally use the Research team and the Prime Agent: Long-Horizon research project. -->
 
 ## Changes
 

--- a/.github/workflows/linear-ticket.yml
+++ b/.github/workflows/linear-ticket.yml
@@ -14,15 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.type != 'Bot'
     steps:
-      - name: Require a Linear ticket reference
+      - name: Require a Linear ticket reference or an explicit opt-out
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const pr = context.payload.pull_request;
             const text = `${pr.title}\n${pr.body ?? ""}\n${pr.head.ref}`;
-            const ticket = /\b(?:res|eng)-\d+\b|linear\.app\/[\w-]+\/issue\/[a-z]+-\d+/i;
+            const ticket = /\bres-\d+\b|linear\.app\/[\w-]+\/issue\/res-\d+/i;
+            const optOut = /^\s*No-Ticket:\s*\S.*$/im;
             if (ticket.test(text)) {
               core.info("Linear ticket reference found.");
+              return;
+            }
+            const match = (pr.body ?? "").match(optOut);
+            if (match) {
+              core.info(`No-ticket opt-out present: ${match[0].trim()}`);
               return;
             }
             core.setFailed(
@@ -31,5 +37,6 @@ jobs:
                 "Prime Agent tickets should normally use the Research team and the Prime Agent: Long-Horizon research project.",
                 "Add the ticket ID (e.g. RES-1234) or a linear.app issue link to the PR title or description,",
                 "or use a branch named after the ticket (e.g. res-1234).",
+                'If this change genuinely has no ticket, add a line to the PR description: "No-Ticket: <short reason>".',
               ].join(" "),
             );

--- a/.github/workflows/linear-ticket.yml
+++ b/.github/workflows/linear-ticket.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.type != 'Bot'
     steps:
-      - name: Require a Linear ticket reference or an explicit opt-out
+      - name: Require a Linear ticket reference
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const pr = context.payload.pull_request;
             const text = `${pr.title}\n${pr.body ?? ""}\n${pr.head.ref}`;
-            const ticket = /\beng-\d+\b|linear\.app\/[\w-]+\/issue\/[a-z]+-\d+/i;
+            const ticket = /\b(?:res|eng)-\d+\b|linear\.app\/[\w-]+\/issue\/[a-z]+-\d+/i;
             if (ticket.test(text)) {
               core.info("Linear ticket reference found.");
               return;
@@ -28,7 +28,8 @@ jobs:
             core.setFailed(
               [
                 "No Linear ticket is linked in this pull request.",
-                "Add the ticket ID (e.g. ENG-1234) or a linear.app issue link to the PR title or description,",
-                "or use a branch named after the ticket (e.g. eng-1234).",
+                "Prime Agent tickets should normally use the Research team and the Prime Agent: Long-Horizon research project.",
+                "Add the ticket ID (e.g. RES-1234) or a linear.app issue link to the PR title or description,",
+                "or use a branch named after the ticket (e.g. res-1234).",
               ].join(" "),
             );


### PR DESCRIPTION
## Context

Prime Agent work now belongs in the Research team's `Prime Agent: Long-Horizon research` project, but the GitHub Linear check only recognizes bare `ENG-*` IDs and its examples direct contributors to Engineering.

Linear: https://linear.app/primeintellect/issue/RES-1241/default-prime-agent-pull-requests-to-research-linear-tickets

## Changes

- Accept only `RES-*` ticket references in PR titles, descriptions, branch names, and Linear issue URLs.
- Use `RES-1234` and `res-1234` in failure guidance.
- Restore the explicit `No-Ticket: <short reason>` opt-out.
- Point new Prime Agent work to Research and `Prime Agent: Long-Horizon research` in the workflow and PR template.

This validates the Research ticket prefix and updates the default guidance. GitHub Actions cannot verify Linear project membership without a Linear API secret.

## Validation

- Parsed `.github/workflows/linear-ticket.yml` as YAML.
- Tested bare and linked `RES-*` tickets, rejected `ENG-*` tickets, valid opt-outs, malformed opt-outs, and missing-ticket cases with Node.js.
- Ran `git diff --check origin/main...HEAD`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and PR-check regex/message changes only; no runtime product or auth logic.
> 
> **Overview**
> Updates the **Linear ticket** GitHub Action and PR template so Prime Agent work is steered toward **Research** (`RES-*`) tickets and the **Prime Agent: Long-Horizon research** project, while still accepting legacy **`ENG-*`** IDs.
> 
> The workflow regex now matches bare `res-` / `eng-` prefixes (plus existing Linear URLs). Failure text and template comments use **`RES-1234`** / `res-1234` examples and Research project guidance instead of Engineering-only wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1101062d9d36414c6574a4d358e053dd392ab614. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require 'RES-' ticket prefix for Prime Agent PRs and add opt-out
> - Updates [linear-ticket.yml](https://github.com/PrimeIntellect-ai/prime-agent/pull/1966/files#diff-ce6fb4658459ed854d72950d809841bbd48b2cbae4ed1ab56d7e1a6b6be59b52) to only accept `res-<num>` tickets or linear.app links, dropping support for `eng-<num>` or other prefixes
> - Introduces a `No-Ticket:` line check in the PR body to explicitly bypass the Linear ticket requirement
> - Updates [PULL_REQUEST_TEMPLATE.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1966/files#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35) with instructions for the Research team and Prime Agent: Long-Horizon project
> - Behavioral Change: The CI check now fails for `ENG-` or other non-`RES` prefixes unless a `No-Ticket:` line is present
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e01a7b4. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->