### PR TITLE
feat(coding-agent): create a git worktree session from the agents view

### DIFF
--- a/packages/coding-agent/.changes/agents-view-new-worktree.md
+++ b/packages/coding-agent/.changes/agents-view-new-worktree.md
@@ -1,1 +1,1 @@
-- Added `alt+w` in the agents view to create a git worktree and start a session in it, with the location overridable via `PRIME_AGENT_WORKTREE_DIR`.
+- Added `alt+w` in the agents view to create a git worktree and start a session in it, with the location and an optional setup script configurable through the `worktree` settings section or the `PRIME_AGENT_WORKTREE_*` environment variables.

--- a/packages/coding-agent/.changes/agents-view-new-worktree.md
+++ b/packages/coding-agent/.changes/agents-view-new-worktree.md
@@ -1,0 +1,1 @@
+- Added `alt+w` in the agents view to create a git worktree and start a session in it, with the location overridable via `PRIME_AGENT_WORKTREE_DIR`.

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -109,6 +109,33 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 | `app.session.fork` | *(none)* | Fork current session (`/fork`) |
 | `app.session.resume` | *(none)* | Open session resume picker (`/resume`) |
 
+### Agents View
+
+Used in the agents view (the session picker opened with `prime-agent agents` or `/resume`).
+
+| Keybinding id | Default | Description |
+|--------|---------|-------------|
+| `app.agents.open` | `right` | Drill into the selected agent |
+| `app.agents.back` | `left` | Return to the parent agent scope |
+| `app.agents.reply` | `space` | Reply to (or resume) the selected agent |
+| `app.agents.new` | `ctrl+n` | Start a new session in the current directory |
+| `app.agents.newWorktree` | `alt+w` | Create a git worktree and start a session in it |
+| `app.agents.rename` | `ctrl+r` | Rename the selected agent session |
+| `app.agents.delete` | `ctrl+x` | Stop or delete the selected agent |
+| `app.agents.program` | `ctrl+o` | Show the program that spawned subagents |
+
+`app.agents.newWorktree` opens an inline prompt for a name. The name is sanitized into
+one path segment and used as the branch name. Confirming runs `git worktree add`, and
+attaches an existing branch instead of creating one. The worktree path resolves in this
+order:
+
+1. `$PRIME_AGENT_WORKTREE_DIR/<name>` when that environment variable is set (a relative
+   value resolves against the repository root); then
+2. `<repoRoot>/.worktrees/<name>`.
+
+An existing worktree at that path is reused. The new session starts with the worktree as
+its working directory.
+
 ### Models and Thinking
 
 | Keybinding id | Default | Description |

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -129,12 +129,16 @@ one path segment and used as the branch name. Confirming runs `git worktree add`
 attaches an existing branch instead of creating one. The worktree path resolves in this
 order:
 
-1. `$PRIME_AGENT_WORKTREE_DIR/<name>` when that environment variable is set (a relative
-   value resolves against the repository root); then
-2. `<repoRoot>/.worktrees/<name>`.
+1. `$PRIME_AGENT_WORKTREE_DIR/<name>` when that environment variable is set;
+2. `<worktree.dir>/<name>` from settings; then
+3. `<repoRoot>/.worktrees/<name>`.
 
