### PR TITLE
fix(coding-agent): stabilize daemon process identity across timezone changes

### DIFF
--- a/packages/coding-agent/.changes/timezone-stable-process-identity.md
+++ b/packages/coding-agent/.changes/timezone-stable-process-identity.md
@@ -1,0 +1,1 @@
+- Fixed daemon session creation after macOS timezone changes ([#879](https://github.com/PrimeIntellect-ai/prime-agent/issues/879))

--- a/packages/coding-agent/src/core/session-lease.ts
+++ b/packages/coding-agent/src/core/session-lease.ts
@@ -110,12 +110,17 @@ function isProcessAlive(pid: number): boolean {
 	}
 }
 
-type ProcessQuery = (command: string, args: string[]) => string;
+interface ProcessQueryOptions {
+	env?: NodeJS.ProcessEnv;
+}
 
-function runProcessQuery(command: string, args: string[]): string {
+type ProcessQuery = (command: string, args: string[], options?: ProcessQueryOptions) => string;
+
+function runProcessQuery(command: string, args: string[], options?: ProcessQueryOptions): string {
 	return execFileSync(command, args, {
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "ignore"],
+		env: options?.env,
 	});
 }
 
@@ -132,6 +137,21 @@ export function getWindowsProcessStartId(pid: number, query: ProcessQuery = runP
 			`([System.Diagnostics.Process]::GetProcessById(${pid})).StartTime.ToUniversalTime().Ticks`,
 		]).trim();
 		return /^\d+$/.test(startTicks) ? `win:${startTicks}` : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function getPsProcessStartId(pid: number, query: ProcessQuery = runProcessQuery): string | undefined {
+	if (!Number.isInteger(pid) || pid <= 0) {
+		return undefined;
+	}
+	try {
+		// `lstart` is rendered in the subprocess timezone and locale, so pin both for a durable identity.
+		const startTime = query("ps", ["-p", String(pid), "-o", "lstart="], {
+			env: { ...process.env, LC_ALL: "C", LC_TIME: "C", LANG: "C", TZ: "UTC" },
+		}).trim();
+		return startTime ? `ps:${startTime}` : undefined;
 	} catch {
 		return undefined;
 	}
@@ -155,12 +175,7 @@ export function getProcessStartId(pid: number): string | undefined {
 	} catch {
 		// Fall through to the portable process listing used on macOS and BSD.
 	}
-	try {
-		const startTime = runProcessQuery("ps", ["-p", String(pid), "-o", "lstart="]).trim();
-		return startTime ? `ps:${startTime}` : undefined;
-	} catch {
-		return undefined;
-	}
+	return getPsProcessStartId(pid);
 }
 
 let currentProcessStartId: string | undefined;

