### PR TITLE
fix: passivated RLM descendants survive restarts as saved-catalog rows

### DIFF
--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -214,6 +214,7 @@ import {
 	RlmSpawnLedger,
 	readLegacyRlmSubagentRegistry as readLegacyRlmSubagentRegistryFile,
 	tombstoneSavedSessionDelete,
+	withPassiveRlmDescendantInfos,
 } from "./rlm-ledger.js";
 import {
 	readRlmSubagentDisplayEntry,
@@ -3875,8 +3876,12 @@ export class AgentDaemon {
 					command.scope === "current"
 						? await SessionManager.list(cwd, sessionDir, callbacks)
 						: await SessionManager.listAll(callbacks, sessionDir);
+				const sessions = await withPassiveRlmDescendantInfos(savedSessions, this.rlmSpawnLedger(), {
+					...(command.scope === "current" ? { cwd } : {}),
+					...(callbacks ? { onSession: callbacks.onSession } : {}),
+				});
 				return success(command.id, "list_saved_sessions", {
-					sessions: savedSessions.map(serializeSavedSessionInfo),
+					sessions: sessions.map(serializeSavedSessionInfo),
 				});
 			}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -166,6 +166,7 @@ import {
 	type RlmLedgerEdge,
 	RlmSpawnLedger,
 	tombstoneSavedSessionDelete,
+	withPassiveRlmDescendantInfos,
 } from "./rlm-ledger.js";
 import { serializeSavedSessionInfo } from "./saved-session-info.js";
 import { SNAPSHOT_TARGET_CHUNK_BYTES, SnapshotTranscriptCache } from "./snapshot-transcript-cache.js";
@@ -2831,7 +2832,11 @@ export class DaemonSupervisor {
 				}
 			: undefined;
 		const saved = await this.catalog.list(command.scope === "current" ? cwd : undefined, sessionDir, callbacks);
-		return success(command.id, "list_saved_sessions", { sessions: saved.map(serializeSavedSessionInfo) });
+		const sessions = await withPassiveRlmDescendantInfos(saved, this.rlmSpawnLedger(), {
+			...(command.scope === "current" ? { cwd } : {}),
+			...(callbacks ? { onSession: callbacks.onSession } : {}),
+		});
+		return success(command.id, "list_saved_sessions", { sessions: sessions.map(serializeSavedSessionInfo) });
 	}
 
 	private async createOrReuseWorker(clientId: string, command: DaemonCreateCommand): Promise<ResidentWorker> {

--- a/packages/coding-agent/src/modes/daemon/rlm-ledger.ts
+++ b/packages/coding-agent/src/modes/daemon/rlm-ledger.ts
@@ -757,6 +757,34 @@ export class RlmSpawnLedger {
 	}
 }
 