-An existing worktree at that path is reused. The new session starts with the worktree as
-its working directory.
+A relative directory value resolves against the repository root. An existing worktree at
+that path is reused.
+
+An optional setup script runs in the new worktree before the session starts. See
+[Settings](settings.md#git-worktrees). The new session starts with the worktree as its
+working directory.
 
 ### Models and Thinking
 

--- a/packages/coding-agent/docs/long-running-agents.md
+++ b/packages/coding-agent/docs/long-running-agents.md
@@ -64,6 +64,11 @@ prime-agent doctor [--fix]          # Diagnose or repair service state
 prime-agent shutdown [--force]      # Stop all agents and services
 ```
 
+In the agents view, `ctrl+n` starts a new session in the current directory and `alt+w` prompts for a
+name, creates a git worktree for it, and starts a session with that worktree as its working directory.
+The worktree is created under `$PRIME_AGENT_WORKTREE_DIR` when that variable is set, and under
+`<repoRoot>/.worktrees` otherwise. See [Keybindings](keybindings.md) for the full action list.
+
 Workers persist transcripts as JSONL and store feature-specific state under the session artifact directory. A worker or supervisor restart can recover session state and schedules and rehydrate retained completed RLM children without treating a terminal client as the owner of the work.
 
 Daemon workers are process-isolated for lifecycle and failure containment, not security-sandboxed. They normally run with the same operating-system permissions as the client.

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -196,6 +196,62 @@ When a provider requests a retry delay longer than `retry.provider.maxRetryDelay
 
 Normally the package manager's global modules location is queried using `root -g`. As a special case, if the first element of `npmCommand` is `"bun"`, the modules location will instead be queried with `pm bin -g`.
 
+### Git Worktrees
+
+Used by the agents view action that creates a git worktree and starts a session in it
+(`app.agents.newWorktree`, default `alt+w`).
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `worktree.dir` | string | `<repoRoot>/.worktrees` | Parent directory for new worktrees; a relative value resolves against the repository root |
+| `worktree.setupScript` | string | - | Script path or shell command run in the new worktree before the session starts |
+| `worktree.setupTimeoutMs` | number | `600000` | Timeout for the setup script (10 minutes) |
+
+```json
+{
+  "worktree": {
+    "dir": "~/worktrees",
+    "setupScript": "scripts/setup-worktree.sh",
+    "setupTimeoutMs": 600000
+  }
+}
+```
+
+Environment variables override the settings for one run:
+
+| Variable | Overrides |
+|----------|-----------|
+| `PRIME_AGENT_WORKTREE_DIR` | `worktree.dir` |
+| `PRIME_AGENT_WORKTREE_SETUP` | `worktree.setupScript` |
+| `PRIME_AGENT_WORKTREE_SETUP_TIMEOUT_MS` | `worktree.setupTimeoutMs` |
+
+Resolution order for each value: environment variable, then the setting, then the default.
+
+`setupScript` runs through the configured shell (`shellPath`) with the new worktree as the
+working directory. A value that names an existing file runs as that script; a relative path
+resolves against the repository root. Any other value runs verbatim as a shell command.
+These variables are exported to the script:
+
+| Variable | Value |
+|----------|-------|
+| `PRIME_AGENT_WORKTREE_PATH` | Absolute path of the new worktree |
+| `PRIME_AGENT_WORKTREE_BRANCH` | Branch checked out in the worktree |
+| `PRIME_AGENT_WORKTREE_REPO_ROOT` | Repository root the worktree was created from |
+
+Example script that copies `.env` from the main worktree and picks a free port:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cp "$PRIME_AGENT_WORKTREE_REPO_ROOT/.env" "$PRIME_AGENT_WORKTREE_PATH/.env"
+port=$(node -e 'const s=require("net").createServer();s.listen(0,()=>{console.log(s.address().port);s.close()})')
+echo "PORT=$port" >> "$PRIME_AGENT_WORKTREE_PATH/.env"
+```
+
+Full stdout and stderr go to `~/.prime/agent/logs/worktree-setup-<branch>.log`. On a
+non-zero exit or a timeout, the agents view shows the last output lines and the log path,
+keeps the created worktree, and does not start the session.
+
 ### Daemon
 
 | Setting | Type | Default | Description |

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -545,6 +545,11 @@ export function getClientErrorLogPath(): string {
 	return join(getLogsDir(), "client-errors.log");
 }
 
+/** Log file capturing the output of one worktree setup script run. */
+export function getWorktreeSetupLogPath(branch: string): string {
+	return join(getLogsDir(), `worktree-setup-${branch.replace(/[^A-Za-z0-9._-]+/g, "-")}.log`);
+}
+
 export function getAgentTracesLogPath(): string {
 	return join(getLogsDir(), "agent-traces.log");
 }

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -45,6 +45,7 @@ export interface AppKeybindings {
 	"app.modal.back": true;
 	"app.agents.reply": true;
 	"app.agents.new": true;
+	"app.agents.newWorktree": true;
 	"app.agents.delete": true;
 	"app.agents.program": true;
 	"app.agents.rename": true;
@@ -156,6 +157,10 @@ export const KEYBINDINGS = {
 	"app.modal.back": { defaultKeys: "left", description: "Go back / close the current dialog" },
 	"app.agents.reply": { defaultKeys: "space", description: "Reply to selected agent" },
 	"app.agents.new": { defaultKeys: "ctrl+n", description: "Start a new session from the agents view" },
+	"app.agents.newWorktree": {
+		defaultKeys: "alt+w",
+		description: "Create a git worktree and start a session in it",
+	},
 	"app.agents.delete": { defaultKeys: "ctrl+x", description: "Stop or delete selected agent" },
 	"app.agents.program": { defaultKeys: "ctrl+o", description: "Show the program that spawned subagents" },
 	"app.agents.rename": { defaultKeys: "ctrl+r", description: "Rename selected agent session" },

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -71,6 +71,15 @@ export interface BundledSkillsSettings {
 	websearch?: boolean; // default: true
 }
 
+export interface WorktreeSettings {
+	/** Parent directory for new worktrees; default `<repoRoot>/.worktrees`. */
+	dir?: string;
+	/** Script path (relative to the repo root) or shell command run in a new worktree. */
+	setupScript?: string;
+	/** Timeout for the setup script; default 600000 (10 minutes). */
+	setupTimeoutMs?: number;
+}
+
 export interface WarningSettings {
 	anthropicExtraUsage?: boolean; // default: true
 }
@@ -172,6 +181,7 @@ export interface Settings {
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
 	markdown?: MarkdownSettings;
 	warnings?: WarningSettings;
+	worktree?: WorktreeSettings; // Agents-view git worktree creation
 	sessionDir?: string; // Custom session storage directory (same format as --session-dir CLI flag)
 }
 
@@ -1114,6 +1124,11 @@ export class SettingsManager {
 
 	getThinkingBudgets(): ThinkingBudgetsSettings | undefined {
 		return this.settings.thinkingBudgets;
+	}
+
+	/** Raw worktree settings; env overrides are applied by the worktree helpers. */
+	getWorktreeSettings(): WorktreeSettings {
+		return { ...this.settings.worktree };
 	}
 
 	getShowImages(): boolean {

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -24,6 +24,7 @@ import {
 	parseSlashCommand,
 	resolveBuiltinSlashCommandName,
 } from "../../core/slash-commands.js";
+import { createGitWorktree } from "../../utils/git-worktree.js";
 import { canonicalizePath } from "../../utils/paths.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import { DaemonAgentConnection } from "../agent-connection/daemon-agent-connection.js";
@@ -108,6 +109,7 @@ const STATUS_MESSAGE_DURATION_MS = 4500;
 const SEARCH_PROMPT_PLACEHOLDER = "Search sessions";
 const REPLY_PROMPT_FALLBACK_PLACEHOLDER = "Write a reply to this agent";
 const RESUME_PROMPT_PLACEHOLDER = "Write a prompt to resume this session";
+const WORKTREE_PROMPT_PLACEHOLDER = "Name the new git worktree branch";
 const COMPLETED_ROW_ICON = "✓";
 const NEEDS_INPUT_ROW_ICON = "●";
 const SELECTED_ROW_MARKER = "\0agents-view-selected-row\0";
@@ -677,6 +679,8 @@ export class AgentsViewMode implements Component, Focusable {
 	private pendingDeleteAgent: PendingDeleteAgent | undefined;
 	private pendingKillSubagent: PendingKillSubagent | undefined;
 	private renameTarget: { activeSessionId?: string; sessionFile?: string; summary: SessionSummary } | undefined;
+	/** True while the inline "new worktree session" prompt owns the editor. */
+	private worktreePromptActive = false;
 	private actionModeSearchQuery: string | undefined;
 	private readonly inactiveAgentIdentities = new Set<string>();
 	private statusMessage: string | undefined;
@@ -888,6 +892,14 @@ export class AgentsViewMode implements Component, Focusable {
 			this.editor.handleInput(data);
 			return;
 		}
+		if (this.worktreePromptActive) {
+			if (this.keybindings.matches(data, "tui.select.cancel")) {
+				this.exitWorktreeMode();
+				return;
+			}
+			this.editor.handleInput(data);
+			return;
+		}
 		if (this.keybindings.matches(data, "app.clear")) {
 			// The composer hints advertise ctrl+c as cancel; it must not start the exit flow.
 			if (this.replyTarget) {
@@ -914,6 +926,10 @@ export class AgentsViewMode implements Component, Focusable {
 		}
 		if (!this.replyTarget && this.keybindings.matches(data, "app.agents.new")) {
 			void this.createNewSession();
+			return;
+		}
+		if (!this.replyTarget && this.keybindings.matches(data, "app.agents.newWorktree")) {
+			this.enterWorktreeMode();
 			return;
 		}
 		if (this.replyTarget && this.keybindings.matches(data, "app.message.followUp")) {
@@ -1237,7 +1253,10 @@ export class AgentsViewMode implements Component, Focusable {
 	}
 
 	private getFilteredRecords(): UnifiedSessionRecord[] {
-		const query = this.replyTarget || this.renameTarget ? (this.actionModeSearchQuery ?? "") : this.editor.getText();
+		const query =
+			this.replyTarget || this.renameTarget || this.worktreePromptActive
+				? (this.actionModeSearchQuery ?? "")
+				: this.editor.getText();
 		return filterUnifiedSessions(this.scopedRecords, (text) => matchesSearchText(text, query));
 	}
 
@@ -1262,6 +1281,10 @@ export class AgentsViewMode implements Component, Focusable {
 	private async submit(value: string, delivery: "steer" | "followUp" = "steer"): Promise<void> {
 		if (this.renameTarget) {
 			await this.confirmRename(value);
+			return;
+		}
+		if (this.worktreePromptActive) {
+			await this.confirmWorktree(value);
 			return;
 		}
 		if (this.replyTarget) {
@@ -1605,6 +1628,60 @@ export class AgentsViewMode implements Component, Focusable {
 		await this.renameSession(target.summary, name);
 	}
 
+	private enterWorktreeMode(): void {
+		this.setReplyTarget(undefined);
+		this.actionModeSearchQuery = this.editor.getText();
+		this.renameTarget = undefined;
+		this.pendingDeleteAgent = undefined;
+		this.pendingKillSubagent = undefined;
+		this.worktreePromptActive = true;
+		this.editor.setPlaceholder(WORKTREE_PROMPT_PLACEHOLDER);
+		this.editor.setText("");
+		this.ui.requestRender();
+	}
+
+	private exitWorktreeMode(): void {
+		this.worktreePromptActive = false;
+		this.editor.setText(this.actionModeSearchQuery ?? this.persistentState.query ?? "");
+		this.actionModeSearchQuery = undefined;
+		this.editor.setPlaceholder(SEARCH_PROMPT_PLACEHOLDER);
+		this.rebuildRows();
+		this.ui.requestRender();
+	}
+
+	private async confirmWorktree(value: string): Promise<void> {
+		if (!this.worktreePromptActive) {
+			return;
+		}
+		const name = value.trim();
+		if (!name) {
+			this.exitWorktreeMode();
+			return;
+		}
+		this.exitWorktreeMode();
+		await this.createWorktreeSession(name);
+	}
+
+	/** Add a git worktree next to the current repository and open a session rooted in it. */
+	private async createWorktreeSession(name: string): Promise<boolean> {
+		if (this.creatingNewSession || this.stopped) {
+			return false;
+		}
+		this.setStatusMessage(`Creating worktree ${name}...`);
+		try {
+			const worktree = await createGitWorktree({ cwd: this.getSavedSessionCwd(), name });
+			if (this.stopped) {
+				return false;
+			}
+			return await this.createNewSession({ ...this.options.config, cwd: worktree.path });
+		} catch (error) {
+			if (!this.stopped) {
+				this.setStatusMessage(formatError("Failed to create worktree", error));
+			}
+			return false;
+		}
+	}
+
 	/** Shared by rename mode and /name: rename, refresh both catalogs, report. */
 	private async renameSession(summary: SessionSummary, name: string): Promise<boolean> {
 		this.setStatusMessage("Renaming agent...");
@@ -1644,6 +1721,9 @@ export class AgentsViewMode implements Component, Focusable {
 	private renderReplyHeaderLine(): string | undefined {
 		if (this.renameTarget) {
 			return theme.fg("warning", "Rename agent session");
+		}
+		if (this.worktreePromptActive) {
+			return theme.fg("warning", "New git worktree session");
 		}
 		if (!this.replyTarget) {
 			return undefined;
@@ -1720,7 +1800,7 @@ export class AgentsViewMode implements Component, Focusable {
 	}
 
 	/** Create a fresh daemon session and open it in the chat view. */
-	private async createNewSession(): Promise<boolean> {
+	private async createNewSession(config: AgentSessionRuntimeConfig = this.options.config): Promise<boolean> {
 		if (this.creatingNewSession || this.stopped) return false;
 		this.creatingNewSession = true;
 		try {
@@ -1729,7 +1809,7 @@ export class AgentsViewMode implements Component, Focusable {
 				this.setStatusMessage("Creating session...");
 				const response = await client.request({
 					type: "create",
-					config: this.options.config,
+					config,
 					env: collectDaemonClientEnv(),
 				});
 				const created = expectSessionSummary(requireDaemonData(response));
@@ -2647,6 +2727,10 @@ export class AgentsViewMode implements Component, Focusable {
 			const hint = `${keyText("tui.select.confirm")} save   ${keyText("tui.select.cancel")} cancel`;
 			return truncateToWidth(theme.fg("muted", hint), width);
 		}
+		if (this.worktreePromptActive) {
+			const hint = `${keyText("tui.select.confirm")} create   ${keyText("tui.select.cancel")} cancel`;
+			return truncateToWidth(theme.fg("muted", hint), width);
+		}
 		if (this.replyTarget) {
 			return truncateToWidth(theme.fg("muted", this.renderReplyComposerHints()), width);
 		}
@@ -2665,6 +2749,7 @@ export class AgentsViewMode implements Component, Focusable {
 				? `${keyText("app.agents.reply")} ${selectedRow?.section === "inactive" ? "resume" : "reply"}`
 				: undefined,
 			`${keyText("app.agents.new")} new`,
+			`${keyText("app.agents.newWorktree")} new worktree`,
 			selectedAgent ? `${keyText("app.agents.rename")} rename` : undefined,
 			selectedAgent
 				? `${keyText("app.agents.delete")} ${selectedRow?.section === "inactive" ? "delete" : "stop/deactivate"}`

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -13,7 +13,14 @@ import {
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
-import { APP_TITLE, appendRotatingLog, getAgentDir, getClientErrorLogPath, VERSION } from "../../config.js";
+import {
+	APP_TITLE,
+	appendRotatingLog,
+	getAgentDir,
+	getClientErrorLogPath,
+	getWorktreeSetupLogPath,
+	VERSION,
+} from "../../config.js";
 import type { AgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
 import { KeybindingsManager } from "../../core/keybindings.js";
 import { SessionManager } from "../../core/session-manager.js";
@@ -27,6 +34,12 @@ import {
 import { createGitWorktree } from "../../utils/git-worktree.js";
 import { canonicalizePath } from "../../utils/paths.js";
 import { ensureTool } from "../../utils/tools-manager.js";
+import {
+	resolveWorktreeSetupScript,
+	resolveWorktreeSetupTimeoutMs,
+	runWorktreeSetup,
+	WorktreeSetupError,
+} from "../../utils/worktree-setup.js";
 import { DaemonAgentConnection } from "../agent-connection/daemon-agent-connection.js";
 import type { AgentConnectionHeartbeat, AgentConnectionSavedSessionInfo } from "../agent-connection/types.js";
 import { DaemonClient, getDaemonSocketCloseReason } from "../daemon/daemon-client.js";
@@ -1667,16 +1680,43 @@ export class AgentsViewMode implements Component, Focusable {
 		if (this.creatingNewSession || this.stopped) {
 			return false;
 		}
+		const settings = this.options.uiServices.settingsManager.getWorktreeSettings();
 		this.setStatusMessage(`Creating worktree ${name}...`);
 		try {
-			const worktree = await createGitWorktree({ cwd: this.getSavedSessionCwd(), name });
+			const worktree = await createGitWorktree({
+				cwd: this.getSavedSessionCwd(),
+				name,
+				worktreeDir: settings.dir,
+			});
 			if (this.stopped) {
 				return false;
 			}
+			const script = resolveWorktreeSetupScript(settings.setupScript);
+			if (script) {
+				this.setStatusMessage("Running worktree setup...");
+				await runWorktreeSetup({
+					script,
+					worktreePath: worktree.path,
+					branch: worktree.branch,
+					repoRoot: worktree.repoRoot,
+					timeoutMs: resolveWorktreeSetupTimeoutMs(settings.setupTimeoutMs),
+					shellPath: this.options.uiServices.settingsManager.getShellPath(),
+					logPath: getWorktreeSetupLogPath(worktree.branch),
+				});
+				if (this.stopped) {
+					return false;
+				}
+			}
 			return await this.createNewSession({ ...this.options.config, cwd: worktree.path });
 		} catch (error) {
+			// A failed setup script keeps the worktree; only the session is skipped.
 			if (!this.stopped) {
-				this.setStatusMessage(formatError("Failed to create worktree", error));
+				this.setStatusMessage(
+					formatError(
+						error instanceof WorktreeSetupError ? "Failed to run worktree setup" : "Failed to create worktree",
+						error,
+					),
+				);
 			}
 			return false;
 		}

--- a/packages/coding-agent/src/utils/git-worktree.ts
+++ b/packages/coding-agent/src/utils/git-worktree.ts
@@ -21,7 +21,7 @@ export interface CreateGitWorktreeOptions {
 	cwd: string;
 	/** User-supplied worktree and branch name; sanitized into a single path segment. */
 	name: string;
-	/** Overrides the parent directory of the worktree; defaults to the env var or `<repoRoot>/.worktrees`. */
+	/** `worktree.dir` setting; the env var still wins over it. */
 	worktreeDir?: string;
 	runGit?: GitCommandRunner;
 	pathExists?: (path: string) => boolean;
@@ -79,12 +79,12 @@ export async function resolveGitRepoRoot(cwd: string, runGit: GitCommandRunner =
 }
 
 /**
- * Resolution order: explicit `worktreeDir`, then `PRIME_AGENT_WORKTREE_DIR`,
- * then `<repoRoot>/.worktrees`. A relative override resolves against the repo root.
+ * Resolution order: `PRIME_AGENT_WORKTREE_DIR`, then the `worktree.dir` setting
+ * passed as `worktreeDir`, then `<repoRoot>/.worktrees`. A relative value
+ * resolves against the repo root.
  */
 export function resolveWorktreeParentDir(repoRoot: string, worktreeDir?: string): string {
-	const override = worktreeDir ?? process.env[WORKTREE_DIR_ENV_VAR];
-	const trimmed = override?.trim();
+	const trimmed = process.env[WORKTREE_DIR_ENV_VAR]?.trim() || worktreeDir?.trim();
 	if (!trimmed) {
 		return join(repoRoot, DEFAULT_WORKTREE_DIR_NAME);
 	}

--- a/packages/coding-agent/src/utils/git-worktree.ts
+++ b/packages/coding-agent/src/utils/git-worktree.ts
@@ -1,0 +1,156 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export const WORKTREE_DIR_ENV_VAR = "PRIME_AGENT_WORKTREE_DIR";
+const DEFAULT_WORKTREE_DIR_NAME = ".worktrees";
+
+export interface GitCommandResult {
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+}
+
+export type GitCommandRunner = (args: readonly string[], cwd: string) => Promise<GitCommandResult>;
+
+export interface CreateGitWorktreeOptions {
+	/** Directory used to locate the repository the worktree is added to. */
+	cwd: string;
+	/** User-supplied worktree and branch name; sanitized into a single path segment. */
+	name: string;
+	/** Overrides the parent directory of the worktree; defaults to the env var or `<repoRoot>/.worktrees`. */
+	worktreeDir?: string;
+	runGit?: GitCommandRunner;
+	pathExists?: (path: string) => boolean;
+}
+
+export interface CreateGitWorktreeResult {
+	path: string;
+	branch: string;
+	repoRoot: string;
+	/** False when an existing worktree at the resolved path was reused. */
+	created: boolean;
+}
+
+interface WorktreeEntry {
+	path: string;
+	branch?: string;
+}
+
+export const runGitCommand: GitCommandRunner = async (args, cwd) => {
+	try {
+		const { stdout, stderr } = await execFileAsync("git", [...args], { cwd, encoding: "utf-8" });
+		return { stdout, stderr, exitCode: 0 };
+	} catch (error) {
+		const failure = error as { stdout?: string; stderr?: string; code?: number; message?: string };
+		return {
+			stdout: failure.stdout ?? "",
+			stderr: failure.stderr ?? failure.message ?? "",
+			exitCode: typeof failure.code === "number" ? failure.code : 1,
+		};
+	}
+};
+
+/** Reduce a free-form name to one safe path segment usable as a branch name. */
+export function sanitizeWorktreeName(name: string): string {
+	const sanitized = name
+		.trim()
+		.replace(/[^A-Za-z0-9._/-]+/g, "-")
+		.replace(/\/+/g, "-")
+		.replace(/-{2,}/g, "-")
+		.replace(/^[-._]+/, "")
+		.replace(/[-._]+$/, "");
+	if (!sanitized) {
+		throw new Error(`Invalid worktree name: ${name}`);
+	}
+	return sanitized;
+}
+
+export async function resolveGitRepoRoot(cwd: string, runGit: GitCommandRunner = runGitCommand): Promise<string> {
+	const result = await runGit(["rev-parse", "--show-toplevel"], cwd);
+	const root = result.stdout.trim();
+	if (result.exitCode !== 0 || !root) {
+		throw new Error(`Not a git repository: ${cwd}`);
+	}
+	return resolve(root);
+}
+
+/**
+ * Resolution order: explicit `worktreeDir`, then `PRIME_AGENT_WORKTREE_DIR`,
+ * then `<repoRoot>/.worktrees`. A relative override resolves against the repo root.
+ */
+export function resolveWorktreeParentDir(repoRoot: string, worktreeDir?: string): string {
+	const override = worktreeDir ?? process.env[WORKTREE_DIR_ENV_VAR];
+	const trimmed = override?.trim();
+	if (!trimmed) {
+		return join(repoRoot, DEFAULT_WORKTREE_DIR_NAME);
+	}
+	return isAbsolute(trimmed) ? resolve(trimmed) : resolve(repoRoot, trimmed);
+}
+
+function parseWorktreeList(stdout: string): WorktreeEntry[] {
+	const entries: WorktreeEntry[] = [];
+	let current: WorktreeEntry | undefined;
+	for (const line of stdout.split("\n")) {
+		if (line.startsWith("worktree ")) {
+			current = { path: resolve(line.slice("worktree ".length).trim()) };
+			entries.push(current);
+			continue;
+		}
+		if (current && line.startsWith("branch ")) {
+			current.branch = line.slice("branch ".length).trim();
+		}
+	}
+	return entries;
+}
+
+async function branchExists(repoRoot: string, branch: string, runGit: GitCommandRunner): Promise<boolean> {
+	const result = await runGit(["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`], repoRoot);
+	return result.exitCode === 0;
+}
+
+/**
+ * Create (or reuse) a git worktree for `name` and return its absolute path.
+ * An existing branch is attached instead of re-created.
+ */
+export async function createGitWorktree(options: CreateGitWorktreeOptions): Promise<CreateGitWorktreeResult> {
+	const runGit = options.runGit ?? runGitCommand;
+	const pathExists = options.pathExists ?? existsSync;
+	const branch = sanitizeWorktreeName(options.name);
+	const repoRoot = await resolveGitRepoRoot(options.cwd, runGit);
+	const worktreePath = join(resolveWorktreeParentDir(repoRoot, options.worktreeDir), branch);
+
+	const listed = await runGit(["worktree", "list", "--porcelain"], repoRoot);
+	if (listed.exitCode !== 0) {
+		throw new Error(`Failed to list worktrees: ${formatGitFailure(listed)}`);
+	}
+	const existing = parseWorktreeList(listed.stdout).find((entry) => entry.path === worktreePath);
+	if (existing) {
+		return {
+			path: worktreePath,
+			branch: existing.branch?.replace(/^refs\/heads\//, "") ?? branch,
+			repoRoot,
+			created: false,
+		};
+	}
+	if (pathExists(worktreePath)) {
+		throw new Error(`Worktree path already exists and is not a worktree: ${worktreePath}`);
+	}
+
+	const addArgs = (await branchExists(repoRoot, branch, runGit))
+		? ["worktree", "add", worktreePath, branch]
+		: ["worktree", "add", worktreePath, "-b", branch];
+	const added = await runGit(addArgs, repoRoot);
+	if (added.exitCode !== 0) {
+		throw new Error(`git ${addArgs.join(" ")} failed: ${formatGitFailure(added)}`);
+	}
+	return { path: worktreePath, branch, repoRoot, created: true };
+}
+
+function formatGitFailure(result: GitCommandResult): string {
+	const message = result.stderr.trim() || result.stdout.trim();
+	return message || `exit code ${result.exitCode}`;
+}

--- a/packages/coding-agent/src/utils/worktree-setup.ts
+++ b/packages/coding-agent/src/utils/worktree-setup.ts
@@ -1,0 +1,192 @@
+import { execFile } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { getShellConfig } from "./shell.js";
+
+export const WORKTREE_SETUP_ENV_VAR = "PRIME_AGENT_WORKTREE_SETUP";
+export const WORKTREE_SETUP_TIMEOUT_ENV_VAR = "PRIME_AGENT_WORKTREE_SETUP_TIMEOUT_MS";
+export const DEFAULT_WORKTREE_SETUP_TIMEOUT_MS = 600_000;
+const ERROR_OUTPUT_LINES = 5;
+
+export interface WorktreeSetupCommandResult {
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+	timedOut: boolean;
+}
+
+export interface WorktreeSetupCommand {
+	command: string;
+	cwd: string;
+	env: Record<string, string>;
+	timeoutMs: number;
+	shellPath?: string;
+}
+
+export type WorktreeSetupRunner = (command: WorktreeSetupCommand) => Promise<WorktreeSetupCommandResult>;
+
+export interface RunWorktreeSetupOptions {
+	/** Script path (absolute, or relative to the repo root) or an inline shell command. */
+	script: string;
+	worktreePath: string;
+	branch: string;
+	repoRoot: string;
+	timeoutMs?: number;
+	shellPath?: string;
+	/** Full stdout and stderr are written here; the path is reported on failure. */
+	logPath?: string;
+	runSetup?: WorktreeSetupRunner;
+	fileExists?: (path: string) => boolean;
+	writeLog?: (path: string, contents: string) => void;
+}
+
+export interface WorktreeSetupResult {
+	command: string;
+	output: string;
+	logPath?: string;
+}
+
+export class WorktreeSetupError extends Error {
+	constructor(
+		message: string,
+		readonly logPath: string | undefined,
+		readonly timedOut: boolean,
+	) {
+		super(message);
+		this.name = "WorktreeSetupError";
+	}
+}
+
+export const runWorktreeSetupCommand: WorktreeSetupRunner = async (command) => {
+	const shell = getShellConfig(command.shellPath);
+	try {
+		const { stdout, stderr } = await new Promise<{ stdout: string; stderr: string }>((resolvePromise, reject) => {
+			execFile(
+				shell.shell,
+				[...shell.args, command.command],
+				{
+					cwd: command.cwd,
+					env: command.env,
+					encoding: "utf-8",
+					timeout: command.timeoutMs,
+					maxBuffer: 16 * 1024 * 1024,
+				},
+				(error, stdout, stderr) => {
+					if (error) {
+						reject(Object.assign(error, { stdout, stderr }));
+						return;
+					}
+					resolvePromise({ stdout, stderr });
+				},
+			);
+		});
+		return { stdout, stderr, exitCode: 0, timedOut: false };
+	} catch (error) {
+		const failure = error as { stdout?: string; stderr?: string; code?: number; killed?: boolean; message?: string };
+		return {
+			stdout: failure.stdout ?? "",
+			stderr: failure.stderr ?? failure.message ?? "",
+			exitCode: typeof failure.code === "number" ? failure.code : 1,
+			timedOut: failure.killed === true,
+		};
+	}
+};
+
+/** Env var wins over the settings value so a single run can override the configured script. */
+export function resolveWorktreeSetupScript(configured?: string): string | undefined {
+	const script = process.env[WORKTREE_SETUP_ENV_VAR]?.trim() || configured?.trim();
+	return script ? script : undefined;
+}
+
+export function resolveWorktreeSetupTimeoutMs(configured?: number): number {
+	const fromEnv = Number.parseInt(process.env[WORKTREE_SETUP_TIMEOUT_ENV_VAR] ?? "", 10);
+	if (Number.isFinite(fromEnv) && fromEnv > 0) return fromEnv;
+	if (configured !== undefined && Number.isFinite(configured) && configured > 0) return configured;
+	return DEFAULT_WORKTREE_SETUP_TIMEOUT_MS;
+}
+
+/**
+ * A value that names an existing file runs as that script; anything else runs
+ * verbatim as a shell command. Relative paths resolve against the repo root.
+ */
+export function buildWorktreeSetupCommand(
+	script: string,
+	repoRoot: string,
+	fileExists: (path: string) => boolean = existsSync,
+): string {
+	const trimmed = script.trim();
+	const candidate = isAbsolute(trimmed) ? trimmed : resolve(repoRoot, trimmed);
+	return fileExists(candidate) ? `"${candidate}"` : trimmed;
+}
+
+export function createWorktreeSetupEnv(context: {
+	worktreePath: string;
+	branch: string;
+	repoRoot: string;
+}): Record<string, string> {
+	const env: Record<string, string> = {};
+	for (const [key, value] of Object.entries(process.env)) {
+		if (value !== undefined) env[key] = value;
+	}
+	env.PRIME_AGENT_WORKTREE_PATH = context.worktreePath;
+	env.PRIME_AGENT_WORKTREE_BRANCH = context.branch;
+	env.PRIME_AGENT_WORKTREE_REPO_ROOT = context.repoRoot;
+	return env;
+}
+
+function lastOutputLines(result: WorktreeSetupCommandResult): string {
+	const source = result.stderr.trim() || result.stdout.trim();
+	return source.split("\n").slice(-ERROR_OUTPUT_LINES).join(" ").trim();
+}
+
+function defaultWriteLog(path: string, contents: string): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, contents, "utf-8");
+}
+
+/**
+ * Run the configured setup script inside a freshly created worktree.
+ * Throws WorktreeSetupError on timeout or non-zero exit; the worktree is kept.
+ */
+export async function runWorktreeSetup(options: RunWorktreeSetupOptions): Promise<WorktreeSetupResult> {
+	const runSetup = options.runSetup ?? runWorktreeSetupCommand;
+	const writeLog = options.writeLog ?? defaultWriteLog;
+	const timeoutMs = resolveWorktreeSetupTimeoutMs(options.timeoutMs);
+	const command = buildWorktreeSetupCommand(options.script, options.repoRoot, options.fileExists);
+	const result = await runSetup({
+		command,
+		cwd: options.worktreePath,
+		env: createWorktreeSetupEnv(options),
+		timeoutMs,
+		shellPath: options.shellPath,
+	});
+
+	const output = `$ ${command}\n${result.stdout}${result.stderr}`;
+	let logPath = options.logPath;
+	if (logPath) {
+		try {
+			writeLog(logPath, output);
+		} catch {
+			// A missing log must not mask the setup outcome.
+			logPath = undefined;
+		}
+	}
+	if (result.timedOut) {
+		throw new WorktreeSetupError(
+			`Worktree setup timed out after ${timeoutMs}ms${logPath ? `; log: ${logPath}` : ""}`,
+			logPath,
+			true,
+		);
+	}
+	if (result.exitCode !== 0) {
+		const detail = lastOutputLines(result);
+		throw new WorktreeSetupError(
+			`Worktree setup exited with code ${result.exitCode}${detail ? `: ${detail}` : ""}${
+				logPath ? `; log: ${logPath}` : ""
+			}`,
+			logPath,
+			false,
+		);
+	}
+	return { command, output, logPath };
+}

