### PR TITLE
fix(coding-agent): finished sessions no longer stay 'running' in the agents view when the summarizer verdict never changes

### DIFF
--- a/packages/coding-agent/.changes/res-1252-roster-activity-republish.md
+++ b/packages/coding-agent/.changes/res-1252-roster-activity-republish.md
@@ -1,0 +1,1 @@
+- Fixed finished agents lingering in the agents view Running section as "classifying" when their status summary text did not change.

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -189,14 +189,6 @@ export async function generateAgentStatus(params: GenerateAgentStatusParams): Pr
 	}
 }
 
-/** True when the new status differs enough from the stored one to be worth broadcasting. */
-export function agentStatusChanged(previous: AgentStatus | undefined, next: AgentStatusResult): boolean {
-	if (!previous) {
-		return true;
-	}
-	return previous.summary !== next.summary || previous.taskState !== next.taskState;
-}
-
 function isSessionWorking(state: ActiveSessionState): boolean {
 	const session = state.runtime.session;
 	return session.isSessionActive;
@@ -357,7 +349,12 @@ export class DaemonSessionSummarizer {
 				taskState,
 				basedOnMessageCount: messageCount,
 			};
-			const changed = previous?.summary !== status.summary || previous?.taskState !== status.taskState;
+			// An idle settle refreshes the verdict's currency, which drives the roster's
+			// activity axis: it must publish even when the verdict text is unchanged.
+			const changed =
+				previous?.summary !== status.summary ||
+				previous?.taskState !== status.taskState ||
+				(!isWorking && previous?.basedOnMessageCount !== status.basedOnMessageCount);
 			state.summaryState = status;
 			// Persist only settled idle verdicts, never mid-stream.
 			if (!isWorking) {

--- a/packages/coding-agent/test/daemon-agent-roster.test.ts
+++ b/packages/coding-agent/test/daemon-agent-roster.test.ts
@@ -395,6 +395,28 @@ describe("worker roster reporter", () => {
 		expect(daemon.rosterReporter.lastComposed.has("session-root-active")).toBe(false);
 	});
 
+	it("republishes a finished row as idle once the settled verdict makes the summary current", async () => {
+		const { daemon, sentDeltas } = makeWorkerReporter();
+		const state = makeState({
+			activeSessionId: "finished",
+			sessionFile: "/tmp/finished.jsonl",
+			messages: [{ role: "user", content: "hi", timestamp: 1 } as unknown as AgentMessage],
+		});
+		daemon.sessions.set("finished", state);
+		daemon.flushRoster();
+		expect(sentDeltas.at(-1)?.entries.map((entry) => entry.summary.activity)).toEqual(["working"]);
+
+		(state as unknown as { summaryState?: unknown }).summaryState = {
+			summary: "Waiting for review",
+			taskState: "needs_input",
+			basedOnMessageCount: 1,
+		};
+		daemon.observeRosterEvent(state, { type: "session_status", activeSessionId: "finished" });
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(sentDeltas.at(-1)?.entries.map((entry) => entry.summary.activity)).toEqual(["idle"]);
+	});
+
 	it("flushes cron and model changes that have no session-event carrier", async () => {
 		const directory = mkdtempSync(join(tmpdir(), "prime-roster-cron-flush-"));
 		tempDirs.push(directory);

--- a/packages/coding-agent/test/daemon-session-summarizer.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer.test.ts
@@ -1,9 +1,10 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import type { AgentStatus } from "../src/core/session-manager.js";
+import type { ActiveSessionState } from "../src/modes/daemon/active-session-state.js";
 import {
-	agentStatusChanged,
 	buildStatusContext,
+	DaemonSessionSummarizer,
 	parseAgentStatusResponse,
 } from "../src/modes/daemon/daemon-session-summarizer.js";
 
@@ -154,15 +155,63 @@ describe("daemon session summarizer", () => {
 		});
 	});
 
-	describe("agentStatusChanged", () => {
-		const base: AgentStatus = { summary: "Working on it", taskState: "needs_input", basedOnMessageCount: 4 };
-		test("is true when there is no previous status", () => {
-			expect(agentStatusChanged(undefined, { summary: "x" })).toBe(true);
+	describe("status change notification", () => {
+		function makeState(options: {
+			messages: AgentMessage[];
+			isSessionActive: boolean;
+			summaryState?: AgentStatus;
+		}): ActiveSessionState {
+			return {
+				activeSessionId: "active-1",
+				summaryState: options.summaryState,
+				runtime: {
+					session: {
+						isSessionActive: options.isSessionActive,
+						messages: options.messages,
+						modelRegistry: {},
+						state: { streamingMessage: undefined },
+						sessionManager: { appendAgentStatus: () => {} },
+					},
+				},
+			} as unknown as ActiveSessionState;
+		}
+
+		async function settle(state: ActiveSessionState, generated: { summary: string; taskState?: "needs_input" }) {
+			const onStatusChanged = vi.fn();
+			const summarizer = new DaemonSessionSummarizer(
+				() => [state],
+				onStatusChanged,
+				async () => generated,
+			);
+			await (summarizer as unknown as { summarize(state: ActiveSessionState): Promise<void> }).summarize(state);
+			return onStatusChanged;
+		}
+
+		test("an idle settle with unchanged verdict text still notifies: its currency drives the roster", async () => {
+			const previous: AgentStatus = { summary: "Working on it", taskState: "needs_input", basedOnMessageCount: 1 };
+			const state = makeState({
+				messages: [userMessage("hi"), userMessage("more")],
+				isSessionActive: false,
+				summaryState: previous,
+			});
+
+			const onStatusChanged = await settle(state, { summary: "Working on it", taskState: "needs_input" });
+
+			expect(state.summaryState?.basedOnMessageCount).toBe(2);
+			expect(onStatusChanged).toHaveBeenCalledOnce();
 		});
-		test("detects summary and verdict changes", () => {
-			expect(agentStatusChanged(base, { summary: "Working on it", taskState: "needs_input" })).toBe(false);
-			expect(agentStatusChanged(base, { summary: "Done", taskState: "needs_input" })).toBe(true);
-			expect(agentStatusChanged(base, { summary: "Working on it", taskState: "completed" })).toBe(true);
+
+		test("a working refresh with unchanged text stays quiet", async () => {
+			const previous: AgentStatus = { summary: "Working on it", taskState: "needs_input", basedOnMessageCount: 2 };
+			const state = makeState({
+				messages: [userMessage("hi"), userMessage("more")],
+				isSessionActive: true,
+				summaryState: previous,
+			});
+
+			const onStatusChanged = await settle(state, { summary: "Working on it" });
+
+			expect(onStatusChanged).not.toHaveBeenCalled();
 		});
 	});
 });


### PR DESCRIPTION
## Symptom

A finished top-level agent could sit in the agents view's Running section forever, labeled `classifying`, even though it stopped working long ago. On setups where the summary model returns the same (or an empty) verdict every time, every finished agent got stuck this way.

## Cause

The agents view trusts the roster row it is pushed. The roster row is republished only when the session summarizer's settle gate decides something changed — and that gate compared just the verdict text and task state. A settle that produced the same text at a new message count silently refreshed the summary's currency (`basedOnMessageCount`), which is exactly what flips the activity derivation from `working` to `idle` — but because the text was unchanged, no notification fired, no flush ran, and the last-published row stayed frozen at `working`/`running`.

## Fix

One predicate term in the settle gate (`daemon-session-summarizer.ts`): an idle settle that refreshes currency now counts as a status change and notifies, so the roster republishes the row and the view flips to Idle through the existing `session_status` → flush wiring. Working-state refreshes with unchanged text stay quiet, so the periodic sweeps add no broadcast noise. No new publish path, no polling.

Also deletes the dead `agentStatusChanged` export — a zero-caller duplicate of the old two-field predicate that had already drifted.

## Validation

- Producer pin (fails on main): an idle settle with unchanged verdict text still notifies — its currency drives the roster.
- Quiet-guard pin: a working refresh with unchanged text does not notify.
- Integration pin in the worker-roster-reporter harness: a row published `working` republishes `idle` once the settled verdict makes the summary current.
- Suites: 575 passed / 8 skipped across 19 files (agents-view*, agent-roster, daemon-agent-roster, daemon-session-list, all daemon-supervisor-*, daemon-mode, summarizer); root `npm run check` green.
- Net src: +6/−9.

Credit: diagnosed independently by Vincent Bailly (https://github.com/VincentBailly/prime-agent/pull/8), whose fork carries a consumer-side workaround; with this producer fix his patch can be dropped per its own deletion procedure.

Linear: https://linear.app/primeintellect/issue/res-1252