--- a/packages/coding-agent/test/suite/regressions/879-timezone-stable-process-identity.test.ts
+++ b/packages/coding-agent/test/suite/regressions/879-timezone-stable-process-identity.test.ts
@@ -1,0 +1,98 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { getPsProcessStartId } from "../../../src/core/session-lease.js";
+import {
+	acquireDaemonSupervisorOwnership,
+	assertDaemonSupervisorOwnerCurrent,
+} from "../../../src/modes/daemon/daemon-supervisor-ownership.js";
+import { createHarness, type Harness } from "../harness.js";
+
+describe("issue #879 stable daemon process identity across timezone changes", () => {
+	const harnesses: Harness[] = [];
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const harness of harnesses.splice(0)) {
+			harness.cleanup();
+		}
+		for (const directory of tempDirs.splice(0)) {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("pins the portable process query to UTC across caller timezone changes", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const calls: Array<{ command: string; args: string[]; env: NodeJS.ProcessEnv | undefined }> = [];
+		const query = (command: string, args: string[], options?: { env?: NodeJS.ProcessEnv }) => {
+			calls.push({ command, args, env: options?.env });
+			return options?.env?.TZ === "UTC" ? "Sat Aug 29 20:55:18 2026\n" : "Sat Aug 29 16:55:18 2026\n";
+		};
+		const originalTimezone = process.env.TZ;
+		let before: string | undefined;
+		let after: string | undefined;
+		try {
+			process.env.TZ = "America/Los_Angeles";
+			before = getPsProcessStartId(42, query);
+			process.env.TZ = "America/New_York";
+			after = getPsProcessStartId(42, query);
+		} finally {
+			if (originalTimezone === undefined) {
+				delete process.env.TZ;
+			} else {
+				process.env.TZ = originalTimezone;
+			}
+		}
+
+		expect(before).toBe("ps:Sat Aug 29 20:55:18 2026");
+		expect(after).toBe(before);
+		expect(calls).toHaveLength(2);
+		for (const call of calls) {
+			expect(call).toMatchObject({
+				command: "ps",
+				args: ["-p", "42", "-o", "lstart="],
+				env: { LC_ALL: "C", LC_TIME: "C", LANG: "C", TZ: "UTC" },
+			});
+		}
+	});
+
+	it.skipIf(process.platform !== "darwin")("keeps supervisor ownership current after a timezone change", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-timezone-ownership-"));
+		tempDirs.push(root);
+		const registryDir = join(root, "registry");
+		const socketPath = join(root, "daemon.sock");
+		const originalTimezone = process.env.TZ;
+		let ownership: Awaited<ReturnType<typeof acquireDaemonSupervisorOwnership>> | undefined;
+		try {
+			process.env.TZ = "America/Los_Angeles";
+			ownership = await acquireDaemonSupervisorOwnership({
+				agentDir: join(root, "agent"),
+				appVersion: "test",
+				descriptorDir: join(root, "workers"),
+				generation: "timezone-regression",
+				registryDir,
+				socketPath,
+			});
+			const identity = {
+				generation: ownership.record.generation,
+				pid: ownership.record.pid,
+				...(ownership.record.processStartId ? { processStartId: ownership.record.processStartId } : {}),
+				socketPath: ownership.record.socketPath,
+			};
+
+			process.env.TZ = "America/New_York";
+			await expect(assertDaemonSupervisorOwnerCurrent(identity, undefined, registryDir, undefined)).resolves.toEqual(
+				expect.any(String),
+			);
+		} finally {
+			await ownership?.release();
+			if (originalTimezone === undefined) {
+				delete process.env.TZ;
+			} else {
+				process.env.TZ = originalTimezone;
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Context

Fixes #879.

Prime Agent 0.9.1 still stores the raw output of `ps -o lstart=` as the macOS/BSD process identity. For the same live supervisor, macOS rendered `Sat Aug 29 13:55:18 2026` in `America/Los_Angeles` and `Sat Aug 29 16:55:18 2026` after switching to `America/New_York`. The durable owner comparison then reported `supervisor_generation_stale`, and new session creation timed out after 30 seconds.

This revives the still-unmerged timezone fix from #908 against current `main` and includes the locale pinning discussed in #1234 and #1607.

## Changes

- Run only the portable `ps -o lstart=` fallback with `TZ=UTC` and a fixed C locale while preserving the rest of the caller environment.
- Keep the Linux `/proc` and Windows UTC-tick identity paths unchanged.
- Add a deterministic regression that changes the caller timezone from `America/Los_Angeles` to `America/New_York` and verifies both probes receive the same UTC identity.
- Add the coding-agent changelog fragment.

This is backward-compatible at the daemon protocol level: no command, event, capability, or response shape changes, and `processStartId` remains an optional opaque string. Pre-fix `ps:` owner records created outside UTC cannot be safely normalized because they contain no offset; a daemon that predates this change may need one session-preserving restart to refresh its durable record.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/879-timezone-stable-process-identity.test.ts` — 2 passed, including a real Darwin supervisor ownership check across the timezone change. The deterministic identity assertion failed before the implementation (`expected "ps:Sat Aug 29 20:55:18 2026", received undefined`).
- Source probe with `process.env.TZ` changed from `America/Los_Angeles` to `America/New_York` — both returned `ps:Tue Sep  1 22:23:57 2026` (`stable: true`).
- `npm run check` — passed with no warnings or errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to macOS/BSD process identity probing for daemon leases; no protocol or API shape changes, with minor risk that old non-UTC `ps:` owner records mismatch until restart.
> 
> **Overview**
> Fixes daemon session creation failing after macOS timezone changes ([#879](https://github.com/PrimeIntellect-ai/prime-agent/issues/879)). The portable **`ps -o lstart=`** fallback for process identity was using the host timezone, so the same supervisor PID could get different `ps:` `processStartId` values and durable ownership checks treated the supervisor as stale.
> 
> **`getPsProcessStartId`** now runs that query with **`TZ=UTC`** and a fixed **C** locale (`LC_ALL`, `LC_TIME`, `LANG`), via an optional **`env`** on **`runProcessQuery`**. Linux **`/proc`** and Windows tick identities are unchanged.
> 
> Adds a regression test (mocked `ps` plus Darwin supervisor ownership across a TZ switch) and a changelog fragment. Pre-fix `ps:` records without UTC normalization may need one restart to refresh stored identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99611ab6977dd2985c6f2f4b441498f450133fcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `getProcessStartId` to pin UTC/C environment in `ps` fallback
> - Adds `getPsProcessStartId` in [session-lease.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1971/files#diff-74865e03a1e2d7f4025a576ca8f4c09dbc1ec7c9e2776b5d93f2691ee29e6cda), which forces `LC_ALL`, `LC_TIME`, `LANG` to `C` and `TZ` to `UTC` in the `ps` subprocess so the `lstart` field is stable across caller timezone or locale changes.
> - Extends `ProcessQuery` and `runProcessQuery` to accept an optional `env` parameter so callers can pin subprocess environment variables.
> - Reworks the POSIX fallback in `getProcessStartId` to delegate to `getPsProcessStartId` instead of issuing an inline `ps` command.
> - Adds a regression test in [879-timezone-stable-process-identity.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1971/files#diff-3534c523837e28258050cdeabeb9c6e880afcb14d6f74aa26f984b10bac5c320) verifying identical identifiers across timezone changes on macOS.
> - Behavioral Change: non-win32 platforms without `/proc` now derive the process start ID from a `ps` subprocess with a pinned UTC/C environment rather than inheriting the caller's locale and timezone.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99611ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## Linear

- [RES-1243](https://linear.app/primeintellect/issue/RES-1243/stabilize-daemon-process-identity-across-timezone-changes)
