### PR TITLE
fix: register ACP MCP tools as native callable tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Prime Agent: A Self-Improving RLM Agent
 </h3>
 
 <p align="center">
-  <a href="https://arxiv.org/abs/2608.23552">Technical Report</a> &bull;
   <a href="packages/coding-agent/docs/index.md">Documentation</a> &bull;
   <a href="https://github.com/PrimeIntellect-ai/verifiers">Verifiers</a> &bull;
   <a href="https://github.com/PrimeIntellect-ai/prime-rl">PRIME-RL</a>
@@ -25,6 +24,9 @@ Prime Agent: A Self-Improving RLM Agent
   </a>
   <a href="https://github.com/PrimeIntellect-ai/prime-agent/actions/workflows/build-binaries.yml">
     <img src="https://github.com/PrimeIntellect-ai/prime-agent/actions/workflows/build-binaries.yml/badge.svg" alt="Build Binaries" />
+  </a>
+  <a href="https://arxiv.org/abs/2608.23552">
+    <img src="https://img.shields.io/badge/arXiv-2608.23552-b31b1b.svg" alt="arXiv" />
   </a>
 </p>
 
@@ -118,3 +120,18 @@ Our agent and TUI is built on top of [`pi`](https://github.com/earendil-works/pi
 ## License
 
 Prime Agent is fully open source and released under the [MIT License](LICENSE).
+
+## Citation
+
+If you use this codebase in your research, please cite Prime Agent:
+
+```bibtex
+@article{karten2026prime,
+  title={Prime Agent: A Self-Improving RLM Harness},
+  author={Karten, Seth and Zhang, Alex L. and Thomas, Kevin and Müller, Sebastian and Bakouch, Elie and Auras, Daniel and Senghaas, Mika and Obeid, Fares and Dunas, Konstantin and Hagemann, Johannes and Jaghouar, Sami},
+  journal={arXiv preprint arXiv:2608.23552},
+  year={2026}
+}
+```
+
+Available at [https://arxiv.org/abs/2608.23552](https://arxiv.org/abs/2608.23552).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Prime Agent: A Self-Improving RLM Agent
 </h3>
 
 <p align="center">
+  <a href="https://arxiv.org/abs/2608.23552">Technical Report</a> &bull;
   <a href="packages/coding-agent/docs/index.md">Documentation</a> &bull;
   <a href="https://github.com/PrimeIntellect-ai/verifiers">Verifiers</a> &bull;
   <a href="https://github.com/PrimeIntellect-ai/prime-rl">PRIME-RL</a>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <h3 align="center">
-Prime Agent: A Self-Improving RLM Agent
+Prime Agent: A Self-Improving RLM Harness
 </h3>
 
 <p align="center">


### PR DESCRIPTION
## Summary

When verifiers sends MCP tool servers (deepwiki, wiki-search) through the ACP protocol's `session/new(mcp_servers=...)`, prime-agent correctly:

1. Receives them in `acp-mode.ts` → calls `replaceAcpMcpServers`
2. Forwards them to the daemon via RPC → `agent-session.ts`
3. Stores them in `McpManager.acpServers`
4. Rebuilds the system prompt with prose guidance about using the servers via `await mcp.call_tool(...)` in IPython

**But the tools are never registered as native callable tools.** The agent only gets a natural-language hint in its system prompt, while PI and Claude Code harnesses expose MCP tools as first-class function calls the model can invoke directly.

## The gap

The task prompt says: "Use the \`deepwiki_ask_question\` tool to ask what programming language..."

- **PI harness**: `deepwiki_ask_question` is a native tool → the model just calls it.
- **Claude Code**: `mcp__deepwiki__ask_question` is a native function → the model calls it.
- **Prime Agent**: `deepwiki_ask_question` is not in the tool list. The model must instead:
  1. Notice the tool is missing
  2. Read the MCP guidance in the system prompt about `mcp.call_tool`
  3. Infer the mapping from prompt text to `await mcp.call_tool("deepwiki", "deepwiki_ask_question", ...)`
  4. Execute this inside a cpython call

This multi-step reasoning often fails. The agent falls back to scraping websites with cpython.

## Fix

In `McpManager`, when ACP servers are registered via `replaceAcpServers`, the host should:

1. Query each ACP MCP server for its tool list (via the MCP protocol's `tools/list`)
2. Register each discovered tool as a native `AgentTool` / `ToolDefinition`
3. These tools would route through the kernel's `mcp.call_tool()` when invoked

This would make ACP-delivered MCP tools behave identically to natively registered ones: the model sees them in its tool list and can call them without intermediate reasoning steps.

## Files affected

- `packages/coding-agent/src/core/mcp/mcp-manager.ts` — add `replaceAcpServers` tool registration
- `packages/coding-agent/src/core/agent-session.ts` — wire native tool definitions from ACP MCP servers
- `packages/coding-agent/src/core/tools/` — ACP MCP tool definitions that wrap `mcp.call_tool`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and branding only; no runtime or security behavior changes.
> 
> **Overview**
> Updates **README** positioning and research discoverability only.
> 
> The headline is renamed from “Self-Improving RLM **Agent**” to “Self-Improving RLM **Harness**,” matching the paper title. A centered **arXiv** badge links to `2608.23552`, and a new **Citation** section adds BibTeX plus the same arXiv URL for researchers citing the codebase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f66877c81225b92f6a3d8ebff55bb2c4d027b77d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update README project description and add citation documentation
> Renames the project description from a self-improving RLM agent to a self-improving RLM harness. Adds an arXiv badge linking to the cited paper and a new Citation section with a BibTeX entry and paper URL in [README.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1998/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f66877c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->