+// The catalog scan never visits session-artifacts, where RLM children persist:
+// without this merge a passivated descendant's row (and its spend) survives only
+// as long as some resident roster remembers it.
+export async function withPassiveRlmDescendantInfos(
+	savedSessions: SessionInfo[],
+	ledger: RlmSpawnLedger,
+	options: { cwd?: string; onSession?: (info: SessionInfo) => void } = {},
+): Promise<SessionInfo[]> {
+	const sessions = [...savedSessions];
+	const seen = new Set(savedSessions.map((info) => canonicalSessionPath(info.path)));
+	for (const edge of await ledger.liveEdges()) {
+		const childPath = canonicalSessionPath(edge.child);
+		if (seen.has(childPath)) continue;
+		seen.add(childPath);
+		const info = await readSessionInfo(childPath);
+		if (!info) continue;
+		if (options.cwd !== undefined && (!info.cwd || resolve(info.cwd) !== resolve(options.cwd))) continue;
+		const merged: SessionInfo = {
+			...info,
+			parentSessionPath: info.parentSessionPath ?? edge.parent,
+			rlmDepth: info.rlmDepth ?? edge.depth,
+		};
+		sessions.push(merged);
+		options.onSession?.(merged);
+	}
+	return sessions;
+}
+
 // Shared user-delete policy: only a readable no-parent transcript is positively top-level; children and
 // unknown targets tombstone via the ledger BEFORE the file delete (a tombstoned-but-undeleted file is
 // the accepted orphan of a failed delete).

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -1559,6 +1559,13 @@ describe("agents view state", () => {
 				[root, registryChild],
 				[
 					makeSessionInfo({ path: rootPath, id: "root-session", rlmDepth: 0 }),
+					// The catalog also lists the resident child's file: it must merge, not duplicate.
+					makeSessionInfo({
+						path: "/tmp/project/registry-child.jsonl",
+						id: "registry-child",
+						parentSessionPath: rootPath,
+						rlmDepth: 1,
+					}),
 					makeSessionInfo({
 						path: "/tmp/project/saved-child.jsonl",
 						id: "saved-child",

--- a/packages/coding-agent/test/rlm-ledger.test.ts
+++ b/packages/coding-agent/test/rlm-ledger.test.ts
@@ -1069,6 +1069,93 @@ interface SupervisorLedgerInternals {
 	catalog: object;
 }
 
+describe("passive descendants in the saved catalog", () => {
+	it("serves passivated descendants in the saved catalog after a supervisor restart", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-rlm-ledger-catalog-supervisor-"));
+		try {
+			const { sessionsDir, parent, parentFile } = makeRoots(tempDir);
+			const parentArtifactDir = parent.getSessionArtifactDir();
+			if (!parentArtifactDir) throw new Error("Missing parent artifact directory");
+			const child = makeChildSession(tempDir, join(parentArtifactDir, "sub-11111111"), parentFile, 1, "worker");
+			child.manager.appendMessage({ role: "user", content: "shard", timestamp: 1 });
+			child.manager.flushNow();
+			const deleted = makeChildSession(tempDir, join(parentArtifactDir, "sub-22222222"), parentFile, 1, "gone");
+			const parentInfo = await sessionManagerModule.readSessionInfo(parentFile);
+			if (!parentInfo) throw new Error("Missing parent session info");
+			// A fresh supervisor with no workers: nothing resident remembers the child.
+			const supervisor = new DaemonSupervisor(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir: sessionsDir },
+				descriptorDir: join(tempDir, "workers"),
+			}) as unknown as SupervisorLedgerInternals;
+			Object.assign(supervisor.catalog, { list: vi.fn(async () => [parentInfo]) });
+			const ledger = supervisor.rlmSpawnLedger();
+			await ledger.appendSpawn({
+				childId: "sub-11111111",
+				parent: parentFile,
+				child: child.file,
+				depth: 1,
+				name: "worker",
+			});
+			await ledger.appendSpawn({
+				childId: "sub-22222222",
+				parent: parentFile,
+				child: deleted.file,
+				depth: 1,
+				name: "gone",
+			});
+			await ledger.appendDelete({ childId: "sub-22222222", child: deleted.file, reason: "user" });
+
+			const response = await supervisor.handleCommand(
+				{},
+				{ type: "list_saved_sessions", cwd: tempDir, sessionDir: sessionsDir, scope: "all" },
+			);
+			if (!response?.success) throw new Error("list_saved_sessions failed");
+			const sessions = (
+				response.data as {
+					sessions: Array<{ id: string; parentSessionPath?: string; rlmDepth?: number; messageCount: number }>;
+				}
+			).sessions;
+			expect(sessions.map(({ id }) => id)).toEqual([parentInfo.id, child.manager.getSessionId()]);
+			expect(sessions[1]).toMatchObject({ parentSessionPath: parentFile, rlmDepth: 1, messageCount: 1 });
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("merges passivated descendants into the worker daemon's saved catalog", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-rlm-ledger-catalog-daemon-"));
+		try {
+			const { internals, sessionsDir } = makeDaemonFixture(tempDir);
+			const { parent, parentFile } = makeRoots(tempDir);
+			const parentArtifactDir = parent.getSessionArtifactDir();
+			if (!parentArtifactDir) throw new Error("Missing parent artifact directory");
+			const child = makeChildSession(tempDir, join(parentArtifactDir, "sub-33333333"), parentFile, 1, "worker");
+			await internals.rlmSpawnLedger().appendSpawn({
+				childId: "sub-33333333",
+				parent: parentFile,
+				child: child.file,
+				depth: 1,
+				name: "worker",
+			});
+
+			const response = (await (
+				internals as unknown as {
+					handleCommand(client: object, command: Record<string, unknown>): Promise<DaemonResponse | undefined>;
+				}
+			).handleCommand({}, { type: "list_saved_sessions", cwd: tempDir, sessionDir: sessionsDir, scope: "all" })) as {
+				success: boolean;
+				data: { sessions: Array<{ id: string; parentSessionPath?: string }> };
+			};
+			expect(response.success).toBe(true);
+			expect(response.data.sessions.filter(({ id }) => id === child.manager.getSessionId())).toEqual([
+				expect.objectContaining({ parentSessionPath: parentFile }),
+			]);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});
+
 describe("rlm spawn ledger supervisor wiring", () => {
 	it("hydrates a ledger-seeded child's cwd before publishing the roster", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-rlm-ledger-supervisor-cwd-"));


### PR DESCRIPTION
An RLM child's transcript lives in `session-artifacts/`, which the saved-session catalog scan never visits. While something resident remembers the child — a retained worker roster entry, or the boot seed of a registered worker's family — its row survives. After a supervisor restart, an inactive parent's passivated descendants silently disappear from the agents view: the roster no longer knows them, the catalog never did. Any spend those children represent vanishes from the parent's subtree total with them, so the same parent reports less than it did a minute earlier (RES-1258's rollup sums visible rows).

## Fix

Both `list_saved_sessions` composition points — the supervisor handler (production topology, catalog process scan) and the worker daemon handler (in-process topology, `SessionManager.list/listAll`) — now append the live spawn-ledger children the directory scan missed, through one shared walk, `withPassiveRlmDescendantInfos` in `rlm-ledger.ts`:

- one `readSessionInfo` per passivated descendant, `parentSessionPath`/`rlmDepth` backfilled from the ledger edge when the transcript header lacks them
- deleted edges excluded (`liveEdges()` — tombstones and vanished files drop out)
- `scope: "current"` keeps the same cwd filter the directory scan applies
- streamed through the existing `onSession` progressive callback

No client or wire change: the view already renders saved-only descendants under their parent (`parentSessionPath` → subagent row) and already merges a resident child's catalog row into its live record by session identity, so resident children cannot duplicate.

## Validation

- `serves passivated descendants in the saved catalog after a supervisor restart` (rlm-ledger.test.ts): fresh supervisor, no workers, parent in the catalog, child only in ledger + artifacts → child listed with `parentSessionPath`, `rlmDepth`, `messageCount`; a tombstoned sibling stays out. **Fails on main**: `expected [ Array(1) ] to deeply equal [ …(2) ]`.
- `merges passivated descendants into the worker daemon's saved catalog` (rlm-ledger.test.ts): same through the worker daemon handler. **Fails on main**: `expected [] to deeply equal [ ObjectContaining{…} ]`.
- No-duplicate pin (agents-view-state.test.ts): the existing passive-descendants view test now also feeds the resident child's file as a catalog row — still one row per child. **Mutation-verified**: breaking the alias merge in `reconcileUnifiedSessions` fails it (`expected 2 to be 3`... rows duplicated).
- Suites: rlm-ledger, agents-view-state, daemon-mode, daemon-supervisor, daemon-session-list, agent-connection-daemon — 402 passed. Root `npm run check` green.

Cost identity (`recursive total identical before/after restart`) is pinned here at the row level (identity, parentage, messageCount); the money assertion itself lives with the usage fields, which are on #2003 (RES-1258) and not yet on main — once both land, the rollup covers restored rows with no further change.

## Performance

Measured at 300 saved sessions with 36 passivated descendants (cold ledger instance, i.e. restart-worst-case): directory scan 43.2ms, ledger merge +10.0ms (~0.3ms per descendant, dominated by per-file `readSessionInfo`). Zero descendants ≈ zero added cost (one ledger replay, no file reads).

## Net source LOC

+36/−2 src (28 helper incl. comment block, 2×5 handler call sites, 2 imports): all mechanical composition; no new state, no schema change.

Linear: RES-1262 https://linear.app/primeintellect/issue/RES-1262

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to saved-session listing composition with no protocol or schema changes; behavior is additive for passivated descendants and reuses existing ledger tombstone semantics.
> 
> **Overview**
> **Passivated RLM child sessions** stored under `session-artifacts/` were missing from `list_saved_sessions` after a supervisor restart because the directory catalog never scans those paths and the roster no longer remembered them.
> 
> Adds **`withPassiveRlmDescendantInfos`** in `rlm-ledger.ts`, which walks **`liveEdges()`** on the spawn ledger, appends children not already in the scan, backfills **`parentSessionPath`** / **`rlmDepth`** from the edge, honors **`scope: "current"`** cwd filtering, and forwards **`onSession`** for streaming. Both composition sites—the **supervisor** and **worker daemon** `list_saved_sessions` handlers—call this helper before serializing results; resident catalog rows are skipped so duplicates do not appear.
> 
> Tests cover post-restart listing (tombstoned siblings excluded), the worker daemon path, and reconciliation when the child file is already in the catalog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e18fc1a29259c82aaec4b0d408300143581f5774. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Recover passivated RLM descendants in `list_saved_sessions` via ledger edges
> - Adds `withPassiveRlmDescendantInfos` in [rlm-ledger.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2023/files#diff-9a37d17b18302358b04d20a1e73f03e0cca1588155de12c6d2cafd1b7f3c32b3), which merges live ledger-known children into saved-session catalog results, skipping unreadable, deleted, or already-cataloged entries and filling in `parentSessionPath`/`rlmDepth` from the ledger edge
> - Wires the helper into both the `AgentDaemon` and `DaemonSupervisor` `list_saved_sessions` handlers so recovered descendants appear in responses and stream through existing session callbacks; current-directory queries filter recovered entries to the requested cwd
> - Adds integration tests covering supervisor and worker-daemon recovery paths, including exclusion of a ledger-tombstoned child
> - Risk: recovered descendants are sourced from `liveEdges()` only; any ledger edge not yet flushed to disk at query time will be missed by `withPassiveRlmDescendantInfos`
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e18fc1a. 3 files reviewed, 4 issues evaluated, 2 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>packages/coding-agent/src/modes/daemon/daemon-mode.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 3879](https://github.com/PrimeIntellect-ai/prime-agent/blob/e18fc1a29259c82aaec4b0d408300143581f5774/packages/coding-agent/src/modes/daemon/daemon-mode.ts#L3879): For `scope: "current"`, the original `SessionManager.list(cwd, sessionDir, ...)` scans only JSONL files directly in the requested `sessionDir`, but `withPassiveRlmDescendantInfos` receives only `cwd` and appends every live ledger child with that cwd. Thus a request targeting a custom session directory (including a subagent's artifact session directory) returns passivated descendants belonging to other session directories in the same project, violating the requested catalog scope and exposing their saved-session metadata. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>packages/coding-agent/src/modes/daemon/daemon-supervisor.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 2835](https://github.com/PrimeIntellect-ai/prime-agent/blob/e18fc1a29259c82aaec4b0d408300143581f5774/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts#L2835): `handleSavedSessionList` always merges descendants from `this.rlmSpawnLedger()`, whose instance is fixed to `defaultSessionConfig.sessionDir`, even when the request supplies a different `command.sessionDir`. Thus a `scope: "all"` request for a non-default session directory can include descendants from the default directory and cannot recover that directory's own passivated children; the returned saved-session catalog no longer matches the requested directory. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->