### PR TITLE
fix(coding-agent): settle late compaction slices and forward daemon subagent lineage

### DIFF
--- a/packages/coding-agent/.changes/res-1261-semantic-edges-producer-fixes.md
+++ b/packages/coding-agent/.changes/res-1261-semantic-edges-producer-fixes.md
@@ -1,0 +1,1 @@
+- Daemon- and runtime-hosted subagents record their spawn lineage again (the production runtime factory dropped it), and a compaction summary slice that resolves after a sibling already failed the compaction settles as failed instead of staying in-flight forever.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -7558,6 +7558,7 @@ export class AgentSession {
 		const semanticCompaction = this._semanticEdges.beginCompaction();
 		let compactionRecorded = false;
 		const uncommittedSlices: string[] = [];
+		let compactionSettled = false;
 		let summary: string;
 		let firstKeptEntryId: string;
 		let tokensBefore: number;
@@ -7599,7 +7600,13 @@ export class AgentSession {
 					}
 					try {
 						const result = await call({ ...headers, ...modelRequestHeaders(requestId) });
-						uncommittedSlices.push(requestId);
+						// A slice resolving after a sibling's rejection already settled the
+						// compaction would push into a drained list and stay in-flight forever.
+						if (compactionSettled) {
+							this._semanticEdges.failRequest(requestId);
+						} else {
+							uncommittedSlices.push(requestId);
+						}
 						return result;
 					} catch (error) {
 						this._semanticEdges.failRequest(requestId);
@@ -7626,6 +7633,7 @@ export class AgentSession {
 			// commits it. Marked first: the ID is consumed even when the write throws, and a
 			// second finish attempt would mask the original I/O error.
 			compactionRecorded = true;
+			compactionSettled = true;
 			for (const requestId of uncommittedSlices.splice(0)) {
 				this._semanticEdges.finishRequest(requestId);
 			}
@@ -7639,6 +7647,7 @@ export class AgentSession {
 				customInstructions,
 			);
 		} catch (error) {
+			compactionSettled = true;
 			for (const requestId of uncommittedSlices.splice(0)) {
 				this._semanticEdges.failRequest(requestId);
 			}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -719,7 +719,64 @@ export function resolveRuntimeSessionOptions(
 		rlmSessionDir: runtimeSessionOptions?.rlmSessionDir,
 		rlmParentNodeId: runtimeSessionOptions?.rlmParentNodeId,
 		rlmParentAgent: runtimeSessionOptions?.rlmParentAgent,
+		semanticParentSessionId: runtimeSessionOptions?.semanticParentSessionId,
+		semanticSpawnedByRequestId: runtimeSessionOptions?.semanticSpawnedByRequestId,
 		subagentRuntimeHost: runtimeSessionOptions?.subagentRuntimeHost,
+	};
+}
+
+/** The production runtime factory: every daemon-hosted and runtime-hosted session is created through this path. */
+export function createDefaultRuntimeFactory(
+	runtimeDefaultSessionConfig: AgentSessionRuntimeConfig,
+	extensionFactories?: ExtensionFactory[],
+): CreateAgentSessionRuntimeFactory {
+	return async ({
+		cwd,
+		agentDir,
+		sessionManager,
+		sessionStartEvent,
+		sessionConfig,
+		sessionOptions: runtimeSessionOptions,
+	}) => {
+		const config = mergeAgentSessionRuntimeConfig(runtimeDefaultSessionConfig, sessionConfig);
+		const prepared = await prepareRuntimeServices({
+			config,
+			cwd,
+			agentDir,
+			sessionManager,
+			extensionFactories,
+			sessionOptionsOverride: runtimeSessionOptions,
+		});
+		const { services, sessionOptions, diagnostics } = prepared;
+		const resolvedSessionOptions = resolveRuntimeSessionOptions(sessionOptions, runtimeSessionOptions);
+
+		const created = await createAgentSessionFromServices({
+			services,
+			sessionManager,
+			sessionStartEvent,
+			...resolvedSessionOptions,
+			// Main agents boot their kernel in the background at session creation;
+			// subagent sessions (rlmDepth > 0) keep the lazy first-call start.
+			prewarmIpythonKernel: true,
+			// Read serializedRefine from the merged runtime config (passed
+			// from the JSON/print client through AgentSessionRuntimeConfig)
+			// so it survives the daemon worker's appMode="daemon" context.
+			serializedRefine: config.serializedRefine ?? false,
+			executionMode: config.executionMode,
+			telemetryDisabled: config.telemetryDisabled,
+			// Only seed initial goal for top-level sessions (rlmDepth 0).
+			initialGoal: (runtimeSessionOptions?.rlmDepth ?? 0) === 0 ? config.initialGoal : undefined,
+		});
+		const cliThinkingOverride = config.thinking !== undefined || prepared.cliThinkingFromModel;
+		if (created.session.model && cliThinkingOverride) {
+			created.session.setThinkingLevel(created.session.thinkingLevel);
+		}
+
+		return {
+			...created,
+			services,
+			diagnostics,
+		};
 	};
 }
 
@@ -1269,54 +1326,7 @@ export async function main(args: string[], options?: MainOptions) {
 	// daemon fallback must not seed that goal into unrelated future sessions.
 	const daemonDefaultSessionConfig = daemonServerDefaultSessionConfig(defaultSessionConfig);
 	const runtimeDefaultSessionConfig = appMode === "daemon" ? daemonDefaultSessionConfig : defaultSessionConfig;
-	const createRuntime: CreateAgentSessionRuntimeFactory = async ({
-		cwd,
-		agentDir,
-		sessionManager,
-		sessionStartEvent,
-		sessionConfig,
-		sessionOptions: runtimeSessionOptions,
-	}) => {
-		const config = mergeAgentSessionRuntimeConfig(runtimeDefaultSessionConfig, sessionConfig);
-		const prepared = await prepareRuntimeServices({
-			config,
-			cwd,
-			agentDir,
-			sessionManager,
-			extensionFactories: options?.extensionFactories,
-			sessionOptionsOverride: runtimeSessionOptions,
-		});
-		const { services, sessionOptions, diagnostics } = prepared;
-		const resolvedSessionOptions = resolveRuntimeSessionOptions(sessionOptions, runtimeSessionOptions);
-
-		const created = await createAgentSessionFromServices({
-			services,
-			sessionManager,
-			sessionStartEvent,
-			...resolvedSessionOptions,
-			// Main agents boot their kernel in the background at session creation;
-			// subagent sessions (rlmDepth > 0) keep the lazy first-call start.
-			prewarmIpythonKernel: true,
-			// Read serializedRefine from the merged runtime config (passed
-			// from the JSON/print client through AgentSessionRuntimeConfig)
-			// so it survives the daemon worker's appMode="daemon" context.
-			serializedRefine: config.serializedRefine ?? false,
-			executionMode: config.executionMode,
-			telemetryDisabled: config.telemetryDisabled,
-			// Only seed initial goal for top-level sessions (rlmDepth 0).
-			initialGoal: (runtimeSessionOptions?.rlmDepth ?? 0) === 0 ? config.initialGoal : undefined,
-		});
-		const cliThinkingOverride = config.thinking !== undefined || prepared.cliThinkingFromModel;
-		if (created.session.model && cliThinkingOverride) {
-			created.session.setThinkingLevel(created.session.thinkingLevel);
-		}
-
-		return {
-			...created,
-			services,
-			diagnostics,
-		};
-	};
+	const createRuntime = createDefaultRuntimeFactory(runtimeDefaultSessionConfig, options?.extensionFactories);
 	time("createRuntime");
 	// Daemon mode never uses the bootstrap runtime, so skip the heavy
 	// createAgentSessionRuntime below and start listening immediately; sessions

--- a/packages/coding-agent/test/agent-session-semantic-edges.test.ts
+++ b/packages/coding-agent/test/agent-session-semantic-edges.test.ts
@@ -834,6 +834,52 @@ describe("AgentSession semantic edges", () => {
 		]);
 	});
 
+	it("settles a slice that resolves after a sibling already failed the compaction", async () => {
+		const harness = await createHarness({
+			persistSession: true,
+			settings: { compaction: { keepRecentTokens: 1 } },
+		});
+		harnesses.push(harness);
+		const ledgerPath = join(harness.sessionManager.getSessionArtifactDir() ?? "", SEMANTIC_EDGES_LEDGER_FILENAME);
+
+		harness.setResponses([fauxAssistantMessage("one"), fauxAssistantMessage("two")]);
+		await harness.session.prompt("one");
+		await harness.session.prompt("two");
+		const preCompactionIds = startedRequestIds(readSemanticEdgeLedger(ledgerPath));
+
+		// The first slice rejects immediately; its sibling resolves only after the
+		// compaction has already settled as failed and drained the slice list.
+		const failingStep = () => fauxAssistantMessage("nope", { stopReason: "error", errorMessage: "slice failed" });
+		const lateSuccessStep = async () => {
+			await sleep(25);
+			return fauxAssistantMessage("late summary");
+		};
+		harness.setResponses([failingStep, lateSuccessStep]);
+		await expect(harness.session.compact()).rejects.toThrow(/failed/);
+
+		// Every summary slice settles; a late success must not stay in-flight forever.
+		await waitForAsync(async () => {
+			const events = readSemanticEdgeLedger(ledgerPath);
+			const summaryIds = startedRequestIds(events).filter((requestId) => !preCompactionIds.includes(requestId));
+			const terminal = new Set(
+				events
+					.filter((event) => event.type === "request_failed" || event.type === "request_finished")
+					.map((event) =>
+						event.type === "request_failed" || event.type === "request_finished" ? event.request_id : "",
+					),
+			);
+			return summaryIds.length === 2 && summaryIds.every((requestId) => terminal.has(requestId));
+		});
+		const events = readSemanticEdgeLedger(ledgerPath);
+		const summaryIds = startedRequestIds(events).filter((requestId) => !preCompactionIds.includes(requestId));
+		const finished = events
+			.filter((event) => event.type === "request_finished")
+			.map((event) => (event.type === "request_finished" ? event.request_id : ""));
+		for (const requestId of summaryIds) {
+			expect(finished).not.toContain(requestId);
+		}
+	});
+
 	it("mints a distinct request identity for each split-turn summary call", async () => {
 		const harness = await createHarness({
 			persistSession: true,

--- a/packages/coding-agent/test/main-interactive-routing.test.ts
+++ b/packages/coding-agent/test/main-interactive-routing.test.ts
@@ -384,6 +384,20 @@ describe("runtime session option resolution", () => {
 		expect(resolved.rlmParentAgent).toBe("parent-worker");
 	});
 
+	test("forwards semantic spawn lineage to the created child session", () => {
+		const resolved = resolveRuntimeSessionOptions(
+			{},
+			{
+				rlmDepth: 1,
+				semanticParentSessionId: "parent-session-id",
+				semanticSpawnedByRequestId: "a".repeat(32),
+			},
+		);
+
+		expect(resolved.semanticParentSessionId).toBe("parent-session-id");
+		expect(resolved.semanticSpawnedByRequestId).toBe("a".repeat(32));
+	});
+
 	test("deep-merges autonomous runtime session overrides", () => {
 		const resolved = resolveRuntimeSessionOptions(
 			{

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -15,7 +15,11 @@ import {
 } from "../../src/core/agent-session-runtime.js";
 import { AuthStorage } from "../../src/core/auth-storage.js";
 import type { SubagentRuntimeHost } from "../../src/core/rlm-runtime.js";
-import { readSemanticEdgeLedger, SEMANTIC_EDGES_LEDGER_FILENAME } from "../../src/core/semantic-edges.js";
+import {
+	deriveSemanticEdges,
+	readSemanticEdgeLedger,
+	SEMANTIC_EDGES_LEDGER_FILENAME,
+} from "../../src/core/semantic-edges.js";
 import { SessionManager } from "../../src/core/session-manager.js";
 import type {
 	ExtensionAPI,
@@ -25,6 +29,7 @@ import type {
 	SessionShutdownEvent,
 	SessionStartEvent,
 } from "../../src/index.js";
+import { createDefaultRuntimeFactory } from "../../src/main.js";
 
 type RecordedSessionEvent =
 	| SessionBeforeSwitchEvent
@@ -447,6 +452,85 @@ describe("AgentSessionRuntime characterization", () => {
 			spawned_by_request_id: spawnedByRequestId,
 		});
 		await runtime.deleteRlmSubagentRuntime("lineage-child", childRuntime.session);
+	});
+
+	it("keeps semantic spawn lineage through the production runtime factory", async () => {
+		const tempDir = join(tmpdir(), `pi-runtime-factory-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		cleanups.push(() => rmSync(tempDir, { recursive: true, force: true }));
+		const faux = registerFauxProvider({ models: [{ id: "faux-1", reasoning: false }] });
+		cleanups.push(() => faux.unregister());
+
+		// The PRODUCTION factory (daemon workers and runtime hosts create every
+		// session through it), not a test factory that forwards all options: the
+		// original defect lived in its sessionOptions whitelist and stayed
+		// invisible to factory-boundary assertions.
+		const factory = createDefaultRuntimeFactory(
+			{
+				agentDir: tempDir,
+				cwd: tempDir,
+				sessionDir: join(tempDir, "sessions"),
+				noSkills: true,
+				noPromptTemplates: true,
+				noThemes: true,
+				telemetryDisabled: true,
+			},
+			[
+				(pi: ExtensionAPI) => {
+					pi.registerProvider(faux.getModel().provider, {
+						baseUrl: faux.getModel().baseUrl,
+						apiKey: "faux-key",
+						api: faux.api,
+						models: faux.models.map((registeredModel) => ({
+							id: registeredModel.id,
+							name: registeredModel.name,
+							api: registeredModel.api,
+							reasoning: registeredModel.reasoning,
+							input: registeredModel.input,
+							cost: registeredModel.cost,
+							contextWindow: registeredModel.contextWindow,
+							maxTokens: registeredModel.maxTokens,
+						})),
+					});
+				},
+			],
+		);
+
+		const childSessionDir = join(tempDir, "lineage-child");
+		const spawnedByRequestId = "a".repeat(32);
+		const created = await factory({
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.create(tempDir, childSessionDir),
+			sessionStartEvent: { type: "session_start", reason: "startup" },
+			sessionOptions: {
+				model: faux.getModel(),
+				thinkingLevel: "off",
+				rlmDepth: 1,
+				rlmMaxDepth: 2,
+				rlmSessionDir: childSessionDir,
+				rlmParentNodeId: "lineage-child",
+				rlmParentAgent: "parent-worker",
+				semanticParentSessionId: "parent-session-id",
+				semanticSpawnedByRequestId: spawnedByRequestId,
+			},
+		});
+		cleanups.push(() => created.session.dispose());
+		await created.session.bindExtensions({});
+
+		const ledgerPath = join(childSessionDir, SEMANTIC_EDGES_LEDGER_FILENAME);
+		expect(readSemanticEdgeLedger(ledgerPath)[0]).toMatchObject({
+			type: "session_registered",
+			parent_session_id: "parent-session-id",
+			spawned_by_request_id: spawnedByRequestId,
+		});
+
+		faux.setResponses([fauxAssistantMessage("child work")]);
+		await created.session.prompt("do the work");
+		const edges = deriveSemanticEdges([readSemanticEdgeLedger(ledgerPath)]).edges;
+		expect(edges.filter((edge) => edge.type === "subagent_call")).toMatchObject([
+			{ source_request_id: spawnedByRequestId },
+		]);
 	});
 
 	it("disposes hosted RLM children during session replacement", async () => {


### PR DESCRIPTION
## What provenance consumers lose today

Two defects in the `ai.prime.acp/semantic-edges-v1` producer (#1885), both found during review of #1984:

1. **Daemon-hosted subagents have no spawn edge.** The runtime and daemon hosts pass `semanticParentSessionId`/`semanticSpawnedByRequestId` correctly, but the production runtime factory rebuilds session options through the `resolveRuntimeSessionOptions()` whitelist — which did not include the two fields. Every session created through that factory (all daemon workers and runtime-hosted subagents) registered with no parent session and no spawning request, so no `subagent_call` edge could ever be derived for them. Only the inline host, which bypasses the factory, produced complete lineage.
2. **A completed summary call can be recorded as forever in-flight.** In a split-turn compaction, the two summary slices run under `Promise.all`. When one slice rejects, the compaction settles as failed and drains the uncommitted-slice list; a sibling slice that resolves *after* that pushed its request ID into the already-drained list, leaving a `request_started` with no terminal event. The fold treats such a request like a crash window (zero edges — no wrong edges are derived), but provenance under-claims a wire call that actually completed.

## The two mechanisms

- `resolveRuntimeSessionOptions()` forwards `semanticParentSessionId` and `semanticSpawnedByRequestId` (2 lines). The factory closure is extracted as `createDefaultRuntimeFactory()` — `main()` remains its consumer — so the new end-to-end pin exercises the **real** factory. The prior coverage asserted the fields on the options handed to *mocked* factories, upstream of the drop; that mock blindness is exactly how this shipped broken.
- `_compact()` keeps a `compactionSettled` flag, set where the slice list drains (commit and catch). A summary slice whose wire call resolves after the compaction settled now settles its own request as `request_failed` instead of pushing into the drained list. No restructuring of the `Promise.all` flow.

## Deliberate behavior notes

- The late slice settles as *failed* even though its wire call succeeded: its output was discarded (the compaction failed), and a failed summary slice contributes no edges — consistent with the existing invariant that a failed or cancelled compaction leaves no committed summary request.
- `createDefaultRuntimeFactory` extraction is mechanical; behavior of the factory is unchanged except the whitelist addition.

## Validation

- new pins (each verified fail-unfixed against the pre-fix code): `main-interactive-routing` — whitelist forwards the two fields; `suite/agent-session-runtime` — a subagent created through the **production** factory registers `parent_session_id`/`spawned_by_request_id` and derives a `subagent_call` edge; `agent-session-semantic-edges` — a slice resolving after a sibling's failure settles as `request_failed`, never left in-flight (the whitelist pins were failed with only the 2 whitelist lines reverted, isolating them from the extraction)
- sanitized suites: `semantic-edges` (52), `agent-session-semantic-edges` (23), `suite/agent-session-compaction`, `suite/agent-session-compaction-continuation`, `daemon-mode` (184), `main-interactive-routing` (53), `suite/agent-session-runtime` (26) — 387 tests, 0 failures
- root `npm run check` (biome, tsgo, installer render, browser smoke) passes via the pre-commit hook

## LOC

Net src: agent-session.ts +9, main.ts +10/−0 effective (58+/48− is the factory extraction moving the closure body; the semantic delta is the 2 whitelist lines + the export wrapper). Tests +145, changelog +1. Classification: mechanism-preserving fixes — no new mechanism beyond the settled flag; the factory extraction is a move, not an addition.

Linear: RES-1261 https://linear.app/primeintellect/issue/RES-1261

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session compaction ledger semantics and subagent session creation on the daemon/runtime factory path; incorrect behavior under-claims provenance or leaves in-flight requests, but changes are narrow guardrails rather than new compaction or spawn flows.
> 
> **Overview**
> Restores **semantic spawn lineage** for daemon- and runtime-hosted subagents by whitelisting `semanticParentSessionId` and `semanticSpawnedByRequestId` in `resolveRuntimeSessionOptions()`, so the production path can again register parent session / spawning request and derive `subagent_call` edges. The daemon runtime factory closure is extracted as exported `createDefaultRuntimeFactory()` (behavior unchanged aside from the whitelist); `main()` now calls that helper.
> 
> Fixes a **split-turn compaction race** where a summary slice that finished after a sibling failure already drained `uncommittedSlices` could leave a `request_started` with no terminal event. `_compact()` tracks `compactionSettled` and marks such late slices as failed instead of enqueueing them after drain.
> 
> Tests pin whitelist forwarding, end-to-end lineage through the real factory, and late slice settlement on the semantic-edges ledger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4ea4a03ed86af618c2fe333d4dd89d8297c170b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix late compaction slice settlement and forward subagent lineage in `AgentSession`
> - Adds a compaction-settled flag to `AgentSession.compact` so summary slices resolving after a sibling failure or after settlement are explicitly failed instead of left in-flight.
> - Forwards `semanticParentSessionId` and `semanticSpawnedByRequestId` from runtime session options into resolved options in `resolveRuntimeSessionOptions`, preserving spawn lineage for child sessions.
> - Extracts the production runtime session factory from `main` into `createDefaultRuntimeFactory` and replaces the inline closure with a call to it.
> - Adds regression and integration tests covering late-summary terminalization and lineage forwarding through the production factory boundary.
> - Risk: `createDefaultRuntimeFactory` is newly exported from [main.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2021/files#diff-4baeaa77e0a68df3cb411f5b9f216f6a26a7a23495a61b955b1d46482f76d586); callers relying on the previous inline closure behavior should use the exported function.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4ea4a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->