--- a/packages/coding-agent/test/agents-view-worktree.test.ts
+++ b/packages/coding-agent/test/agents-view-worktree.test.ts
@@ -1,9 +1,10 @@
-import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setKeybindings } from "@earendil-works/pi-tui";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.js";
+import type { WorktreeSettings } from "../src/core/settings-manager.js";
 import { AgentsViewMode } from "../src/modes/agents-view/agents-view-mode.js";
 import {
 	createGitWorktree,
@@ -13,6 +14,15 @@ import {
 	runGitCommand,
 	sanitizeWorktreeName,
 } from "../src/utils/git-worktree.js";
+import {
+	buildWorktreeSetupCommand,
+	DEFAULT_WORKTREE_SETUP_TIMEOUT_MS,
+	resolveWorktreeSetupScript,
+	resolveWorktreeSetupTimeoutMs,
+	runWorktreeSetup,
+	type WorktreeSetupCommand,
+	WorktreeSetupError,
+} from "../src/utils/worktree-setup.js";
 
 const keybindings = new KeybindingsManager();
 
@@ -25,6 +35,13 @@ function invoke(method: string, self: object, ...args: unknown[]): unknown {
 // Raw sequences for the defaults asserted in "binds the worktree prompt to alt+w".
 const NEW_WORKTREE_KEY = "\x1bw";
 const CANCEL_KEY = "\x1b";
+
+async function initRepo(repoRoot: string): Promise<void> {
+	await runGitCommand(["init", "-b", "main"], repoRoot);
+	await runGitCommand(["config", "user.email", "test@example.com"], repoRoot);
+	await runGitCommand(["config", "user.name", "test"], repoRoot);
+	await runGitCommand(["commit", "--allow-empty", "-m", "init"], repoRoot);
+}
 
 function ok(stdout = ""): GitCommandResult {
 	return { stdout, stderr: "", exitCode: 0 };
@@ -55,6 +72,13 @@ function createEditorStub(): {
 	return editor;
 }
 
+function createSettingsStub(worktree: WorktreeSettings = {}): {
+	getWorktreeSettings: () => WorktreeSettings;
+	getShellPath: () => string | undefined;
+} {
+	return { getWorktreeSettings: () => worktree, getShellPath: () => undefined };
+}
+
 function createViewStub(overrides: Record<string, unknown> = {}): Record<string, unknown> {
 	const editor = createEditorStub();
 	const self: Record<string, unknown> = {
@@ -71,7 +95,10 @@ function createViewStub(overrides: Record<string, unknown> = {}): Record<string,
 		actionModeSearchQuery: undefined,
 		pendingDeleteAgent: undefined,
 		pendingKillSubagent: undefined,
-		options: { config: { cwd: "/repo" }, uiServices: { getInitialCwd: () => "/repo" } },
+		options: {
+			config: { cwd: "/repo" },
+			uiServices: { getInitialCwd: () => "/repo", settingsManager: createSettingsStub() },
+		},
 		ui: { requestRender: vi.fn() },
 		setStatusMessage: vi.fn(),
 		clearStickyStatusMessage: vi.fn(),
@@ -104,7 +131,11 @@ function createViewStub(overrides: Record<string, unknown> = {}): Record<string,
 }
 
 // A developer-set override must not change the expected default locations.
-beforeEach(() => vi.stubEnv("PRIME_AGENT_WORKTREE_DIR", ""));
+beforeEach(() => {
+	vi.stubEnv("PRIME_AGENT_WORKTREE_DIR", "");
+	vi.stubEnv("PRIME_AGENT_WORKTREE_SETUP", "");
+	vi.stubEnv("PRIME_AGENT_WORKTREE_SETUP_TIMEOUT_MS", "");
+});
 afterEach(() => vi.unstubAllEnvs());
 
 describe("git worktree helper", () => {
@@ -207,6 +238,95 @@ describe("git worktree helper", () => {
 	});
 });
 
+describe("worktree setup script", () => {
+	it("prefers the env override over the configured script", () => {
+		expect(resolveWorktreeSetupScript("scripts/setup.sh")).toBe("scripts/setup.sh");
+		expect(resolveWorktreeSetupScript(undefined)).toBeUndefined();
+		vi.stubEnv("PRIME_AGENT_WORKTREE_SETUP", "make bootstrap");
+		expect(resolveWorktreeSetupScript("scripts/setup.sh")).toBe("make bootstrap");
+	});
+
+	it("resolves the timeout from env, settings, then the default", () => {
+		expect(resolveWorktreeSetupTimeoutMs(undefined)).toBe(DEFAULT_WORKTREE_SETUP_TIMEOUT_MS);
+		expect(resolveWorktreeSetupTimeoutMs(1000)).toBe(1000);
+		vi.stubEnv("PRIME_AGENT_WORKTREE_SETUP_TIMEOUT_MS", "2500");
+		expect(resolveWorktreeSetupTimeoutMs(1000)).toBe(2500);
+	});
+
+	it("runs an existing file as a script and anything else as a shell command", () => {
+		const exists = (path: string) => path === join("/repo", "scripts", "setup.sh");
+		expect(buildWorktreeSetupCommand("scripts/setup.sh", "/repo", exists)).toBe(
+			`"${join("/repo", "scripts", "setup.sh")}"`,
+		);
+		expect(buildWorktreeSetupCommand("cp ../.env .env", "/repo", exists)).toBe("cp ../.env .env");
+	});
+
+	it("runs the script in the worktree with the worktree env exported", async () => {
+		const seen: WorktreeSetupCommand[] = [];
+		const written: { path: string; contents: string }[] = [];
+		const result = await runWorktreeSetup({
+			script: "setup",
+			worktreePath: "/repo/.worktrees/feature",
+			branch: "feature",
+			repoRoot: "/repo",
+			logPath: "/logs/worktree-setup-feature.log",
+			fileExists: () => false,
+			writeLog: (path, contents) => written.push({ path, contents }),
+			runSetup: async (command) => {
+				seen.push(command);
+				return { stdout: "ready\n", stderr: "", exitCode: 0, timedOut: false };
+			},
+		});
+
+		expect(seen[0]?.cwd).toBe("/repo/.worktrees/feature");
+		expect(seen[0]?.command).toBe("setup");
+		expect(seen[0]?.env.PRIME_AGENT_WORKTREE_PATH).toBe("/repo/.worktrees/feature");
+		expect(seen[0]?.env.PRIME_AGENT_WORKTREE_BRANCH).toBe("feature");
+		expect(seen[0]?.env.PRIME_AGENT_WORKTREE_REPO_ROOT).toBe("/repo");
+		expect(seen[0]?.timeoutMs).toBe(DEFAULT_WORKTREE_SETUP_TIMEOUT_MS);
+		expect(written[0]?.path).toBe("/logs/worktree-setup-feature.log");
+		expect(written[0]?.contents).toContain("ready");
+		expect(result.logPath).toBe("/logs/worktree-setup-feature.log");
+	});
+
+	it("reports the exit code, the last stderr lines, and the log path", async () => {
+		const error = await runWorktreeSetup({
+			script: "setup",
+			worktreePath: "/worktree",
+			branch: "feature",
+			repoRoot: "/repo",
+			logPath: "/logs/setup.log",
+			fileExists: () => false,
+			writeLog: () => undefined,
+			runSetup: async () => ({ stdout: "", stderr: "line1\nboom: no free port\n", exitCode: 3, timedOut: false }),
+		}).catch((caught: unknown) => caught);
+
+		expect(error).toBeInstanceOf(WorktreeSetupError);
+		const failure = error as WorktreeSetupError;
+		expect(failure.timedOut).toBe(false);
+		expect(failure.logPath).toBe("/logs/setup.log");
+		expect(failure.message).toContain("exited with code 3");
+		expect(failure.message).toContain("boom: no free port");
+		expect(failure.message).toContain("/logs/setup.log");
+	});
+
+	it("reports a timeout", async () => {
+		const error = await runWorktreeSetup({
+			script: "sleep 100",
+			worktreePath: "/worktree",
+			branch: "feature",
+			repoRoot: "/repo",
+			timeoutMs: 50,
+			fileExists: () => false,
+			runSetup: async () => ({ stdout: "", stderr: "", exitCode: 1, timedOut: true }),
+		}).catch((caught: unknown) => caught);
+
+		expect(error).toBeInstanceOf(WorktreeSetupError);
+		expect((error as WorktreeSetupError).timedOut).toBe(true);
+		expect((error as WorktreeSetupError).message).toContain("timed out after 50ms");
+	});
+});
+
 describe("AgentsViewMode worktree prompt", () => {
 	beforeAll(() => setKeybindings(keybindings));
 	afterEach(() => vi.restoreAllMocks());
@@ -247,15 +367,15 @@ describe("AgentsViewMode worktree prompt", () => {
 	it("creates the worktree and a session rooted in it on confirm", async () => {
 		const repoRoot = realpathSync(mkdtempSync(join(tmpdir(), "prime-worktree-repo-")));
 		try {
-			await runGitCommand(["init", "-b", "main"], repoRoot);
-			await runGitCommand(["config", "user.email", "test@example.com"], repoRoot);
-			await runGitCommand(["config", "user.name", "test"], repoRoot);
-			await runGitCommand(["commit", "--allow-empty", "-m", "init"], repoRoot);
+			await initRepo(repoRoot);
 
 			const createNewSession = vi.fn(async () => true);
 			const self = createViewStub({
 				createNewSession,
-				options: { config: { cwd: repoRoot }, uiServices: { getInitialCwd: () => repoRoot } },
+				options: {
+					config: { cwd: repoRoot },
+					uiServices: { getInitialCwd: () => repoRoot, settingsManager: createSettingsStub() },
+				},
 			});
 
 			invoke("handleInput", self, NEW_WORKTREE_KEY);
@@ -272,13 +392,83 @@ describe("AgentsViewMode worktree prompt", () => {
 		}
 	});
 
+	it("runs the configured setup script in the new worktree before starting the session", async () => {
+		const repoRoot = realpathSync(mkdtempSync(join(tmpdir(), "prime-worktree-setup-")));
+		try {
+			await initRepo(repoRoot);
+			vi.stubEnv("PRIME_AGENT_CODING_AGENT_DIR", join(repoRoot, "agent-dir"));
+			const createNewSession = vi.fn(async () => true);
+			const self = createViewStub({
+				createNewSession,
+				options: {
+					config: { cwd: repoRoot },
+					uiServices: {
+						getInitialCwd: () => repoRoot,
+						settingsManager: createSettingsStub({
+							setupScript: 'printf "%s" "$PRIME_AGENT_WORKTREE_BRANCH" > branch.txt',
+						}),
+					},
+				},
+			});
+
+			invoke("handleInput", self, NEW_WORKTREE_KEY);
+			await invoke("submit", self, "setup-me");
+
+			const worktreePath = join(repoRoot, ".worktrees", "setup-me");
+			expect(readFileSync(join(worktreePath, "branch.txt"), "utf-8")).toBe("setup-me");
+			expect(createNewSession).toHaveBeenCalledWith({ cwd: worktreePath });
+			const statuses = (self.setStatusMessage as ReturnType<typeof vi.fn>).mock.calls.map((call) => String(call[0]));
+			expect(statuses).toContain("Running worktree setup...");
+		} finally {
+			rmSync(repoRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps the worktree but skips the session when the setup script fails", async () => {
+		const repoRoot = realpathSync(mkdtempSync(join(tmpdir(), "prime-worktree-setup-fail-")));
+		try {
+			await initRepo(repoRoot);
+			vi.stubEnv("PRIME_AGENT_CODING_AGENT_DIR", join(repoRoot, "agent-dir"));
+			const createNewSession = vi.fn(async () => true);
+			const self = createViewStub({
+				createNewSession,
+				options: {
+					config: { cwd: repoRoot },
+					uiServices: {
+						getInitialCwd: () => repoRoot,
+						settingsManager: createSettingsStub({ setupScript: "echo no-free-port >&2; exit 3" }),
+					},
+				},
+			});
+
+			invoke("handleInput", self, NEW_WORKTREE_KEY);
+			await invoke("submit", self, "broken-setup");
+
+			expect(createNewSession).not.toHaveBeenCalled();
+			expect(existsSync(join(repoRoot, ".worktrees", "broken-setup"))).toBe(true);
+			const statuses = (self.setStatusMessage as ReturnType<typeof vi.fn>).mock.calls.map((call) => String(call[0]));
+			const failure = statuses.find((status) => status.startsWith("Failed to run worktree setup"));
+			expect(failure).toBeDefined();
+			expect(failure).toContain("no-free-port");
+			expect(failure).toContain("worktree-setup-broken-setup.log");
+			expect(
+				readFileSync(join(repoRoot, "agent-dir", "logs", "worktree-setup-broken-setup.log"), "utf-8"),
+			).toContain("no-free-port");
+		} finally {
+			rmSync(repoRoot, { recursive: true, force: true });
+		}
+	});
+
 	it("reports a status message when the directory is not a git repository", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "prime-worktree-plain-"));
 		try {
 			const createNewSession = vi.fn(async () => true);
 			const self = createViewStub({
 				createNewSession,
-				options: { config: { cwd: dir }, uiServices: { getInitialCwd: () => dir } },
+				options: {
+					config: { cwd: dir },
+					uiServices: { getInitialCwd: () => dir, settingsManager: createSettingsStub() },
+				},
 			});
 
 			invoke("handleInput", self, NEW_WORKTREE_KEY);

--- a/packages/coding-agent/test/agents-view-worktree.test.ts
+++ b/packages/coding-agent/test/agents-view-worktree.test.ts
@@ -1,0 +1,295 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setKeybindings } from "@earendil-works/pi-tui";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { KeybindingsManager } from "../src/core/keybindings.js";
+import { AgentsViewMode } from "../src/modes/agents-view/agents-view-mode.js";
+import {
+	createGitWorktree,
+	type GitCommandResult,
+	type GitCommandRunner,
+	resolveWorktreeParentDir,
+	runGitCommand,
+	sanitizeWorktreeName,
+} from "../src/utils/git-worktree.js";
+
+const keybindings = new KeybindingsManager();
+
+function invoke(method: string, self: object, ...args: unknown[]): unknown {
+	const member = Reflect.get(AgentsViewMode.prototype, method) as ((...a: unknown[]) => unknown) | undefined;
+	if (typeof member !== "function") throw new Error(`AgentsViewMode.${method} no longer exists`);
+	return member.call(self, ...args);
+}
+
+// Raw sequences for the defaults asserted in "binds the worktree prompt to alt+w".
+const NEW_WORKTREE_KEY = "\x1bw";
+const CANCEL_KEY = "\x1b";
+
+function ok(stdout = ""): GitCommandResult {
+	return { stdout, stderr: "", exitCode: 0 };
+}
+
+function createEditorStub(): {
+	text: string;
+	placeholder: string;
+	getText: () => string;
+	setText: (value: string) => void;
+	setPlaceholder: (value: string) => void;
+	handleInput: (data: string) => void;
+} {
+	const editor = {
+		text: "",
+		placeholder: "",
+		getText: () => editor.text,
+		setText: (value: string) => {
+			editor.text = value;
+		},
+		setPlaceholder: (value: string) => {
+			editor.placeholder = value;
+		},
+		handleInput: (data: string) => {
+			editor.text += data;
+		},
+	};
+	return editor;
+}
+
+function createViewStub(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	const editor = createEditorStub();
+	const self: Record<string, unknown> = {
+		editor,
+		keybindings,
+		persistentState: {},
+		rows: [],
+		selectedIndex: 0,
+		stopped: false,
+		creatingNewSession: false,
+		worktreePromptActive: false,
+		renameTarget: undefined,
+		replyTarget: undefined,
+		actionModeSearchQuery: undefined,
+		pendingDeleteAgent: undefined,
+		pendingKillSubagent: undefined,
+		options: { config: { cwd: "/repo" }, uiServices: { getInitialCwd: () => "/repo" } },
+		ui: { requestRender: vi.fn() },
+		setStatusMessage: vi.fn(),
+		clearStickyStatusMessage: vi.fn(),
+		clearCtrlCExitHint: vi.fn(),
+		clearDeleteConfirmation: vi.fn(),
+		rebuildRows: vi.fn(),
+		setReplyTarget: vi.fn(),
+		createNewSession: vi.fn(async () => true),
+		handleListNavigation: vi.fn(() => false),
+		queryChanged: vi.fn(),
+		isSearchCursorAtEnd: vi.fn(() => true),
+		getSavedSessionCwd() {
+			return invoke("getSavedSessionCwd", self);
+		},
+		confirmWorktree(value: string) {
+			return invoke("confirmWorktree", self, value);
+		},
+		enterWorktreeMode() {
+			return invoke("enterWorktreeMode", self);
+		},
+		exitWorktreeMode() {
+			return invoke("exitWorktreeMode", self);
+		},
+		createWorktreeSession(name: string) {
+			return invoke("createWorktreeSession", self, name);
+		},
+		...overrides,
+	};
+	return self;
+}
+
+// A developer-set override must not change the expected default locations.
+beforeEach(() => vi.stubEnv("PRIME_AGENT_WORKTREE_DIR", ""));
+afterEach(() => vi.unstubAllEnvs());
+
+describe("git worktree helper", () => {
+	it("sanitizes names into a single path segment", () => {
+		expect(sanitizeWorktreeName("  Feature/One two  ")).toBe("Feature-One-two");
+		expect(sanitizeWorktreeName("--weird--name--")).toBe("weird-name");
+		expect(() => sanitizeWorktreeName("  ///  ")).toThrow(/Invalid worktree name/);
+	});
+
+	it("resolves the worktree parent directory in order", () => {
+		expect(resolveWorktreeParentDir("/repo")).toBe(join("/repo", ".worktrees"));
+		expect(resolveWorktreeParentDir("/repo", "/trees")).toBe("/trees");
+		expect(resolveWorktreeParentDir("/repo", "trees")).toBe(join("/repo", "trees"));
+	});
+
+	it("creates a branch and worktree under the repo root", async () => {
+		const calls: string[][] = [];
+		const runGit: GitCommandRunner = async (args) => {
+			calls.push([...args]);
+			if (args[0] === "rev-parse" && args[1] === "--show-toplevel") return ok("/repo\n");
+			if (args[0] === "worktree" && args[1] === "list") return ok("worktree /repo\nbranch refs/heads/main\n");
+			if (args[0] === "rev-parse") return { stdout: "", stderr: "", exitCode: 1 };
+			return ok();
+		};
+
+		const result = await createGitWorktree({ cwd: "/repo/src", name: "my feature", runGit, pathExists: () => false });
+
+		expect(result).toEqual({
+			path: join("/repo", ".worktrees", "my-feature"),
+			branch: "my-feature",
+			repoRoot: "/repo",
+			created: true,
+		});
+		expect(calls).toContainEqual(["worktree", "add", join("/repo", ".worktrees", "my-feature"), "-b", "my-feature"]);
+	});
+
+	it("attaches an existing branch instead of creating one", async () => {
+		const calls: string[][] = [];
+		const runGit: GitCommandRunner = async (args) => {
+			calls.push([...args]);
+			if (args[0] === "rev-parse" && args[1] === "--show-toplevel") return ok("/repo\n");
+			if (args[0] === "worktree" && args[1] === "list") return ok("worktree /repo\n");
+			return ok();
+		};
+
+		const result = await createGitWorktree({ cwd: "/repo", name: "existing", runGit, pathExists: () => false });
+
+		expect(result.created).toBe(true);
+		expect(calls).toContainEqual(["worktree", "add", join("/repo", ".worktrees", "existing"), "existing"]);
+	});
+
+	it("reuses a worktree already registered at the target path", async () => {
+		const target = join("/repo", ".worktrees", "reuse");
+		const runGit: GitCommandRunner = async (args) => {
+			if (args[0] === "rev-parse" && args[1] === "--show-toplevel") return ok("/repo\n");
+			if (args[0] === "worktree" && args[1] === "list") {
+				return ok(`worktree /repo\n\nworktree ${target}\nbranch refs/heads/reuse\n`);
+			}
+			throw new Error(`unexpected git call: ${args.join(" ")}`);
+		};
+
+		const result = await createGitWorktree({ cwd: "/repo", name: "reuse", runGit, pathExists: () => true });
+
+		expect(result).toEqual({ path: target, branch: "reuse", repoRoot: "/repo", created: false });
+	});
+
+	it("rejects an occupied path that is not a worktree", async () => {
+		const runGit: GitCommandRunner = async (args) => {
+			if (args[0] === "rev-parse" && args[1] === "--show-toplevel") return ok("/repo\n");
+			return ok("worktree /repo\n");
+		};
+
+		await expect(createGitWorktree({ cwd: "/repo", name: "taken", runGit, pathExists: () => true })).rejects.toThrow(
+			/already exists and is not a worktree/,
+		);
+	});
+
+	it("reports git failures from worktree add", async () => {
+		const runGit: GitCommandRunner = async (args) => {
+			if (args[0] === "rev-parse" && args[1] === "--show-toplevel") return ok("/repo\n");
+			if (args[0] === "worktree" && args[1] === "list") return ok("worktree /repo\n");
+			if (args[0] === "rev-parse") return { stdout: "", stderr: "", exitCode: 1 };
+			return { stdout: "", stderr: "fatal: invalid reference", exitCode: 128 };
+		};
+
+		await expect(createGitWorktree({ cwd: "/repo", name: "bad", runGit, pathExists: () => false })).rejects.toThrow(
+			/fatal: invalid reference/,
+		);
+	});
+
+	it("fails when the directory is not a git repository", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "prime-worktree-"));
+		try {
+			await expect(createGitWorktree({ cwd: dir, name: "any", runGit: runGitCommand })).rejects.toThrow(
+				/Not a git repository/,
+			);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("AgentsViewMode worktree prompt", () => {
+	beforeAll(() => setKeybindings(keybindings));
+	afterEach(() => vi.restoreAllMocks());
+
+	it("binds the worktree prompt to alt+w without colliding with other agents-view actions", () => {
+		expect(keybindings.getKeys("app.agents.newWorktree")).toEqual(["alt+w"]);
+		for (const id of ["app.agents.new", "app.agents.delete", "app.agents.rename", "app.agents.reply"] as const) {
+			expect(keybindings.getKeys(id)).not.toContain("alt+w");
+		}
+	});
+
+	it("opens the inline prompt on the configured keybinding", () => {
+		const self = createViewStub();
+
+		invoke("handleInput", self, NEW_WORKTREE_KEY);
+
+		expect(self.worktreePromptActive).toBe(true);
+		const editor = self.editor as ReturnType<typeof createEditorStub>;
+		expect(editor.placeholder).toBe("Name the new git worktree branch");
+		expect(editor.text).toBe("");
+	});
+
+	it("cancels the prompt and restores the search query", () => {
+		const self = createViewStub();
+		const editor = self.editor as ReturnType<typeof createEditorStub>;
+		editor.setText("query");
+
+		invoke("handleInput", self, NEW_WORKTREE_KEY);
+		expect(self.actionModeSearchQuery).toBe("query");
+
+		invoke("handleInput", self, CANCEL_KEY);
+
+		expect(self.worktreePromptActive).toBe(false);
+		expect(editor.text).toBe("query");
+		expect(editor.placeholder).toBe("Search sessions");
+	});
+
+	it("creates the worktree and a session rooted in it on confirm", async () => {
+		const repoRoot = realpathSync(mkdtempSync(join(tmpdir(), "prime-worktree-repo-")));
+		try {
+			await runGitCommand(["init", "-b", "main"], repoRoot);
+			await runGitCommand(["config", "user.email", "test@example.com"], repoRoot);
+			await runGitCommand(["config", "user.name", "test"], repoRoot);
+			await runGitCommand(["commit", "--allow-empty", "-m", "init"], repoRoot);
+
+			const createNewSession = vi.fn(async () => true);
+			const self = createViewStub({
+				createNewSession,
+				options: { config: { cwd: repoRoot }, uiServices: { getInitialCwd: () => repoRoot } },
+			});
+
+			invoke("handleInput", self, NEW_WORKTREE_KEY);
+			await invoke("submit", self, "My Feature");
+
+			expect(self.worktreePromptActive).toBe(false);
+			expect(createNewSession).toHaveBeenCalledWith({
+				cwd: join(repoRoot, ".worktrees", "My-Feature"),
+			});
+			const listed = await runGitCommand(["worktree", "list", "--porcelain"], repoRoot);
+			expect(listed.stdout).toContain(join(repoRoot, ".worktrees", "My-Feature"));
+		} finally {
+			rmSync(repoRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("reports a status message when the directory is not a git repository", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "prime-worktree-plain-"));
+		try {
+			const createNewSession = vi.fn(async () => true);
+			const self = createViewStub({
+				createNewSession,
+				options: { config: { cwd: dir }, uiServices: { getInitialCwd: () => dir } },
+			});
+
+			invoke("handleInput", self, NEW_WORKTREE_KEY);
+			await invoke("submit", self, "feature");
+
+			expect(createNewSession).not.toHaveBeenCalled();
+			const setStatusMessage = self.setStatusMessage as ReturnType<typeof vi.fn>;
+			const messages = setStatusMessage.mock.calls.map((call) => String(call[0]));
+			expect(messages.some((message) => message.includes("Failed to create worktree"))).toBe(true);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Adds a way to create a git worktree and start a session in it directly from the agents view (the startup session picker), plus a configurable setup script that runs in the new worktree before the session starts.

Motivation: multi-worktree workflows currently require leaving the picker, creating the worktree by hand, bootstrapping it (env files, ports, deps), and starting the agent again in that directory.

## Behavior

- New configurable keybinding `app.agents.newWorktree` (default `alt+w`) opens an inline prompt in the agents view for a worktree/branch name. `esc` cancels and restores the search query.
- On confirm: resolve the repo root, create or reuse `<worktreeDir>/<name>` with `git worktree add` (attaches an existing branch, creates one otherwise), run the optional setup script, then create the session with `cwd` set to the worktree path.
- No daemon protocol change: the daemon `create` command already honors a `config.cwd` override.

## Configuration

New `worktree` settings section (global and project, deep merged):

- `worktree.dir` - parent directory for new worktrees. Default `<repoRoot>/.worktrees`. Relative paths resolve against the repo root.
- `worktree.setupScript` - script path or shell command run in the new worktree. Unset by default, so behavior is unchanged for users who do not configure it.
- `worktree.setupTimeoutMs` - default 600000.

Env overrides win over settings: `PRIME_AGENT_WORKTREE_DIR`, `PRIME_AGENT_WORKTREE_SETUP`, `PRIME_AGENT_WORKTREE_SETUP_TIMEOUT_MS`.

The setup script runs with the worktree as cwd through the configured shell, and receives `PRIME_AGENT_WORKTREE_PATH`, `PRIME_AGENT_WORKTREE_BRANCH`, and `PRIME_AGENT_WORKTREE_REPO_ROOT`.

## Failure handling

Non-zero exit or timeout keeps the created worktree, skips session creation, and reports the exit code or timeout with the last stderr lines. Full output goes to `~/.prime/agent/logs/worktree-setup-<branch>.log`. Git failures and setup failures are reported distinctly.

## Tests

`packages/coding-agent/test/agents-view-worktree.test.ts` (21 tests): name sanitizing, path resolution order, create/attach/reuse/occupied-path/git-failure, non-git cwd, keypress opens the prompt, cancel restores the query, real temp git repo end-to-end asserting the session cwd, setup script env/cwd/timeout injection, failing script keeps the worktree and skips session creation.

Existing `agents-view-mode` and `settings-manager` suites pass. `npm run check` is clean.

## Docs

`docs/keybindings.md` (new Agents View section), `docs/settings.md` (Git Worktrees section with a `.env` + free-port example), `docs/long-running-agents.md`, and a changelog fragment.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add git worktree session creation to the agents view via `alt+w`
> - Adds an inline worktree-name prompt in the agents view (`alt+w`) that sanitizes the name, creates or reuses a git worktree, optionally runs a setup script, and starts a new session rooted in the worktree.
> - Introduces [git-worktree.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1973/files#diff-5fdb073ba83cd922b482775917c22a28e7ac7589ece231a64575db19cc1e90ba) for repo-root resolution, worktree-path precedence (`PRIME_AGENT_WORKTREE_DIR` → `worktree.dir` → repo `.worktrees`), branch creation/attachment, and registered-worktree reuse.
> - Introduces [worktree-setup.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1973/files#diff-16a1c09e4517422c8740fe50bac02812bcd59a199f1c75c2bee2454d22c68883) for running an optional setup script with configurable timeout (default 600000 ms), shell, environment variables, and sanitized log output.
> - Adds `worktree.dir`, `worktree.setupScript`, and `worktree.setupTimeoutMs` to [settings-manager.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1973/files#diff-6e8b43ea9be5845c1f130f3a12344386eb8e1e03ca381c3577a40713e6a3d8ab) with environment-variable overrides.
> - Risk: `createNewSession` in [agents-view-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1973/files#diff-116f4364505fa125d57532296cde69f9a73543363de3d3cd48bd4f48b2ee6e10) now accepts an optional runtime configuration; setup failures leave the worktree on disk without starting a session.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c28df7d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->