### PR TITLE
fix(ai): build from the committed model catalog instead of refetching it

### DIFF
--- a/packages/ai/.changes/res-1269-deterministic-model-catalog-build.md
+++ b/packages/ai/.changes/res-1269-deterministic-model-catalog-build.md
@@ -1,0 +1,1 @@
+- Changed the build to compile from the committed model catalog instead of refetching it; run `npm run generate-models` explicitly to refresh `models.generated.ts`.

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -65,7 +65,7 @@
 	"scripts": {
 		"clean": "shx rm -rf dist",
 		"generate-models": "npx tsx scripts/generate-models.ts",
-		"build": "npm run generate-models && tsgo -p tsconfig.build.json",
+		"build": "tsgo -p tsconfig.build.json",
 		"dev": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
 		"dev:tsc": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
 		"test": "vitest --run",


### PR DESCRIPTION
## Problem

`packages/ai` `npm run build` was `npm run generate-models && tsgo ...`: every build (CI `Build and check`, every `Test (*)` job, and release `build-binaries.yml` — all run `npm run build`) fetched the live model catalog and rewrote `src/models.generated.ts` in place.

Upstream removed `claude-sonnet-4.5` from the catalog sources, but the committed `models.generated.ts` and 28 in-repo references (including `packages/ai` tests) still use it. So on every CI run the Build step silently swapped in a catalog without that model, and the subsequent `npm run check` / `Test (ai)` failed with e.g.:

```
packages/ai/test/context-overflow.test.ts(119,46): error TS2345: Argument of type '"claude-sonnet-4.5"' is not assignable to parameter of type '"claude-fable-5" | ...'
```

Every PR fails `Build and check`, `Test (ai)`, and `build-check-test` regardless of content (example: run 33854776241 on #1947).

## Fix

Build compiles the committed catalog only:

- `packages/ai` `build` is now just `tsgo -p tsconfig.build.json`.
- `npm run generate-models` stays as the explicit, reviewed refresh step (it is the existing documented command in AGENTS.md, README, and the generated-file header; no new alias added).

`src/models.generated.ts` is the generator's only output and is committed (not gitignored), so clean checkouts build and test with no network fetch of the catalog. This PR deliberately does NOT regenerate the catalog — removing `claude-sonnet-4.5` references is a separate reviewed refresh.

## Evidence since filing (release gates)

The class kept firing after the original incident:

- The v0.9.2 and v0.9.3 release gates both observed live regen drift during the release build itself — the shipped catalog depended on the fetch minute, not on the reviewed tree.
- #2069's peak-tariff derivation removed the worst deterministic offender (OpenRouter's clock-dependent time-windowed pricing, which flipped rows twice or six times per day), but the last gate still saw 16 lines of genuine live churn (price jitter, listing renames, adds/removals) between review and release.
- Every catalog PR in the RES-1273 line (#2057, #2069, #2074, #2042) has had to document "fetch-time ride-alongs" precisely because CI regenerates on every run. With this PR, catalog changes only enter through an explicit, reviewed `npm run generate-models` diff.

Verified on the rebased branch (current main, post-#2074): `npm run build` performs zero generation, catalog md5 unchanged through the build, `npm run check` clean, full `packages/ai` suite green against the committed catalog.

## Callers audited

`generate-models` had exactly one caller: the `packages/ai` `build` script. Root `build`, `prepublishOnly` (npm publish), `ci.yml` (`Build and check` + all test jobs), and `build-binaries.yml` (release/beta binaries) all funnel through it, so all now build from the committed catalog. No other workflow, script, or hook invokes `generate-models`.

## Verification (clean checkout in a Prime sandbox, source-only sync + `npm ci`)

- `npm run build`: exit 0; `models.generated.ts` md5 identical before/after; `generate-models` never invoked.
- `npm run check`: exit 0 (biome, root tsgo `--noEmit`, installer check, browser smoke).
- `packages/ai` `npm test`: 50 files passed / 22 skipped, 341 tests passed / 720 skipped, 0 failures.

Linear: RES-1269

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script-only change; `generate-models` remains available for intentional catalog refreshes with no auth or runtime behavior changes.
> 
> **Overview**
> **Stops implicit model-catalog refresh on every `packages/ai` build** so CI and local builds use the committed `models.generated.ts` instead of rewriting it from live upstream data.
> 
> The `build` script no longer runs `generate-models` before `tsgo`; catalog updates stay on the explicit `npm run generate-models` step. A changelog note documents that workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6b20595470e2c2a52cb15360e948d7c2c43cb0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## LOC

Total src: **+0/−0 (net +0)**; tests: +0/−0 (net +0).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop refetching model catalog during `npm run build` in `packages/ai`
> Removes the `generate-models` step from the `packages/ai` build script so builds compile against the committed `models.generated.ts`. Run `npm run generate-models` explicitly when the catalog needs refreshing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6b2059.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
