### PR TITLE
fix: register ACP MCP tools as native callable tools via cpython proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Prime Agent: A Self-Improving RLM Agent
 </h3>
 
 <p align="center">
-  <a href="https://arxiv.org/abs/2608.23552">Technical Report</a> &bull;
   <a href="packages/coding-agent/docs/index.md">Documentation</a> &bull;
   <a href="https://github.com/PrimeIntellect-ai/verifiers">Verifiers</a> &bull;
   <a href="https://github.com/PrimeIntellect-ai/prime-rl">PRIME-RL</a>
@@ -25,6 +24,9 @@ Prime Agent: A Self-Improving RLM Agent
   </a>
   <a href="https://github.com/PrimeIntellect-ai/prime-agent/actions/workflows/build-binaries.yml">
     <img src="https://github.com/PrimeIntellect-ai/prime-agent/actions/workflows/build-binaries.yml/badge.svg" alt="Build Binaries" />
+  </a>
+  <a href="https://arxiv.org/abs/2608.23552">
+    <img src="https://img.shields.io/badge/arXiv-2608.23552-b31b1b.svg" alt="arXiv" />
   </a>
 </p>
 
@@ -118,3 +120,18 @@ Our agent and TUI is built on top of [`pi`](https://github.com/earendil-works/pi
 ## License
 
 Prime Agent is fully open source and released under the [MIT License](LICENSE).
+
+## Citation
+
+If you use this codebase in your research, please cite Prime Agent:
+
+```bibtex
+@article{karten2026prime,
+  title={Prime Agent: A Self-Improving RLM Harness},
+  author={Karten, Seth and Zhang, Alex L. and Thomas, Kevin and Müller, Sebastian and Bakouch, Elie and Auras, Daniel and Senghaas, Mika and Obeid, Fares and Dunas, Konstantin and Hagemann, Johannes and Jaghouar, Sami},
+  journal={arXiv preprint arXiv:2608.23552},
+  year={2026}
+}
+```
+
+Available at [https://arxiv.org/abs/2608.23552](https://arxiv.org/abs/2608.23552).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Prime Agent: A Self-Improving RLM Agent
 </h3>
 
 <p align="center">
+  <a href="https://arxiv.org/abs/2608.23552">Technical Report</a> &bull;
   <a href="packages/coding-agent/docs/index.md">Documentation</a> &bull;
   <a href="https://github.com/PrimeIntellect-ai/verifiers">Verifiers</a> &bull;
   <a href="https://github.com/PrimeIntellect-ai/prime-rl">PRIME-RL</a>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <h3 align="center">
-Prime Agent: A Self-Improving RLM Agent
+Prime Agent: A Self-Improving RLM Harness
 </h3>
 
 <p align="center">

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -268,6 +268,7 @@ import { createSyntheticSourceInfo, type SourceInfo } from "./source-info.js";
 import { type BuildSystemPromptOptions, buildSystemPrompt } from "./system-prompt.js";
 import { THINKING_LEVELS } from "./thinking-levels.js";
 import { type BashOperations, createLocalBashOperations } from "./tools/bash.js";
+import { createAcpMcpToolDefinitions } from "./tools/acp-mcp.js";
 import { createAllToolDefinitions } from "./tools/index.js";
 import { IpythonKernelProvisioner } from "./tools/ipython.js";
 import { createToolDefinitionFromAgentTool } from "./tools/tool-definition-wrapper.js";
@@ -1378,6 +1379,30 @@ export class AgentSession {
 			activeToolNames: this.getActiveToolNames(),
 			includeAllExtensionTools: true,
 		});
+
+		// Register native proxy tools for each ACP MCP server so the model
+		// sees typed, callable entries in its tool list instead of having to
+		// infer the correct cpython incantation from prose guidance alone.
+		// Execution routes through the kernel (await mcp.call_tool(...)), so
+		// the cpython-first architecture is preserved.
+		const acpServers = this._mcpManager?.getAcpServers() ?? [];
+		if (acpServers.length > 0 && this._ipythonKernelProvisioner) {
+			const mcpTools = createAcpMcpToolDefinitions(acpServers, this._ipythonKernelProvisioner);
+			for (const tool of mcpTools) {
+				// Deduplicate: replace any prior custom tool with the same name.
+				const existing = this._customTools.findIndex((t) => t.name === tool.name);
+				if (existing >= 0) {
+					this._customTools[existing] = tool;
+				} else {
+					this._customTools.push(tool);
+				}
+			}
+			this._refreshToolRegistry({
+				activeToolNames: this.getActiveToolNames(),
+				includeAllExtensionTools: true,
+			});
+		}
+
 		this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
 		this.agent.state.systemPrompt = this._baseSystemPrompt;
 	}

