### PR TITLE
fix(coding-agent): observe closeSession on draft discard; honor pendingAttaches

### DIFF
--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -6048,7 +6048,9 @@ export class AgentDaemon {
 			// runs, in which case the draft is no longer abandoned and must be kept.
 			queueMicrotask(() => {
 				if (this.sessions.has(state.activeSessionId) && this.isDiscardableDraft(state)) {
-					void this.closeSession(state, "killed");
+					void this.closeSession(state, "killed").catch((error) =>
+						this.log(`failed to discard empty draft ${state.activeSessionId}: ${String(error)}`),
+					);
 				}
 			});
 		}
@@ -6059,6 +6061,9 @@ export class AgentDaemon {
 			return false;
 		}
 		if (state.clients.size > 0) {
+			return false;
+		}
+		if (state.pendingAttaches > 0) {
 			return false;
 		}
 		if (state.runtime.metadata.kind === "subagent") {
@@ -6616,7 +6621,9 @@ export class AgentDaemon {
 				(eventType === "turn_end" || eventType === "compaction_end" || eventType === "bash_end") &&
 				this.isDiscardableDraft(state)
 			) {
-				void this.closeSession(state, "killed");
+				void this.closeSession(state, "killed").catch((error) =>
+					this.log(`failed to discard empty draft ${state.activeSessionId}: ${String(error)}`),
+				);
 			}
 			if (RECOVERY_CHECKPOINT_EVENTS.has(eventType)) {
 				this.recordWorkerRecoveryState(state, eventType);

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -3595,6 +3595,75 @@ describe("daemon mode helpers", () => {
 		expect(client.attachedActiveSessionIds).not.toContain(state.activeSessionId);
 	});
 
+	it("does not treat a client-less draft as discardable while an attach is in flight", () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const state = makeEmptyTopLevelDraft("draft");
+		const internals = daemon as unknown as {
+			isDiscardableDraft(state: ActiveSessionState): boolean;
+		};
+		expect(state.clients.size).toBe(0);
+		expect(state.pendingAttaches).toBe(0);
+		expect(internals.isDiscardableDraft(state)).toBe(true);
+
+		state.pendingAttaches = 1;
+		expect(internals.isDiscardableDraft(state)).toBe(false);
+	});
+
+	it.each(["broadcast", "detach"] as const)(
+		"observes closeSession rejection on %s draft discard instead of unhandledRejection",
+		async (site) => {
+			const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+				defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+				createRuntime: vi.fn(),
+			});
+			const state = makeEmptyTopLevelDraft("draft");
+			const closeSession = vi.fn(() => Promise.reject(new Error("teardown failed")));
+			const log = vi.fn();
+			const internals = daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				closeSession: typeof closeSession;
+				log: typeof log;
+				broadcastToSession(state: ActiveSessionState, message: DaemonOutbound): void;
+				detachClientFromSession(client: DaemonSocketClient, state: ActiveSessionState): void;
+				write: ReturnType<typeof vi.fn>;
+			};
+			internals.sessions.set(state.activeSessionId, state);
+			internals.closeSession = closeSession;
+			internals.log = log;
+			internals.write = vi.fn();
+
+			const unhandled: unknown[] = [];
+			const onUnhandled = (reason: unknown) => unhandled.push(reason);
+			process.on("unhandledRejection", onUnhandled);
+			try {
+				if (site === "broadcast") {
+					internals.broadcastToSession(state, {
+						type: "session_event",
+						activeSessionId: state.activeSessionId,
+						event: { type: "bash_end", exitCode: 0, cancelled: false, truncated: false },
+					});
+				} else {
+					const client = makeClient("client-1", state.activeSessionId);
+					state.clients.add(client);
+					internals.detachClientFromSession(client, state);
+				}
+				await Promise.resolve();
+				await Promise.resolve();
+				await new Promise((resolve) => setImmediate(resolve));
+				expect(closeSession).toHaveBeenCalledWith(state, "killed");
+				expect(log).toHaveBeenCalledWith(
+					expect.stringContaining(`failed to discard empty draft ${state.activeSessionId}`),
+				);
+				expect(unhandled).toEqual([]);
+			} finally {
+				process.off("unhandledRejection", onUnhandled);
+			}
+		},
+	);
+
 	it("drops a backpressure catch-up when the client detaches during snapshot creation", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
@@ -9478,6 +9547,23 @@ function makeAgentFamilyState(
 		},
 	} as never;
 	return { state, acceptAgentMessagePrompt };
+}
+
+function makeEmptyTopLevelDraft(activeSessionId: string): ActiveSessionState {
+	const state = makeState(activeSessionId);
+	state.extensionUiRequests = new Map();
+	state.runtime = {
+		...state.runtime,
+		metadata: { kind: "top-level", createdAt: 1 },
+		session: {
+			messages: [],
+			isBashRunning: false,
+			isSessionActive: false,
+			hasRunningRlmChildren: () => false,
+			sessionManager: { hasUserContent: () => false },
+		},
+	} as unknown as ActiveSessionState["runtime"];
+	return state;
 }
 
 function makeState(activeSessionId: string, parentActiveSessionId?: string): ActiveSessionState {


### PR DESCRIPTION
## Summary
- Observe `closeSession` rejections on non-worker empty-draft discard (`broadcastToSession` and `detachClientFromSession`) so best-effort teardown cannot hit `unhandledRejection` and exit the daemon.
- Treat `pendingAttaches > 0` as non-discardable so a `turn_end`/`compaction_end`/`bash_end` cannot discard a draft in the attach window before the client joins `state.clients`.

Worker-mode `isDiscardableDraft` still returns false; no roster/worker changes.

Fixes #1922.

## Test plan
- [x] `cd packages/coding-agent && npx vitest --run test/daemon-mode.test.ts` (189 passed)
- [ ] Attach to a non-worker empty draft while a turn is ending; attach should succeed (draft not discarded mid-`pendingAttaches`)
- [ ] Detach last client from a non-worker empty draft; draft still discarded

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Observe `closeSession` rejections on draft discard and respect `pendingAttaches` in `AgentDaemon`
> - Wraps empty-draft cleanup in `AgentDaemon.detachClientFromSession` and `AgentDaemon.broadcastToSession` with rejection handlers that log the active-session ID instead of leaving unhandled promise rejections.
> - Updates `AgentDaemon.isDiscardableDraft` to return false while a draft has pending session attaches, so clientless empty drafts are retained during in-flight attaches.
> - Adds tests for both disposal entry points using a new `makeEmptyTopLevelDraft` fixture, verifying that `closeSession` rejections are logged without producing process-level unhandled rejections.
> - Behavioral Change: drafts with `pendingAttaches > 0` are no longer eligible for disposal; callers relying on immediate discard of empty drafts during attach must wait for the attach count to reach zero.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f98109c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->