### PR TITLE
fix(daemon): raise Windows worker handshake timeouts above measured latency

### DIFF
--- a/packages/coding-agent/src/modes/daemon/daemon-client.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-client.ts
@@ -292,7 +292,10 @@ export class DaemonClient {
 
 	async request(
 		command: DaemonCommandBody,
-		timeoutMs = 30000,
+		// Windows cold start is far slower than Unix: the worker runs through tsx and the
+		// daemon's identity checks shell out to synchronous powershell.exe calls. A measured
+		// supervisor->worker-ready cycle took ~16s, so a 30s budget for "create" is marginal.
+		timeoutMs = process.platform === "win32" ? 120_000 : 30_000,
 		options: DaemonClientRequestOptions = {},
 	): Promise<DaemonResponse> {
 		if (!this.socket || this.socket.destroyed) {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -162,6 +162,11 @@ const IDLE_EVICTION_DRAIN_TIMEOUT_MS = 5_000;
 const CHILD_PASSIVATION_PER_WORKER_CAP = 2;
 const SUPERVISOR_CONFIG_FILE_NAME = "supervisor-config";
 const WORKER_STARTUP_GATE_FD = 3;
+// getProcessStartId() shells out to a synchronous powershell.exe on Windows (measured ~400ms per
+// call, and the worker_auth path makes several). That blocks the worker's event loop well past
+// the 1s handshake budget that is generous on Unix, so hello/auth time out. The timeout must sit
+// above measured latency, not at it.
+const WORKER_HANDSHAKE_TIMEOUT_MS = process.platform === "win32" ? 15_000 : 1_000;
 
 const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"ack_result",
@@ -2647,11 +2652,11 @@ export class DaemonSupervisor {
 			const client = new DaemonWorkerClient(worker.descriptor.socketPath);
 			try {
 				await client.connect(Math.min(500, Math.max(50, deadline - Date.now())));
-				await client.waitForHello(1000);
+				await client.waitForHello(WORKER_HANDSHAKE_TIMEOUT_MS);
 				await client.authenticateWorker(
 					worker.descriptor.authenticationToken,
 					this.supervisorAuthenticationClaim(),
-					1000,
+					WORKER_HANDSHAKE_TIMEOUT_MS,
 				);
 				await this.assertRecoveryAllowed();
 				client.onFrame((frame) => this.handleWorkerFrame(worker, frame));


### PR DESCRIPTION
## Problem

On native Windows the daemon supervisor cannot bring up a session worker. Every `create` fails after 30s with:

```
Timed out waiting for daemon worker response to worker_auth
```

This makes the agent unusable on Windows — `prime-agent -p` never completes. Reproduced on Windows 11 / Node 24.12 across multiple checkouts and several weeks.

## Root cause

Two timeouts are set *at* rather than *above* the latency actually observed on Windows.

**1. Handshake budget (1s).** `getProcessStartId()` shells out to a **synchronous `powershell.exe`** on Windows:

https://github.com/PrimeIntellect-ai/prime-agent/blob/main/packages/coding-agent/src/core/session-lease.ts#L122-L138

The `worker_auth` path makes several of these calls, which blocks the worker's event loop well past the 1s `waitForHello` / `authenticateWorker` budget in `connectWorker()`. That budget is entirely generous on Unix, where the same function is a `readFileSync("/proc/<pid>/stat")`.

The tell-tale symptom is a flaky alternation between `hello` and `worker_auth` failures across runs — the classic signature of a timeout sitting at real latency rather than above it.

**2. Client create budget (30s).** A measured supervisor → worker-ready cycle takes **~20–28s** on Windows (tsx startup plus the PowerShell identity checks), leaving no headroom in the 30s default in `DaemonClient.request()`.

## Fix

Both raised on `win32` only:

| | Unix (unchanged) | Windows |
|---|---|---|
| `waitForHello` / `authenticateWorker` | 1s | 15s |
| `DaemonClient.request()` default | 30s | 120s |

`process.platform !== "win32"` keeps the existing constants, so **this is a literal no-op on Linux and macOS** — including CI.

## What this deliberately does *not* change

The fd-3 startup gate was my first suspect, since Windows stdio inheritance is a common source of this failure shape. **It is not at fault.** A direct probe confirmed Node on Windows inherits a fourth stdio pipe and the child reads it via `readFileSync(3)` under `detached: true`:

```js
const child = spawn(process.execPath, ["gate-child.cjs"], {
  stdio: ["ignore", "ignore", "pipe", "pipe"],
  detached: true,
});
child.stdio[3].end("start\n");
// child: fs.readFileSync(3, "utf8")  ->  "start\n"   ✅
```

So the gate is left exactly as-is and its durability guarantee is retained on every platform. An earlier draft of this fix skipped the gate on win32; that was reverted after the probe, and after it was measured to break 5 `daemon-supervisor-monitor` tests.

## Verification (Windows 11, Node 24.12)

- `prime-agent -p "Reply with exactly: OK"` → completes in **~28s cold**; previously always timed out.
- **Zero net test regressions.** `vitest --run daemon` gives `33 failed | 668 passed | 9 skipped` both with and without this patch on the same machine. Those 33 are pre-existing Windows failures where tests bind Unix-domain `.sock` paths (`EACCES: listen ... \Temp\pa-launch-*\d.sock`) — unrelated to this change and present on unpatched `main`.
- Repo pre-commit gate passes: `biome check --error-on-warnings` (931 files), `tsgo --noEmit`, installer render check, browser smoke.

Happy to split this into two commits, add a `docs/windows.md` note, or gate the constants behind an env override if you'd prefer any of those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LykhrzDEWmrfDxgqbj2ys


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise Windows `DaemonClient.request` and `DaemonSupervisor` handshake timeouts above measured latency
> - `DaemonClient.request` now defaults to a 120s timeout on Windows (30s elsewhere) when no explicit timeout is given, reflecting measured Windows startup cost.
> - `WORKER_HANDSHAKE_TIMEOUT_MS` is now platform-dependent: 15s on Windows, 1s on other platforms. Both the worker hello-wait and authentication-wait steps in `DaemonSupervisor.connectWorker` use this shared constant instead of the prior fixed 1s limit.
> - Risk: Windows worker connection attempts can spend up to 15s per handshake step before failing, versus 1s before; non-Windows behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab47dfa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->