--- a/packages/coding-agent/src/core/mcp/mcp-manager.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-manager.ts
@@ -219,6 +219,10 @@ export class McpManager {
 	}
 
 	/** Enabled persistent and session-scoped servers available through the generic kernel API. */
+	getAcpServers(): AcpMcpServerConfig[] {
+		return [...this.acpServers.values()];
+	}
+
 	getEnabledGenericServers(): string[] {
 		const servers = Array.from(this.integrations.values())
 			.filter(

--- a/packages/coding-agent/src/core/tools/acp-mcp.ts
+++ b/packages/coding-agent/src/core/tools/acp-mcp.ts
@@ -1,0 +1,82 @@
+import type { ToolDefinition } from "../extensions/types.js";
+import type { IpythonKernelProvisioner } from "./ipython.js";
+import type { AcpMcpServerConfig } from "../mcp/acp-mcp-types.js";
+
+/**
+ * Create native ToolDefinition entries for ACP MCP servers.
+ *
+ * Each server gets two model-visible tools:
+ * - `mcp_list_tools_{name}` -- discover available tools
+ * - `mcp_call_{name}` -- call a tool by name with JSON arguments
+ *
+ * Execution flows through the IPython kernel via `await mcp.call_tool(...)`,
+ * consistent with prime-agent's cpython-first architecture.
+ */
+export function createAcpMcpToolDefinitions(
+	servers: readonly AcpMcpServerConfig[],
+	provisioner: IpythonKernelProvisioner,
+): ToolDefinition[] {
+	const definitions: ToolDefinition[] = [];
+
+	for (const server of servers) {
+		const safeName = server.name.replace(/[^a-zA-Z0-9_-]/g, "_");
+		const serverName = JSON.stringify(server.name);
+
+		definitions.push({
+			name: `mcp_list_tools_${safeName}`,
+			label: `list tools from ${server.name}`,
+			description: `List every tool the "${server.name}" MCP server exposes. ` +
+				`Call this first, then use mcp_call_${safeName} to invoke a specific tool.`,
+			parameters: {
+				type: "object",
+				properties: {},
+				required: [],
+				additionalProperties: false,
+			} as any,
+			execute: async (_toolCallId, _params, signal, _onUpdate, _ctx) => {
+				const m = await provisioner.ensure(() => {}, signal);
+				const code = `import json; tools = await mcp.list_tools(${serverName}); print(json.dumps(tools, default=str))`;
+				const result = await m.execute(code, { signal });
+				return {
+					content: [{ type: "text" as const, text: result.stdout || result.stderr || "(empty)" }],
+				};
+			},
+		});
+
+		definitions.push({
+			name: `mcp_call_${safeName}`,
+			label: `call tool on ${server.name}`,
+			description: `Call a tool on the "${server.name}" MCP server. ` +
+				`Use mcp_list_tools_${safeName} first to discover available tool names and argument schemas.`,
+			parameters: {
+				type: "object",
+				properties: {
+					tool: { type: "string", description: `Tool name on "${server.name}".` },
+					arguments: {
+						type: "object",
+						description: "JSON arguments for the tool.",
+						additionalProperties: true,
+					},
+				},
+				required: ["tool", "arguments"],
+				additionalProperties: false,
+			} as any,
+			execute: async (_toolCallId, params, signal, _onUpdate, _ctx) => {
+				const { tool, arguments: args } = params as { tool: string; arguments: Record<string, unknown> };
+				const argsJson = JSON.stringify(args ?? {});
+				const m = await provisioner.ensure(() => {}, signal);
+				const code = `import json; result = await mcp.call_tool(${serverName}, ${JSON.stringify(tool)}, ${argsJson}); print(json.dumps(result, default=str))`;
+				try {
+					const result = await m.execute(code, { signal });
+					return {
+						content: [{ type: "text" as const, text: result.stdout || result.stderr || "(empty)" }],
+					};
+				} catch (error) {
+					return { content: [{ type: "text" as const, text: `Error: ${String(error)}` }] };
+				}
+			},
+		});
+	}
+
+	return definitions;
+}

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -37,6 +37,8 @@ export {
 	truncateTail,
 } from "./truncate.js";
 
+export { createAcpMcpToolDefinitions } from "./acp-mcp.js";
+
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import type { ToolDefinition } from "../extensions/types.js";
 import { createIpythonToolDefinition, type IpythonToolOptions } from "./ipython.js";


### PR DESCRIPTION
## Problem

When verifiers sends MCP tool servers (deepwiki, wiki-search) to prime-agent via the ACP protocol's `session/new(mcp_servers=...)`, the servers are correctly received and stored, but their tools are only described in 
prose in the system prompt. The model must figure out that it needs to write `await mcp.call_tool(...)` in a cpython cell. This extra reasoning step often fails — the agent falls back to scraping websites with cpython.

PI and Claude Code harnesses expose MCP tools as first-class function calls the model can invoke directly. Prime-agent should too.

## Solution

Register native `ToolDefinition` entries for each ACP MCP server that the model sees in its tool list. Each server gets two tools:

- `mcp_list_tools_{server}` — discover available tools (returns tool names + schemas)
- `mcp_call_{server}` — call a specific tool with JSON arguments

When the model calls one of these tools, the execute method generates the correct `await mcp.call_tool(...)` Python code and runs it in the IPython kernel. This is the "symbolic link" approach: the model sees typed native tool entries, but execution still flows through cpython, consistent with prime-agent's architecture.

## Changes

| File | Change |
|---|---|
| `packages/coding-agent/src/core/tools/acp-mcp.ts` | **NEW** — Creates ToolDefinition entries for each ACP MCP server |
| `packages/coding-agent/src/core/tools/index.ts` | Exports `createAcpMcpToolDefinitions` |
| `packages/coding-agent/src/core/agent-session.ts` | Wires MCP proxy tools into `_rebuildRuntimeForAcpMcpServers` |
| `packages/coding-agent/src/core/mcp/mcp-manager.ts` | Adds `getAcpServers()` public getter |

## Testing

1. Install this branch's prime-agent into verifiers
2. Run the eval suite: deepwiki-v1 and wiki-search-v1 with prime-agent harness
3. Verify the model calls `mcp_list_tools_deepwiki` and `mcp_call_deepwiki` instead of falling back to cpython

## Related

PR #1998 (closed) — initial investigation of the MCP tool gap

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tools the model can invoke and how MCP calls are routed at runtime; scope is limited to ACP MCP sessions and still executes through the existing kernel MCP API rather than new direct transports.
> 
> **Overview**
> **ACP MCP servers** from verifiers/ACP (`session/new` with `mcp_servers`) are now registered as first-class model tools instead of relying on system-prompt prose and hand-written `await mcp.call_tool(...)` in cells.
> 
> For each configured server, the harness adds **`mcp_list_tools_{server}`** and **`mcp_call_{server}`** `ToolDefinition`s whose `execute` paths run the equivalent `mcp.list_tools` / `mcp.call_tool` code in the IPython kernel. **`McpManager.getAcpServers()`** feeds server configs into **`createAcpMcpToolDefinitions`**, which **`_rebuildRuntimeForAcpMcpServers`** merges into custom tools (replace-by-name), refreshes the tool registry, and rebuilds the system prompt.
> 
> The README renames the project subtitle to **“Self-Improving RLM Harness”**, adds an **arXiv** badge, and a **Citation** block for arXiv:2608.23552.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e83742ff53eab5d24606a805aebf0e66c014dd75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Register ACP MCP tools as native callable tools in `AgentSession`
> - Add `createAcpMcpToolDefinitions` factory in [acp-mcp.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1999/files#diff-95d8258a4e3cfa48046e1d96d0d535315139893e03d3df8fd4f6c3479ebbb820) that creates a discovery tool and a call proxy tool for each ACP MCP server
> - Update `AgentSession._rebuildRuntimeForAcpMcpServers` in [agent-session.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1999/files#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448ae) to replace existing custom tools with matching names or append new tools, then refresh the tool registry and rebuild the system prompt
> - The new tools execute through an IPython kernel, invoking `mcp.list_tools` or `mcp.call_tool` with supplied JSON arguments and returning stdout or stderr as text
> - Risk: replacing existing tools with matching names during runtime rebuild could override custom tool definitions if ACP MCP server names collide with existing tool identifiers
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e83742f. 5 files reviewed, 6 issues evaluated, 2 issues filtered, 4 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>README.md — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 131](https://github.com/PrimeIntellect-ai/prime-agent/blob/e83742ff53eab5d24606a805aebf0e66c014dd75/README.md#L131): The citation reverses Daniel Auras's name as `Auras, Daniel`. The linked arXiv record lists the author as Daniel Auras, so exported BibTeX and downstream citations will misattribute this author (surname `Daniel`, given name `Auras`). <b>[ Failed validation ]</b>
> </details>
>
> <details>
> <summary>packages/coding-agent/src/core/tools/acp-mcp.ts — 2 comments posted, 3 evaluated, 1 filtered</summary>
>
> - [line 25](https://github.com/PrimeIntellect-ai/prime-agent/blob/e83742ff53eab5d24606a805aebf0e66c014dd75/packages/coding-agent/src/core/tools/acp-mcp.ts#L25): The generated proxy definitions are retained in `_customTools`, but ACP release/replacement only clears `McpManager.acpServers` and never removes the definitions created here. After an ACP client releases its servers (or replaces server `A` with `B`), `mcp_list_tools_A` and `mcp_call_A` remain model-visible and invoke a server no longer configured in the kernel, so the new native-tool path advertises unusable stale tools. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->