### PR TITLE
feat(sandbox): add lifecycle and ownership foundation

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -354,11 +354,32 @@ jobs:
           test -n "$R2_BUCKET"
           test -n "$R2_ENDPOINT_URL"
 
+          archive_count=0
           for artifact in "$PRODUCTION_DIR"/*.tar.gz; do
             test -f "$artifact" || continue
+            archive_count=$((archive_count + 1))
+            test -f "${artifact%.tar.gz}.manifest.json"
+          done
+          manifest_count=0
+          for manifest in "$PRODUCTION_DIR"/*.manifest.json; do
+            test -f "$manifest" || continue
+            manifest_count=$((manifest_count + 1))
+            test -f "${manifest%.manifest.json}.tar.gz"
+          done
+          if [ "$archive_count" -ne 4 ]; then echo "Expected 4 production archives, got ${archive_count}" >&2; exit 1; fi
+          if [ "$manifest_count" -ne 4 ]; then echo "Expected 4 production manifests, got ${manifest_count}" >&2; exit 1; fi
+          if [ "$archive_count" -ne "$manifest_count" ]; then echo "Production archive/manifest count mismatch" >&2; exit 1; fi
+
+          for artifact in "$PRODUCTION_DIR"/*.tar.gz; do
             aws s3 cp "$artifact" "s3://${R2_BUCKET}/${RELEASE_PREFIX}/$(basename "$artifact")" \
               --endpoint-url "$R2_ENDPOINT_URL" \
               --content-type application/gzip \
+              --cache-control 'public, max-age=31536000, immutable'
+          done
+          for manifest in "$PRODUCTION_DIR"/*.manifest.json; do
+            aws s3 cp "$manifest" "s3://${R2_BUCKET}/${RELEASE_PREFIX}/$(basename "$manifest")" \
+              --endpoint-url "$R2_ENDPOINT_URL" \
+              --content-type application/json \
               --cache-control 'public, max-age=31536000, immutable'
           done
 
@@ -421,11 +442,32 @@ jobs:
           test -n "$R2_BUCKET"
           test -n "$R2_ENDPOINT_URL"
 
+          archive_count=0
           for artifact in "$BETA_DIR"/*.tar.gz; do
             test -f "$artifact" || continue
+            archive_count=$((archive_count + 1))
+            test -f "${artifact%.tar.gz}.manifest.json"
+          done
+          manifest_count=0
+          for manifest in "$BETA_DIR"/*.manifest.json; do
+            test -f "$manifest" || continue
+            manifest_count=$((manifest_count + 1))
+            test -f "${manifest%.manifest.json}.tar.gz"
+          done
+          if [ "$archive_count" -eq 0 ]; then echo "No beta archives to upload" >&2; exit 1; fi
+          if [ "$manifest_count" -eq 0 ]; then echo "No beta manifests to upload" >&2; exit 1; fi
+          if [ "$archive_count" -ne "$manifest_count" ]; then echo "Beta archive/manifest count mismatch" >&2; exit 1; fi
+
+          for artifact in "$BETA_DIR"/*.tar.gz; do
             aws s3 cp "$artifact" "s3://${R2_BUCKET}/${RELEASE_PREFIX}/$(basename "$artifact")" \
               --endpoint-url "$R2_ENDPOINT_URL" \
               --content-type application/gzip \
+              --cache-control 'public, max-age=31536000, immutable'
+          done
+          for manifest in "$BETA_DIR"/*.manifest.json; do
+            aws s3 cp "$manifest" "s3://${R2_BUCKET}/${RELEASE_PREFIX}/$(basename "$manifest")" \
+              --endpoint-url "$R2_ENDPOINT_URL" \
+              --content-type application/json \
               --cache-control 'public, max-age=31536000, immutable'
           done
 

--- a/SANDBOX_SESSIONS_PLAN.md
+++ b/SANDBOX_SESSIONS_PLAN.md
@@ -1,0 +1,286 @@
+# Sandbox-backed Prime Agent sessions execution plan
+
+Status: approved on 2026-09-04  
+Owner: Prime Agent  
+Tracking issue: RES-1264  
+Archived predecessor: `SANDBOX_SESSIONS_PLAN_HISTORY_2026-09-04.md` in the session artifacts
+
+## Product objective
+
+A request with `sandbox: true` must create a complete Prime Agent child session inside a Prime Sandbox. Home keeps identity, authorization, provider credentials, billing, lifecycle control, durable routing, artifacts, workspace orchestration, and physical deletion.
+
+The required product flow is:
+
+1. Home receives `sandbox: true`.
+2. Home creates one Prime Sandbox.
+3. Home installs or uploads the exact Prime Agent runtime.
+4. Home starts that runtime inside the sandbox.
+5. The sandbox agent communicates with Home.
+6. Model requests are proxied through Home. Provider credentials never enter the sandbox.
+7. Messaging, observation, and workspace synchronization work across the connection.
+8. Home recovers the same session after a restart without creating another sandbox.
+9. Deleting the session also deletes the Prime Sandbox and all private hosted state.
+
+## Non-negotiable safety rules
+
+- Bun 1.4.0 is the primary development, check, test, build, and runtime workflow.
+- The clean stack is based on the updated Bun primary-runtime branch, then current `main`.
+- `sandbox=false` remains behavior-compatible.
+- `sandbox:true` continues to return exactly `Sandbox execution is not available for this session` until the complete stack passes its evidence matrix.
+- Do not advertise `sandbox_sessions` before final activation.
+- Do not expose sandbox IDs, regions, credentials, grants, paths, URLs, provider handles, the real session directory, prompts, messages, or exceptions through public DTOs or evidence APIs.
+- Public execution metadata is only `{type:"prime-sandbox"}`.
+- Home is the only owner of physical sandbox deletion.
+- Never synthesize or cast an `AgentSession` for a remote child.
+- Sandbox bootstrap credentials are one-time, scoped, bounded, and transferred through a private stream, not argv or environment.
+- All external calls and cleanup operations are bounded.
+- Large workspace contents use PAWS streaming, not JSON or base64 relay frames.
+- Every paid end-to-end run is explicit, bounded, fully harvested, and verified deleted.
+
+## Branch and PR strategy
+
+PR #2025 remains an archive until the replacement stack reproduces the accepted behavior. Do not force-push or extend it.
+
+1. Update PR #1970, `feat/bun-primary-runtime`, against current `main` and restore green CI.
+2. Create a new clean sandbox integration branch from that Bun tip.
+3. Move code from PR #2025 only after file-level review. Do not merge or cherry-pick the full historical branch.
+4. Deliver the feature as a stacked set of reviewable PRs.
+5. Close PR #2025 only after the replacement stack has full behavior and evidence.
+
+## Source triage policy
+
+Every sandbox-related file from PR #2025 receives one decision:
+
+- **Keep and fix now:** needed by the next vertical slice, production-reachable, and locally testable.
+- **Rewrite:** the concept is needed but the implementation violates the current contract or platform behavior.
+- **Defer:** useful only after the basic remote child works.
+- **Remove:** obsolete, conflicting, rejected, duplicated, or test-only code without meaningful behavior.
+
+No file enters the clean stack without a production caller, a current purpose, behavior tests, explicit ownership, and a bounded cleanup path.
+
+Immediate expected decisions:
+
+- Keep and fix the public option contract, execution metadata, Prime CLI lifecycle adapter, tunnel manager, SSH process handling, bootstrap payload, and private framing.
+- Rewrite Prime CLI parsing, the production command runner, ownership persistence, the hosted runtime factory, provider application composition, and invalid constructor branding.
+- Defer durable relay recovery, advanced messaging recovery, observation persistence, PAWS, and restart recovery until the walking skeleton works.
+- Remove `workspace-sync.ts`, its obsolete isolated test, historical experiments, redundant copy-only tests, and rejected composition candidates.
+- Keep the messaging and trusted-inbox stash out of the stack until the basic runtime and Home relay work.
+
+## Prime platform contract for v1
+
+The first implementation uses the Prime CLI on Home through an argv-only runner.
+
+- Establish and test an explicit supported Prime CLI version range.
+- Parse the documented JSON schema for that supported version.
+- Use container sandboxes because the current launch path requires Prime SSH.
+- Record the container and unrestricted-egress tradeoff in the threat model.
+- Do not enable idle timeout because SSH does not refresh it.
+- Use a finite total lifetime as a cleanup backstop.
+- Never pass model-provider credentials with `--env` or `--secret`.
+- Transfer only a one-time relay/bootstrap credential through SSH stdin.
+- Use a lifecycle-derived, non-secret provider label for discovery.
+- Decide native API idempotency versus label reconciliation before restart support.
+- Respect the documented 200 MB per-file upload limit.
+
+## Milestone 1: Bun base and plan cleanup
+
+Deliverables:
+
+- PR #1970 updated against current `main`.
+- `bun install --frozen-lockfile` passes with Bun 1.4.0.
+- `bun run check` passes.
+- Conflict-focused tests pass.
+- This concise plan replaces the stale progress ledger in the clean sandbox branch.
+- The old plan is archived outside the review path.
+
+## Milestone 2: Prime Sandbox lifecycle
+
+Covers product steps 1 and 2.
+
+Deliverables:
+
+- Production argv-only `CommandRunner`.
+- Exact Prime CLI preflight and version compatibility result.
+- Current JSON parsers for list and get.
+- Create, get, wait, logs, upload, download, run, and delete operations needed by the runtime.
+- Durable pre-admission before provider creation.
+- Discovery and reconciliation through a derived label.
+- Idempotent deletion and a basic orphan cleanup path.
+- Capability remains disabled.
+
+Acceptance:
+
+- Fake tests cover success, cancellation, timeout, malformed output, provider uncertainty, duplicate discovery, and delete-not-found.
+- Fixtures match the supported Prime CLI schema.
+- Allocation uncertainty never causes a blind second create.
+- Public results contain no provider details.
+
+## Milestone 3: Runtime installation and launch
+
+Covers product steps 3 and 4.
+
+Deliverables:
+
+- Exact Linux runtime package and manifest.
+- Manifest includes Prime Agent version and commit, Bun version, target OS and architecture, protocol version, and artifact hashes.
+- Upload strategy keeps every file within Prime limits.
+- Sandbox-side verification before launch.
+- SSH remote wrapper receives one bounded bootstrap frame on stdin.
+- The wrapper launches the real runtime with a private FD3 credential channel.
+- Versioned READY handshake.
+- Real internal reserved-mode dispatch replaces `ORCHESTRATION_UNAVAILABLE`.
+- Capability remains disabled.
+
+Acceptance:
+
+- Wrong hashes, versions, architecture, protocol, truncated input, extra input, and failed launch all fail before activation.
+- Partial installation and launch failures have proven cleanup.
+- Secrets do not appear in argv, environment, logs, or provider metadata.
+
+## Milestone 4: Home communication and provider proxy
+
+Covers product steps 5 and 6.
+
+Deliverables:
+
+- Authenticated Home listener and Prime Tunnel.
+- Sandbox-to-Home connection with one-time admission.
+- Side-specific ingress and impossible-direction rejection before mutation.
+- One remote child run request and result.
+- Provider requests execute only on Home.
+- Cancellation durability precedes `proxy.cancel`.
+- Bounded disconnect and shutdown.
+- Capability remains disabled.
+
+Acceptance:
+
+- One sandbox child completes an agent turn through the Home provider proxy.
+- No provider secret exists in sandbox environment, files, metadata, logs, process arguments, or evidence output.
+- Disconnects never report false success.
+
+## Milestone 5: Messaging and observation
+
+Covers the messaging and observation part of product step 7.
+
+Deliverables:
+
+- `agent_message` communication for hosted children.
+- Family listing and direct agent-to-agent communication.
+- Hosted observation text and status events.
+- Authorization and durable trusted-inbox admission are serialized.
+- Ordered relay exclusively generates domain acknowledgements.
+- Accepted side-domain frames enter the ordered relay.
+- Capability remains disabled.
+
+Acceptance:
+
+- Authorized messages survive disconnect and replay once.
+- Unauthorized or impossible-direction frames cause no mutation.
+- Observation exposes no private hosted state.
+
+## Milestone 6: PAWS workspace synchronization
+
+Completes product step 7.
+
+Deliverables:
+
+- Remove `workspace-sync.ts` and its obsolete test.
+- Construction-bound private workspace and verifier roots.
+- Immutable PAWS artifact publication and application.
+- Initial Home-to-sandbox transfer.
+- Checkpoint transfer.
+- Final sandbox-to-Home sync.
+- Path-free operation DTOs and results.
+- Bounded streaming for large contents.
+- Capability remains disabled.
+
+Acceptance:
+
+- Traversal, symlink, race, malformed archive, duplicate path, oversized file, and cleanup failures fail safely.
+- Publication is atomic and no-overwrite.
+- Every temporary and owned byte copy is erased and verified.
+- Workspace changes survive final sync without leaking Home paths.
+
+## Milestone 7: Restart recovery
+
+Covers product step 8.
+
+Deliverables:
+
+- Separate immutable hosted-child ledger with only `parentSessionId`, `sessionId`, `childId`, and `lifecycleKey`.
+- Separate `.spawn` and `.delete` records.
+- Home restart reconstruction from trusted records.
+- Provider label reconciliation before unrelated validation.
+- Relay, provider call, messaging, observation, and workspace recovery.
+- No duplicate sandbox after restart.
+- Capability remains disabled.
+
+Acceptance:
+
+- Kill Home during create, activation, provider execution, message delivery, checkpoint, and deletion.
+- Restart either recovers the same sandbox or reports bounded uncertainty.
+- No test path creates a second sandbox for the same lifecycle.
+
+## Milestone 8: Complete deletion and activation
+
+Covers product step 9.
+
+Required cleanup order:
+
+1. Checkpoint and final workspace sync.
+2. Shut down the sandbox runtime.
+3. Close relay, listener, and tunnel.
+4. Physically delete the Prime Sandbox.
+5. Verify lifecycle and platform deletion.
+6. Persist deletion proof.
+7. Delete hosted-child ledger state.
+8. Remove the session registry entry.
+
+Deliverables:
+
+- Reverse-acquisition owner close with identity-based alias deduplication.
+- Physical delete remains owned by the Home runtime host.
+- Orphan reaper for stale provisioning and incomplete deletion.
+- Complete error and uncertainty policy.
+- Capability advertisement only after the full evidence matrix passes.
+
+## Controlled Prime Sandbox end-to-end test
+
+No paid resource is created until milestones 2 through 4 pass locally.
+
+The authorized controlled run uses:
+
+- one CPU-only container sandbox
+- no GPU
+- finite total timeout
+- no unnecessary exposed sandbox ports
+- one exact runtime installation
+- one Home-proxied model request
+- one remote child result
+- explicit evidence capture before cleanup
+- bounded shutdown and physical deletion
+- post-delete provider verification
+
+Save all lifecycle events, sanitized command results, manifests, relay evidence, workspace evidence, and deletion proof before stopping or deleting the run. Never store secrets.
+
+## Final evidence matrix
+
+The feature is done only when one scenario proves all of the following:
+
+1. Create a Home session.
+2. Create a sandbox child.
+3. Confirm exactly one Prime Sandbox exists.
+4. Confirm the child runtime executes inside it.
+5. Send and receive a message.
+6. Perform a Home-proxied model request.
+7. Observe the child through the public observation contract.
+8. Modify workspace files in the sandbox.
+9. Restart Home.
+10. Recover the same child without allocating another sandbox.
+11. Complete the child task.
+12. Sync workspace changes back.
+13. Delete the session.
+14. Confirm the Prime Sandbox, tunnel, credentials, journals, temporary artifacts, and workspace staging data are gone.
+15. Run the full Bun suite and security, crash, secret, orphan, workspace, and deletion matrices.
+
+Only after all fifteen checks pass may the implementation advertise `sandbox_sessions` and accept public `sandbox:true` execution.

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -10,7 +10,12 @@ import type {
 import { isNoModelsAvailableMessage } from "./auth-guidance.js";
 import type { ReplacedSessionContext, SessionShutdownEvent, SessionStartEvent } from "./extensions/index.js";
 import { emitSessionShutdownEvent } from "./extensions/runner.js";
-import type { CreateRlmSubagentRuntimeOptions, RlmSubagentRuntime, SubagentRuntimeHost } from "./rlm-runtime.js";
+import {
+	type CreateRlmSubagentRuntimeOptions,
+	RLM_SANDBOX_UNAVAILABLE_MESSAGE,
+	type RlmSubagentRuntime,
+	type SubagentRuntimeHost,
+} from "./rlm-runtime.js";
 import type { CreateAgentSessionResult } from "./sdk.js";
 import { assertSessionCwdExists } from "./session-cwd.js";
 import { SessionImportFileNotFoundError } from "./session-import-errors.js";
@@ -314,6 +319,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 	}
 
 	async createRlmSubagentRuntime(options: CreateRlmSubagentRuntimeOptions): Promise<RlmSubagentRuntime> {
+		if (options.sandbox === true) throw new Error(RLM_SANDBOX_UNAVAILABLE_MESSAGE);
 		const sessionManager = SessionManager.create(options.parentSession.sessionManager.getCwd(), options.sessionDir);
 		if (options.parentSession.sessionFile) {
 			sessionManager.newSession({

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -220,9 +220,11 @@ import {
 	createRlmListSubagentsHostHandler,
 	createRlmRunHostHandler,
 	findRlmModelMatches,
+	normalizeRequestedRlmSandbox,
 	normalizeRequestedRlmSubagentModel,
 	normalizeRequestedRlmSubagentSessionName,
 	normalizeRequestedRlmSubagentThinkingLevel,
+	RLM_SANDBOX_UNAVAILABLE_MESSAGE,
 	type RlmDeleteSubagentResult,
 	type RlmFindModelsResult,
 	type RlmListSubagentsResult,
@@ -230,6 +232,7 @@ import {
 	type RlmSubagentRegistryEntry,
 	type RlmSubagentRuntime,
 	type SubagentRuntimeHost,
+	snapshotRlmRunKwargs,
 } from "./rlm-runtime.js";
 import {
 	modelRequestHeaders,
@@ -9623,6 +9626,7 @@ export class AgentSession {
 	}
 
 	private async _createRlmSubagentRuntime(options: CreateRlmSubagentRuntimeOptions): Promise<RlmSubagentRuntime> {
+		if (options.sandbox === true) throw new Error(RLM_SANDBOX_UNAVAILABLE_MESSAGE);
 		if (this._subagentRuntimeHost) {
 			return await this._subagentRuntimeHost.createRlmSubagentRuntime(options);
 		}
@@ -9631,6 +9635,7 @@ export class AgentSession {
 	}
 
 	private _createInlineRlmSubagentRuntime(options: CreateRlmSubagentRuntimeOptions): RlmSubagentRuntime {
+		if (options.sandbox === true) throw new Error(RLM_SANDBOX_UNAVAILABLE_MESSAGE);
 		const childSessionManager = SessionManager.create(this._cwd, options.sessionDir);
 		if (options.parentSession.sessionFile) {
 			childSessionManager.newSession({
@@ -10556,14 +10561,18 @@ export class AgentSession {
 		// executing now. A spawn arriving outside an active run (a detached kernel task
 		// firing while the parent is idle) has no such turn; an absent edge beats a wrong one.
 		const spawnedByRequestId = this.isStreaming ? this._semanticEdges.lastTurnRequestId : undefined;
-		const { name: rawName, model: rawModel, thinking: rawThinking, ...unsupported } = kwargs;
-		const unsupportedKwargs = Object.keys(unsupported);
+		const kwargSnapshot = snapshotRlmRunKwargs(kwargs);
+		const requestedSandbox = normalizeRequestedRlmSandbox(kwargSnapshot.sandbox);
+		const unsupportedKwargs = [...kwargSnapshot.unsupported];
 		if (unsupportedKwargs.length > 0) {
 			throw new Error(`Unsupported rlm.run kwargs: ${unsupportedKwargs.sort().join(", ")}`);
 		}
-		const requestedSessionName = normalizeRequestedRlmSubagentSessionName(rawName);
-		const requestedModel = normalizeRequestedRlmSubagentModel(rawModel);
-		const requestedThinkingLevel = normalizeRequestedRlmSubagentThinkingLevel(rawThinking);
+		if (requestedSandbox) {
+			throw new Error(RLM_SANDBOX_UNAVAILABLE_MESSAGE);
+		}
+		const requestedSessionName = normalizeRequestedRlmSubagentSessionName(kwargSnapshot.name);
+		const requestedModel = normalizeRequestedRlmSubagentModel(kwargSnapshot.model);
+		const requestedThinkingLevel = normalizeRequestedRlmSubagentThinkingLevel(kwargSnapshot.thinking);
 		if (requestedSessionName) assertDirectAgentMessageTarget(requestedSessionName);
 		if (this._rlmDepth >= this._rlmMaxDepth) {
 			throw new Error(

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -215,12 +215,68 @@ export interface RlmSubagentRuntime {
 	session: AgentSession;
 }
 
+export const RLM_SANDBOX_UNAVAILABLE_MESSAGE = "Sandbox execution is not available for this session";
+
+export function normalizeRequestedRlmSandbox(value: unknown): boolean {
+	if (value === undefined || value === false) return false;
+	if (value === true) return true;
+	throw new Error("rlm.run sandbox must be a boolean");
+}
+
+export type RlmRunKwargsSnapshot = Readonly<{
+	name: unknown;
+	model: unknown;
+	thinking: unknown;
+	sandbox: unknown;
+	unsupported: readonly string[];
+}>;
+
+export function snapshotRlmRunKwargs(value: unknown): RlmRunKwargsSnapshot {
+	let keys: readonly (string | symbol)[];
+	try {
+		if (typeof value !== "object" || value === null || Object.getPrototypeOf(value) !== Object.prototype) {
+			throw new Error("invalid");
+		}
+		keys = Reflect.ownKeys(value);
+	} catch {
+		throw new Error("rlm.run kwargs are invalid");
+	}
+	if (keys.length > 64) throw new Error("rlm.run kwargs are invalid");
+	let name: unknown;
+	let model: unknown;
+	let thinking: unknown;
+	let sandbox: unknown;
+	const unsupported: string[] = [];
+	for (const key of keys) {
+		if (typeof key !== "string" || key.length === 0 || key.length > 64 || /[\x00-\x1f\x7f]/.test(key)) {
+			throw new Error("rlm.run kwargs are invalid");
+		}
+		let descriptor: PropertyDescriptor | undefined;
+		try {
+			descriptor = Object.getOwnPropertyDescriptor(value, key);
+		} catch {
+			throw new Error("rlm.run kwargs are invalid");
+		}
+		if (descriptor === undefined || !Object.hasOwn(descriptor, "value") || !descriptor.enumerable) {
+			throw new Error("rlm.run kwargs are invalid");
+		}
+		if (key === "name") name = descriptor.value;
+		else if (key === "model") model = descriptor.value;
+		else if (key === "thinking") thinking = descriptor.value;
+		else if (key === "sandbox") sandbox = descriptor.value;
+		else unsupported.push(key);
+	}
+	return Object.freeze({ name, model, thinking, sandbox, unsupported: Object.freeze(unsupported) });
+}
+
 export interface CreateRlmSubagentRuntimeOptions {
 	parentSession: AgentSession;
 	id: string;
 	prompt: string;
 	sessionName: string;
 	sessionDir: string;
+	/** Reserved fail-closed request marker. Local runtimes must reject it. */
+	sandbox?: true;
 	model: Model<any>;
 	thinkingLevel: ThinkingLevel;
 	serviceTier: ServiceTier;

--- a/packages/coding-agent/src/modes/daemon/command-runner.ts
+++ b/packages/coding-agent/src/modes/daemon/command-runner.ts
@@ -1,0 +1,972 @@
+/**
+ * Private Home-daemon Bun CLI command runner.
+ *
+ * Executes argv arrays only. Returns exact frozen result unions, never
+ * thrown Error objects.
+ *
+ * Process capture order (per contract):
+ *   1. capture kill → validate function → wire tryKillDirect → cancelRunReady
+ *   2. capture exit → capture then once via Reflect → attach observed exitPromise
+ *      before stream getters
+ *   3. capture stdout/stderr/getReader → validate getReader
+ *
+ * Uses a shared promise-based cancel signal (no AbortController) to avoid
+ * Bun AbortSignal quirks.
+ *
+ * Cleanup: one boundedSettle deadline for pending operations.
+ * Normal exit: no cleanup timer; original op timeout stays active.
+ *
+ * Hard security: 1 MiB per-stream cap, byte-verified zeroing, fatal UTF-8,
+ * fixed frozen exact unions. No casts, assertions, non-null, any, or
+ * dynamic imports. No process-group claim.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type FailureCode =
+	| "INPUT_INVALID"
+	| "SPAWN_FAILED"
+	| "ABORTED"
+	| "TIMED_OUT"
+	| "OUTPUT_OVERFLOW"
+	| "STREAM_FAILED"
+	| "PROCESS_UNCERTAIN";
+
+export type CommandResult =
+	| {
+			readonly ok: true;
+			readonly value: {
+				readonly stdout: string;
+				readonly stderr: string;
+				readonly exitCode: number;
+				readonly durationMs: number;
+			};
+	  }
+	| { readonly ok: false; readonly code: FailureCode };
+
+export interface SpawnedProcess {
+	readonly stdout: ReadableStream<Uint8Array>;
+	readonly stderr: ReadableStream<Uint8Array>;
+	readonly exited: Promise<number>;
+	kill(): void;
+}
+
+export type SpawnFn = (cmd: string[]) => SpawnedProcess;
+
+export interface CliCommandRunner {
+	runCommand(argv: readonly string[], timeoutMs: number, signal?: AbortSignal): Promise<CommandResult>;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MIN_ARGC = 1;
+const MAX_ARGC = 64;
+const MIN_ARG_BYTES = 1;
+const MAX_ARG_BYTES = 4096;
+const MAX_AGGREGATE_BYTES = 65536;
+export const MAX_OUTPUT_BYTES = 1048576;
+const MIN_TIMEOUT_MS = 100;
+const MAX_TIMEOUT_MS = 600000;
+const DEFAULT_CLEANUP_MS = 5000;
+
+// ---------------------------------------------------------------------------
+// Default spawn
+// ---------------------------------------------------------------------------
+
+declare var Bun: {
+	spawn(
+		cmd: string[],
+		opts: {
+			stdin: "ignore" | "pipe";
+			stdout: "pipe" | "inherit";
+			stderr: "pipe" | "inherit";
+			killSignal: number;
+		},
+	): {
+		stdout: ReadableStream<Uint8Array>;
+		stderr: ReadableStream<Uint8Array>;
+		exited: Promise<number>;
+		kill(signal: number): void;
+	};
+	version: string;
+};
+
+function defaultSpawn(cmd: string[]): SpawnedProcess {
+	const p = Bun.spawn(cmd, {
+		stdin: "ignore",
+		stdout: "pipe",
+		stderr: "pipe",
+		killSignal: 9,
+	});
+	return {
+		stdout: p.stdout,
+		stderr: p.stderr,
+		exited: p.exited,
+		kill() {
+			p.kill(9);
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Input validation (wrapped so runCommand never rejects)
+// ---------------------------------------------------------------------------
+
+const CONTROL_RE = /[\x00-\x1f\x7f]/;
+
+function hasLoneSurrogate(s: string): boolean {
+	for (let i = 0; i < s.length; i++) {
+		const c = s.charCodeAt(i);
+		if (c >= 0xd800 && c <= 0xdbff) {
+			if (i + 1 >= s.length) return true;
+			const n = s.charCodeAt(i + 1);
+			if (n < 0xdc00 || n > 0xdfff) return true;
+			i += 1;
+		} else if (c >= 0xdc00 && c <= 0xdfff) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function readAbortState(signal: AbortSignal): boolean | undefined {
+	try {
+		return signal.aborted;
+	} catch {
+		return undefined;
+	}
+}
+
+function addAbortListener(signal: AbortSignal, listener: () => void): boolean {
+	try {
+		signal.addEventListener("abort", listener, { once: true });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function removeAbortListener(signal: AbortSignal | undefined, listener: () => void): void {
+	if (signal === undefined) return;
+	try {
+		signal.removeEventListener("abort", listener);
+	} catch {
+		// The listener target is hostile. Cleanup remains best-effort.
+	}
+}
+
+function copyValidatedInputs(argv: readonly string[], timeoutMs: number): string[] | undefined {
+	if (!(Number.isFinite(timeoutMs) && Number.isSafeInteger(timeoutMs))) return undefined;
+	if (timeoutMs < MIN_TIMEOUT_MS || timeoutMs > MAX_TIMEOUT_MS) return undefined;
+
+	let keys: (string | symbol)[];
+	let lengthDescriptor: PropertyDescriptor | undefined;
+	try {
+		if (!Array.isArray(argv)) return undefined;
+		keys = Reflect.ownKeys(argv);
+		lengthDescriptor = Object.getOwnPropertyDescriptor(argv, "length");
+	} catch {
+		return undefined;
+	}
+	if (lengthDescriptor === undefined || !("value" in lengthDescriptor)) return undefined;
+	const rawLength: unknown = lengthDescriptor.value;
+	if (typeof rawLength !== "number" || !Number.isSafeInteger(rawLength)) return undefined;
+	if (rawLength < MIN_ARGC || rawLength > MAX_ARGC) return undefined;
+	if (keys.length !== rawLength + 1) return undefined;
+
+	const owned: string[] = [];
+	let aggregateBytes = 0;
+	for (let index = 0; index < rawLength; index++) {
+		const key = String(index);
+		let descriptor: PropertyDescriptor | undefined;
+		try {
+			descriptor = Object.getOwnPropertyDescriptor(argv, key);
+		} catch {
+			return undefined;
+		}
+		if (descriptor === undefined || !("value" in descriptor)) return undefined;
+		const arg: unknown = descriptor.value;
+		if (typeof arg !== "string" || arg.length === 0) return undefined;
+		if (CONTROL_RE.test(arg) || hasLoneSurrogate(arg)) return undefined;
+		let byteLength: number;
+		try {
+			byteLength = new TextEncoder().encode(arg).byteLength;
+		} catch {
+			return undefined;
+		}
+		if (byteLength < MIN_ARG_BYTES || byteLength > MAX_ARG_BYTES) return undefined;
+		aggregateBytes += byteLength;
+		if (aggregateBytes > MAX_AGGREGATE_BYTES) return undefined;
+		owned.push(arg);
+	}
+	for (const key of keys) {
+		if (key === "length") continue;
+		if (typeof key !== "string") return undefined;
+		const index = Number(key);
+		if (!Number.isSafeInteger(index) || index < 0 || index >= rawLength || String(index) !== key) {
+			return undefined;
+		}
+	}
+	return owned;
+}
+
+// ---------------------------------------------------------------------------
+// Erasure
+// ---------------------------------------------------------------------------
+
+function eraseAndVerify(buf: Uint8Array): void {
+	buf.fill(0);
+	for (let i = 0; i < buf.byteLength; i++) {
+		if (buf[i] !== 0) buf[i] = 0;
+	}
+}
+
+function clearChunks(sink: Uint8Array[]): void {
+	for (const c of sink) eraseAndVerify(c);
+	sink.length = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Merge (wrapped so calling code never throws)
+// ---------------------------------------------------------------------------
+
+function mergeChunks(chunks: Uint8Array[]): Uint8Array | undefined {
+	try {
+		if (chunks.length === 0) return new Uint8Array(0);
+		let total = 0;
+		for (let i = 0; i < chunks.length; i++) {
+			let c: Uint8Array;
+			try {
+				c = chunks[i];
+			} catch {
+				return undefined;
+			}
+			if (!(c instanceof Uint8Array)) return undefined;
+			let bl: number;
+			try {
+				bl = c.byteLength;
+			} catch {
+				return undefined;
+			}
+			total += bl;
+		}
+		const m = new Uint8Array(total);
+		let off = 0;
+		for (let i = 0; i < chunks.length; i++) {
+			let c: Uint8Array;
+			try {
+				c = chunks[i];
+			} catch {
+				eraseAndVerify(m);
+				return undefined;
+			}
+			if (!(c instanceof Uint8Array)) {
+				eraseAndVerify(m);
+				return undefined;
+			}
+			try {
+				m.set(c, off);
+				off += c.byteLength;
+			} catch {
+				eraseAndVerify(m);
+				return undefined;
+			}
+		}
+		return m;
+	} catch {
+		return undefined;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Cancel-signal factory (promise-based, no AbortSignal)
+// ---------------------------------------------------------------------------
+
+interface CancelHandle {
+	readonly promise: Promise<"CANCEL">;
+	cancel(): void;
+}
+
+function createCancelHandle(): CancelHandle {
+	let resolve: (value: "CANCEL") => void = () => {};
+	const promise = new Promise<"CANCEL">((r) => {
+		resolve = r;
+	});
+	return {
+		promise,
+		cancel() {
+			resolve("CANCEL");
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Bounded settlement
+// ---------------------------------------------------------------------------
+
+function boundedSettle<T>(prom: Promise<T>, deadlineMs: number): Promise<"SETTLED" | "DEADLINE"> {
+	let tid: ReturnType<typeof setTimeout>;
+	const result = new Promise<"SETTLED" | "DEADLINE">((resolve) => {
+		tid = setTimeout(() => resolve("DEADLINE"), deadlineMs);
+		prom.then(
+			() => {
+				clearTimeout(tid);
+				resolve("SETTLED");
+			},
+			() => {
+				clearTimeout(tid);
+				resolve("SETTLED");
+			},
+		);
+	});
+	return result;
+}
+
+// ---------------------------------------------------------------------------
+// Safe thenable attach — one helper, no casts, Reflect-based
+
+function safeExitThenAttach(value: unknown, onReject: () => void): Promise<number> | undefined {
+	if (value === null || value === undefined) return undefined;
+	if (typeof value !== "object" && typeof value !== "function") return undefined;
+	const target: object = value;
+
+	let thenFn: unknown;
+	try {
+		thenFn = Reflect.get(target, "then");
+	} catch {
+		return undefined;
+	}
+	if (typeof thenFn !== "function") return undefined;
+
+	let once = false;
+
+	const result = new Promise<number>((resolve) => {
+		try {
+			Reflect.apply(thenFn, target, [
+				(code: unknown) => {
+					if (once) return;
+					once = true;
+					if (typeof code === "number" && Number.isSafeInteger(code) && code >= 0) {
+						resolve(code);
+					} else {
+						onReject();
+						resolve(-1);
+					}
+				},
+				() => {
+					if (once) return;
+					once = true;
+					onReject();
+					resolve(-1);
+				},
+			]);
+		} catch {
+			if (once) return;
+			once = true;
+			onReject();
+			resolve(-1);
+		}
+	});
+	result.catch(() => {});
+	return result;
+}
+
+function captureGetReader(value: unknown): (() => unknown) | undefined {
+	if (value === null || value === undefined) return undefined;
+	if (typeof value !== "object" && typeof value !== "function") return undefined;
+	const target: object = value;
+	let getReader: unknown;
+	try {
+		getReader = Reflect.get(target, "getReader");
+	} catch {
+		return undefined;
+	}
+	if (typeof getReader !== "function") return undefined;
+	return (): unknown => Reflect.apply(getReader, target, []);
+}
+
+function isExactPlainDataObject(target: object, expectedKeys: readonly string[]): boolean {
+	try {
+		const prototype: unknown = Object.getPrototypeOf(target);
+		if (prototype !== Object.prototype && prototype !== null) return false;
+		const keys = Reflect.ownKeys(target);
+		if (keys.length !== expectedKeys.length) return false;
+		for (const expected of expectedKeys) {
+			if (!keys.includes(expected)) return false;
+			const descriptor = Object.getOwnPropertyDescriptor(target, expected);
+			if (descriptor === undefined || !("value" in descriptor)) return false;
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createPrimeCliCommandRunner(spawn?: SpawnFn, cleanupTimeoutMs?: number): CliCommandRunner {
+	const spawnIsValid = spawn === undefined || typeof spawn === "function";
+	const cleanupIsValid =
+		cleanupTimeoutMs === undefined ||
+		(typeof cleanupTimeoutMs === "number" &&
+			Number.isFinite(cleanupTimeoutMs) &&
+			Number.isSafeInteger(cleanupTimeoutMs) &&
+			cleanupTimeoutMs > 0 &&
+			cleanupTimeoutMs <= MAX_TIMEOUT_MS);
+	const doSpawn: SpawnFn = spawnIsValid && spawn !== undefined ? spawn : defaultSpawn;
+	const cleanupMs = cleanupIsValid && cleanupTimeoutMs !== undefined ? cleanupTimeoutMs : DEFAULT_CLEANUP_MS;
+
+	return Object.freeze({
+		async runCommand(argv: readonly string[], timeoutMs: number, signal?: AbortSignal) {
+			if (!spawnIsValid || !cleanupIsValid) {
+				return Object.freeze({ ok: false, code: "INPUT_INVALID" });
+			}
+			const ownedArgs = copyValidatedInputs(argv, timeoutMs);
+			if (ownedArgs === undefined) {
+				return Object.freeze({ ok: false, code: "INPUT_INVALID" });
+			}
+
+			// ---- shared cancellation machinery ----
+			let primaryCode: FailureCode | null = null;
+			let killed = false;
+			let cancelRunReady = false;
+			let callerAborted = false;
+
+			function trySetPrimary(code: FailureCode): boolean {
+				if (primaryCode !== null) return false;
+				primaryCode = code;
+				return true;
+			}
+
+			// cancelRun — function declaration hoists
+			function cancelRun(code: FailureCode): void {
+				if (!trySetPrimary(code)) return;
+				cancelNotify();
+				tryKillDirect();
+			}
+
+			const cancelHandle = createCancelHandle();
+			const cancelNotify = cancelHandle.cancel;
+
+			// ---- pre-abort check (before doSpawn, rechecked after listener wiring) ----
+			function onAbort(): void {
+				callerAborted = true;
+				if (cancelRunReady) {
+					cancelRun("ABORTED");
+				}
+			}
+
+			if (signal !== undefined) {
+				let isAbortSignal = false;
+				try {
+					isAbortSignal = signal instanceof AbortSignal;
+				} catch {
+					return Object.freeze({ ok: false, code: "INPUT_INVALID" });
+				}
+				if (!isAbortSignal) return Object.freeze({ ok: false, code: "INPUT_INVALID" });
+				const initialAbortState = readAbortState(signal);
+				if (initialAbortState === undefined) {
+					return Object.freeze({ ok: false, code: "INPUT_INVALID" });
+				}
+				if (initialAbortState) {
+					return Object.freeze({ ok: false, code: "ABORTED" });
+				}
+				if (!addAbortListener(signal, onAbort)) {
+					return Object.freeze({ ok: false, code: "INPUT_INVALID" });
+				}
+				const wiredAbortState = readAbortState(signal);
+				if (wiredAbortState === undefined) {
+					removeAbortListener(signal, onAbort);
+					return Object.freeze({ ok: false, code: "INPUT_INVALID" });
+				}
+				if (wiredAbortState) callerAborted = true;
+			}
+			if (callerAborted) {
+				removeAbortListener(signal, onAbort);
+				return Object.freeze({ ok: false, code: "ABORTED" });
+			}
+
+			// ---- spawn ----
+			let startTime: number;
+			try {
+				startTime = performance.now();
+			} catch {
+				removeAbortListener(signal, onAbort);
+				return Object.freeze({ ok: false, code: "PROCESS_UNCERTAIN" });
+			}
+			if (!Number.isFinite(startTime)) {
+				removeAbortListener(signal, onAbort);
+				return Object.freeze({ ok: false, code: "PROCESS_UNCERTAIN" });
+			}
+			let spawnedValue: unknown;
+			try {
+				spawnedValue = doSpawn(ownedArgs);
+			} catch {
+				removeAbortListener(signal, onAbort);
+				return Object.freeze({ ok: false, code: "SPAWN_FAILED" });
+			}
+			if (spawnedValue === null || (typeof spawnedValue !== "object" && typeof spawnedValue !== "function")) {
+				removeAbortListener(signal, onAbort);
+				return Object.freeze({ ok: false, code: "PROCESS_UNCERTAIN" });
+			}
+			const procTarget: object = spawnedValue;
+
+			// -----------------------------------------------------------------
+			// Step 1: capture kill → validate function → wire tryKillDirect → cancelRunReady
+			// -----------------------------------------------------------------
+
+			let procKill: unknown;
+			try {
+				procKill = Reflect.get(procTarget, "kill");
+			} catch {
+				cancelNotify();
+				removeAbortListener(signal, onAbort);
+				return Object.freeze({ ok: false, code: "PROCESS_UNCERTAIN" });
+			}
+
+			if (typeof procKill !== "function") {
+				cancelNotify();
+				removeAbortListener(signal, onAbort);
+				return Object.freeze({ ok: false, code: "PROCESS_UNCERTAIN" });
+			}
+
+			const procKillFn: () => void = () => {
+				Reflect.apply(procKill, procTarget, []);
+			};
+
+			function tryKillDirect(): void {
+				if (killed) return;
+				killed = true;
+				try {
+					procKillFn();
+				} catch {
+					// kill threw — bounded cleanup will handle
+				}
+			}
+
+			cancelRunReady = true;
+
+			// ---- recheck after listener wiring (closes pre-abort race) ----
+			if (callerAborted) {
+				cancelRun("ABORTED");
+			}
+
+			// -----------------------------------------------------------------
+			// Step 2: capture exit → capture then once via Reflect →
+			//         attach observed exitPromise BEFORE stream getters
+			// -----------------------------------------------------------------
+
+			let procExitedRaw: unknown;
+			try {
+				procExitedRaw = Reflect.get(procTarget, "exited");
+			} catch {
+				tryKillDirect();
+				cancelNotify();
+				removeAbortListener(signal, onAbort);
+				return Object.freeze({ ok: false, code: "PROCESS_UNCERTAIN" });
+			}
+
+			// Attach exit promise IMMEDIATELY (before stream getters).
+			// Use the captured raw promise with one Reflect.get then call.
+			let exitPromise: Promise<number>;
+			const exitAttached = safeExitThenAttach(procExitedRaw, () => {
+				cancelRun("PROCESS_UNCERTAIN");
+			});
+			if (exitAttached === undefined) {
+				tryKillDirect();
+				cancelNotify();
+				removeAbortListener(signal, onAbort);
+				return Object.freeze({ ok: false, code: "PROCESS_UNCERTAIN" });
+			}
+			exitPromise = exitAttached;
+
+			if (!isExactPlainDataObject(procTarget, ["stdout", "stderr", "exited", "kill"])) {
+				tryKillDirect();
+				await boundedSettle(exitPromise, cleanupMs);
+				cancelNotify();
+				removeAbortListener(signal, onAbort);
+				return Object.freeze({ ok: false, code: "PROCESS_UNCERTAIN" });
+			}
+
+			// -----------------------------------------------------------------
+			// Step 3: capture stdout/stderr/getReader → validate getReader
+			//         (uses already-observed exitPromise for bounded settle)
+			// -----------------------------------------------------------------
+
+			let stdoutValue: unknown;
+			let stderrValue: unknown;
+			try {
+				stdoutValue = Reflect.get(procTarget, "stdout");
+				stderrValue = Reflect.get(procTarget, "stderr");
+			} catch {
+				tryKillDirect();
+				const settled = await boundedSettle(exitPromise, cleanupMs);
+				cancelNotify();
+				removeAbortListener(signal, onAbort);
+				return Object.freeze({
+					ok: false,
+					code: settled === "DEADLINE" ? "PROCESS_UNCERTAIN" : "STREAM_FAILED",
+				});
+			}
+
+			const getStdoutReader = captureGetReader(stdoutValue);
+			const getStderrReader = captureGetReader(stderrValue);
+			if (getStdoutReader === undefined || getStderrReader === undefined) {
+				tryKillDirect();
+				const settled = await boundedSettle(exitPromise, cleanupMs);
+				cancelNotify();
+				removeAbortListener(signal, onAbort);
+				return Object.freeze({
+					ok: false,
+					code: settled === "DEADLINE" ? "PROCESS_UNCERTAIN" : "STREAM_FAILED",
+				});
+			}
+
+			await Promise.resolve();
+
+			// ---- start readers ----
+			const stdoutSink: Uint8Array[] = [];
+			const stderrSink: Uint8Array[] = [];
+			let mergedStdout: Uint8Array | undefined;
+			let mergedStderr: Uint8Array | undefined;
+
+			const reader1 = readStream(getStdoutReader, stdoutSink, cancelHandle, cancelRun).then(
+				() => {},
+				() => {},
+			);
+			const reader2 = readStream(getStderrReader, stderrSink, cancelHandle, cancelRun).then(
+				() => {},
+				() => {},
+			);
+
+			let setupElapsed: number;
+			try {
+				setupElapsed = performance.now() - startTime;
+			} catch {
+				setupElapsed = Number.NaN;
+			}
+			const remainingMs = timeoutMs - setupElapsed;
+			const timeoutId = setTimeout(() => cancelRun("TIMED_OUT"), Math.max(1, remainingMs));
+			if (!Number.isFinite(setupElapsed) || setupElapsed < 0) {
+				cancelRun("PROCESS_UNCERTAIN");
+			} else if (remainingMs <= 0) {
+				cancelRun("TIMED_OUT");
+			}
+
+			try {
+				const outcome = await Promise.race([
+					Promise.all([reader1, reader2]).then((): "READERS" => "READERS"),
+					cancelHandle.promise,
+				]);
+
+				if (outcome === "CANCEL") {
+					clearTimeout(timeoutId);
+					const settled = await boundedSettle(Promise.all([reader1, reader2, exitPromise]), cleanupMs);
+					if (settled === "DEADLINE") {
+						return Object.freeze({ ok: false, code: "PROCESS_UNCERTAIN" });
+					}
+					if (primaryCode === "TIMED_OUT" && callerAborted) {
+						return Object.freeze({ ok: false, code: "ABORTED" });
+					}
+					return Object.freeze({
+						ok: false,
+						code: primaryCode ?? "PROCESS_UNCERTAIN",
+					});
+				}
+
+				if (primaryCode !== null) {
+					clearTimeout(timeoutId);
+					if (!killed) tryKillDirect();
+					const settled = await boundedSettle(exitPromise, cleanupMs);
+					if (settled === "DEADLINE") {
+						return Object.freeze({ ok: false, code: "PROCESS_UNCERTAIN" });
+					}
+					if (primaryCode === "TIMED_OUT" && callerAborted) {
+						return Object.freeze({ ok: false, code: "ABORTED" });
+					}
+					return Object.freeze({ ok: false, code: primaryCode });
+				}
+
+				// ---- normal path: readers finished, wait for exit ----
+				let exitCode: number;
+				try {
+					const winner = await Promise.race([exitPromise, cancelHandle.promise]);
+					if (winner === "CANCEL") {
+						clearTimeout(timeoutId);
+						if (!killed) tryKillDirect();
+						const settled = await boundedSettle(exitPromise, cleanupMs);
+						if (settled === "DEADLINE") {
+							return Object.freeze({
+								ok: false,
+								code: "PROCESS_UNCERTAIN",
+							});
+						}
+						if (primaryCode === "TIMED_OUT" && callerAborted) {
+							return Object.freeze({ ok: false, code: "ABORTED" });
+						}
+						return Object.freeze({
+							ok: false,
+							code: primaryCode ?? "PROCESS_UNCERTAIN",
+						});
+					}
+					exitCode = winner;
+				} catch {
+					clearTimeout(timeoutId);
+					return Object.freeze({ ok: false, code: "PROCESS_UNCERTAIN" });
+				}
+				clearTimeout(timeoutId);
+
+				if (!(Number.isSafeInteger(exitCode) && exitCode >= 0)) {
+					return Object.freeze({ ok: false, code: "PROCESS_UNCERTAIN" });
+				}
+
+				mergedStdout = mergeChunks(stdoutSink);
+				if (mergedStdout === undefined) {
+					return Object.freeze({ ok: false, code: "STREAM_FAILED" });
+				}
+				let stdoutStr: string;
+				try {
+					stdoutStr = new TextDecoder("utf-8", { fatal: true }).decode(mergedStdout);
+				} catch {
+					return Object.freeze({ ok: false, code: "STREAM_FAILED" });
+				}
+
+				mergedStderr = mergeChunks(stderrSink);
+				if (mergedStderr === undefined) {
+					return Object.freeze({ ok: false, code: "STREAM_FAILED" });
+				}
+				let stderrStr: string;
+				try {
+					stderrStr = new TextDecoder("utf-8", { fatal: true }).decode(mergedStderr);
+				} catch {
+					return Object.freeze({ ok: false, code: "STREAM_FAILED" });
+				}
+
+				const rawDuration = performance.now() - startTime;
+				if (!(Number.isFinite(rawDuration) && Number.isSafeInteger(Math.round(rawDuration)) && rawDuration >= 0)) {
+					return Object.freeze({ ok: false, code: "PROCESS_UNCERTAIN" });
+				}
+				const safeDurationMs = Math.round(rawDuration);
+
+				return Object.freeze({
+					ok: true,
+					value: Object.freeze({
+						stdout: stdoutStr,
+						stderr: stderrStr,
+						exitCode,
+						durationMs: safeDurationMs,
+					}),
+				});
+			} finally {
+				clearTimeout(timeoutId);
+				removeAbortListener(signal, onAbort);
+				cancelNotify();
+				clearChunks(stdoutSink);
+				clearChunks(stderrSink);
+				if (mergedStdout !== undefined) eraseAndVerify(mergedStdout);
+				if (mergedStderr !== undefined) eraseAndVerify(mergedStderr);
+			}
+		},
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Stream reader with guarded cancel (Reflect-based, no casts)
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Safe observe — wrap a potentially hostile value in an observed settlement
+// promise that never throws and never lets hostile getters escape
+// ---------------------------------------------------------------------------
+
+function neverSettles(): Promise<void> {
+	return new Promise<void>(() => {});
+}
+
+function safeObservePromise(raw: unknown): Promise<void> {
+	if (raw === null || raw === undefined) return neverSettles();
+	if (typeof raw !== "object" && typeof raw !== "function") return neverSettles();
+	const target: object = raw;
+	let thenFn: unknown;
+	try {
+		thenFn = Reflect.get(target, "then");
+	} catch {
+		return neverSettles();
+	}
+	if (typeof thenFn !== "function") return neverSettles();
+	return new Promise<void>((resolve) => {
+		let settled = false;
+		const settle = (): void => {
+			if (settled) return;
+			settled = true;
+			resolve();
+		};
+		try {
+			Reflect.apply(thenFn, target, [settle, settle]);
+		} catch {
+			if (!settled) return;
+		}
+	});
+}
+
+interface CapturedReader {
+	read(): unknown;
+	cancel(): unknown;
+	release(): void;
+}
+
+function captureReader(getReader: () => unknown): CapturedReader | undefined {
+	let rawReader: unknown;
+	try {
+		rawReader = getReader();
+	} catch {
+		return undefined;
+	}
+	if (rawReader === null || rawReader === undefined) return undefined;
+	if (typeof rawReader !== "object" && typeof rawReader !== "function") return undefined;
+	const target: object = rawReader;
+	let readMethod: unknown;
+	let cancelMethod: unknown;
+	let releaseMethod: unknown;
+	try {
+		readMethod = Reflect.get(target, "read");
+		cancelMethod = Reflect.get(target, "cancel");
+		releaseMethod = Reflect.get(target, "releaseLock");
+	} catch {
+		return undefined;
+	}
+	if (typeof readMethod !== "function" || typeof cancelMethod !== "function") return undefined;
+	if (typeof releaseMethod !== "function") return undefined;
+	return Object.freeze({
+		read: (): unknown => Reflect.apply(readMethod, target, []),
+		cancel: (): unknown => Reflect.apply(cancelMethod, target, []),
+		release: (): void => {
+			Reflect.apply(releaseMethod, target, []);
+		},
+	});
+}
+
+function guardedCancel(cancelReader: () => unknown): Promise<void> {
+	let rawResult: unknown;
+	try {
+		rawResult = cancelReader();
+	} catch {
+		return Promise.resolve();
+	}
+	if (rawResult === null || rawResult === undefined) return Promise.resolve();
+	if (typeof rawResult !== "object" && typeof rawResult !== "function") return Promise.resolve();
+	return safeObservePromise(rawResult);
+}
+
+interface DecodedReadResult {
+	readonly done: boolean;
+	readonly value: unknown;
+}
+
+function decodeReadResult(raw: unknown): DecodedReadResult | undefined {
+	if (raw === null || typeof raw !== "object") return undefined;
+	if (!isExactPlainDataObject(raw, ["value", "done"])) return undefined;
+	const doneDescriptor = Object.getOwnPropertyDescriptor(raw, "done");
+	const valueDescriptor = Object.getOwnPropertyDescriptor(raw, "value");
+	if (doneDescriptor === undefined || valueDescriptor === undefined) return undefined;
+	if (!("value" in doneDescriptor) || !("value" in valueDescriptor)) return undefined;
+	const done: unknown = doneDescriptor.value;
+	if (typeof done !== "boolean") return undefined;
+	const value: unknown = valueDescriptor.value;
+	return Object.freeze({ done, value });
+}
+
+async function readStream(
+	getReader: () => unknown,
+	chunks: Uint8Array[],
+	cancelHandle: CancelHandle,
+	cancelRun: (code: FailureCode) => void,
+): Promise<void> {
+	let total = 0;
+	const reader = captureReader(getReader);
+	if (reader === undefined) {
+		cancelRun("STREAM_FAILED");
+		return;
+	}
+
+	try {
+		while (true) {
+			let pendingRead: unknown;
+			try {
+				pendingRead = reader.read();
+			} catch {
+				cancelRun("STREAM_FAILED");
+				await guardedCancel(reader.cancel);
+				break;
+			}
+
+			let raced: unknown;
+			try {
+				raced = await Promise.race([pendingRead, cancelHandle.promise]);
+			} catch {
+				cancelRun("STREAM_FAILED");
+				await Promise.all([guardedCancel(reader.cancel), safeObservePromise(pendingRead)]);
+				break;
+			}
+			if (raced === "CANCEL") {
+				await Promise.all([guardedCancel(reader.cancel), safeObservePromise(pendingRead)]);
+				break;
+			}
+			const readResult = decodeReadResult(raced);
+			if (readResult === undefined) {
+				cancelRun("STREAM_FAILED");
+				await guardedCancel(reader.cancel);
+				break;
+			}
+			if (readResult.done) break;
+
+			const value = readResult.value;
+			if (!(value instanceof Uint8Array)) {
+				cancelRun("STREAM_FAILED");
+				await guardedCancel(reader.cancel);
+				break;
+			}
+			let valueLength: number;
+			try {
+				valueLength = value.byteLength;
+			} catch {
+				cancelRun("STREAM_FAILED");
+				await guardedCancel(reader.cancel);
+				break;
+			}
+			const nextTotal = total + valueLength;
+			if (!Number.isSafeInteger(nextTotal) || nextTotal > MAX_OUTPUT_BYTES) {
+				cancelRun("OUTPUT_OVERFLOW");
+				await guardedCancel(reader.cancel);
+				break;
+			}
+
+			const owned = new Uint8Array(valueLength);
+			try {
+				owned.set(value);
+			} catch {
+				eraseAndVerify(owned);
+				cancelRun("STREAM_FAILED");
+				await guardedCancel(reader.cancel);
+				break;
+			}
+			chunks.push(owned);
+			total = nextTotal;
+		}
+	} catch {
+		cancelRun("STREAM_FAILED");
+		await guardedCancel(reader.cancel);
+	} finally {
+		try {
+			reader.release();
+		} catch {
+			// The process outcome remains uncertain only when pending work fails to settle.
+		}
+	}
+}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -89,7 +89,11 @@ import {
 } from "../../core/cron-jobs.js";
 import { ORPHAN_PROCESS_JOURNAL_ENV } from "../../core/orphan-process-journal.js";
 import { PromptAdmissionCancelledError, waitForPromptAdmission } from "../../core/prompt-admission.js";
-import type { CreateRlmSubagentRuntimeOptions, SubagentRuntimeHost } from "../../core/rlm-runtime.js";
+import {
+	type CreateRlmSubagentRuntimeOptions,
+	RLM_SANDBOX_UNAVAILABLE_MESSAGE,
+	type SubagentRuntimeHost,
+} from "../../core/rlm-runtime.js";
 import {
 	canPassivateSession,
 	type IdleEvictionMinutes,
@@ -2518,6 +2522,7 @@ export class AgentDaemon {
 		parentState: ActiveSessionState,
 		options: CreateRlmSubagentRuntimeOptions,
 	): Promise<AgentSessionRuntime> {
+		if (options.sandbox === true) throw new Error(RLM_SANDBOX_UNAVAILABLE_MESSAGE);
 		const sessionManager = SessionManager.create(options.parentSession.sessionManager.getCwd(), options.sessionDir);
 		sessionManager.newSession({
 			parentSession: options.parentSession.sessionFile,

--- a/packages/coding-agent/src/modes/daemon/sandbox-ownership-journal.ts
+++ b/packages/coding-agent/src/modes/daemon/sandbox-ownership-journal.ts
@@ -1,6 +1,17 @@
+import { createHash } from "node:crypto";
 import { constants } from "node:fs";
 import { type FileHandle, lstat, mkdir, open, readdir } from "node:fs/promises";
 import process from "node:process";
+import {
+	type Clock,
+	createSandboxLifecycle,
+	type DelayFn,
+	type DeleteProof,
+	type LifecycleConfig,
+	type ProofConsumer,
+	type RunCommand,
+	type SandboxLifecycle,
+} from "./sandbox/prime-sandbox-lifecycle.js";
 import {
 	createPreAdmitOwnershipRecord,
 	decideNonDeletedOwnershipTransition,
@@ -697,4 +708,423 @@ export async function createOwnershipJournal(
 			dT(u, jP, jD, jI, sessionRoot, rD, rI, tg, i, t),
 	});
 	return Object.freeze({ ok: true, value: Object.freeze(j) });
+}
+
+// ── V4 Deletion composition types ──────────────────────────
+
+export type OwnershipDeletionCode = OwnershipJournalCode | "LIFECYCLE_FAILED" | "PROOF_INVALID";
+
+export type OwnershipDeletionResult = Readonly<{ ok: true } | { ok: false; code: OwnershipDeletionCode }>;
+
+export type OwnershipDeletionFactoryResult = Readonly<
+	| {
+			ok: true;
+			value: Readonly<{
+				lifecycle: SandboxLifecycle;
+				finalizeDeleted: (proof: DeleteProof, recordedAt: string) => Promise<OwnershipDeletionResult>;
+			}>;
+	  }
+	| { ok: false; code: OwnershipDeletionCode }
+>;
+
+// ── V4 typed result constructors (no assertions) ──────────
+
+function delOk(): OwnershipDeletionResult {
+	return Object.freeze({ ok: true });
+}
+
+function delFail(code: OwnershipDeletionCode): OwnershipDeletionResult {
+	return Object.freeze({ ok: false, code });
+}
+
+type DeletionBundle = Readonly<{
+	lifecycle: SandboxLifecycle;
+	finalizeDeleted: (proof: DeleteProof, recordedAt: string) => Promise<OwnershipDeletionResult>;
+}>;
+
+function factOk(value: DeletionBundle): OwnershipDeletionFactoryResult {
+	return Object.freeze({ ok: true, value: Object.freeze(value) });
+}
+
+function factFail(code: OwnershipDeletionCode): OwnershipDeletionFactoryResult {
+	return Object.freeze({ ok: false, code });
+}
+
+// ── V4 canonical timestamp and digest checks ──────────────
+
+const HEX_64_RE: RegExp = /^[0-9a-f]{64}$/;
+
+function validTimestampMs(v: unknown): v is string {
+	if (typeof v !== "string") return false;
+	const d = new Date(v);
+	return Number.isFinite(d.getTime()) && d.toISOString() === v;
+}
+
+function validDigest64(v: unknown): v is string {
+	return typeof v === "string" && HEX_64_RE.test(v);
+}
+
+function canonicalDeletedPrefix(
+	sequence: 6,
+	intent: OwnershipIntent,
+	recordedAt: string,
+	previousDigest: string | null,
+): string {
+	return `{"version":1,"sequence":${sequence},"stage":"deleted","lifecycleKey":${JSON.stringify(intent.lifecycleKey)},"parentSessionId":${JSON.stringify(intent.parentSessionId)},"childSessionId":${JSON.stringify(intent.childSessionId)},"recordedAt":${JSON.stringify(recordedAt)},"previousDigest":${previousDigest === null ? "null" : JSON.stringify(previousDigest)}`;
+}
+
+function digestHex(prefix: string): string | undefined {
+	const bytes = new TextEncoder().encode(prefix);
+	let digest: string;
+	try {
+		digest = createHash("sha256").update(bytes).digest("hex");
+	} catch {
+		ev(bytes);
+		return undefined;
+	}
+	if (!ev(bytes)) return undefined;
+	return digest;
+}
+
+function produceDeletedRecordBytes(
+	intent: OwnershipIntent,
+	recordedAt: string,
+	previousDigest: string | null,
+): Uint8Array | undefined {
+	if (!validTimestampMs(recordedAt)) return undefined;
+	if (previousDigest !== null && !validDigest64(previousDigest)) return undefined;
+	const prefix = canonicalDeletedPrefix(6, intent, recordedAt, previousDigest);
+	const cd = digestHex(prefix);
+	if (cd === undefined) return undefined;
+	const full = new TextEncoder().encode(`${prefix},"contentDigest":${JSON.stringify(cd)}}`);
+	if (full.byteLength > MAX_SZ) {
+		ev(full);
+		return undefined;
+	}
+	return full;
+}
+
+function buildDeletedRecordFromBytes(bytes: Uint8Array): OwnershipRecord | undefined {
+	const dd = decodeOwnershipRecord(bytes);
+	if (!dd.ok) return undefined;
+	return dd.value;
+}
+
+function buildSixChain(existing: ValidatedOwnershipChain, deletedRecord: OwnershipRecord): readonly OwnershipRecord[] {
+	const all = [...existing.records, deletedRecord];
+	return Object.freeze(all);
+}
+
+function validateDeletedCandidateSixChain(existing: ValidatedOwnershipChain, deletedRecord: OwnershipRecord): boolean {
+	const all = buildSixChain(existing, deletedRecord);
+	const cv = validateOwnershipChain(all);
+	return cv.ok;
+}
+
+// ── V4 copyIntentViaPreAdmit (captured descriptor values) ──
+
+const FIXED_COPY_TIMESTAMP = "2026-09-04T01:02:03.004Z";
+
+function copyIntentViaPreAdmit(value: unknown): OwnershipIntent | undefined {
+	if (typeof value !== "object" || value === null) return undefined;
+	try {
+		const proto = Object.getPrototypeOf(value);
+		if (proto !== Object.prototype) return undefined;
+
+		const ownKeys: readonly (string | symbol)[] = Reflect.ownKeys(value);
+		if (ownKeys.length !== 3) return undefined;
+		for (const k of ownKeys) {
+			if (typeof k !== "string") return undefined;
+			if (k !== "lifecycleKey" && k !== "parentSessionId" && k !== "childSessionId") return undefined;
+		}
+
+		// Capture descriptor values — no Proxy get traps
+		const lkD = Object.getOwnPropertyDescriptor(value, "lifecycleKey");
+		if (lkD === undefined || !Object.hasOwn(lkD, "value") || !lkD.enumerable) return undefined;
+		const psD = Object.getOwnPropertyDescriptor(value, "parentSessionId");
+		if (psD === undefined || !Object.hasOwn(psD, "value") || !psD.enumerable) return undefined;
+		const csD = Object.getOwnPropertyDescriptor(value, "childSessionId");
+		if (csD === undefined || !Object.hasOwn(csD, "value") || !csD.enumerable) return undefined;
+
+		const lifecycleKey: unknown = lkD.value;
+		const parentSessionId: unknown = psD.value;
+		const childSessionId: unknown = csD.value;
+
+		if (
+			typeof lifecycleKey !== "string" ||
+			typeof parentSessionId !== "string" ||
+			typeof childSessionId !== "string"
+		) {
+			return undefined;
+		}
+
+		const wrapper: OwnershipIntent = Object.freeze({
+			lifecycleKey,
+			parentSessionId,
+			childSessionId,
+		});
+		const result = createPreAdmitOwnershipRecord(wrapper, FIXED_COPY_TIMESTAMP);
+		if (!result.ok) return undefined;
+
+		const record = result.value.record;
+		const intent: OwnershipIntent = Object.freeze({
+			lifecycleKey: record.lifecycleKey,
+			parentSessionId: record.parentSessionId,
+			childSessionId: record.childSessionId,
+		});
+		if (!result.value.payload.discard()) return undefined;
+		return intent;
+	} catch {
+		return undefined;
+	}
+}
+
+// ── V4 helper predicates ──────────────────────────────────
+
+function sameBoundIntent(a: OwnershipIntent, b: OwnershipIntent): boolean {
+	return (
+		a.lifecycleKey === b.lifecycleKey &&
+		a.parentSessionId === b.parentSessionId &&
+		a.childSessionId === b.childSessionId
+	);
+}
+
+function expectDeletingSeq5(chain: ValidatedOwnershipChain, intent: OwnershipIntent): boolean {
+	const cur = chain.current;
+	if (cur.sequence !== 5) return false;
+	if (cur.stage !== "deleting") return false;
+	if (!sameBoundIntent(chain.intent, intent)) return false;
+	return true;
+}
+
+function laterTimestamp(a: string, b: string): boolean {
+	return Number.isFinite(Date.parse(a)) && Number.isFinite(Date.parse(b)) && Date.parse(a) > Date.parse(b);
+}
+
+// ── V4 Factory ─────────────────────────────────────────────
+
+/**
+ * Create an ownership journal with V4 deletion composition.
+ *
+ * Requires an existing nonempty journal with exact sequence 5 "deleting"
+ * bound to the given OwnershipIntent. Calls createSandboxLifecycle only
+ * after ownership recovery validates the chain. Returns the lifecycle and
+ * a narrow finalizeDeleted closure.
+ */
+export async function createOwnershipJournalWithDeletion(
+	sessionRoot: string,
+	boundIntent: OwnershipIntent,
+	runCommand: RunCommand,
+	config: LifecycleConfig,
+	clock?: Clock,
+	delay?: DelayFn,
+): Promise<OwnershipDeletionFactoryResult> {
+	if (!isValidPath(sessionRoot)) return factFail("INPUT_INVALID");
+
+	const intent = copyIntentViaPreAdmit(boundIntent);
+	if (intent === undefined) return factFail("INPUT_INVALID");
+
+	const u = process.getuid?.();
+	if (u === undefined || typeof u !== "number" || !Number.isFinite(u) || u < 0) return factFail("DIRECTORY_UNSAFE");
+
+	let rs: Awaited<ReturnType<typeof lstat>>;
+	try {
+		rs = await lstat(sessionRoot);
+	} catch {
+		return factFail("DIRECTORY_UNSAFE");
+	}
+	if (rs.isSymbolicLink() || !rs.isDirectory()) return factFail("DIRECTORY_UNSAFE");
+	if (rs.uid !== u || (rs.mode & 0o7777) !== D_MODE) return factFail("DIRECTORY_UNSAFE");
+	const rD = rs.dev,
+		rI = rs.ino;
+
+	const ro = await oD(u, sessionRoot, rD, rI);
+	if (!ro.ok) return factFail("DIRECTORY_UNSAFE");
+	const rc = await cl(ro.fd);
+	if (rc !== "ok") return factFail("IO_UNCERTAIN");
+
+	const jP = `${sessionRoot}/${J_DIR}`;
+
+	let jDirStat: Awaited<ReturnType<typeof lstat>>;
+	try {
+		jDirStat = await lstat(jP);
+	} catch {
+		return factFail("DIRECTORY_UNSAFE");
+	}
+	if (jDirStat.isSymbolicLink() || !jDirStat.isDirectory()) return factFail("DIRECTORY_UNSAFE");
+	if (jDirStat.uid !== u || (jDirStat.mode & 0o7777) !== D_MODE) return factFail("DIRECTORY_UNSAFE");
+	const jDirDev = jDirStat.dev,
+		jDirIno = jDirStat.ino;
+
+	const jo = await oD(u, jP, jDirDev, jDirIno);
+	if (!jo.ok) return factFail(jo.code);
+	const jc = await cl(jo.fd);
+	if (jc !== "ok") return factFail("IO_UNCERTAIN");
+
+	const ss = await sD(u, sessionRoot, rD, rI);
+	if (ss !== "ok") return factFail(ss.code);
+
+	// Recover existing journal — must be nonempty and at seq5 deleting
+	const preRecovered = await rC(u, jP, jDirDev, jDirIno, false);
+	if (!preRecovered.ok) return factFail(preRecovered.code);
+
+	if (!expectDeletingSeq5(preRecovered.chain, intent)) return factFail("CORRUPT");
+
+	// Only now call createSandboxLifecycle
+	const lifecycleResult = await createSandboxLifecycle(runCommand, config, clock, delay);
+	if (!lifecycleResult.ok) return factFail("LIFECYCLE_FAILED");
+
+	const bundle = lifecycleResult.value;
+	const lifecycle: SandboxLifecycle = bundle.lifecycle;
+	const proofConsumer: ProofConsumer = bundle.proofConsumer;
+
+	// Closure-private V4 state
+	const retryState = new WeakMap<DeleteProof, OwnershipRecord>();
+	const completed = new WeakSet<DeleteProof>();
+
+	const finalizeDeleted = async (proof: DeleteProof, recordedAt: string): Promise<OwnershipDeletionResult> => {
+		try {
+			if (completed.has(proof)) return delFail("PROOF_INVALID");
+
+			const expected = retryState.get(proof);
+			const isRetry = expected !== undefined;
+
+			// Recover chain (always first)
+			const chainResult = await rC(u, jP, jDirDev, jDirIno, false);
+			if (!chainResult.ok) return delFail(chainResult.code);
+			const chain = chainResult.chain;
+
+			if (isRetry) {
+				// ── Retry path ──────────────────────────────────────
+
+				// Accept exact full seq6 match before requiring seq5
+				if (chain.records.length === 6) {
+					const last = chain.records[5];
+					if (
+						last.sequence === 6 &&
+						last.stage === "deleted" &&
+						recEq(last, expected) &&
+						sameBoundIntent(chain.intent, intent)
+					) {
+						retryState.delete(proof);
+						completed.add(proof);
+						return delOk();
+					}
+					return delFail("CORRUPT");
+				}
+
+				// Still on seq5 — validate and re-publish
+				if (!expectDeletingSeq5(chain, intent)) return delFail("CORRUPT");
+
+				// A retry is authority for exactly the stored candidate, including its timestamp.
+				if (recordedAt !== expected.recordedAt) return delFail("INPUT_INVALID");
+				const storedRecordedAt: string = expected.recordedAt;
+				const storedPreviousDigest: string | null = expected.previousDigest;
+
+				// Regenerate canonical bytes from stored record
+				const regenBytes = produceDeletedRecordBytes(intent, storedRecordedAt, storedPreviousDigest);
+				if (regenBytes === undefined) return delFail("CORRUPT");
+
+				const pubBytes = new Uint8Array(regenBytes);
+				try {
+					const redecoded = buildDeletedRecordFromBytes(new Uint8Array(regenBytes));
+					if (redecoded === undefined || !recEq(redecoded, expected)) return delFail("CORRUPT");
+
+					const pub = await pRec(u, rp(jP, 6), pubBytes, redecoded, jP, jDirDev, jDirIno, sessionRoot, rD, rI);
+					if (!pub.ok) return delFail(pub.code);
+
+					// Post-publish verification
+					const pp = await rC(u, jP, jDirDev, jDirIno, false);
+					if (!pp.ok || pp.chain.records.length !== 6) return delFail("IO_UNCERTAIN");
+					const pl = pp.chain.records[5];
+					if (
+						pl.sequence !== 6 ||
+						pl.stage !== "deleted" ||
+						!recEq(pl, redecoded) ||
+						!sameBoundIntent(pp.chain.intent, intent)
+					)
+						return delFail("IO_UNCERTAIN");
+
+					retryState.delete(proof);
+					completed.add(proof);
+					return delOk();
+				} finally {
+					ev(pubBytes);
+					ev(regenBytes);
+				}
+			}
+
+			// ── First attempt path ────────────────────────────────
+
+			if (!validTimestampMs(recordedAt)) return delFail("INPUT_INVALID");
+
+			if (!expectDeletingSeq5(chain, intent)) return delFail("CORRUPT");
+
+			if (!laterTimestamp(recordedAt, chain.current.recordedAt)) return delFail("INPUT_INVALID");
+
+			// Build candidate sequence-6 record privately
+			const seq5Digest = chain.current.contentDigest;
+			const candidateBytes = produceDeletedRecordBytes(intent, recordedAt, seq5Digest);
+			if (candidateBytes === undefined) return delFail("INPUT_INVALID");
+
+			let candidateRec: OwnershipRecord | undefined;
+			let pubBytes: Uint8Array | undefined;
+			try {
+				const decodeBytes = new Uint8Array(candidateBytes);
+				candidateRec = buildDeletedRecordFromBytes(decodeBytes);
+				if (!ev(decodeBytes)) return delFail("IO_UNCERTAIN");
+				if (candidateRec === undefined) return delFail("CORRUPT");
+
+				// Validate candidate six-chain BEFORE consuming proof
+				if (!validateDeletedCandidateSixChain(chain, candidateRec)) return delFail("CORRUPT");
+
+				// Consume genuine proof BEFORE setting retry auth
+				const consumeResult = proofConsumer.consumeProof(proof);
+				if (!consumeResult.ok) return delFail("PROOF_INVALID");
+
+				// Set retry authorization synchronously AFTER successful proof consumption
+				retryState.set(proof, candidateRec);
+
+				// Publish with O_EXCL in caught try — auth already set
+				pubBytes = new Uint8Array(candidateBytes);
+				try {
+					const pub = await pRec(u, rp(jP, 6), pubBytes, candidateRec, jP, jDirDev, jDirIno, sessionRoot, rD, rI);
+					if (!pub.ok) {
+						// IO_UNCERTAIN — retryState retains authorization
+						return delFail(pub.code);
+					}
+
+					// Post-publish recovery and exact equality check
+					const pp = await rC(u, jP, jDirDev, jDirIno, false);
+					if (!pp.ok || pp.chain.records.length !== 6) return delFail("IO_UNCERTAIN");
+					const pl = pp.chain.records[5];
+					if (
+						pl.sequence !== 6 ||
+						pl.stage !== "deleted" ||
+						!recEq(pl, candidateRec) ||
+						!sameBoundIntent(pp.chain.intent, intent)
+					)
+						return delFail("IO_UNCERTAIN");
+
+					// Success — clear retry auth
+					retryState.delete(proof);
+					completed.add(proof);
+					return delOk();
+				} finally {
+					ev(pubBytes);
+				}
+			} finally {
+				ev(candidateBytes);
+			}
+		} catch {
+			// Never propagate exception
+			return delFail("IO_UNCERTAIN");
+		}
+	};
+
+	const value: DeletionBundle = Object.freeze({
+		lifecycle,
+		finalizeDeleted,
+	});
+	return factOk(value);
 }

--- a/packages/coding-agent/src/modes/daemon/sandbox-ownership-journal.ts
+++ b/packages/coding-agent/src/modes/daemon/sandbox-ownership-journal.ts
@@ -1,0 +1,700 @@
+import { constants } from "node:fs";
+import { type FileHandle, lstat, mkdir, open, readdir } from "node:fs/promises";
+import process from "node:process";
+import {
+	createPreAdmitOwnershipRecord,
+	decideNonDeletedOwnershipTransition,
+	decodeOwnershipRecord,
+	type NonDeletedTransitionStage,
+	type OwnershipIntent,
+	type OwnershipRecord,
+	type ValidatedOwnershipChain,
+	validateOwnershipChain,
+} from "./sandbox-ownership-record.js";
+
+// ── Constants ──────────────────────────────────────────────
+
+const J_DIR = ".sandbox-ownership";
+const MAX_REC = 6;
+const REC_RE = /^000[1-6]\.ownership-v1$/;
+const D_MODE = 0o700;
+const F_MODE = 0o600;
+const MAX_SZ = 4096;
+const MAX_ROOT_BYTES = 4096;
+
+// ── Public types ───────────────────────────────────────────
+
+export type OwnershipJournalCode =
+	| "INPUT_INVALID"
+	| "CONFLICT"
+	| "DIRECTORY_UNSAFE"
+	| "CORRUPT"
+	| "IO_UNCERTAIN"
+	| "INVALID_TRANSITION";
+
+export type JournalResult = Readonly<
+	{ ok: true; value: Readonly<{ chain: ValidatedOwnershipChain }> } | { ok: false; code: OwnershipJournalCode }
+>;
+
+export interface OwnershipJournal {
+	readonly admit: (intent: OwnershipIntent, recordedAt: string) => Promise<JournalResult>;
+	readonly recover: () => Promise<JournalResult>;
+	readonly transition: (
+		target: NonDeletedTransitionStage,
+		intent: OwnershipIntent,
+		recordedAt: string,
+	) => Promise<JournalResult>;
+}
+
+// ── Internal helpers ───────────────────────────────────────
+
+function fc(c: OwnershipJournalCode): { ok: false; code: OwnershipJournalCode } {
+	return Object.freeze({ ok: false, code: c });
+}
+
+function rp(d: string, s: number): string {
+	return `${d}/000${s}.ownership-v1`;
+}
+
+function ev(b: Uint8Array): boolean {
+	b.fill(0);
+	for (let i = 0; i < b.length; i++) if (b[i] !== 0) return false;
+	return true;
+}
+
+async function cl(fd: FileHandle | undefined): Promise<"ok" | { ok: false; code: OwnershipJournalCode }> {
+	if (!fd) return "ok";
+	try {
+		await fd.close();
+		return "ok";
+	} catch {
+		return fc("IO_UNCERTAIN");
+	}
+}
+
+function recEq(a: OwnershipRecord, b: OwnershipRecord): boolean {
+	return (
+		a.version === b.version &&
+		a.sequence === b.sequence &&
+		a.stage === b.stage &&
+		a.lifecycleKey === b.lifecycleKey &&
+		a.parentSessionId === b.parentSessionId &&
+		a.childSessionId === b.childSessionId &&
+		a.recordedAt === b.recordedAt &&
+		a.previousDigest === b.previousDigest &&
+		a.contentDigest === b.contentDigest
+	);
+}
+
+async function oD(
+	u: number,
+	p: string,
+	eD: number,
+	eI: number,
+): Promise<{ ok: true; fd: FileHandle } | { ok: false; code: OwnershipJournalCode }> {
+	let fd: FileHandle;
+	try {
+		fd = await open(p, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+	} catch {
+		return fc("DIRECTORY_UNSAFE");
+	}
+	let st: Awaited<ReturnType<FileHandle["stat"]>>;
+	try {
+		st = await fd.stat();
+	} catch {
+		const r = await cl(fd);
+		return r === "ok" ? fc("DIRECTORY_UNSAFE") : r;
+	}
+	if (st.uid !== u || !st.isDirectory() || (st.mode & 0o7777) !== D_MODE || st.dev !== eD || st.ino !== eI) {
+		const r = await cl(fd);
+		return r === "ok" ? fc("DIRECTORY_UNSAFE") : r;
+	}
+	return { ok: true, fd };
+}
+
+async function sD(
+	u: number,
+	p: string,
+	eD: number,
+	eI: number,
+): Promise<"ok" | { ok: false; code: OwnershipJournalCode }> {
+	const d = await oD(u, p, eD, eI);
+	if (!d.ok) return d;
+	try {
+		await d.fd.sync();
+	} catch {
+		const r = await cl(d.fd);
+		return r === "ok" ? fc("IO_UNCERTAIN") : r;
+	}
+	let st: Awaited<ReturnType<FileHandle["stat"]>>;
+	try {
+		st = await d.fd.stat();
+	} catch {
+		const r = await cl(d.fd);
+		return r === "ok" ? fc("DIRECTORY_UNSAFE") : r;
+	}
+	if (st.uid !== u || !st.isDirectory() || (st.mode & 0o7777) !== D_MODE || st.dev !== eD || st.ino !== eI) {
+		const r = await cl(d.fd);
+		return r === "ok" ? fc("DIRECTORY_UNSAFE") : r;
+	}
+	return cl(d.fd);
+}
+
+async function rRec(
+	u: number,
+	p: string,
+): Promise<{ ok: true; record: OwnershipRecord } | { ok: false; code: OwnershipJournalCode }> {
+	let ls: Awaited<ReturnType<typeof lstat>>;
+	try {
+		ls = await lstat(p);
+	} catch {
+		return fc("CORRUPT");
+	}
+	if (ls.isSymbolicLink() || !ls.isFile()) return fc("CORRUPT");
+	if (ls.uid !== u) return fc("CORRUPT");
+	if ((ls.mode & 0o7777) !== F_MODE) return fc("CORRUPT");
+	if (ls.nlink !== 1) return fc("CORRUPT");
+	if (ls.size < 1 || ls.size > MAX_SZ) return fc("CORRUPT");
+	const eD = ls.dev,
+		eI = ls.ino,
+		fS = ls.size;
+
+	let fd: FileHandle;
+	try {
+		fd = await open(p, constants.O_RDONLY | constants.O_NOFOLLOW);
+	} catch {
+		return fc("CORRUPT");
+	}
+	let os: Awaited<ReturnType<FileHandle["stat"]>>;
+	try {
+		os = await fd.stat();
+	} catch {
+		const r = await cl(fd);
+		return r === "ok" ? fc("IO_UNCERTAIN") : r;
+	}
+	if (
+		os.uid !== u ||
+		!os.isFile() ||
+		(os.mode & 0o7777) !== F_MODE ||
+		os.nlink !== 1 ||
+		os.dev !== eD ||
+		os.ino !== eI ||
+		os.size !== fS
+	) {
+		const r = await cl(fd);
+		return r === "ok" ? fc("CORRUPT") : r;
+	}
+
+	const buf = new Uint8Array(fS);
+	let pos: number = 0;
+	while (pos < fS) {
+		let rr: { bytesRead: number; buffer: Uint8Array };
+		try {
+			rr = await fd.read(buf, pos, fS - pos, pos);
+		} catch {
+			ev(buf);
+			const r = await cl(fd);
+			return r === "ok" ? fc("IO_UNCERTAIN") : r;
+		}
+		if (
+			typeof rr !== "object" ||
+			!rr ||
+			typeof rr.bytesRead !== "number" ||
+			!Number.isFinite(rr.bytesRead) ||
+			rr.bytesRead <= 0 ||
+			rr.bytesRead > fS - pos
+		) {
+			ev(buf);
+			const r = await cl(fd);
+			return r === "ok" ? fc("IO_UNCERTAIN") : r;
+		}
+		pos += rr.bytesRead;
+	}
+	const eB = new Uint8Array(1);
+	let eof: { bytesRead: number; buffer: Uint8Array };
+	try {
+		eof = await fd.read(eB, 0, 1, fS);
+	} catch {
+		ev(buf);
+		ev(eB);
+		const r = await cl(fd);
+		return r === "ok" ? fc("IO_UNCERTAIN") : r;
+	}
+	if (typeof eof !== "object" || !eof || typeof eof.bytesRead !== "number" || eof.bytesRead !== 0) {
+		ev(buf);
+		ev(eB);
+		const r = await cl(fd);
+		return r === "ok" ? fc("CORRUPT") : r;
+	}
+	ev(eB);
+	let af: Awaited<ReturnType<FileHandle["stat"]>>;
+	try {
+		af = await fd.stat();
+	} catch {
+		ev(buf);
+		const r = await cl(fd);
+		return r === "ok" ? fc("IO_UNCERTAIN") : r;
+	}
+	if (
+		af.uid !== u ||
+		!af.isFile() ||
+		(af.mode & 0o7777) !== F_MODE ||
+		af.nlink !== 1 ||
+		af.dev !== eD ||
+		af.ino !== eI ||
+		af.size !== fS
+	) {
+		ev(buf);
+		const r = await cl(fd);
+		return r === "ok" ? fc("CORRUPT") : r;
+	}
+	const cr = await cl(fd);
+	if (cr !== "ok") {
+		ev(buf);
+		return cr;
+	}
+	const dd = decodeOwnershipRecord(buf);
+	if (!dd.ok) return fc("CORRUPT");
+	return { ok: true, record: dd.value };
+}
+
+async function pRec(
+	u: number,
+	p: string,
+	b: Uint8Array,
+	exp: OwnershipRecord,
+	jD: string,
+	jDv: number,
+	jIn: number,
+	rD: string,
+	rDv: number,
+	rIn: number,
+): Promise<{ ok: true } | { ok: false; code: OwnershipJournalCode }> {
+	let wf: FileHandle;
+	try {
+		wf = await open(p, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, F_MODE);
+	} catch {
+		ev(b);
+		return fc("IO_UNCERTAIN");
+	}
+	let cs: Awaited<ReturnType<FileHandle["stat"]>>;
+	try {
+		cs = await wf.stat();
+	} catch {
+		ev(b);
+		const r = await cl(wf);
+		return r === "ok" ? fc("IO_UNCERTAIN") : r;
+	}
+	if (cs.uid !== u || !cs.isFile() || (cs.mode & 0o7777) !== F_MODE || cs.nlink !== 1 || cs.size !== 0) {
+		ev(b);
+		const r = await cl(wf);
+		return r === "ok" ? fc("IO_UNCERTAIN") : r;
+	}
+	const cD = cs.dev,
+		cI = cs.ino;
+	let w: number = 0;
+	while (w < b.byteLength) {
+		let wr: { bytesWritten: number; buffer: Uint8Array };
+		try {
+			wr = await wf.write(b, w, b.byteLength - w, w);
+		} catch {
+			ev(b);
+			const r = await cl(wf);
+			return r === "ok" ? fc("IO_UNCERTAIN") : r;
+		}
+		if (
+			typeof wr !== "object" ||
+			!wr ||
+			typeof wr.bytesWritten !== "number" ||
+			!Number.isFinite(wr.bytesWritten) ||
+			wr.bytesWritten <= 0 ||
+			wr.bytesWritten > b.byteLength - w
+		) {
+			ev(b);
+			const r = await cl(wf);
+			return r === "ok" ? fc("IO_UNCERTAIN") : r;
+		}
+		w += wr.bytesWritten;
+	}
+	let ps: Awaited<ReturnType<FileHandle["stat"]>>;
+	try {
+		ps = await wf.stat();
+	} catch {
+		ev(b);
+		const r = await cl(wf);
+		return r === "ok" ? fc("IO_UNCERTAIN") : r;
+	}
+	if (
+		ps.uid !== u ||
+		!ps.isFile() ||
+		(ps.mode & 0o7777) !== F_MODE ||
+		ps.nlink !== 1 ||
+		ps.dev !== cD ||
+		ps.ino !== cI ||
+		ps.size !== b.byteLength
+	) {
+		ev(b);
+		const r = await cl(wf);
+		return r === "ok" ? fc("IO_UNCERTAIN") : r;
+	}
+	try {
+		await wf.sync();
+	} catch {
+		ev(b);
+		const r = await cl(wf);
+		return r === "ok" ? fc("IO_UNCERTAIN") : r;
+	}
+	try {
+		ps = await wf.stat();
+	} catch {
+		ev(b);
+		const r = await cl(wf);
+		return r === "ok" ? fc("IO_UNCERTAIN") : r;
+	}
+	if (
+		ps.uid !== u ||
+		!ps.isFile() ||
+		(ps.mode & 0o7777) !== F_MODE ||
+		ps.nlink !== 1 ||
+		ps.dev !== cD ||
+		ps.ino !== cI ||
+		ps.size !== b.byteLength
+	) {
+		ev(b);
+		const r = await cl(wf);
+		return r === "ok" ? fc("IO_UNCERTAIN") : r;
+	}
+	const wc = await cl(wf);
+	if (wc !== "ok") {
+		ev(b);
+		return wc;
+	}
+
+	const rb = await rRec(u, p);
+	if (!rb.ok) {
+		ev(b);
+		return fc("IO_UNCERTAIN");
+	}
+	if (!recEq(rb.record, exp)) {
+		ev(b);
+		return fc("IO_UNCERTAIN");
+	}
+	if (!ev(b)) return fc("IO_UNCERTAIN");
+
+	const js = await sD(u, jD, jDv, jIn);
+	if (js !== "ok") return js;
+	const rs = await sD(u, rD, rDv, rIn);
+	if (rs !== "ok") return rs;
+	return { ok: true };
+}
+
+async function rSN(
+	u: number,
+	p: string,
+	eD: number,
+	eI: number,
+): Promise<{ ok: true; names: readonly string[] } | { ok: false; code: OwnershipJournalCode }> {
+	const b = await oD(u, p, eD, eI);
+	if (!b.ok) return b;
+	const bc = await cl(b.fd);
+	if (bc !== "ok") return bc;
+	let r: string[];
+	try {
+		r = await readdir(p);
+	} catch {
+		return fc("IO_UNCERTAIN");
+	}
+	const ns = Object.freeze([...r].sort());
+	const a = await oD(u, p, eD, eI);
+	if (!a.ok) return a;
+	const ac = await cl(a.fd);
+	if (ac !== "ok") return ac;
+	return { ok: true, names: ns };
+}
+
+type InternalChainResult = { ok: true; chain: ValidatedOwnershipChain } | { ok: false; code: OwnershipJournalCode };
+type InternalEmptyResult = { ok: false; empty: true };
+
+async function rC(u: number, p: string, eD: number, eI: number, allowEmpty: false): Promise<InternalChainResult>;
+async function rC(
+	u: number,
+	p: string,
+	eD: number,
+	eI: number,
+	allowEmpty: true,
+): Promise<InternalChainResult | InternalEmptyResult>;
+async function rC(
+	u: number,
+	p: string,
+	eD: number,
+	eI: number,
+	allowEmpty: boolean,
+): Promise<InternalChainResult | InternalEmptyResult> {
+	const nr = await rSN(u, p, eD, eI);
+	if (!nr.ok) return nr;
+	const bf = nr.names;
+	if (bf.length === 0) {
+		if (allowEmpty) return Object.freeze({ ok: false, empty: true });
+		return fc("CORRUPT");
+	}
+	if (bf.length > MAX_REC) return fc("CORRUPT");
+	const sq: number[] = [];
+	for (const n of bf) {
+		if (!REC_RE.test(n)) return fc("CORRUPT");
+		sq.push(Number.parseInt(n.slice(3, 4), 10));
+	}
+	sq.sort((a, b) => a - b);
+	if (sq[0] !== 1) return fc("CORRUPT");
+	for (let i = 1; i < sq.length; i++) if (sq[i] !== sq[i - 1] + 1) return fc("CORRUPT");
+	const recs: OwnershipRecord[] = [];
+	for (const s of sq) {
+		const rr = await rRec(u, rp(p, s));
+		if (!rr.ok) return rr;
+		recs.push(rr.record);
+	}
+	const ar = await rSN(u, p, eD, eI);
+	if (!ar.ok) return ar;
+	if (ar.names.length !== bf.length) return fc("CORRUPT");
+	for (let i = 0; i < ar.names.length; i++) if (ar.names[i] !== bf[i]) return fc("CORRUPT");
+	const cv = validateOwnershipChain(recs);
+	if (!cv.ok) return fc("CORRUPT");
+	return { ok: true, chain: cv.value };
+}
+
+// ── Root validation ────────────────────────────────────────
+
+function isValidPath(s: string): boolean {
+	if (typeof s !== "string" || s.length === 0 || s[0] !== "/") return false;
+	let bytes: number = 0;
+	for (let i = 0; i < s.length; i++) {
+		const c = s.charCodeAt(i);
+		if (c <= 0x1f || c === 0x7f) return false;
+		if (c >= 0xd800 && c <= 0xdbff) {
+			if (i + 1 >= s.length || s.charCodeAt(i + 1) < 0xdc00 || s.charCodeAt(i + 1) > 0xdfff) return false;
+			bytes += 4;
+			i++;
+		} else if (c >= 0xdc00 && c <= 0xdfff) {
+			return false;
+		} else if (c <= 0x7f) {
+			bytes += 1;
+		} else if (c <= 0x7ff) {
+			bytes += 2;
+		} else {
+			bytes += 3;
+		}
+		if (bytes > MAX_ROOT_BYTES) return false;
+	}
+	return true;
+}
+
+// ── Admit (sequence 1) ─────────────────────────────────────
+
+async function dA(
+	u: number,
+	jD: string,
+	jDv: number,
+	jIn: number,
+	rD: string,
+	rDv: number,
+	rIn: number,
+	oneShot: { used: boolean },
+	intent: OwnershipIntent,
+	t: string,
+): Promise<JournalResult> {
+	const vl = createPreAdmitOwnershipRecord(intent, t);
+	if (!vl.ok) return fc("INPUT_INVALID");
+
+	const rc = await rC(u, jD, jDv, jIn, true);
+	if (rc.ok) {
+		const ch = rc.chain;
+		if (
+			ch.intent.lifecycleKey !== vl.value.record.lifecycleKey ||
+			ch.intent.parentSessionId !== vl.value.record.parentSessionId ||
+			ch.intent.childSessionId !== vl.value.record.childSessionId
+		) {
+			if (!vl.value.payload.discard()) return fc("IO_UNCERTAIN");
+			return fc("CONFLICT");
+		}
+		if (!vl.value.payload.discard()) return fc("IO_UNCERTAIN");
+		return Object.freeze({ ok: true, value: Object.freeze({ chain: ch }) });
+	}
+
+	if ("code" in rc) {
+		if (!vl.value.payload.discard()) return fc("IO_UNCERTAIN");
+		return rc;
+	}
+
+	// Empty journal — oneShot.used controls publish authority
+	if (oneShot.used) {
+		if (!vl.value.payload.discard()) return fc("IO_UNCERTAIN");
+		return fc("CORRUPT");
+	}
+	oneShot.used = true;
+
+	// Take ownership of canonical bytes
+	const owned = vl.value.payload.take();
+	if (!owned) {
+		if (!vl.value.payload.discard()) return fc("IO_UNCERTAIN");
+		return fc("IO_UNCERTAIN");
+	}
+
+	try {
+		const expRec = vl.value.record;
+		const pub = await pRec(u, rp(jD, 1), owned, expRec, jD, jDv, jIn, rD, rDv, rIn);
+		if (!pub.ok) return pub;
+
+		const po = await rC(u, jD, jDv, jIn, false);
+		if (!po.ok) return po;
+		return Object.freeze({ ok: true, value: Object.freeze({ chain: po.chain }) });
+	} finally {
+		ev(owned);
+	}
+}
+// ── Transition ─────────────────────────────────────────────
+
+async function dT(
+	u: number,
+	jD: string,
+	jDv: number,
+	jIn: number,
+	rD: string,
+	rDv: number,
+	rIn: number,
+	tg: NonDeletedTransitionStage,
+	intent: OwnershipIntent,
+	t: string,
+): Promise<JournalResult> {
+	const rc = await rC(u, jD, jDv, jIn, false);
+	if (!rc.ok) return rc;
+	const dc = decideNonDeletedOwnershipTransition(rc.chain, tg, intent, t);
+	if (!dc.ok) {
+		if (dc.code === "INPUT_INVALID") return fc("INPUT_INVALID");
+		if (dc.code === "CONFLICT") return fc("CONFLICT");
+		if (dc.code === "INVALID_TRANSITION") return fc("INVALID_TRANSITION");
+		return fc("CORRUPT");
+	}
+	if (dc.idempotent) {
+		return Object.freeze({ ok: true, value: Object.freeze({ chain: rc.chain }) });
+	}
+
+	const expRec = dc.value.record;
+	const by = dc.value.payload.take();
+	if (!by) {
+		if (!dc.value.payload.discard()) return fc("IO_UNCERTAIN");
+		return fc("IO_UNCERTAIN");
+	}
+
+	try {
+		const pub = await pRec(u, rp(jD, expRec.sequence), by, expRec, jD, jDv, jIn, rD, rDv, rIn);
+		if (!pub.ok) {
+			return pub;
+		}
+
+		const po = await rC(u, jD, jDv, jIn, false);
+		if (!po.ok) return po;
+		return Object.freeze({ ok: true, value: Object.freeze({ chain: po.chain }) });
+	} catch {
+		ev(by);
+		return fc("IO_UNCERTAIN");
+	}
+}
+
+// ── Factory ─────────────────────────────────────────────────
+
+/**
+ * Create a hostile-filesystem ownership journal store.
+ *
+ * Accepts a Home-private absolute session root. Creates
+ * `.sandbox-ownership` (0700), validates every directory identity
+ * by lstat + O_RDONLY|O_DIRECTORY|O_NOFOLLOW open + fstat,
+ * captures UID once per construction, and returns a frozen
+ * capability. No raw path or FileHandle leaves the module.
+ *
+ * Residual same-UID path-swap window: Node.js and Bun do not
+ * expose openat(2) or mkdirat(2), so every path-based operation
+ * has a window between lstat and its paired open+fstat. A same-UID
+ * attacker can rename a validated directory and replace it between
+ * the two calls. This implementation mitigates with fstat-after-open
+ * verification of every stat invariant (dev, ino, uid, mode, type,
+ * nlink), before-and-after verification for enumeration+sync, and
+ * construction-bound identity capture, but it cannot eliminate the
+ * race on any single path operation. The correct fix would be
+ * openat/mkdirat.
+ */
+export async function createOwnershipJournal(
+	sessionRoot: string,
+): Promise<{ ok: true; value: OwnershipJournal } | { ok: false; code: OwnershipJournalCode }> {
+	if (!isValidPath(sessionRoot)) return fc("INPUT_INVALID");
+
+	const u = process.getuid?.();
+	if (u === undefined || typeof u !== "number" || !Number.isFinite(u) || u < 0) return fc("DIRECTORY_UNSAFE");
+
+	let rs: Awaited<ReturnType<typeof lstat>>;
+	try {
+		rs = await lstat(sessionRoot);
+	} catch {
+		return fc("DIRECTORY_UNSAFE");
+	}
+	if (rs.isSymbolicLink() || !rs.isDirectory()) return fc("DIRECTORY_UNSAFE");
+	if (rs.uid !== u || (rs.mode & 0o7777) !== D_MODE) return fc("DIRECTORY_UNSAFE");
+	const rD = rs.dev,
+		rI = rs.ino;
+
+	const ro = await oD(u, sessionRoot, rD, rI);
+	if (!ro.ok) return ro;
+	const rc = await cl(ro.fd);
+	if (rc !== "ok") return rc;
+
+	const jP = `${sessionRoot}/${J_DIR}`;
+	let createdByUs: boolean = false;
+	try {
+		await mkdir(jP, { recursive: false, mode: D_MODE });
+		createdByUs = true;
+	} catch {
+		try {
+			const vs = await lstat(jP);
+			if (vs.isSymbolicLink() || !vs.isDirectory()) return fc("DIRECTORY_UNSAFE");
+			if (vs.uid !== u || (vs.mode & 0o7777) !== D_MODE) return fc("DIRECTORY_UNSAFE");
+		} catch {
+			return fc("DIRECTORY_UNSAFE");
+		}
+	}
+
+	let js: Awaited<ReturnType<typeof lstat>>;
+	try {
+		js = await lstat(jP);
+	} catch {
+		return fc("DIRECTORY_UNSAFE");
+	}
+	if (js.isSymbolicLink() || !js.isDirectory()) return fc("DIRECTORY_UNSAFE");
+	if (js.uid !== u || (js.mode & 0o7777) !== D_MODE) return fc("DIRECTORY_UNSAFE");
+	const jD = js.dev,
+		jI = js.ino;
+
+	const jo = await oD(u, jP, jD, jI);
+	if (!jo.ok) return jo;
+	const jc = await cl(jo.fd);
+	if (jc !== "ok") return jc;
+
+	const ss = await sD(u, sessionRoot, rD, rI);
+	if (ss !== "ok") return ss;
+
+	if (!createdByUs) {
+		const pre = await rC(u, jP, jD, jI, false);
+		if (!pre.ok) return pre;
+	}
+
+	const oneShot = { used: !createdByUs };
+
+	const j: OwnershipJournal = Object.freeze({
+		admit: (i: OwnershipIntent, t: string) => dA(u, jP, jD, jI, sessionRoot, rD, rI, oneShot, i, t),
+		recover: async () => {
+			const r = await rC(u, jP, jD, jI, false);
+			if (!r.ok) return r;
+			return Object.freeze({ ok: true, value: Object.freeze({ chain: r.chain }) });
+		},
+		transition: (tg: NonDeletedTransitionStage, i: OwnershipIntent, t: string) =>
+			dT(u, jP, jD, jI, sessionRoot, rD, rI, tg, i, t),
+	});
+	return Object.freeze({ ok: true, value: Object.freeze(j) });
+}

--- a/packages/coding-agent/src/modes/daemon/sandbox-ownership-record.ts
+++ b/packages/coding-agent/src/modes/daemon/sandbox-ownership-record.ts
@@ -1,0 +1,469 @@
+import { createHash } from "node:crypto";
+
+export const MAX_OWNERSHIP_RECORD_BYTES = 4096;
+export const MAX_OWNERSHIP_FIELD_BYTES = 256;
+
+export type OwnershipStage = "pre_admit" | "creating" | "active" | "delete_intent" | "deleting" | "deleted";
+
+export type NonDeletedTransitionStage = "creating" | "active" | "delete_intent" | "deleting";
+export type OwnershipSequence = 1 | 2 | 3 | 4 | 5 | 6;
+
+export type OwnershipIntent = Readonly<{
+	lifecycleKey: string;
+	parentSessionId: string;
+	childSessionId: string;
+}>;
+
+export type OwnershipRecord = Readonly<{
+	version: 1;
+	sequence: OwnershipSequence;
+	stage: OwnershipStage;
+	lifecycleKey: string;
+	parentSessionId: string;
+	childSessionId: string;
+	recordedAt: string;
+	previousDigest: string | null;
+	contentDigest: string;
+}>;
+
+export type OwnershipCodecFailureCode = "INPUT_INVALID" | "CORRUPT" | "CONFLICT" | "INVALID_TRANSITION";
+export type OwnershipCodecFailure = Readonly<{ ok: false; code: OwnershipCodecFailureCode }>;
+
+export type CanonicalOwnershipPayload = Readonly<{
+	byteLength: number;
+	take: () => Uint8Array | undefined;
+	discard: () => boolean;
+}>;
+
+export type OwnershipRecordCreation = Readonly<{
+	record: OwnershipRecord;
+	payload: CanonicalOwnershipPayload;
+}>;
+
+export type OwnershipCreateResult = Readonly<{ ok: true; value: OwnershipRecordCreation }> | OwnershipCodecFailure;
+
+export type OwnershipDecodeResult = Readonly<{ ok: true; value: OwnershipRecord }> | OwnershipCodecFailure;
+
+export type ValidatedOwnershipChain = Readonly<{
+	records: readonly OwnershipRecord[];
+	current: OwnershipRecord;
+	intent: OwnershipIntent;
+}>;
+
+export type OwnershipChainResult = Readonly<{ ok: true; value: ValidatedOwnershipChain }> | OwnershipCodecFailure;
+
+export type OwnershipTransitionResult =
+	| Readonly<{ ok: true; idempotent: false; value: OwnershipRecordCreation }>
+	| Readonly<{ ok: true; idempotent: true; value: OwnershipRecord }>
+	| OwnershipCodecFailure;
+
+const MISSING = Symbol("missing-own-data-property");
+type Missing = typeof MISSING;
+const ISO_MILLISECONDS = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const LOWER_HEX_DIGEST = /^[0-9a-f]{64}$/;
+const RECORD_KEYS: readonly string[] = Object.freeze([
+	"version",
+	"sequence",
+	"stage",
+	"lifecycleKey",
+	"parentSessionId",
+	"childSessionId",
+	"recordedAt",
+	"previousDigest",
+	"contentDigest",
+]);
+const validatedChains = new WeakSet<object>();
+
+function failure(code: OwnershipCodecFailureCode): OwnershipCodecFailure {
+	return Object.freeze({ ok: false, code });
+}
+
+function ownData(object: object, key: string): unknown | Missing {
+	const descriptor = Object.getOwnPropertyDescriptor(object, key);
+	if (descriptor === undefined || !Object.hasOwn(descriptor, "value")) return MISSING;
+	const value: unknown = descriptor.value;
+	return value;
+}
+
+function isOrdinaryObject(value: unknown): value is object {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		!Array.isArray(value) &&
+		Object.getPrototypeOf(value) === Object.prototype
+	);
+}
+
+function exactRecordObject(value: unknown, requireFrozen: boolean): value is object {
+	if (!isOrdinaryObject(value)) return false;
+	const keys = Object.keys(value);
+	if (keys.length !== RECORD_KEYS.length) return false;
+	for (let index = 0; index < keys.length; index++) {
+		if (keys[index] !== RECORD_KEYS[index]) return false;
+		const descriptor = Object.getOwnPropertyDescriptor(value, keys[index]);
+		if (
+			descriptor === undefined ||
+			!Object.hasOwn(descriptor, "value") ||
+			descriptor.enumerable !== true ||
+			descriptor.configurable !== !requireFrozen ||
+			descriptor.writable !== !requireFrozen
+		) {
+			return false;
+		}
+	}
+	if (Object.getOwnPropertyNames(value).length !== RECORD_KEYS.length) return false;
+	return !requireFrozen || Object.isFrozen(value);
+}
+
+function boundedIdentity(value: unknown): value is string {
+	if (typeof value !== "string" || value.length === 0) return false;
+	let bytes = 0;
+	for (let index = 0; index < value.length; index++) {
+		const unit = value.charCodeAt(index);
+		if (unit <= 0x1f || unit === 0x7f) return false;
+		if (unit <= 0x7f) {
+			bytes += 1;
+		} else if (unit <= 0x7ff) {
+			bytes += 2;
+		} else if (unit >= 0xd800 && unit <= 0xdbff) {
+			if (index + 1 >= value.length) return false;
+			const next = value.charCodeAt(index + 1);
+			if (next < 0xdc00 || next > 0xdfff) return false;
+			bytes += 4;
+			index++;
+		} else if (unit >= 0xdc00 && unit <= 0xdfff) {
+			return false;
+		} else {
+			bytes += 3;
+		}
+		if (bytes > MAX_OWNERSHIP_FIELD_BYTES) return false;
+	}
+	return true;
+}
+
+function validTimestamp(value: unknown): value is string {
+	if (typeof value !== "string" || !ISO_MILLISECONDS.test(value)) return false;
+	const parsed = new Date(value);
+	return Number.isFinite(parsed.getTime()) && parsed.toISOString() === value;
+}
+
+function validDigest(value: unknown): value is string {
+	return typeof value === "string" && LOWER_HEX_DIGEST.test(value);
+}
+
+function validStage(value: unknown): value is OwnershipStage {
+	return (
+		value === "pre_admit" ||
+		value === "creating" ||
+		value === "active" ||
+		value === "delete_intent" ||
+		value === "deleting" ||
+		value === "deleted"
+	);
+}
+
+function validSequence(value: unknown): value is OwnershipSequence {
+	return value === 1 || value === 2 || value === 3 || value === 4 || value === 5 || value === 6;
+}
+
+function validNonDeletedTarget(value: unknown): value is NonDeletedTransitionStage {
+	return value === "creating" || value === "active" || value === "delete_intent" || value === "deleting";
+}
+
+function edgeAllowed(from: OwnershipStage, to: OwnershipStage): boolean {
+	if (from === "pre_admit") return to === "creating" || to === "deleted";
+	if (from === "creating") return to === "active" || to === "delete_intent";
+	if (from === "active") return to === "delete_intent";
+	if (from === "delete_intent") return to === "deleting" || to === "deleted";
+	if (from === "deleting") return to === "deleted";
+	return false;
+}
+
+function sameIntent(first: OwnershipIntent, second: OwnershipIntent): boolean {
+	return (
+		first.lifecycleKey === second.lifecycleKey &&
+		first.parentSessionId === second.parentSessionId &&
+		first.childSessionId === second.childSessionId
+	);
+}
+
+function copyIntentUnsafe(value: unknown): OwnershipIntent | undefined {
+	if (!isOrdinaryObject(value)) return undefined;
+	const lifecycleKey = ownData(value, "lifecycleKey");
+	const parentSessionId = ownData(value, "parentSessionId");
+	const childSessionId = ownData(value, "childSessionId");
+	if (!boundedIdentity(lifecycleKey) || !boundedIdentity(parentSessionId) || !boundedIdentity(childSessionId)) {
+		return undefined;
+	}
+	return Object.freeze({ lifecycleKey, parentSessionId, childSessionId });
+}
+
+function copyIntent(value: unknown): OwnershipIntent | undefined {
+	try {
+		return copyIntentUnsafe(value);
+	} catch {
+		return undefined;
+	}
+}
+
+function canonicalPrefix(record: Omit<OwnershipRecord, "contentDigest">): string {
+	return `{"version":1,"sequence":${record.sequence},"stage":${JSON.stringify(record.stage)},"lifecycleKey":${JSON.stringify(record.lifecycleKey)},"parentSessionId":${JSON.stringify(record.parentSessionId)},"childSessionId":${JSON.stringify(record.childSessionId)},"recordedAt":${JSON.stringify(record.recordedAt)},"previousDigest":${record.previousDigest === null ? "null" : JSON.stringify(record.previousDigest)}`;
+}
+
+function eraseAndVerify(bytes: Uint8Array): boolean {
+	bytes.fill(0);
+	for (let index = 0; index < bytes.length; index++) {
+		if (bytes[index] !== 0) return false;
+	}
+	return true;
+}
+
+function digestPrefix(prefix: string): string | undefined {
+	const bytes = new TextEncoder().encode(prefix);
+	let digest: string;
+	try {
+		digest = createHash("sha256").update(bytes).digest("hex");
+	} catch {
+		eraseAndVerify(bytes);
+		return undefined;
+	}
+	if (!eraseAndVerify(bytes)) return undefined;
+	return digest;
+}
+
+function createPayload(bytes: Uint8Array): CanonicalOwnershipPayload {
+	let available: Uint8Array | undefined = bytes;
+	const byteLength = bytes.byteLength;
+	return Object.freeze({
+		byteLength,
+		take: () => {
+			const result = available;
+			available = undefined;
+			return result;
+		},
+		discard: () => {
+			if (available === undefined) return true;
+			const erased = eraseAndVerify(available);
+			available = undefined;
+			return erased;
+		},
+	});
+}
+
+function freezeRecord(record: OwnershipRecord): OwnershipRecord {
+	return Object.freeze({
+		version: 1,
+		sequence: record.sequence,
+		stage: record.stage,
+		lifecycleKey: record.lifecycleKey,
+		parentSessionId: record.parentSessionId,
+		childSessionId: record.childSessionId,
+		recordedAt: record.recordedAt,
+		previousDigest: record.previousDigest,
+		contentDigest: record.contentDigest,
+	});
+}
+
+function finalizeRecord(
+	sequence: OwnershipSequence,
+	stage: OwnershipStage,
+	intent: OwnershipIntent,
+	previousDigest: string | null,
+	recordedAt: string,
+): OwnershipCreateResult {
+	if (
+		!boundedIdentity(intent.lifecycleKey) ||
+		!boundedIdentity(intent.parentSessionId) ||
+		!boundedIdentity(intent.childSessionId) ||
+		!validTimestamp(recordedAt) ||
+		(previousDigest !== null && !validDigest(previousDigest))
+	) {
+		return failure("INPUT_INVALID");
+	}
+	const withoutDigest: Omit<OwnershipRecord, "contentDigest"> = {
+		version: 1,
+		sequence,
+		stage,
+		lifecycleKey: intent.lifecycleKey,
+		parentSessionId: intent.parentSessionId,
+		childSessionId: intent.childSessionId,
+		recordedAt,
+		previousDigest,
+	};
+	const prefix = canonicalPrefix(withoutDigest);
+	const contentDigest = digestPrefix(prefix);
+	if (contentDigest === undefined) return failure("INPUT_INVALID");
+	const bytes = new TextEncoder().encode(`${prefix},"contentDigest":${JSON.stringify(contentDigest)}}`);
+	if (bytes.byteLength > MAX_OWNERSHIP_RECORD_BYTES) {
+		eraseAndVerify(bytes);
+		return failure("INPUT_INVALID");
+	}
+	const record = freezeRecord({ ...withoutDigest, contentDigest });
+	const value: OwnershipRecordCreation = Object.freeze({ record, payload: createPayload(bytes) });
+	return Object.freeze({ ok: true, value });
+}
+
+function copyValidatedRecordUnsafe(value: unknown, requireFrozen: boolean): OwnershipRecord | undefined {
+	if (!exactRecordObject(value, requireFrozen)) return undefined;
+	const version = ownData(value, "version");
+	const sequence = ownData(value, "sequence");
+	const stage = ownData(value, "stage");
+	const lifecycleKey = ownData(value, "lifecycleKey");
+	const parentSessionId = ownData(value, "parentSessionId");
+	const childSessionId = ownData(value, "childSessionId");
+	const recordedAt = ownData(value, "recordedAt");
+	const previousDigest = ownData(value, "previousDigest");
+	const contentDigest = ownData(value, "contentDigest");
+	if (
+		version !== 1 ||
+		!validSequence(sequence) ||
+		!validStage(stage) ||
+		!boundedIdentity(lifecycleKey) ||
+		!boundedIdentity(parentSessionId) ||
+		!boundedIdentity(childSessionId) ||
+		!validTimestamp(recordedAt) ||
+		(previousDigest !== null && !validDigest(previousDigest)) ||
+		!validDigest(contentDigest)
+	) {
+		return undefined;
+	}
+	const record = freezeRecord({
+		version: 1,
+		sequence,
+		stage,
+		lifecycleKey,
+		parentSessionId,
+		childSessionId,
+		recordedAt,
+		previousDigest,
+		contentDigest,
+	});
+	const prefix = canonicalPrefix(record);
+	const expected = digestPrefix(prefix);
+	if (expected === undefined || expected !== contentDigest) return undefined;
+	const canonical = new TextEncoder().encode(`${prefix},"contentDigest":${JSON.stringify(contentDigest)}}`);
+	const validSize = canonical.byteLength <= MAX_OWNERSHIP_RECORD_BYTES;
+	if (!eraseAndVerify(canonical) || !validSize) return undefined;
+	return record;
+}
+
+function copyValidatedRecord(value: unknown, requireFrozen: boolean): OwnershipRecord | undefined {
+	try {
+		return copyValidatedRecordUnsafe(value, requireFrozen);
+	} catch {
+		return undefined;
+	}
+}
+
+export function createPreAdmitOwnershipRecord(intent: OwnershipIntent, recordedAt: string): OwnershipCreateResult {
+	const copiedIntent = copyIntent(intent);
+	if (copiedIntent === undefined) return failure("INPUT_INVALID");
+	return finalizeRecord(1, "pre_admit", copiedIntent, null, recordedAt);
+}
+
+export function decodeOwnershipRecord(input: Uint8Array): OwnershipDecodeResult {
+	if (!(input instanceof Uint8Array) || input.byteLength === 0 || input.byteLength > MAX_OWNERSHIP_RECORD_BYTES) {
+		if (input instanceof Uint8Array) eraseAndVerify(input);
+		return failure("CORRUPT");
+	}
+	let text: string;
+	try {
+		text = new TextDecoder("utf-8", { fatal: true }).decode(input);
+	} catch {
+		eraseAndVerify(input);
+		return failure("CORRUPT");
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch {
+		eraseAndVerify(input);
+		return failure("CORRUPT");
+	}
+	const record = copyValidatedRecord(parsed, false);
+	if (record === undefined) {
+		eraseAndVerify(input);
+		return failure("CORRUPT");
+	}
+	const prefix = canonicalPrefix(record);
+	const canonical = new TextEncoder().encode(`${prefix},"contentDigest":${JSON.stringify(record.contentDigest)}}`);
+	let equal = canonical.byteLength === input.byteLength;
+	for (let index = 0; equal && index < input.byteLength; index++) {
+		if (canonical[index] !== input[index]) equal = false;
+	}
+	const canonicalErased = eraseAndVerify(canonical);
+	const inputErased = eraseAndVerify(input);
+	if (!equal || !canonicalErased || !inputErased) return failure("CORRUPT");
+	return Object.freeze({ ok: true, value: record });
+}
+
+function validateOwnershipChainUnsafe(records: readonly OwnershipRecord[]): OwnershipChainResult {
+	if (!Array.isArray(records) || records.length < 1 || records.length > 6) return failure("CORRUPT");
+	const copies: OwnershipRecord[] = [];
+	for (let index = 0; index < records.length; index++) {
+		const value = ownData(records, String(index));
+		const record = copyValidatedRecord(value, true);
+		if (record === undefined || record.sequence !== index + 1) return failure("CORRUPT");
+		copies.push(record);
+	}
+	const first = copies[0];
+	if (first.stage !== "pre_admit" || first.previousDigest !== null) return failure("CORRUPT");
+	const intent: OwnershipIntent = Object.freeze({
+		lifecycleKey: first.lifecycleKey,
+		parentSessionId: first.parentSessionId,
+		childSessionId: first.childSessionId,
+	});
+	for (let index = 1; index < copies.length; index++) {
+		const prior = copies[index - 1];
+		const current = copies[index];
+		if (
+			!sameIntent(intent, current) ||
+			current.previousDigest !== prior.contentDigest ||
+			!edgeAllowed(prior.stage, current.stage) ||
+			Date.parse(current.recordedAt) < Date.parse(prior.recordedAt)
+		) {
+			return failure("CORRUPT");
+		}
+	}
+	const frozenRecords = Object.freeze(copies);
+	const value: ValidatedOwnershipChain = Object.freeze({
+		records: frozenRecords,
+		current: frozenRecords[frozenRecords.length - 1],
+		intent,
+	});
+	validatedChains.add(value);
+	return Object.freeze({ ok: true, value });
+}
+
+export function validateOwnershipChain(records: readonly OwnershipRecord[]): OwnershipChainResult {
+	try {
+		return validateOwnershipChainUnsafe(records);
+	} catch {
+		return failure("CORRUPT");
+	}
+}
+
+export function decideNonDeletedOwnershipTransition(
+	chain: ValidatedOwnershipChain,
+	target: NonDeletedTransitionStage,
+	intent: OwnershipIntent,
+	recordedAt: string,
+): OwnershipTransitionResult {
+	if (!validatedChains.has(chain)) return failure("CORRUPT");
+	if (!validNonDeletedTarget(target) || !validTimestamp(recordedAt)) return failure("INPUT_INVALID");
+	const copiedIntent = copyIntent(intent);
+	if (copiedIntent === undefined) return failure("INPUT_INVALID");
+	if (!sameIntent(chain.intent, copiedIntent)) return failure("CONFLICT");
+	for (const record of chain.records) {
+		if (record.stage === target) {
+			return Object.freeze({ ok: true, idempotent: true, value: chain.current });
+		}
+	}
+	if (!edgeAllowed(chain.current.stage, target)) return failure("INVALID_TRANSITION");
+	if (Date.parse(recordedAt) < Date.parse(chain.current.recordedAt)) return failure("INPUT_INVALID");
+	const nextSequence = chain.records.length + 1;
+	if (!validSequence(nextSequence)) return failure("INVALID_TRANSITION");
+	const created = finalizeRecord(nextSequence, target, copiedIntent, chain.current.contentDigest, recordedAt);
+	if (!created.ok) return created;
+	return Object.freeze({ ok: true, idempotent: false, value: created.value });
+}

--- a/packages/coding-agent/src/modes/daemon/sandbox/prime-cli-create-version-codec.ts
+++ b/packages/coding-agent/src/modes/daemon/sandbox/prime-cli-create-version-codec.ts
@@ -1,0 +1,126 @@
+/**
+ * Private codec for the exact Prime CLI 0.6.21 version and create output.
+ * Callers must pass the version gate before any lifecycle command. Supporting a
+ * different version requires new source hashes, fixtures, and codec review.
+ */
+
+const PRIME_CLI_VERSION_OUTPUT = "Prime CLI version: 0.6.21\n";
+const MAX_CREATE_OUTPUT_BYTES = 1_048_576;
+const MAX_SANDBOX_ID_BYTES = 128;
+const SANDBOX_ID_PREFIX = "sb_";
+
+export type PrimeCliCodecFailure = Readonly<{
+	ok: false;
+	code: "INVALID_OUTPUT";
+}>;
+
+export type PrimeCliVersion = Readonly<{
+	version: "0.6.21";
+}>;
+
+export type PrimeCliSandboxIdentity = Readonly<{
+	id: string;
+}>;
+
+export type PrimeCliVersionResult = Readonly<{ ok: true; value: PrimeCliVersion }> | PrimeCliCodecFailure;
+
+export type PrimeCliCreateResult = Readonly<{ ok: true; value: PrimeCliSandboxIdentity }> | PrimeCliCodecFailure;
+
+function invalidOutput(): PrimeCliCodecFailure {
+	return Object.freeze({ ok: false, code: "INVALID_OUTPUT" });
+}
+
+function boundedUtf8(value: string, maximumBytes: number): boolean {
+	let bytes = 0;
+	for (let index = 0; index < value.length; index++) {
+		const unit = value.charCodeAt(index);
+		if (unit <= 0x7f) {
+			bytes += 1;
+		} else if (unit <= 0x7ff) {
+			bytes += 2;
+		} else if (unit >= 0xd800 && unit <= 0xdbff) {
+			if (index + 1 >= value.length) return false;
+			const next = value.charCodeAt(index + 1);
+			if (next < 0xdc00 || next > 0xdfff) return false;
+			bytes += 4;
+			index++;
+		} else if (unit >= 0xdc00 && unit <= 0xdfff) {
+			return false;
+		} else {
+			bytes += 3;
+		}
+		if (bytes > maximumBytes) return false;
+	}
+	return true;
+}
+
+function isTokenBoundary(unit: number): boolean {
+	return (
+		unit === 0x09 ||
+		unit === 0x0a ||
+		unit === 0x0d ||
+		unit === 0x20 ||
+		unit === 0x22 ||
+		unit === 0x27 ||
+		unit === 0x28 ||
+		unit === 0x29 ||
+		unit === 0x2c ||
+		unit === 0x3a ||
+		unit === 0x3b ||
+		unit === 0x5b ||
+		unit === 0x5d ||
+		unit === 0x7b ||
+		unit === 0x7d
+	);
+}
+
+function isHexadecimal(unit: number): boolean {
+	return (unit >= 0x30 && unit <= 0x39) || (unit >= 0x41 && unit <= 0x46) || (unit >= 0x61 && unit <= 0x66);
+}
+
+function createSuccess(id: string): PrimeCliCreateResult {
+	const value: PrimeCliSandboxIdentity = Object.freeze({ id });
+	return Object.freeze({ ok: true, value });
+}
+
+export function parsePrimeCliVersionOutput(stdout: string): PrimeCliVersionResult {
+	if (stdout !== PRIME_CLI_VERSION_OUTPUT) return invalidOutput();
+	const value: PrimeCliVersion = Object.freeze({ version: "0.6.21" });
+	return Object.freeze({ ok: true, value });
+}
+
+export function parsePrimeCliCreateOutput(stdout: string): PrimeCliCreateResult {
+	if (!boundedUtf8(stdout, MAX_CREATE_OUTPUT_BYTES)) return invalidOutput();
+
+	let foundId: string | undefined;
+	let searchFrom = 0;
+	while (searchFrom < stdout.length) {
+		const start = stdout.indexOf(SANDBOX_ID_PREFIX, searchFrom);
+		if (start < 0) break;
+		if (start > 0 && !isTokenBoundary(stdout.charCodeAt(start - 1))) return invalidOutput();
+
+		let end = start + SANDBOX_ID_PREFIX.length;
+		const hexadecimalStart = end;
+		while (end < stdout.length && isHexadecimal(stdout.charCodeAt(end))) end++;
+		if (end === hexadecimalStart) return invalidOutput();
+		if (end < stdout.length && !isTokenBoundary(stdout.charCodeAt(end))) return invalidOutput();
+
+		const id = stdout.slice(start, end);
+		if (!boundedUtf8(id, MAX_SANDBOX_ID_BYTES)) return invalidOutput();
+		if (foundId === undefined) {
+			foundId = id;
+		} else if (foundId !== id) {
+			return invalidOutput();
+		}
+		searchFrom = end;
+	}
+
+	if (foundId === undefined) return invalidOutput();
+	const successLine = `Successfully created sandbox ${foundId}`;
+	let successCount = 0;
+	for (const line of stdout.split("\n")) {
+		if (line === successLine) successCount++;
+	}
+	if (successCount !== 1) return invalidOutput();
+	return createSuccess(foundId);
+}

--- a/packages/coding-agent/src/modes/daemon/sandbox/prime-cli-json-codec.ts
+++ b/packages/coding-agent/src/modes/daemon/sandbox/prime-cli-json-codec.ts
@@ -1,0 +1,449 @@
+/**
+ * Strict private decoder for Prime CLI 0.6.21 sandbox list/get JSON.
+ * Supporting another CLI version requires new source hashes, fixtures, and review.
+ */
+
+const MAX_OUTPUT_BYTES = 1_048_576;
+const MAX_FIELD_BYTES = 512;
+const MAX_ROWS = 100;
+const MAX_COLLECTION_ITEMS = 100;
+const MAX_PAGE_NUMBER = 1_000_000;
+const MAX_RESOURCE_NUMBER = 1_000_000_000;
+const MAX_TIMEOUT_MINUTES = 1_000_000;
+const MISSING = Symbol("missing-own-data-property");
+
+type Missing = typeof MISSING;
+export type PrimeSandboxStatus = "PENDING" | "PROVISIONING" | "RUNNING" | "PAUSED" | "ERROR" | "TERMINATED" | "TIMEOUT";
+
+export type PrimeCliJsonFailureCode = "INPUT_INVALID" | "INVALID_OUTPUT";
+export type PrimeCliJsonFailure = Readonly<{ ok: false; code: PrimeCliJsonFailureCode }>;
+
+export type PrimeSandboxListRow = Readonly<{
+	id: string;
+	status: PrimeSandboxStatus;
+	labels: readonly string[];
+}>;
+
+export type PrimeSandboxListPage = Readonly<{
+	sandboxes: readonly PrimeSandboxListRow[];
+	total: number;
+	page: number;
+	perPage: number;
+	hasNext: boolean;
+}>;
+
+export type PrimeSandboxListResult = Readonly<{ ok: true; value: PrimeSandboxListPage }> | PrimeCliJsonFailure;
+
+export type PrimeSandboxDetail = Readonly<{
+	id: string;
+	status: PrimeSandboxStatus;
+	labels: readonly string[];
+	vm: boolean;
+	type: "VM" | "Container";
+}>;
+
+export type PrimeSandboxGetResult = Readonly<{ ok: true; value: PrimeSandboxDetail }> | PrimeCliJsonFailure;
+
+function failure(code: PrimeCliJsonFailureCode): PrimeCliJsonFailure {
+	return Object.freeze({ ok: false, code });
+}
+
+function ownData(object: object, key: string): unknown | Missing {
+	const descriptor = Object.getOwnPropertyDescriptor(object, key);
+	if (descriptor === undefined || !Object.hasOwn(descriptor, "value")) return MISSING;
+	const value: unknown = descriptor.value;
+	return value;
+}
+
+function isPlainObject(value: unknown): value is object {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		!Array.isArray(value) &&
+		Object.getPrototypeOf(value) === Object.prototype
+	);
+}
+
+function boundedUtf8(value: string, maximumBytes: number, allowEmpty: boolean): boolean {
+	if (!allowEmpty && value.length === 0) return false;
+	let bytes = 0;
+	for (let index = 0; index < value.length; index++) {
+		const unit = value.charCodeAt(index);
+		if (unit <= 0x7f) {
+			bytes += 1;
+		} else if (unit <= 0x7ff) {
+			bytes += 2;
+		} else if (unit >= 0xd800 && unit <= 0xdbff) {
+			if (index + 1 >= value.length) return false;
+			const next = value.charCodeAt(index + 1);
+			if (next < 0xdc00 || next > 0xdfff) return false;
+			bytes += 4;
+			index++;
+		} else if (unit >= 0xdc00 && unit <= 0xdfff) {
+			return false;
+		} else {
+			bytes += 3;
+		}
+		if (bytes > maximumBytes) return false;
+	}
+	return true;
+}
+
+function controlFree(value: string): boolean {
+	for (let index = 0; index < value.length; index++) {
+		const unit = value.charCodeAt(index);
+		if (unit <= 0x1f || unit === 0x7f) return false;
+	}
+	return true;
+}
+
+function boundedString(value: unknown, allowEmpty = true): value is string {
+	return typeof value === "string" && boundedUtf8(value, MAX_FIELD_BYTES, allowEmpty) && controlFree(value);
+}
+
+function validSandboxId(value: unknown): value is string {
+	if (typeof value !== "string" || value.length < 4 || value.length > 128) return false;
+	if (value[0] !== "s" || value[1] !== "b" || value[2] !== "_") return false;
+	for (let index = 3; index < value.length; index++) {
+		const unit = value.charCodeAt(index);
+		const hexadecimal =
+			(unit >= 0x30 && unit <= 0x39) || (unit >= 0x41 && unit <= 0x46) || (unit >= 0x61 && unit <= 0x66);
+		if (!hexadecimal) return false;
+	}
+	return true;
+}
+
+function validStatus(value: unknown): value is PrimeSandboxStatus {
+	return (
+		value === "PENDING" ||
+		value === "PROVISIONING" ||
+		value === "RUNNING" ||
+		value === "PAUSED" ||
+		value === "ERROR" ||
+		value === "TERMINATED" ||
+		value === "TIMEOUT"
+	);
+}
+
+function digit(value: string, index: number): number | undefined {
+	const unit = value.charCodeAt(index);
+	if (unit < 0x30 || unit > 0x39) return undefined;
+	return unit - 0x30;
+}
+
+function twoDigits(value: string, index: number): number | undefined {
+	const first = digit(value, index);
+	const second = digit(value, index + 1);
+	if (first === undefined || second === undefined) return undefined;
+	return first * 10 + second;
+}
+
+function fourDigits(value: string): number | undefined {
+	const first = twoDigits(value, 0);
+	const second = twoDigits(value, 2);
+	if (first === undefined || second === undefined) return undefined;
+	return first * 100 + second;
+}
+
+function validPrimeTimestamp(value: unknown): value is string {
+	if (typeof value !== "string" || value.length !== 23) return false;
+	if (
+		value[4] !== "-" ||
+		value[7] !== "-" ||
+		value[10] !== " " ||
+		value[13] !== ":" ||
+		value[16] !== ":" ||
+		value.slice(19) !== " UTC"
+	) {
+		return false;
+	}
+	const year = fourDigits(value);
+	const month = twoDigits(value, 5);
+	const day = twoDigits(value, 8);
+	const hour = twoDigits(value, 11);
+	const minute = twoDigits(value, 14);
+	const second = twoDigits(value, 17);
+	if (
+		year === undefined ||
+		month === undefined ||
+		day === undefined ||
+		hour === undefined ||
+		minute === undefined ||
+		second === undefined ||
+		year < 1 ||
+		month < 1 ||
+		month > 12 ||
+		hour > 23 ||
+		minute > 59 ||
+		second > 59
+	) {
+		return false;
+	}
+	let maximumDay = 31;
+	if (month === 4 || month === 6 || month === 9 || month === 11) maximumDay = 30;
+	if (month === 2) {
+		const leap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+		maximumDay = leap ? 29 : 28;
+	}
+	return day >= 1 && day <= maximumDay;
+}
+
+function finiteInteger(value: unknown, minimum: number, maximum: number): value is number {
+	return (
+		typeof value === "number" &&
+		Number.isFinite(value) &&
+		Number.isSafeInteger(value) &&
+		value >= minimum &&
+		value <= maximum
+	);
+}
+
+function finiteNumber(value: unknown, minimum: number, maximum: number): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value >= minimum && value <= maximum;
+}
+
+function stringArray(value: unknown): readonly string[] | undefined {
+	if (!Array.isArray(value) || value.length > MAX_COLLECTION_ITEMS) return undefined;
+	const output: string[] = [];
+	for (let index = 0; index < value.length; index++) {
+		const item = ownData(value, String(index));
+		if (!boundedString(item)) return undefined;
+		output.push(item);
+	}
+	return Object.freeze(output);
+}
+
+function nullableString(value: unknown): boolean {
+	return value === null || boundedString(value);
+}
+
+function nullableTimestamp(value: unknown): boolean {
+	return value === null || validPrimeTimestamp(value);
+}
+
+function nullableInteger(value: unknown, minimum: number, maximum: number): boolean {
+	return value === null || finiteInteger(value, minimum, maximum);
+}
+
+function optionalValue(object: object, key: string): unknown | Missing {
+	return ownData(object, key);
+}
+
+function validateOptionalTimestamp(object: object, key: string): boolean {
+	const value = optionalValue(object, key);
+	return value === MISSING || validPrimeTimestamp(value);
+}
+
+function validateOptionalExitCode(object: object): boolean {
+	const value = optionalValue(object, "exit_code");
+	return value === MISSING || finiteInteger(value, -2_147_483_648, 2_147_483_647);
+}
+
+function validateStringMap(value: unknown): boolean {
+	if (!isPlainObject(value)) return false;
+	const keys = Object.keys(value);
+	if (keys.length > MAX_COLLECTION_ITEMS) return false;
+	for (const key of keys) {
+		if (!boundedUtf8(key, MAX_FIELD_BYTES, true)) return false;
+		const item = ownData(value, key);
+		if (!boundedString(item)) return false;
+	}
+	return true;
+}
+
+function validateJsonValue(value: unknown, depth: number): boolean {
+	if (value === null || typeof value === "boolean") return true;
+	if (typeof value === "string") return boundedUtf8(value, MAX_FIELD_BYTES, true);
+	if (typeof value === "number") return Number.isFinite(value);
+	if (depth >= 4) return false;
+	if (Array.isArray(value)) {
+		if (value.length > MAX_COLLECTION_ITEMS) return false;
+		for (let index = 0; index < value.length; index++) {
+			if (!validateJsonValue(ownData(value, String(index)), depth + 1)) return false;
+		}
+		return true;
+	}
+	if (!isPlainObject(value)) return false;
+	const keys = Object.keys(value);
+	if (keys.length > MAX_COLLECTION_ITEMS) return false;
+	for (const key of keys) {
+		if (!boundedUtf8(key, MAX_FIELD_BYTES, true)) return false;
+		if (!validateJsonValue(ownData(value, key), depth + 1)) return false;
+	}
+	return true;
+}
+
+function validateOptionalObject(object: object, key: string, advanced: boolean): boolean {
+	const value = optionalValue(object, key);
+	if (value === MISSING) return true;
+	return advanced ? validateJsonValue(value, 0) && isPlainObject(value) : validateStringMap(value);
+}
+
+function parseJsonObject(stdout: string): object | undefined {
+	if (!boundedUtf8(stdout, MAX_OUTPUT_BYTES, false)) return undefined;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(stdout);
+	} catch {
+		return undefined;
+	}
+	return isPlainObject(parsed) ? parsed : undefined;
+}
+
+function decodeListRow(value: unknown, expectedLabel: string): PrimeSandboxListRow | undefined {
+	if (!isPlainObject(value)) return undefined;
+	const id = ownData(value, "id");
+	const name = ownData(value, "name");
+	const image = ownData(value, "image");
+	const status = ownData(value, "status");
+	const resources = ownData(value, "resources");
+	const region = ownData(value, "region");
+	const labelsValue = ownData(value, "labels");
+	const createdAt = ownData(value, "created_at");
+	const timeoutMinutes = ownData(value, "timeout_minutes");
+	const expiresAt = ownData(value, "expires_at");
+	if (
+		!validSandboxId(id) ||
+		!boundedString(name) ||
+		!boundedString(image, false) ||
+		!validStatus(status) ||
+		!boundedString(resources, false) ||
+		!nullableString(region) ||
+		!validPrimeTimestamp(createdAt) ||
+		!finiteInteger(timeoutMinutes, 1, MAX_TIMEOUT_MINUTES) ||
+		!nullableTimestamp(expiresAt)
+	) {
+		return undefined;
+	}
+	const labels = stringArray(labelsValue);
+	if (labels === undefined || !labels.includes(expectedLabel)) return undefined;
+	return Object.freeze({ id, status, labels });
+}
+
+export function parsePrimeSandboxListOutput(stdout: string, expectedLabel: string): PrimeSandboxListResult {
+	if (!boundedUtf8(expectedLabel, MAX_FIELD_BYTES, false) || !controlFree(expectedLabel)) {
+		return failure("INPUT_INVALID");
+	}
+	const object = parseJsonObject(stdout);
+	if (object === undefined) return failure("INVALID_OUTPUT");
+	const sandboxesValue = ownData(object, "sandboxes");
+	const total = ownData(object, "total");
+	const page = ownData(object, "page");
+	const perPage = ownData(object, "per_page");
+	const hasNext = ownData(object, "has_next");
+	if (
+		!Array.isArray(sandboxesValue) ||
+		sandboxesValue.length > MAX_ROWS ||
+		!finiteInteger(total, 0, MAX_PAGE_NUMBER) ||
+		!finiteInteger(page, 1, MAX_PAGE_NUMBER) ||
+		!finiteInteger(perPage, 1, MAX_ROWS) ||
+		typeof hasNext !== "boolean" ||
+		sandboxesValue.length > perPage ||
+		sandboxesValue.length > total ||
+		(hasNext ? page * perPage >= total : page * perPage < total)
+	) {
+		return failure("INVALID_OUTPUT");
+	}
+	const rows: PrimeSandboxListRow[] = [];
+	for (let index = 0; index < sandboxesValue.length; index++) {
+		const row = decodeListRow(ownData(sandboxesValue, String(index)), expectedLabel);
+		if (row === undefined) return failure("INVALID_OUTPUT");
+		for (const prior of rows) {
+			if (prior.id === row.id) return failure("INVALID_OUTPUT");
+		}
+		rows.push(row);
+	}
+	const value: PrimeSandboxListPage = Object.freeze({
+		sandboxes: Object.freeze(rows),
+		total,
+		page,
+		perPage,
+		hasNext,
+	});
+	return Object.freeze({ ok: true, value });
+}
+
+function validateRequiredDetailFields(object: object): boolean {
+	const name = ownData(object, "name");
+	const dockerImage = ownData(object, "docker_image");
+	const startCommand = ownData(object, "start_command");
+	const cpuCores = ownData(object, "cpu_cores");
+	const memoryGb = ownData(object, "memory_gb");
+	const diskSizeGb = ownData(object, "disk_size_gb");
+	const diskMountPath = ownData(object, "disk_mount_path");
+	const gpuCount = ownData(object, "gpu_count");
+	const gpuType = ownData(object, "gpu_type");
+	const networkAllowlist = ownData(object, "network_allowlist");
+	const networkDenylist = ownData(object, "network_denylist");
+	const timeoutMinutes = ownData(object, "timeout_minutes");
+	const idleTimeoutMinutes = ownData(object, "idle_timeout_minutes");
+	const terminationReason = ownData(object, "termination_reason");
+	const createdAt = ownData(object, "created_at");
+	const userId = ownData(object, "user_id");
+	const teamId = ownData(object, "team_id");
+	const region = ownData(object, "region");
+	const registryCredentialsId = ownData(object, "registry_credentials_id");
+	return (
+		boundedString(name) &&
+		boundedString(dockerImage, false) &&
+		(startCommand === null || boundedString(startCommand)) &&
+		finiteNumber(cpuCores, 0, MAX_RESOURCE_NUMBER) &&
+		finiteNumber(memoryGb, 0, MAX_RESOURCE_NUMBER) &&
+		finiteNumber(diskSizeGb, 0, MAX_RESOURCE_NUMBER) &&
+		boundedString(diskMountPath, false) &&
+		finiteInteger(gpuCount, 0, 1024) &&
+		nullableString(gpuType) &&
+		(networkAllowlist === null || stringArray(networkAllowlist) !== undefined) &&
+		(networkDenylist === null || stringArray(networkDenylist) !== undefined) &&
+		finiteInteger(timeoutMinutes, 1, MAX_TIMEOUT_MINUTES) &&
+		nullableInteger(idleTimeoutMinutes, 1, MAX_TIMEOUT_MINUTES) &&
+		nullableString(terminationReason) &&
+		validPrimeTimestamp(createdAt) &&
+		nullableString(userId) &&
+		nullableString(teamId) &&
+		nullableString(region) &&
+		nullableString(registryCredentialsId)
+	);
+}
+
+export function parsePrimeSandboxGetOutput(
+	stdout: string,
+	expectedId: string,
+	expectedLabel: string,
+): PrimeSandboxGetResult {
+	if (
+		!validSandboxId(expectedId) ||
+		!boundedUtf8(expectedLabel, MAX_FIELD_BYTES, false) ||
+		!controlFree(expectedLabel)
+	) {
+		return failure("INPUT_INVALID");
+	}
+	const object = parseJsonObject(stdout);
+	if (object === undefined) return failure("INVALID_OUTPUT");
+	const id = ownData(object, "id");
+	const status = ownData(object, "status");
+	const labelsValue = ownData(object, "labels");
+	const vm = ownData(object, "vm");
+	const type = ownData(object, "type");
+	if (
+		!validSandboxId(id) ||
+		id !== expectedId ||
+		!validStatus(status) ||
+		typeof vm !== "boolean" ||
+		(type !== "VM" && type !== "Container") ||
+		(vm ? type !== "VM" : type !== "Container") ||
+		!validateRequiredDetailFields(object) ||
+		!validateOptionalTimestamp(object, "started_at") ||
+		!validateOptionalTimestamp(object, "terminated_at") ||
+		!validateOptionalExitCode(object) ||
+		!validateOptionalObject(object, "environment_vars", false) ||
+		!validateOptionalObject(object, "secrets", false) ||
+		!validateOptionalObject(object, "advanced_configs", true)
+	) {
+		return failure("INVALID_OUTPUT");
+	}
+	const labels = stringArray(labelsValue);
+	if (labels === undefined || !labels.includes(expectedLabel)) return failure("INVALID_OUTPUT");
+	const value: PrimeSandboxDetail = Object.freeze({ id, status, labels, vm, type });
+	return Object.freeze({ ok: true, value });
+}

--- a/packages/coding-agent/src/modes/daemon/sandbox/prime-sandbox-lifecycle.ts
+++ b/packages/coding-agent/src/modes/daemon/sandbox/prime-sandbox-lifecycle.ts
@@ -88,7 +88,11 @@ class DeleteProofToken {
 export type DeleteProof = DeleteProofToken;
 
 export type InspectOutcome =
-	| Readonly<{ ok: true; kind: "empty"; value: CreatePermission }>
+	| Readonly<{
+			ok: true;
+			kind: "empty";
+			value: Readonly<{ createPermission: CreatePermission; absenceProof: DeleteProof }>;
+	  }>
 	| Readonly<{ ok: true; kind: "single"; value: SandboxHandle }>
 	| Readonly<{ ok: false; code: "COLLISION" }>
 	| LifecycleError;
@@ -330,8 +334,8 @@ function defaultDelay(ms: number, signal?: AbortSignal): Promise<DelayResult> {
 
 // -- Typed result constructors --
 
-function okEmpty(p: CreatePermission): InspectOutcome {
-	return Object.freeze({ ok: true, kind: "empty", value: p });
+function okEmpty(p: CreatePermission, absenceProof: DeleteProof): InspectOutcome {
+	return Object.freeze({ ok: true, kind: "empty", value: Object.freeze({ createPermission: p, absenceProof }) });
 }
 
 function okSingle(h: SandboxHandle): InspectOutcome {
@@ -472,6 +476,9 @@ export async function createSandboxLifecycle(
 	if (versionResult.value.exitCode !== 0 || versionResult.value.stderr !== "") return err("VERSION_MISMATCH");
 	if (!parsePrimeCliVersionOutput(versionResult.value.stdout).ok) return err("VERSION_MISMATCH");
 
+	// One Home session owner serializes lifecycle effects. Provider-side
+	// same-label mutations remain outside this local token protocol.
+
 	// Closure-private state
 	const handleIdMap = new WeakMap<SandboxHandleToken, string>();
 	const deleteIssued = new WeakSet<SandboxHandleToken>();
@@ -479,6 +486,8 @@ export async function createSandboxLifecycle(
 	const createUsed = new WeakSet<CreatePermissionToken>();
 	const proofSet = new WeakSet<DeleteProofToken>();
 	const proofConsumed = new WeakSet<DeleteProofToken>();
+	const permToPairedProof = new WeakMap<CreatePermissionToken, DeleteProofToken>();
+	const proofToPairedPerm = new WeakMap<DeleteProofToken, CreatePermissionToken>();
 
 	function newHandle(id: string): SandboxHandle {
 		const o = new SandboxHandleToken();
@@ -499,6 +508,8 @@ export async function createSandboxLifecycle(
 		if (!createPerms.has(p)) return "invalid";
 		if (createUsed.has(p)) return "used";
 		createUsed.add(p);
+		const pairedProof = permToPairedProof.get(p);
+		if (pairedProof !== undefined) proofConsumed.add(pairedProof);
 		return "ok";
 	}
 
@@ -514,6 +525,8 @@ export async function createSandboxLifecycle(
 		if (!proofSet.has(p)) return false;
 		if (proofConsumed.has(p)) return false;
 		proofConsumed.add(p);
+		const pairedPerm = proofToPairedPerm.get(p);
+		if (pairedPerm !== undefined) createUsed.add(pairedPerm);
 		return true;
 	}
 
@@ -683,7 +696,13 @@ export async function createSandboxLifecycle(
 			const s = await scanAll(d, sig);
 			if (!s.ok) return s;
 
-			if (s.rows.length === 0) return okEmpty(newPerm());
+			if (s.rows.length === 0) {
+				const perm = newPerm();
+				const proof = newProof();
+				permToPairedProof.set(perm, proof);
+				proofToPairedPerm.set(proof, perm);
+				return okEmpty(perm, proof);
+			}
 			for (const r of s.rows) {
 				if (r.status === "TERMINATED") return err("UNCERTAIN");
 			}

--- a/packages/coding-agent/src/modes/daemon/sandbox/prime-sandbox-lifecycle.ts
+++ b/packages/coding-agent/src/modes/daemon/sandbox/prime-sandbox-lifecycle.ts
@@ -1,0 +1,864 @@
+/**
+ * Home-private Prime CLI 0.6.21 sandbox lifecycle adapter.
+ *
+ * Consumes a narrow injected async runner; never spawns directly.
+ * All handles, permissions, proofs are closure-private
+ * WeakMap/WeakSet brands with no serializable fields.
+ */
+
+import { parsePrimeCliCreateOutput, parsePrimeCliVersionOutput } from "./prime-cli-create-version-codec.js";
+import { parsePrimeSandboxGetOutput, parsePrimeSandboxListOutput } from "./prime-cli-json-codec.js";
+
+// -- Port types --
+
+export type RunnerSuccess = Readonly<{
+	ok: true;
+	value: Readonly<{ stdout: string; stderr: string; exitCode: number; durationMs: number }>;
+}>;
+
+export type RunnerFailure = Readonly<{ ok: false; code: RunnerFailureCode }>;
+export type RunnerFailureCode =
+	| "INPUT_INVALID"
+	| "SPAWN_FAILED"
+	| "ABORTED"
+	| "TIMED_OUT"
+	| "OUTPUT_OVERFLOW"
+	| "STREAM_FAILED"
+	| "PROCESS_UNCERTAIN";
+export type RunnerResult = RunnerSuccess | RunnerFailure;
+
+export type RunCommand = (argv: readonly string[], timeoutMs: number, signal?: AbortSignal) => Promise<RunnerResult>;
+
+export type Clock = Readonly<{ now: () => number }>;
+export type DelayResult = "elapsed" | "aborted";
+export type DelayFn = (ms: number, signal?: AbortSignal) => Promise<DelayResult>;
+
+// -- Config --
+
+export type LifecycleConfig = Readonly<{
+	primeCliPath: string;
+	label: string;
+	image: string;
+	name: string;
+	cpuCores: number;
+	memoryGb: number;
+	diskSizeGb: number;
+	sandboxTimeoutMinutes: number;
+	operationTimeoutMs: number;
+	pollIntervalMs: number;
+}>;
+
+// -- Error types --
+
+export type LifecycleErrorCode =
+	| "CONFIG_REJECTED"
+	| "VERSION_MISMATCH"
+	| "COLLISION"
+	| "RECOVERY_REQUIRED"
+	| "READY_TERMINAL"
+	| "DEADLINE_EXCEEDED"
+	| "ABORTED"
+	| "HANDLE_INVALID"
+	| "TOKEN_INVALID"
+	| "TOKEN_CONSUMED"
+	| "DUPLICATE_DELETE"
+	| "ABSENCE_UNCERTAIN"
+	| "UNCERTAIN"
+	| "INPUT_INVALID"
+	| "POLL_LIMIT"
+	| "PROOF_INVALID";
+
+export type LifecycleError = Readonly<{ ok: false; code: LifecycleErrorCode }>;
+
+// -- Nominal brand classes --
+
+class SandboxHandleToken {
+	private declare readonly _handle: undefined;
+}
+export type SandboxHandle = SandboxHandleToken;
+
+class CreatePermissionToken {
+	private declare readonly _permission: undefined;
+}
+export type CreatePermission = CreatePermissionToken;
+
+class DeleteProofToken {
+	private declare readonly _proof: undefined;
+}
+export type DeleteProof = DeleteProofToken;
+
+export type InspectOutcome =
+	| Readonly<{ ok: true; kind: "empty"; value: CreatePermission }>
+	| Readonly<{ ok: true; kind: "single"; value: SandboxHandle }>
+	| Readonly<{ ok: false; code: "COLLISION" }>
+	| LifecycleError;
+
+export interface SandboxLifecycle {
+	inspect(signal?: AbortSignal): Promise<InspectOutcome>;
+	create(
+		permission: CreatePermission,
+		signal?: AbortSignal,
+	): Promise<Readonly<{ ok: true; value: SandboxHandle }> | LifecycleError>;
+	waitUntilReady(
+		handle: SandboxHandle,
+		signal?: AbortSignal,
+	): Promise<Readonly<{ ok: true }> | Readonly<{ ok: false; code: "READY_TERMINAL" }> | LifecycleError>;
+	deleteAndProveAbsent(
+		handle: SandboxHandle,
+		signal?: AbortSignal,
+	): Promise<Readonly<{ ok: true; value: DeleteProof }> | LifecycleError>;
+}
+
+export interface ProofConsumer {
+	/** Consume one DeleteProof from this adapter. One-shot per proof. */
+	consumeProof(proof: DeleteProof): Readonly<{ ok: true }> | LifecycleError;
+}
+
+export type SandboxLifecycleBundle = Readonly<{
+	lifecycle: SandboxLifecycle;
+	proofConsumer: ProofConsumer;
+}>;
+
+// -- Constants --
+
+const MAX_PATH_BYTES = 4096;
+const MAX_FIELD_BYTES = 512;
+const MIN_TO = 100;
+const MAX_TO = 600_000;
+const PER_PAGE = 100;
+const MAX_LIST_PAGES = 1000;
+const MAX_TOTAL_ROWS = 100_000;
+const MAX_READY_POLLS = 600;
+const MAX_DELETE_POLLS = 600;
+
+// -- Pure helpers --
+
+function b8(s: string, max: number, empty: boolean): boolean {
+	if (!empty && s.length === 0) return false;
+	let b = 0;
+	for (let i = 0; i < s.length; i++) {
+		const c = s.charCodeAt(i);
+		if (c <= 0x7f) {
+			b += 1;
+		} else if (c <= 0x7ff) {
+			b += 2;
+		} else if (c >= 0xd800 && c <= 0xdbff) {
+			if (i + 1 >= s.length) return false;
+			const n = s.charCodeAt(i + 1);
+			if (n < 0xdc00 || n > 0xdfff) return false;
+			b += 4;
+			i++;
+		} else if (c >= 0xdc00 && c <= 0xdfff) {
+			return false;
+		} else {
+			b += 3;
+		}
+		if (b > max) return false;
+	}
+	return true;
+}
+
+function cf(s: string): boolean {
+	for (let i = 0; i < s.length; i++) {
+		const c = s.charCodeAt(i);
+		if (c <= 0x1f || c === 0x7f) return false;
+	}
+	return true;
+}
+
+function absPath(v: string): boolean {
+	return typeof v === "string" && v.length > 0 && v.charCodeAt(0) === 0x2f && cf(v) && b8(v, MAX_PATH_BYTES, false);
+}
+
+function labelOk(v: string): boolean {
+	return typeof v === "string" && b8(v, MAX_FIELD_BYTES, false) && cf(v);
+}
+
+function intGe1(v: number, max: number): boolean {
+	return typeof v === "number" && Number.isFinite(v) && Number.isSafeInteger(v) && v >= 1 && v <= max;
+}
+
+function err(c: LifecycleErrorCode): LifecycleError {
+	return Object.freeze({ ok: false, code: c });
+}
+
+function toCap(ms: number): number | undefined {
+	if (!Number.isFinite(ms)) return undefined;
+	if (ms < MIN_TO) return undefined;
+	return ms > MAX_TO ? MAX_TO : Math.floor(ms);
+}
+
+function od(source: object, key: string): unknown | undefined {
+	try {
+		const d = Object.getOwnPropertyDescriptor(source, key);
+		if (d === undefined) return undefined;
+		if (!Object.hasOwn(d, "value")) return undefined;
+		return d.value;
+	} catch {
+		return undefined;
+	}
+}
+
+function strictPlainObject(v: unknown): v is object {
+	if (typeof v !== "object" || v === null) return false;
+	try {
+		const proto = Object.getPrototypeOf(v);
+		if (proto !== Object.prototype && proto !== null) return false;
+	} catch {
+		return false;
+	}
+	return true;
+}
+
+function checkConfig(v: unknown): v is LifecycleConfig {
+	if (!strictPlainObject(v)) return false;
+	let ownKeys: readonly (string | symbol)[];
+	try {
+		ownKeys = Reflect.ownKeys(v);
+	} catch {
+		return false;
+	}
+	if (ownKeys.length !== 10) return false;
+	const expected: Record<string, true> = {
+		primeCliPath: true,
+		label: true,
+		image: true,
+		name: true,
+		cpuCores: true,
+		memoryGb: true,
+		diskSizeGb: true,
+		sandboxTimeoutMinutes: true,
+		operationTimeoutMs: true,
+		pollIntervalMs: true,
+	};
+	for (const k of ownKeys) {
+		if (typeof k !== "string") return false;
+		if (!Object.hasOwn(expected, k)) return false;
+	}
+	for (const k of ownKeys) {
+		if (typeof k !== "string") return false;
+		const d = od(v, k);
+		if (d === undefined) return false;
+	}
+	return true;
+}
+
+function exactOwnDataObject(v: unknown, expected: readonly string[]): v is object {
+	if (!strictPlainObject(v)) return false;
+	try {
+		const ownKeys = Reflect.ownKeys(v);
+		if (ownKeys.length !== expected.length) return false;
+		for (const key of ownKeys) {
+			if (typeof key !== "string" || !expected.includes(key)) return false;
+			const descriptor = Object.getOwnPropertyDescriptor(v, key);
+			if (descriptor === undefined || !Object.hasOwn(descriptor, "value")) return false;
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function decodeSuccessValue(v: unknown): RunnerSuccess["value"] | undefined {
+	if (!exactOwnDataObject(v, ["stdout", "stderr", "exitCode", "durationMs"])) return undefined;
+	const stdout = od(v, "stdout");
+	const stderr = od(v, "stderr");
+	const exitCode = od(v, "exitCode");
+	const durationMs = od(v, "durationMs");
+	if (typeof stdout !== "string" || typeof stderr !== "string") return undefined;
+	if (typeof exitCode !== "number" || !Number.isFinite(exitCode) || !Number.isSafeInteger(exitCode)) return undefined;
+	if (
+		typeof durationMs !== "number" ||
+		!Number.isFinite(durationMs) ||
+		!Number.isSafeInteger(durationMs) ||
+		durationMs < 0
+	)
+		return undefined;
+	return Object.freeze({ stdout, stderr, exitCode, durationMs });
+}
+
+function validRunnerFailureCode(v: unknown): v is RunnerFailureCode {
+	return (
+		v === "INPUT_INVALID" ||
+		v === "SPAWN_FAILED" ||
+		v === "ABORTED" ||
+		v === "TIMED_OUT" ||
+		v === "OUTPUT_OVERFLOW" ||
+		v === "STREAM_FAILED" ||
+		v === "PROCESS_UNCERTAIN"
+	);
+}
+
+function decodeRunnerResult(v: unknown): RunnerResult | undefined {
+	if (!exactOwnDataObject(v, ["ok", "value"]) && !exactOwnDataObject(v, ["ok", "code"])) return undefined;
+	const ok = od(v, "ok");
+	if (ok === true) {
+		const value = decodeSuccessValue(od(v, "value"));
+		if (value === undefined) return undefined;
+		return Object.freeze({ ok: true, value });
+	}
+	if (ok === false) {
+		const code = od(v, "code");
+		if (!validRunnerFailureCode(code)) return undefined;
+		return Object.freeze({ ok: false, code });
+	}
+	return undefined;
+}
+
+function defaultDelay(ms: number, signal?: AbortSignal): Promise<DelayResult> {
+	if (!Number.isFinite(ms) || ms < 0) return Promise.resolve("elapsed");
+	return new Promise((resolve) => {
+		if (signal !== undefined) {
+			if (signal.aborted) {
+				resolve("aborted");
+				return;
+			}
+			const onAbort = (): void => {
+				clearTimeout(timer);
+				resolve("aborted");
+			};
+			const timer = setTimeout(() => {
+				signal.removeEventListener("abort", onAbort);
+				resolve("elapsed");
+			}, ms);
+			signal.addEventListener("abort", onAbort, { once: true });
+		} else {
+			setTimeout(() => resolve("elapsed"), ms);
+		}
+	});
+}
+
+// -- Typed result constructors --
+
+function okEmpty(p: CreatePermission): InspectOutcome {
+	return Object.freeze({ ok: true, kind: "empty", value: p });
+}
+
+function okSingle(h: SandboxHandle): InspectOutcome {
+	return Object.freeze({ ok: true, kind: "single", value: h });
+}
+
+function collision(): InspectOutcome {
+	return Object.freeze({ ok: false, code: "COLLISION" });
+}
+
+function okRunning(): Readonly<{ ok: true }> | Readonly<{ ok: false; code: "READY_TERMINAL" }> | LifecycleError {
+	return Object.freeze({ ok: true });
+}
+
+function terminal(): Readonly<{ ok: true }> | Readonly<{ ok: false; code: "READY_TERMINAL" }> | LifecycleError {
+	return Object.freeze({ ok: false, code: "READY_TERMINAL" });
+}
+
+function okResultCap(h: SandboxHandle): Readonly<{ ok: true; value: SandboxHandle }> | LifecycleError {
+	return Object.freeze({ ok: true, value: h });
+}
+
+function okProof(p: DeleteProof): Readonly<{ ok: true; value: DeleteProof }> | LifecycleError {
+	return Object.freeze({ ok: true, value: p });
+}
+
+function okProofConsumed(): Readonly<{ ok: true }> | LifecycleError {
+	return Object.freeze({ ok: true });
+}
+
+// -- Factory --
+
+export async function createSandboxLifecycle(
+	runCommand: RunCommand,
+	config: LifecycleConfig,
+	clock?: Clock,
+	delay?: DelayFn,
+): Promise<Readonly<{ ok: true; value: SandboxLifecycleBundle }> | LifecycleError> {
+	if (typeof runCommand !== "function") return err("CONFIG_REJECTED");
+
+	if (!checkConfig(config)) return err("CONFIG_REJECTED");
+
+	const primeCliPathRaw = od(config, "primeCliPath");
+	const labelRaw = od(config, "label");
+	const imageRaw = od(config, "image");
+	const nameRaw = od(config, "name");
+	const cpuCoresRaw = od(config, "cpuCores");
+	const memoryGbRaw = od(config, "memoryGb");
+	const diskSizeGbRaw = od(config, "diskSizeGb");
+	const sandboxTimeoutMinutesRaw = od(config, "sandboxTimeoutMinutes");
+	const operationTimeoutMsRaw = od(config, "operationTimeoutMs");
+	const pollIntervalMsRaw = od(config, "pollIntervalMs");
+
+	if (
+		typeof primeCliPathRaw !== "string" ||
+		typeof labelRaw !== "string" ||
+		typeof imageRaw !== "string" ||
+		typeof nameRaw !== "string" ||
+		typeof cpuCoresRaw !== "number" ||
+		typeof memoryGbRaw !== "number" ||
+		typeof diskSizeGbRaw !== "number" ||
+		typeof sandboxTimeoutMinutesRaw !== "number" ||
+		typeof operationTimeoutMsRaw !== "number" ||
+		typeof pollIntervalMsRaw !== "number"
+	)
+		return err("CONFIG_REJECTED");
+
+	const primeCliPath: string = primeCliPathRaw;
+	const label: string = labelRaw;
+	const image: string = imageRaw;
+	const name: string = nameRaw;
+	const cpuCores: number = cpuCoresRaw;
+	const memoryGb: number = memoryGbRaw;
+	const diskSizeGb: number = diskSizeGbRaw;
+	const sandboxTimeoutMinutes: number = sandboxTimeoutMinutesRaw;
+	const operationTimeoutMs: number = operationTimeoutMsRaw;
+	const pollIntervalMs: number = pollIntervalMsRaw;
+
+	if (!absPath(primeCliPath) || !labelOk(label) || !labelOk(image) || !labelOk(name)) return err("CONFIG_REJECTED");
+	if (image.length > 0 && image.charCodeAt(0) === 0x2d) return err("CONFIG_REJECTED");
+	if (!intGe1(cpuCores, 1024) || !intGe1(memoryGb, 1_000_000) || !intGe1(diskSizeGb, 1_000_000))
+		return err("CONFIG_REJECTED");
+	if (
+		!intGe1(sandboxTimeoutMinutes, 1_000_000) ||
+		!intGe1(operationTimeoutMs, MAX_TO) ||
+		!intGe1(pollIntervalMs, MAX_TO)
+	)
+		return err("CONFIG_REJECTED");
+
+	// If clock is provided with a valid .now() function, use it; otherwise Date.now
+	let clockNow: () => number;
+	if (clock !== undefined) {
+		try {
+			const cd = Object.getOwnPropertyDescriptor(clock, "now");
+			if (cd !== undefined && Object.hasOwn(cd, "value") && typeof cd.value === "function") {
+				clockNow = cd.value;
+			} else {
+				clockNow = Date.now;
+			}
+		} catch {
+			clockNow = Date.now;
+		}
+	} else {
+		clockNow = Date.now;
+	}
+
+	let lastNow = Number.NEGATIVE_INFINITY;
+	function readNow(): number | undefined {
+		let t: number;
+		try {
+			t = clockNow();
+		} catch {
+			return undefined;
+		}
+		if (!Number.isFinite(t)) return undefined;
+		if (t < lastNow) return undefined;
+		lastNow = t;
+		return t;
+	}
+
+	{
+		const init = readNow();
+		if (init === undefined) return err("CONFIG_REJECTED");
+	}
+
+	const safeDelay: DelayFn = typeof delay === "function" ? delay : defaultDelay;
+
+	const gt = toCap(Math.min(operationTimeoutMs, 30_000));
+	if (gt === undefined) return err("CONFIG_REJECTED");
+	let vr: unknown;
+	try {
+		vr = await runCommand([primeCliPath, "--version"], gt);
+	} catch {
+		return err("VERSION_MISMATCH");
+	}
+	const versionResult = decodeRunnerResult(vr);
+	if (versionResult === undefined || !versionResult.ok) return err("VERSION_MISMATCH");
+	if (versionResult.value.exitCode !== 0 || versionResult.value.stderr !== "") return err("VERSION_MISMATCH");
+	if (!parsePrimeCliVersionOutput(versionResult.value.stdout).ok) return err("VERSION_MISMATCH");
+
+	// Closure-private state
+	const handleIdMap = new WeakMap<SandboxHandleToken, string>();
+	const deleteIssued = new WeakSet<SandboxHandleToken>();
+	const createPerms = new WeakSet<CreatePermissionToken>();
+	const createUsed = new WeakSet<CreatePermissionToken>();
+	const proofSet = new WeakSet<DeleteProofToken>();
+	const proofConsumed = new WeakSet<DeleteProofToken>();
+
+	function newHandle(id: string): SandboxHandle {
+		const o = new SandboxHandleToken();
+		Object.freeze(o);
+		handleIdMap.set(o, id);
+		return o;
+	}
+
+	function newPerm(): CreatePermission {
+		const o = new CreatePermissionToken();
+		Object.freeze(o);
+		createPerms.add(o);
+		return o;
+	}
+
+	function tryUsePerm(p: CreatePermission): "invalid" | "used" | "ok" {
+		if (!(p instanceof CreatePermissionToken)) return "invalid";
+		if (!createPerms.has(p)) return "invalid";
+		if (createUsed.has(p)) return "used";
+		createUsed.add(p);
+		return "ok";
+	}
+
+	function newProof(): DeleteProof {
+		const o = new DeleteProofToken();
+		Object.freeze(o);
+		proofSet.add(o);
+		return o;
+	}
+
+	function tryUseProof(p: DeleteProof): boolean {
+		if (!(p instanceof DeleteProofToken)) return false;
+		if (!proofSet.has(p)) return false;
+		if (proofConsumed.has(p)) return false;
+		proofConsumed.add(p);
+		return true;
+	}
+
+	function remaining(deadline: number): number | LifecycleError {
+		const n = readNow();
+		if (n === undefined) return err("UNCERTAIN");
+		const r = deadline - n;
+		if (!Number.isFinite(r)) return err("UNCERTAIN");
+		if (r < MIN_TO) return err("DEADLINE_EXCEEDED");
+		const capped = r > MAX_TO ? MAX_TO : Math.floor(r);
+		return capped;
+	}
+
+	function unpackRunner(r: unknown): Readonly<{ ok: true; stdout: string }> | LifecycleError {
+		const decoded = decodeRunnerResult(r);
+		if (decoded === undefined) return err("UNCERTAIN");
+		if (!decoded.ok) {
+			if (decoded.code === "INPUT_INVALID") return err("INPUT_INVALID");
+			if (decoded.code === "ABORTED") return err("ABORTED");
+			return err("UNCERTAIN");
+		}
+		if (decoded.value.exitCode !== 0 || decoded.value.stderr !== "") return err("UNCERTAIN");
+		return Object.freeze({ ok: true, stdout: decoded.value.stdout });
+	}
+
+	async function runCE(
+		argv: readonly string[],
+		toMs: number,
+		sig?: AbortSignal,
+	): Promise<Readonly<{ ok: true; stdout: string }> | LifecycleError> {
+		if (sig !== undefined && sig.aborted) return err("ABORTED");
+		const t = toCap(toMs);
+		if (t === undefined) return err("INPUT_INVALID");
+		let res: unknown;
+		try {
+			res = await runCommand(argv, t, sig);
+		} catch {
+			return err("UNCERTAIN");
+		}
+		return unpackRunner(res);
+	}
+
+	async function boundedDelay(
+		dm: number,
+		deadline: number,
+		sig?: AbortSignal,
+	): Promise<LifecycleError | "elapsed" | "aborted"> {
+		const pr = remaining(deadline);
+		if (typeof pr !== "number") return pr;
+		if (sig !== undefined && sig.aborted) return "aborted";
+
+		const actualMs = Math.min(dm, pr, MAX_TO);
+
+		if (safeDelay === defaultDelay) {
+			try {
+				const dr = await defaultDelay(actualMs, sig);
+				if (dr !== "elapsed" && dr !== "aborted") return err("UNCERTAIN");
+				if (sig !== undefined && sig.aborted) return "aborted";
+				return dr;
+			} catch {
+				return err("UNCERTAIN");
+			}
+		} else {
+			// Injected delay: race against a trusted, disposable guard.
+			const guardController = new AbortController();
+			const abortGuard = (): void => guardController.abort();
+			if (sig !== undefined) {
+				if (sig.aborted) guardController.abort();
+				else {
+					sig.addEventListener("abort", abortGuard, { once: true });
+					if (sig.aborted) guardController.abort();
+				}
+			}
+			const guard = defaultDelay(actualMs, guardController.signal);
+			try {
+				const result = await Promise.race([
+					safeDelay(actualMs, sig),
+					guard.then((guardResult) => (guardResult === "aborted" ? "aborted" : "guard-timeout")),
+				]);
+				if (result === "guard-timeout") return err("UNCERTAIN");
+				if (result !== "elapsed" && result !== "aborted") return err("UNCERTAIN");
+				if (sig !== undefined && sig.aborted) return "aborted";
+				return result;
+			} catch {
+				return err("UNCERTAIN");
+			} finally {
+				if (sig !== undefined) sig.removeEventListener("abort", abortGuard);
+				guardController.abort();
+			}
+		}
+	}
+
+	async function scanAll(
+		deadline: number,
+		sig?: AbortSignal,
+	): Promise<
+		Readonly<{ ok: true; rows: readonly Readonly<{ id: string; status: string }>[]; total: number }> | LifecycleError
+	> {
+		if (sig !== undefined && sig.aborted) return err("ABORTED");
+
+		const all: Array<Readonly<{ id: string; status: string }>> = [];
+		const seenIds = new Set<string>();
+		let page = 1;
+		let vTotal = -1;
+		let completed = false;
+
+		while (page <= MAX_LIST_PAGES) {
+			const r = remaining(deadline);
+			if (typeof r !== "number") return r;
+			if (sig !== undefined && sig.aborted) return err("ABORTED");
+
+			const r2 = await runCE(
+				[
+					primeCliPath,
+					"--plain",
+					"sandbox",
+					"list",
+					"--label",
+					label,
+					"--page",
+					String(page),
+					"--num",
+					"100",
+					"--output",
+					"json",
+				],
+				r,
+				sig,
+			);
+			if (!r2.ok) return r2;
+
+			const p = parsePrimeSandboxListOutput(r2.stdout, label);
+			if (!p.ok) return err("UNCERTAIN");
+
+			const l = p.value;
+			if (l.perPage !== PER_PAGE || l.page !== page) return err("UNCERTAIN");
+			if (vTotal < 0) vTotal = l.total;
+			if (vTotal !== l.total) return err("UNCERTAIN");
+			if (vTotal > MAX_TOTAL_ROWS) return err("UNCERTAIN");
+			if (l.sandboxes.length > l.perPage) return err("UNCERTAIN");
+
+			for (const row of l.sandboxes) {
+				if (seenIds.has(row.id)) return err("UNCERTAIN");
+				seenIds.add(row.id);
+				all.push(Object.freeze({ id: row.id, status: row.status }));
+			}
+
+			if (!l.hasNext) {
+				completed = true;
+				break;
+			}
+			page++;
+		}
+
+		if (!completed) return err("UNCERTAIN");
+		if (all.length !== vTotal) return err("UNCERTAIN");
+		return Object.freeze({ ok: true, rows: Object.freeze(all), total: vTotal });
+	}
+
+	const lifecycle: SandboxLifecycle = Object.freeze({
+		async inspect(sig?: AbortSignal): Promise<InspectOutcome> {
+			if (sig !== undefined && sig.aborted) return err("ABORTED");
+			const start = readNow();
+			if (start === undefined) return err("UNCERTAIN");
+			const d = start + operationTimeoutMs;
+
+			const s = await scanAll(d, sig);
+			if (!s.ok) return s;
+
+			if (s.rows.length === 0) return okEmpty(newPerm());
+			for (const r of s.rows) {
+				if (r.status === "TERMINATED") return err("UNCERTAIN");
+			}
+			if (s.rows.length > 1) return collision();
+
+			const row = s.rows[0];
+			const gr = remaining(d);
+			if (typeof gr !== "number") return gr;
+			if (sig !== undefined && sig.aborted) return err("ABORTED");
+
+			const g = await runCE([primeCliPath, "--plain", "sandbox", "get", row.id, "--output", "json"], gr, sig);
+			if (!g.ok) return g;
+
+			const gp = parsePrimeSandboxGetOutput(g.stdout, row.id, label);
+			if (!gp.ok || gp.value.vm || gp.value.type !== "Container") return err("UNCERTAIN");
+
+			return okSingle(newHandle(gp.value.id));
+		},
+
+		async create(
+			perm: CreatePermission,
+			sig?: AbortSignal,
+		): Promise<Readonly<{ ok: true; value: SandboxHandle }> | LifecycleError> {
+			if (sig !== undefined && sig.aborted) return err("ABORTED");
+			const permStatus = tryUsePerm(perm);
+			if (permStatus !== "ok") {
+				return permStatus === "invalid" ? err("TOKEN_INVALID") : err("TOKEN_CONSUMED");
+			}
+
+			const start = readNow();
+			if (start === undefined) return err("UNCERTAIN");
+			const d = start + operationTimeoutMs;
+
+			const cr = remaining(d);
+			if (typeof cr !== "number") return err("DEADLINE_EXCEEDED");
+			if (sig !== undefined && sig.aborted) return err("ABORTED");
+
+			const cResult = await runCE(
+				[
+					primeCliPath,
+					"--plain",
+					"sandbox",
+					"create",
+					image,
+					"--name",
+					name,
+					"--cpu-cores",
+					String(cpuCores),
+					"--memory-gb",
+					String(memoryGb),
+					"--disk-size-gb",
+					String(diskSizeGb),
+					"--timeout-minutes",
+					String(sandboxTimeoutMinutes),
+					"--label",
+					label,
+					"--yes",
+				],
+				cr,
+				sig,
+			);
+			if (!cResult.ok) return err("RECOVERY_REQUIRED");
+
+			const cp = parsePrimeCliCreateOutput(cResult.stdout);
+			if (!cp.ok) return err("RECOVERY_REQUIRED");
+
+			const nid = cp.value.id;
+			const ggr = remaining(d);
+			if (typeof ggr !== "number") return err("RECOVERY_REQUIRED");
+			if (sig !== undefined && sig.aborted) return err("RECOVERY_REQUIRED");
+
+			const g = await runCE([primeCliPath, "--plain", "sandbox", "get", nid, "--output", "json"], ggr, sig);
+			if (!g.ok) return err("RECOVERY_REQUIRED");
+
+			const gp = parsePrimeSandboxGetOutput(g.stdout, nid, label);
+			if (!gp.ok || gp.value.vm || gp.value.type !== "Container") return err("RECOVERY_REQUIRED");
+
+			return okResultCap(newHandle(gp.value.id));
+		},
+
+		async waitUntilReady(
+			h: SandboxHandle,
+			sig?: AbortSignal,
+		): Promise<Readonly<{ ok: true }> | Readonly<{ ok: false; code: "READY_TERMINAL" }> | LifecycleError> {
+			if (sig !== undefined && sig.aborted) return err("ABORTED");
+			if (!(h instanceof SandboxHandleToken)) return err("HANDLE_INVALID");
+			const id = handleIdMap.get(h);
+			if (id === undefined) return err("HANDLE_INVALID");
+
+			const start = readNow();
+			if (start === undefined) return err("UNCERTAIN");
+			const d = start + operationTimeoutMs;
+
+			let polls = 0;
+			while (polls < MAX_READY_POLLS) {
+				polls++;
+				if (sig !== undefined && sig.aborted) return err("ABORTED");
+				const r = remaining(d);
+				if (typeof r !== "number") return r;
+
+				const g = await runCE([primeCliPath, "--plain", "sandbox", "get", id, "--output", "json"], r, sig);
+				if (!g.ok) {
+					if (g.code === "ABORTED") return g;
+					return err("UNCERTAIN");
+				}
+
+				const gp = parsePrimeSandboxGetOutput(g.stdout, id, label);
+				if (!gp.ok) return err("UNCERTAIN");
+
+				const detail = gp.value;
+				if (detail.vm || detail.type !== "Container") return err("UNCERTAIN");
+
+				const s = detail.status;
+				if (s === "RUNNING") return okRunning();
+				if (s === "ERROR" || s === "TIMEOUT" || s === "TERMINATED") return terminal();
+
+				const dr = await boundedDelay(pollIntervalMs, d, sig);
+				if (dr === "aborted") return err("ABORTED");
+				if (typeof dr === "object" && !dr.ok) return dr;
+			}
+			return err("POLL_LIMIT");
+		},
+
+		async deleteAndProveAbsent(
+			h: SandboxHandle,
+			sig?: AbortSignal,
+		): Promise<Readonly<{ ok: true; value: DeleteProof }> | LifecycleError> {
+			if (sig !== undefined && sig.aborted) return err("ABORTED");
+			if (!(h instanceof SandboxHandleToken)) return err("HANDLE_INVALID");
+			const id = handleIdMap.get(h);
+			if (id === undefined) return err("HANDLE_INVALID");
+
+			if (deleteIssued.has(h)) return err("DUPLICATE_DELETE");
+			deleteIssued.add(h);
+
+			const start = readNow();
+			if (start === undefined) return err("UNCERTAIN");
+			const d = start + operationTimeoutMs;
+
+			const dr = remaining(d);
+			if (typeof dr === "number" && (sig === undefined || !sig.aborted)) {
+				await runCE([primeCliPath, "--plain", "sandbox", "delete", id, "--yes"], dr, sig);
+			}
+
+			let polls = 0;
+			while (polls < MAX_DELETE_POLLS) {
+				polls++;
+				if (sig !== undefined && sig.aborted) return err("ABORTED");
+				const s = await scanAll(d, sig);
+				if (!s.ok) {
+					if (s.code === "DEADLINE_EXCEEDED" || s.code === "ABORTED") return s;
+					return err("ABSENCE_UNCERTAIN");
+				}
+
+				if (s.total === 0) return okProof(newProof());
+
+				const dr2 = await boundedDelay(pollIntervalMs, d, sig);
+				if (dr2 === "aborted") return err("ABORTED");
+				if (typeof dr2 === "object" && !dr2.ok) return dr2;
+			}
+			return err("POLL_LIMIT");
+		},
+	});
+
+	const proofConsumer: ProofConsumer = Object.freeze({
+		consumeProof(proof: DeleteProof): Readonly<{ ok: true }> | LifecycleError {
+			if (!tryUseProof(proof)) return err("PROOF_INVALID");
+			return okProofConsumed();
+		},
+	});
+
+	const bundle: SandboxLifecycleBundle = Object.freeze({
+		lifecycle,
+		proofConsumer,
+	});
+
+	return Object.freeze({ ok: true, value: bundle });
+}

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2814,6 +2814,56 @@ describe("AgentSession rlm recursion", () => {
 		);
 	});
 
+	it("treats sandbox false exactly like an omitted request", async () => {
+		const root = createSession();
+		const spawned = await root.runRlmChild("local child", { sandbox: false });
+		expect(spawned.rlm_child_id).toBeTruthy();
+		expect(spawned.session_dir).toBeTruthy();
+	});
+
+	it("rejects sandbox true before reserving or publishing a child", async () => {
+		const root = createSession();
+		const beforeEntries = readdirSync(join(tempDir, "sessions")).sort();
+		await expect(root.runRlmChild("sandbox child", { sandbox: true })).rejects.toThrow(
+			"Sandbox execution is not available for this session",
+		);
+		expect((root as unknown as InspectableRlmSession)._activeRlmChildRuns.size).toBe(0);
+		expect((await root.listRlmSubagents()).subagents).toEqual([]);
+		expect(readdirSync(join(tempDir, "sessions")).sort()).toEqual(beforeEntries);
+	});
+
+	it("rejects non-boolean sandbox values with a fixed error", async () => {
+		const root = createSession();
+		await expect(root.runRlmChild("sandbox child", { sandbox: "true" })).rejects.toThrow(
+			"rlm.run sandbox must be a boolean",
+		);
+	});
+
+	it("rejects accessor and throwing Proxy kwargs without invoking values", async () => {
+		const root = createSession();
+		let getterCalled = false;
+		const accessor: Record<string, unknown> = {};
+		Object.defineProperty(accessor, "sandbox", {
+			enumerable: true,
+			get() {
+				getterCalled = true;
+				return true;
+			},
+		});
+		await expect(root.runRlmChild("accessor", accessor)).rejects.toThrow("rlm.run kwargs are invalid");
+		expect(getterCalled).toBe(false);
+
+		const hostile = new Proxy<Record<string, unknown>>(
+			{},
+			{
+				ownKeys() {
+					throw new Error("secret proxy failure");
+				},
+			},
+		);
+		await expect(root.runRlmChild("proxy", hostile)).rejects.toThrow("rlm.run kwargs are invalid");
+	});
+
 	it("rejects a non-string rlm.run thinking kwarg", async () => {
 		const root = createSession();
 

--- a/packages/coding-agent/test/bun-release-archives.test.ts
+++ b/packages/coding-agent/test/bun-release-archives.test.ts
@@ -1,20 +1,77 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
 	chmodSync,
+	closeSync,
 	cpSync,
 	existsSync,
+	lstatSync,
 	mkdirSync,
 	mkdtempSync,
+	openSync,
 	readdirSync,
 	readFileSync,
+	readSync,
 	rmSync,
+	statSync,
 	symlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { gunzipSync } from "node:zlib";
+
+/** Compare two strings by code-unit order for deterministic sorting. */
+function codeUnitCompare(a: string, b: string): number {
+	if (a < b) return -1;
+	if (a > b) return 1;
+	return 0;
+}
+
+function bytewiseCompare(a: string, b: string): number {
+	return Buffer.compare(Buffer.from(a, "utf8"), Buffer.from(b, "utf8"));
+}
+
+function sha256FileBoundedForTest(path: string): string {
+	const fd = openSync(path, "r");
+	try {
+		const digest = createHash("sha256");
+		const buffer = Buffer.alloc(65536);
+		let count = 0;
+		do {
+			count = readSync(fd, buffer, 0, buffer.byteLength, null);
+			if (count > 0) digest.update(buffer.subarray(0, count));
+		} while (count > 0);
+		return digest.digest("hex");
+	} finally {
+		closeSync(fd);
+	}
+}
+
+/** Minimal typed helper to decode an unknown JSON value as a plain object. */
+function asRecord(v: unknown): Record<string, unknown> {
+	if (typeof v !== "object" || v === null) throw new Error("expected object");
+	return v as Record<string, unknown>;
+}
+
+/** Decode unknown as a string. */
+function asString(v: unknown): string {
+	if (typeof v !== "string") throw new Error("expected string");
+	return v;
+}
+
+/** Decode unknown as a number. */
+function asNumber(v: unknown): number {
+	if (typeof v !== "number") throw new Error("expected number");
+	return v;
+}
+
+function asRecordArray(v: unknown): Record<string, unknown>[] {
+	if (!Array.isArray(v)) throw new Error("expected array");
+	return v.map(asRecord);
+}
 
 const packageDir = join(dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = join(packageDir, "..", "..");
@@ -24,7 +81,14 @@ const temporaryRoots: string[] = [];
 const outputDirs: string[] = [];
 const platforms = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"];
 
-function fixture(): { root: string; binaries: string; sidecars: string; output: string } {
+interface FixturePaths {
+	root: string;
+	binaries: string;
+	sidecars: string;
+	output: string;
+}
+
+function fixture(): FixturePaths {
 	const root = mkdtempSync(join(tmpdir(), "prime-agent-release-"));
 	temporaryRoots.push(root);
 	const binaries = join(root, "binaries");
@@ -67,7 +131,7 @@ function fixture(): { root: string; binaries: string; sidecars: string; output: 
 	return { root, binaries, sidecars, output };
 }
 
-function pack(f: ReturnType<typeof fixture>, extra: string[] = []) {
+function fullPack(f: FixturePaths, extra: string[] = []) {
 	return spawnSync(
 		process.execPath,
 		[
@@ -98,13 +162,15 @@ afterEach(() => {
 describe("compiled release archives", () => {
 	test("creates all platform archives with flat required sidecars and rendered installer", () => {
 		const f = fixture();
-		const result = pack(f);
+		const result = fullPack(f);
 		expect(result.status, result.stderr).toBe(0);
 		const artifacts = join(f.output, "artifacts");
 		const archives = readdirSync(artifacts).filter((name) => name.endsWith(".tar.gz"));
-		expect(archives.sort()).toEqual(platforms.map((platform) => `prime-agent-1.2.3-${platform}.tar.gz`).sort());
+		archives.sort(codeUnitCompare);
+		const expected = platforms.map((p) => `prime-agent-1.2.3-${p}`).sort(codeUnitCompare);
+		expect(archives).toEqual(expected.map((p) => `${p}.tar.gz`));
 		expect(readFileSync(join(artifacts, "stable"), "utf8")).toBe("v1.2.3\n");
-		expect(readFileSync(join(artifacts, "SHA256SUMS"), "utf8").trim().split("\n")).toHaveLength(4);
+		expect(readFileSync(join(artifacts, "SHA256SUMS"), "utf8").trim().split("\n")).toHaveLength(8);
 
 		const extracted = join(f.root, "extracted");
 		mkdirSync(extracted);
@@ -140,7 +206,7 @@ describe("compiled release archives", () => {
 
 	test("supports a single-platform local archive", () => {
 		const f = fixture();
-		const result = pack(f, ["--platform", "linux-x64"]);
+		const result = fullPack(f, ["--platform", "linux-x64"]);
 		expect(result.status, result.stderr).toBe(0);
 		expect(readdirSync(join(f.output, "artifacts")).filter((name) => name.endsWith(".tar.gz"))).toEqual([
 			"prime-agent-1.2.3-linux-x64.tar.gz",
@@ -150,7 +216,7 @@ describe("compiled release archives", () => {
 	test("fails closed when a required sidecar is missing", () => {
 		const f = fixture();
 		rmSync(join(f.sidecars, "theme"), { recursive: true });
-		const result = pack(f);
+		const result = fullPack(f);
 		expect(result.status).not.toBe(0);
 		expect(result.stderr).toContain("Missing required sidecars");
 	});
@@ -158,7 +224,7 @@ describe("compiled release archives", () => {
 	test("fails closed when a nested required sidecar is missing", () => {
 		const f = fixture();
 		rmSync(join(f.sidecars, "prime-agent-runtime", "pyproject.toml"));
-		const result = pack(f);
+		const result = fullPack(f);
 		expect(result.status).not.toBe(0);
 		expect(result.stderr).toContain("prime-agent-runtime/pyproject.toml");
 	});
@@ -166,32 +232,38 @@ describe("compiled release archives", () => {
 	test("rejects dependency directories in release sidecars", () => {
 		const f = fixture();
 		mkdirSync(join(f.sidecars, "examples", "node_modules"));
-		const result = pack(f);
+		const result = fullPack(f);
 		expect(result.status).not.toBe(0);
 		expect(result.stderr).toContain("forbidden dependency or cache directory");
 	});
 	test("normalizes v-prefixed versions for binary archive metadata", () => {
 		const f = fixture();
-		const result = pack(f, ["--version", "v1.2.3"]);
+		const result = fullPack(f, ["--version", "v1.2.3"]);
 		expect(result.status, result.stderr).toBe(0);
-		const manifest = JSON.parse(readFileSync(join(f.output, "artifacts", "latest.json"), "utf8"));
-		expect(manifest.version).toBe("v1.2.3");
-		expect(manifest.package).toBe("@earendil-works/pi-coding-agent");
-		expect(manifest.baseUrl).toBe("https://downloads.example.test/releases/v1.2.3");
+		const channelManifest = JSON.parse(readFileSync(join(f.output, "artifacts", "latest.json"), "utf8")) as Record<
+			string,
+			unknown
+		>;
+		expect(asString(channelManifest.version)).toBe("v1.2.3");
+		expect(asString(channelManifest.package)).toBe("@earendil-works/pi-coding-agent");
+		expect(asString(channelManifest.baseUrl)).toBe("https://downloads.example.test/releases/v1.2.3");
 		expect(existsSync(join(f.output, "artifacts", "prime-agent-1.2.3-darwin-arm64.tar.gz"))).toBe(true);
 	});
 
 	test("trims release base URLs before writing binary metadata", () => {
 		const f = fixture();
-		const result = pack(f, ["--base-url", "  https://downloads.example.test/  "]);
+		const result = fullPack(f, ["--base-url", "  https://downloads.example.test/  "]);
 		expect(result.status, result.stderr).toBe(0);
-		const manifest = JSON.parse(readFileSync(join(f.output, "artifacts", "latest.json"), "utf8"));
-		expect(manifest.baseUrl).toBe("https://downloads.example.test/releases/v1.2.3");
+		const channelManifest = JSON.parse(readFileSync(join(f.output, "artifacts", "latest.json"), "utf8")) as Record<
+			string,
+			unknown
+		>;
+		expect(asString(channelManifest.baseUrl)).toBe("https://downloads.example.test/releases/v1.2.3");
 	});
 
 	test("rejects insecure release base URLs", () => {
 		const f = fixture();
-		const result = pack(f, ["--base-url", "http://downloads.example.test"]);
+		const result = fullPack(f, ["--base-url", "http://downloads.example.test"]);
 		expect(result.status).not.toBe(0);
 		expect(result.stderr).toContain("must use HTTPS");
 	});
@@ -199,7 +271,7 @@ describe("compiled release archives", () => {
 	test("rejects empty query and fragment delimiters in release base URLs", () => {
 		for (const delimiter of ["?", "#"]) {
 			const f = fixture();
-			const result = pack(f, ["--base-url", `https://downloads.example.test/${delimiter}`]);
+			const result = fullPack(f, ["--base-url", `https://downloads.example.test/${delimiter}`]);
 			expect(result.status).not.toBe(0);
 			expect(result.stderr).toContain("must not contain a query or fragment");
 		}
@@ -207,7 +279,7 @@ describe("compiled release archives", () => {
 
 	test("rejects shell-active release base URLs", () => {
 		const f = fixture();
-		const result = pack(f, ["--base-url", "https://downloads.example.test/$(touch-danger)"]);
+		const result = fullPack(f, ["--base-url", "https://downloads.example.test/$(touch-danger)"]);
 		expect(result.status).not.toBe(0);
 		expect(result.stderr).toContain("unsafe shell characters");
 	});
@@ -218,7 +290,7 @@ describe("compiled release archives", () => {
 		mkdirSync(dirname(sentinel), { recursive: true });
 		writeFileSync(sentinel, "keep");
 		rmSync(join(f.sidecars, "theme"), { recursive: true });
-		const result = pack(f);
+		const result = fullPack(f);
 		expect(result.status).not.toBe(0);
 		expect(readFileSync(sentinel, "utf8")).toBe("keep");
 	});
@@ -232,9 +304,501 @@ describe("compiled release archives", () => {
 		const link = join(releaseRoot, `link-${process.pid}-${Math.random().toString(36).slice(2)}`);
 		outputDirs.push(link);
 		symlinkSync(outside, link, "dir");
-		const result = pack(f, ["--out-dir", join(link, "old")]);
+		const result = fullPack(f, ["--out-dir", join(link, "old")]);
 		expect(result.status).not.toBe(0);
 		expect(result.stderr).toContain("symlinked output path");
 		expect(readFileSync(sentinel, "utf8")).toBe("keep");
+	});
+});
+
+describe("entry manifest generation", () => {
+	function fixture(): FixturePaths {
+		const root = mkdtempSync(join(tmpdir(), "prime-agent-release-"));
+		temporaryRoots.push(root);
+		const binaries = join(root, "binaries");
+		const sidecars = join(root, "sidecars");
+		for (const platform of platforms) {
+			const dir = join(binaries, platform);
+			mkdirSync(dir, { recursive: true });
+			cpSync("/bin/echo", join(dir, "pi"));
+			chmodSync(join(dir, "pi"), 0o755);
+		}
+		mkdirSync(sidecars, { recursive: true });
+		for (const name of ["prime-agent-runtime", "skills", "theme", "assets", "export-html", "docs", "examples"]) {
+			mkdirSync(join(sidecars, name));
+			writeFileSync(join(sidecars, name, ".keep"), "fixture");
+		}
+		for (const name of [
+			"prime-agent-runtime/pyproject.toml",
+			"theme/prime.json",
+			"theme/dark.json",
+			"theme/light.json",
+			"theme/theme-schema.json",
+			"export-html/template.html",
+			"export-html/template.css",
+			"export-html/template.js",
+			"export-html/vendor/.keep",
+		]) {
+			mkdirSync(dirname(join(sidecars, name)), { recursive: true });
+			writeFileSync(join(sidecars, name), "fixture");
+		}
+		writeFileSync(join(sidecars, "package.json"), JSON.stringify({ name: "prime-agent", version: "1.2.3" }));
+		writeFileSync(join(sidecars, "README.md"), "readme");
+		writeFileSync(join(sidecars, "CHANGELOG.md"), "changelog");
+		const installerContent =
+			'#!/bin/sh\nbase="__PRIME_AGENT_DOWNLOAD_BASE_URL__"\nchannel="__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__"\n';
+		writeFileSync(join(sidecars, "install.sh"), installerContent);
+		writeFileSync(join(sidecars, "photon_rs_bg.wasm"), "wasm");
+		chmodSync(join(sidecars, "install.sh"), 0o755);
+		const output = join(releaseRoot, `test-${process.pid}-${Math.random().toString(36).slice(2)}`);
+		outputDirs.push(output);
+		return { root, binaries, sidecars, output };
+	}
+
+	function singlePack(f: FixturePaths, platform = "darwin-arm64", extra: string[] = []) {
+		const result = spawnSync(
+			process.execPath,
+			[
+				packScript,
+				"--base-url",
+				"https://downloads.example.test",
+				"--channel",
+				"stable",
+				"--version",
+				"0.0.0",
+				"--binary-base-dir",
+				f.binaries,
+				"--sidecar-dir",
+				f.sidecars,
+				"--out-dir",
+				f.output,
+				"--platform",
+				platform,
+				...extra,
+			],
+			{ encoding: "utf8" },
+		);
+		return result;
+	}
+
+	function readManifest(f: FixturePaths, version = "0.0.0", platform = "darwin-arm64"): Record<string, unknown> {
+		const manifestPath = join(f.output, "artifacts", `prime-agent-${version}-${platform}.manifest.json`);
+		return JSON.parse(readFileSync(manifestPath, "utf8")) as Record<string, unknown>;
+	}
+
+	test("produces deterministic manifest bytes for identical input", () => {
+		const f1 = fixture();
+		const r1 = singlePack(f1);
+		expect(r1.status, r1.stderr).toBe(0);
+		const m1 = readManifest(f1);
+		const json1 = JSON.stringify(m1);
+
+		const f2 = fixture();
+		const r2 = singlePack(f2);
+		expect(r2.status, r2.stderr).toBe(0);
+		const m2 = readManifest(f2);
+		const json2 = JSON.stringify(m2);
+
+		expect(json1).toBe(json2);
+		expect(asNumber(m1.totalFiles)).toBe(asNumber(m2.totalFiles));
+		expect(asNumber(m1.totalDirectories)).toBe(asNumber(m2.totalDirectories));
+	});
+
+	test("reports correct file modes and SHA-256 digests", () => {
+		const f = fixture();
+		const extraScript = join(f.sidecars, "prime-agent-runtime", "script.sh");
+		writeFileSync(extraScript, "#!/bin/sh\necho hi");
+		chmodSync(extraScript, 0o755);
+		const result = singlePack(f);
+		expect(result.status, result.stderr).toBe(0);
+		const manifest = readManifest(f);
+
+		const entries = asRecordArray(manifest.entries);
+		const primeAgentEntry = entries.find((e) => e.path === "prime-agent");
+		expect(primeAgentEntry).toBeDefined();
+		expect(asString(primeAgentEntry!.type)).toBe("file");
+		expect(asString(primeAgentEntry!.mode)).toBe("0755");
+		expect(asString(primeAgentEntry!.sha256)).toMatch(/^[a-f0-9]{64}$/);
+
+		const keepEntry = entries.find((e) => e.path === "theme/.keep");
+		expect(keepEntry).toBeDefined();
+		expect(asString(keepEntry!.type)).toBe("file");
+		expect(asString(keepEntry!.mode)).toBe("0644");
+
+		const dirEntry = entries.find((e) => e.path === "theme");
+		expect(dirEntry).toBeDefined();
+		expect(asString(dirEntry!.type)).toBe("directory");
+		expect(asString(dirEntry!.mode)).toBe("0755");
+
+		const scriptEntry = entries.find((e) => e.path === "prime-agent-runtime/script.sh");
+		expect(scriptEntry).toBeDefined();
+		expect(asString(scriptEntry!.type)).toBe("file");
+		expect(asString(scriptEntry!.mode)).toBe("0755");
+
+		for (const entry of entries) {
+			if (entry.type === "file") {
+				expect(asString(entry.sha256!)).toMatch(/^[a-f0-9]{64}$/);
+				expect(asNumber(entry.size)).toBeGreaterThan(0);
+			} else {
+				expect(entry.sha256).toBeUndefined();
+				expect(asNumber(entry.size)).toBe(0);
+			}
+		}
+	});
+
+	test("rejects symlinks in staging tree", () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-agent-link-reject-"));
+		temporaryRoots.push(root);
+		const binaries = join(root, "binaries");
+		const sidecars = join(root, "sidecars");
+		const linkOutput = join(releaseRoot, `link-test-${process.pid}-${Math.random().toString(36).slice(2)}`);
+		outputDirs.push(linkOutput);
+		mkdirSync(join(binaries, "darwin-arm64"), { recursive: true });
+		cpSync("/bin/echo", join(binaries, "darwin-arm64", "pi"));
+		chmodSync(join(binaries, "darwin-arm64", "pi"), 0o755);
+		mkdirSync(sidecars, { recursive: true });
+		writeFileSync(join(sidecars, "package.json"), JSON.stringify({ name: "p", version: "1.0.0" }));
+		writeFileSync(join(sidecars, "README.md"), "r");
+		writeFileSync(join(sidecars, "CHANGELOG.md"), "c");
+		writeFileSync(join(sidecars, "install.sh"), "#!/bin/sh");
+		chmodSync(join(sidecars, "install.sh"), 0o755);
+		writeFileSync(join(sidecars, "photon_rs_bg.wasm"), "w");
+		mkdirSync(join(sidecars, "prime-agent-runtime"));
+		writeFileSync(join(sidecars, "prime-agent-runtime", "pyproject.toml"), "x");
+		mkdirSync(join(sidecars, "skills"));
+		mkdirSync(join(sidecars, "theme"));
+		writeFileSync(join(sidecars, "theme", "prime.json"), "x");
+		writeFileSync(join(sidecars, "theme", "dark.json"), "x");
+		writeFileSync(join(sidecars, "theme", "light.json"), "x");
+		writeFileSync(join(sidecars, "theme", "theme-schema.json"), "x");
+		mkdirSync(join(sidecars, "assets"));
+		mkdirSync(join(sidecars, "export-html"));
+		writeFileSync(join(sidecars, "export-html", "template.html"), "x");
+		writeFileSync(join(sidecars, "export-html", "template.css"), "x");
+		writeFileSync(join(sidecars, "export-html", "template.js"), "x");
+		mkdirSync(join(sidecars, "export-html", "vendor"));
+		writeFileSync(join(sidecars, "export-html", "vendor", ".keep"), "x");
+		mkdirSync(join(sidecars, "docs"));
+		mkdirSync(join(sidecars, "examples"));
+		symlinkSync("/etc/passwd", join(sidecars, "prime-agent-runtime", "malicious-link"), "file");
+
+		const result = spawnSync(
+			process.execPath,
+			[
+				packScript,
+				"--base-url",
+				"https://downloads.example.test",
+				"--channel",
+				"stable",
+				"--version",
+				"0.0.0",
+				"--binary-base-dir",
+				binaries,
+				"--sidecar-dir",
+				sidecars,
+				"--out-dir",
+				linkOutput,
+				"--platform",
+				"darwin-arm64",
+			],
+			{ encoding: "utf8" },
+		);
+		expect(result.status).not.toBe(0);
+		expect(result.stderr).toContain("symlink");
+	});
+
+	test("rejects directory symlinks in staging tree", () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-agent-dirlink-"));
+		temporaryRoots.push(root);
+		const binaries = join(root, "binaries");
+		const sidecars = join(root, "sidecars");
+		const linkOutput = join(releaseRoot, `dirlink-test-${process.pid}-${Math.random().toString(36).slice(2)}`);
+		outputDirs.push(linkOutput);
+		mkdirSync(join(binaries, "darwin-arm64"), { recursive: true });
+		cpSync("/bin/echo", join(binaries, "darwin-arm64", "pi"));
+		chmodSync(join(binaries, "darwin-arm64", "pi"), 0o755);
+		mkdirSync(sidecars, { recursive: true });
+		writeFileSync(join(sidecars, "package.json"), JSON.stringify({ name: "p", version: "1.0.0" }));
+		writeFileSync(join(sidecars, "README.md"), "r");
+		writeFileSync(join(sidecars, "CHANGELOG.md"), "c");
+		writeFileSync(join(sidecars, "install.sh"), "#!/bin/sh");
+		chmodSync(join(sidecars, "install.sh"), 0o755);
+		writeFileSync(join(sidecars, "photon_rs_bg.wasm"), "w");
+		mkdirSync(join(sidecars, "prime-agent-runtime"));
+		writeFileSync(join(sidecars, "prime-agent-runtime", "pyproject.toml"), "x");
+		mkdirSync(join(sidecars, "skills"));
+		mkdirSync(join(sidecars, "theme"));
+		writeFileSync(join(sidecars, "theme", "prime.json"), "x");
+		writeFileSync(join(sidecars, "theme", "dark.json"), "x");
+		writeFileSync(join(sidecars, "theme", "light.json"), "x");
+		writeFileSync(join(sidecars, "theme", "theme-schema.json"), "x");
+		mkdirSync(join(sidecars, "assets"));
+		mkdirSync(join(sidecars, "export-html"));
+		writeFileSync(join(sidecars, "export-html", "template.html"), "x");
+		writeFileSync(join(sidecars, "export-html", "template.css"), "x");
+		writeFileSync(join(sidecars, "export-html", "template.js"), "x");
+		mkdirSync(join(sidecars, "export-html", "vendor"));
+		writeFileSync(join(sidecars, "export-html", "vendor", ".keep"), "x");
+		mkdirSync(join(sidecars, "docs"));
+		mkdirSync(join(sidecars, "examples"));
+		symlinkSync("/tmp", join(sidecars, "prime-agent-runtime", "malicious-dir-link"), "dir");
+
+		const result = spawnSync(
+			process.execPath,
+			[
+				packScript,
+				"--base-url",
+				"https://downloads.example.test",
+				"--channel",
+				"stable",
+				"--version",
+				"0.0.0",
+				"--binary-base-dir",
+				binaries,
+				"--sidecar-dir",
+				sidecars,
+				"--out-dir",
+				linkOutput,
+				"--platform",
+				"darwin-arm64",
+			],
+			{ encoding: "utf8" },
+		);
+		expect(result.status).not.toBe(0);
+		expect(result.stderr).toContain("symlink");
+	});
+
+	test("SHA256SUMS matches actual file digests", () => {
+		const f = fixture();
+		const result = singlePack(f);
+		expect(result.status, result.stderr).toBe(0);
+
+		const artifactsDir = join(f.output, "artifacts");
+		const sums = readFileSync(join(artifactsDir, "SHA256SUMS"), "utf8");
+		const lines = sums.trim().split("\n").filter(Boolean);
+
+		expect(lines).toHaveLength(2);
+
+		for (const line of lines) {
+			const [expectedSha, filename] = line.split(/\s+/);
+			expect(expectedSha).toMatch(/^[a-f0-9]{64}$/);
+			expect(filename).toMatch(/^prime-agent-0\.0\.0/);
+
+			const filePath = join(artifactsDir, filename);
+			const actualSha = sha256FileBoundedForTest(filePath);
+			expect(actualSha, `SHA256 mismatch for ${filename}`).toBe(expectedSha);
+		}
+
+		expect(lines.some((l: string) => l.endsWith(".tar.gz"))).toBe(true);
+		expect(lines.some((l: string) => l.endsWith(".manifest.json"))).toBe(true);
+	});
+
+	test("records archive byteSize, sha256, manifest metadata in latest.json", () => {
+		const f = fixture();
+		const result = singlePack(f);
+		expect(result.status, result.stderr).toBe(0);
+
+		const latestRaw = readFileSync(join(f.output, "artifacts", "latest.json"), "utf8");
+		const latest = asRecord(JSON.parse(latestRaw));
+
+		expect(asString(latest.version)).toBe("v0.0.0");
+		const platformList = asRecordArray(latest.platforms);
+		expect(platformList).toHaveLength(1);
+		const platform = platformList[0];
+		expect(asString(platform.platform)).toBe("darwin-arm64");
+		expect(asString(platform.file)).toMatch(/\.tar\.gz$/);
+		expect(asString(platform.sha256)).toMatch(/^[a-f0-9]{64}$/);
+		expect(typeof asNumber(platform.byteSize)).toBe("number");
+		expect(asNumber(platform.byteSize)).toBeGreaterThan(0);
+		expect(asNumber(platform.decompressedTarBytes)).toBeGreaterThan(0);
+		expect(asNumber(platform.decompressedTarBytes) % 512).toBe(0);
+		expect(asString(platform.manifestFile)).toMatch(/\.manifest\.json$/);
+		expect(asString(platform.manifestSha256)).toMatch(/^[a-f0-9]{64}$/);
+		expect(typeof asNumber(platform.manifestByteSize)).toBe("number");
+		expect(asNumber(platform.manifestByteSize)).toBeGreaterThan(0);
+		const artifacts = join(f.output, "artifacts");
+		const archivePath = join(artifacts, asString(platform.file));
+		const manifestPath = join(artifacts, asString(platform.manifestFile));
+		expect(asNumber(platform.byteSize)).toBe(statSync(archivePath).size);
+		expect(asString(platform.sha256)).toBe(sha256FileBoundedForTest(archivePath));
+		expect(asNumber(platform.manifestByteSize)).toBe(statSync(manifestPath).size);
+		expect(asString(platform.manifestSha256)).toBe(sha256FileBoundedForTest(manifestPath));
+	});
+
+	test("produces correct v1 manifest schema with deterministic sort", () => {
+		const f = fixture();
+		const result = singlePack(f);
+		expect(result.status, result.stderr).toBe(0);
+		const manifest = readManifest(f);
+
+		expect(asNumber(manifest.manifestVersion)).toBe(1);
+		expect(asString(manifest.version)).toBe("0.0.0");
+		expect(asString(manifest.platform)).toBe("darwin-arm64");
+		expect(asString(manifest.archive)).toMatch(/^prime-agent-0\.0\.0-darwin-arm64\.tar\.gz$/);
+
+		const entries = asRecordArray(manifest.entries);
+		const fileEntries = entries.filter((e) => e.type === "file");
+		const dirEntries = entries.filter((e) => e.type === "directory");
+		expect(asNumber(manifest.totalFiles)).toBe(fileEntries.length);
+		expect(asNumber(manifest.totalDirectories)).toBe(dirEntries.length);
+
+		const computedSize = fileEntries.reduce((sum, e) => sum + asNumber(e.size), 0);
+		expect(asNumber(manifest.totalSize)).toBe(computedSize);
+
+		expect(asString(entries[0].path)).toBe(".");
+		expect(asString(entries[0].type)).toBe("directory");
+
+		const paths = entries.map((e) => asString(e.path));
+		const sorted = [...paths].sort(codeUnitCompare);
+		expect(paths).toEqual(sorted);
+
+		for (const entry of entries) {
+			expect(entry).toHaveProperty("path");
+			expect(entry).toHaveProperty("type");
+			expect(entry).toHaveProperty("mode");
+			expect(entry).toHaveProperty("size");
+			expect(["file", "directory"]).toContain(asString(entry.type));
+			expect(asString(entry.mode)).toMatch(/^0\d{3}$/);
+		}
+	});
+
+	test("manifest matches actual archive contents by extraction", () => {
+		const f = fixture();
+		const result = singlePack(f);
+		expect(result.status, result.stderr).toBe(0);
+		const manifest = readManifest(f);
+		const manifestEntries = asRecordArray(manifest.entries);
+
+		const archivePath = join(f.output, "artifacts", "prime-agent-0.0.0-darwin-arm64.tar.gz");
+		const listing = spawnSync("tar", ["-tzf", archivePath], { encoding: "utf8" });
+		expect(listing.status, listing.stderr).toBe(0);
+		const listedPaths = listing.stdout
+			.trim()
+			.split("\n")
+			.map((path) => {
+				const withoutPrefix = path.startsWith("./") ? path.slice(2) : path;
+				const withoutDirectorySlash = withoutPrefix.endsWith("/") ? withoutPrefix.slice(0, -1) : withoutPrefix;
+				return withoutDirectorySlash === "" ? "." : withoutDirectorySlash;
+			});
+		const manifestPaths = manifestEntries.map((entry) => asString(entry.path));
+		expect(listedPaths).toHaveLength(manifestPaths.length);
+		expect(new Set(listedPaths).size).toBe(listedPaths.length);
+		expect([...listedPaths].sort(bytewiseCompare)).toEqual(manifestPaths);
+
+		// Extract archive to a temp directory
+		const extractDir = mkdtempSync(join(tmpdir(), "prime-agent-extract-"));
+		try {
+			const extractResult = spawnSync("tar", ["-xzf", archivePath, "-C", extractDir], { encoding: "utf8" });
+			expect(extractResult.status, extractResult.stderr).toBe(0);
+
+			// Walk extracted tree and build a lookup
+			const diskEntries = new Map<string, { type: string; mode: string; size: number; sha256: string }>();
+
+			function walkExtracted(dir: string, relativePath: string) {
+				const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) => codeUnitCompare(a.name, b.name));
+				for (const entry of entries) {
+					const childRelative = relativePath === "" ? entry.name : `${relativePath}/${entry.name}`;
+					const fullPath = join(dir, entry.name);
+					const st = lstatSync(fullPath);
+					if (st.isDirectory()) {
+						diskEntries.set(childRelative, { type: "directory", mode: "0755", size: 0, sha256: "" });
+						walkExtracted(fullPath, childRelative);
+					} else if (st.isFile()) {
+						const isExecutable = (st.mode & 0o111) !== 0;
+						const perm = isExecutable ? "0755" : "0644";
+						diskEntries.set(childRelative, {
+							type: "file",
+							mode: perm,
+							size: st.size,
+							sha256: sha256FileBoundedForTest(fullPath),
+						});
+					}
+				}
+			}
+			walkExtracted(extractDir, "");
+			diskEntries.set(".", { type: "directory", mode: "0755", size: 0, sha256: "" });
+
+			// Every manifest entry must exist on disk (including root)
+			for (const me of manifestEntries) {
+				const mp = asString(me.path);
+				const diskEntry = diskEntries.get(mp);
+				expect(diskEntry, `manifest path ${mp} not found in extracted archive`).toBeDefined();
+				expect(diskEntry!.type, `type mismatch for ${mp}`).toBe(asString(me.type));
+				expect(diskEntry!.mode, `mode mismatch for ${mp}`).toBe(asString(me.mode));
+				if (asString(me.type) === "file") {
+					expect(diskEntry!.size, `size mismatch for ${mp}`).toBe(asNumber(me.size));
+					expect(diskEntry!.sha256, `sha256 mismatch for ${mp}`).toBe(asString(me.sha256));
+				}
+			}
+
+			// No extra entries on disk that are not in the manifest
+			expect(diskEntries.size, "extracted entries count must match manifest").toBe(manifestEntries.length);
+		} finally {
+			rmSync(extractDir, { recursive: true, force: true });
+		}
+	});
+
+	test("archives use the exact ustar magic and version required by the runtime verifier", () => {
+		const f = fixture();
+		const result = singlePack(f);
+		expect(result.status, result.stderr).toBe(0);
+		const archivePath = join(f.output, "artifacts", "prime-agent-0.0.0-darwin-arm64.tar.gz");
+		const tarBytes = gunzipSync(readFileSync(archivePath));
+		expect(tarBytes.subarray(257, 263)).toEqual(Buffer.from("ustar\0", "binary"));
+		expect(tarBytes.subarray(263, 265)).toEqual(Buffer.from("00", "ascii"));
+	});
+
+	test("decompressedTarBytes matches gzip ISIZE read from last four bytes", () => {
+		const f = fixture();
+		const result = singlePack(f);
+		expect(result.status, result.stderr).toBe(0);
+		const manifest = readManifest(f);
+
+		const archivePath = join(f.output, "artifacts", "prime-agent-0.0.0-darwin-arm64.tar.gz");
+		const st = statSync(archivePath);
+		expect(st.size).toBeGreaterThanOrEqual(18);
+		const fd = openSync(archivePath, "r");
+		const buf = Buffer.alloc(4);
+		readSync(fd, buf, 0, 4, st.size - 4);
+		closeSync(fd);
+		const isize = buf.readUInt32LE(0);
+		expect(isize).toBeGreaterThan(0);
+		expect(isize).toBeLessThanOrEqual(256 * 1024 * 1024);
+		expect(isize % 512).toBe(0);
+		expect(asNumber(manifest.decompressedTarBytes)).toBe(isize);
+	});
+
+	test("R2 publication validates complete archive-manifest pairs before uploading", () => {
+		const workflow = readFileSync(join(repoRoot, ".github", "workflows", "build-binaries.yml"), "utf8");
+		for (const [startMarker, endMarker] of [
+			["- name: Publish production channel to R2", "- name: Create production GitHub release"],
+			["- name: Publish immutable beta artifacts to R2", "- name: Advance beta release"],
+		]) {
+			const start = workflow.indexOf(startMarker);
+			const end = workflow.indexOf(endMarker, start);
+			expect(start).toBeGreaterThanOrEqual(0);
+			expect(end).toBeGreaterThan(start);
+			const block = workflow.slice(start, end);
+			expect(block).toMatch(/\$\{artifact%\.tar\.gz\}\.manifest\.json/);
+			expect(block).toMatch(/\$\{manifest%\.manifest\.json\}\.tar\.gz/);
+			const countGate = block.indexOf('archive_count" -ne "$manifest_count');
+			const firstUpload = block.indexOf("aws s3 cp");
+			expect(countGate).toBeGreaterThanOrEqual(0);
+			expect(firstUpload).toBeGreaterThan(countGate);
+		}
+	});
+
+	test("deterministic sort uses UTF-8 byte order", () => {
+		const f = fixture();
+		writeFileSync(join(f.sidecars, "docs", "\u{e000}"), "bmp");
+		writeFileSync(join(f.sidecars, "docs", "\u{10000}"), "astral");
+		const result = singlePack(f);
+		expect(result.status, result.stderr).toBe(0);
+		const manifest = readManifest(f);
+		const paths = asRecordArray(manifest.entries).map((entry) => asString(entry.path));
+		for (let index = 0; index < paths.length - 1; index++) {
+			expect(bytewiseCompare(paths[index], paths[index + 1])).toBeLessThan(0);
+		}
+		expect(paths.indexOf("docs/\u{e000}")).toBeLessThan(paths.indexOf("docs/\u{10000}"));
 	});
 });

--- a/packages/coding-agent/test/command-runner.test.ts
+++ b/packages/coding-agent/test/command-runner.test.ts
@@ -1,0 +1,1173 @@
+import { describe, expect, it } from "vitest";
+import { createPrimeCliCommandRunner, type SpawnedProcess, type SpawnFn } from "../src/modes/daemon/command-runner.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function noopProcess(exitCode = 0, stdout = "", stderr = ""): SpawnedProcess {
+	const enc = new TextEncoder();
+	return {
+		stdout: new ReadableStream({
+			start(ctrl) {
+				if (stdout.length > 0) ctrl.enqueue(enc.encode(stdout));
+				ctrl.close();
+			},
+		}),
+		stderr: new ReadableStream({
+			start(ctrl) {
+				if (stderr.length > 0) ctrl.enqueue(enc.encode(stderr));
+				ctrl.close();
+			},
+		}),
+		exited: Promise.resolve(exitCode),
+		kill() {},
+	};
+}
+
+function streamFrom(data: Uint8Array): ReadableStream<Uint8Array> {
+	return new ReadableStream({
+		start(ctrl) {
+			ctrl.enqueue(data);
+			ctrl.close();
+		},
+	});
+}
+
+/* streamChunkThenHang removed */
+
+function streamError(msg = "stream error"): ReadableStream<Uint8Array> {
+	return new ReadableStream({
+		start(ctrl) {
+			ctrl.error(new Error(msg));
+		},
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createPrimeCliCommandRunner", () => {
+	// ---- input validation ----
+
+	it("rejects empty argv", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = await runner.runCommand([], 1000);
+		expect(r).toEqual({ ok: false, code: "INPUT_INVALID" });
+	});
+
+	it("rejects argv with 65 elements", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = await runner.runCommand(
+			Array.from({ length: 65 }, () => "a"),
+			1000,
+		);
+		expect(r).toEqual({ ok: false, code: "INPUT_INVALID" });
+	});
+
+	it("rejects empty-string argv element", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = await runner.runCommand(["valid", ""], 1000);
+		expect(r).toEqual({ ok: false, code: "INPUT_INVALID" });
+	});
+
+	it("rejects control-character in argv", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = await runner.runCommand(["hello\x00world"], 1000);
+		expect(r).toEqual({ ok: false, code: "INPUT_INVALID" });
+	});
+
+	it("rejects DEL character in argv", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = await runner.runCommand(["hello\x7fworld"], 1000);
+		expect(r).toEqual({ ok: false, code: "INPUT_INVALID" });
+	});
+
+	it("rejects argv element > 4096 UTF-8 bytes", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = await runner.runCommand(["a".repeat(4097)], 1000);
+		expect(r).toEqual({ ok: false, code: "INPUT_INVALID" });
+	});
+
+	it("rejects aggregate argv exceeding 64 KiB", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const big = "a".repeat(4000);
+		const r = await runner.runCommand(
+			[big, big, big, big, big, big, big, big, big, big, big, big, big, big, big, big, big],
+			1000,
+		);
+		expect(r).toEqual({ ok: false, code: "INPUT_INVALID" });
+	});
+
+	it("rejects non-integer timeout", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = await runner.runCommand(["echo"], 100.5);
+		expect(r).toEqual({ ok: false, code: "INPUT_INVALID" });
+	});
+
+	it("rejects NaN timeout", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = await runner.runCommand(["echo"], NaN);
+		expect(r).toEqual({ ok: false, code: "INPUT_INVALID" });
+	});
+
+	it("rejects Infinity timeout", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = await runner.runCommand(["echo"], Infinity);
+		expect(r).toEqual({ ok: false, code: "INPUT_INVALID" });
+	});
+
+	it("rejects timeout < 100 ms", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = await runner.runCommand(["echo"], 99);
+		expect(r).toEqual({ ok: false, code: "INPUT_INVALID" });
+	});
+
+	it("rejects timeout > 600 s", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = await runner.runCommand(["echo"], 600_001);
+		expect(r).toEqual({ ok: false, code: "INPUT_INVALID" });
+	});
+
+	// ---- lone surrogate ----
+
+	it("rejects lone high surrogate in argv", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = await runner.runCommand(["echo", "\ud800"], 1000);
+		expect(r).toEqual({ ok: false, code: "INPUT_INVALID" });
+	});
+
+	it("rejects lone low surrogate in argv", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = await runner.runCommand(["echo", "\udc00"], 1000);
+		expect(r).toEqual({ ok: false, code: "INPUT_INVALID" });
+	});
+
+	it("accepts valid surrogate pair (emoji) in argv", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = await runner.runCommand(["echo", "\ud83d\ude00"], 1000);
+		expect(r).toEqual({
+			ok: true,
+			value: expect.objectContaining({ exitCode: 0 }),
+		});
+	});
+
+	// ---- pre-abort ----
+
+	it("returns ABORTED without spawning when signal is already aborted", async () => {
+		let spawned = false;
+		const runner = createPrimeCliCommandRunner(() => {
+			spawned = true;
+			return noopProcess();
+		});
+		const ctrl = new AbortController();
+		ctrl.abort();
+		const r = await runner.runCommand(["echo"], 1000, ctrl.signal);
+		expect(r).toEqual({ ok: false, code: "ABORTED" });
+		expect(spawned).toBe(false);
+	});
+
+	// ---- spawn failure ----
+
+	it("returns SPAWN_FAILED when spawn throws", async () => {
+		const runner = createPrimeCliCommandRunner(() => {
+			throw new Error("exec not found");
+		});
+		const r = await runner.runCommand(["nonexistent-cmd"], 1000);
+		expect(r).toEqual({ ok: false, code: "SPAWN_FAILED" });
+	});
+
+	// ---- real Bun processes ----
+
+	it("executes a basic command and returns output", async () => {
+		const runner = createPrimeCliCommandRunner();
+		const r = await runner.runCommand(["echo", "hello world"], 5000);
+		expect(r).toEqual({
+			ok: true,
+			value: expect.objectContaining({
+				stdout: "hello world\n",
+				stderr: "",
+				exitCode: 0,
+				durationMs: expect.any(Number),
+			}),
+		});
+	});
+
+	it("captures stderr output", async () => {
+		const runner = createPrimeCliCommandRunner();
+		const r = await runner.runCommand(["bash", "-c", "echo stderr-msg >&2"], 5000);
+		expect(r).toEqual({
+			ok: true,
+			value: expect.objectContaining({
+				stdout: "",
+				stderr: "stderr-msg\n",
+				exitCode: 0,
+			}),
+		});
+	});
+
+	it("reports nonzero exit", async () => {
+		const runner = createPrimeCliCommandRunner();
+		const r = await runner.runCommand(["bash", "-c", "exit 42"], 5000);
+		expect(r).toEqual({
+			ok: true,
+			value: expect.objectContaining({
+				stdout: "",
+				stderr: "",
+				exitCode: 42,
+			}),
+		});
+	});
+
+	it("kills on timeout (process sleeps past limit)", async () => {
+		const runner = createPrimeCliCommandRunner();
+		const r = await runner.runCommand(["sleep", "10"], 200);
+		expect(r).toEqual({ ok: false, code: "TIMED_OUT" });
+	});
+
+	it("aborts mid-run via AbortSignal", async () => {
+		const runner = createPrimeCliCommandRunner();
+		const ctrl = new AbortController();
+		const promise = runner.runCommand(["sleep", "30"], 60_000, ctrl.signal);
+		await new Promise((r) => setTimeout(r, 100));
+		ctrl.abort();
+		const r = await promise;
+		expect(r).toEqual({ ok: false, code: "ABORTED" });
+	});
+
+	it("handles simultaneous stdout and stderr output", async () => {
+		const runner = createPrimeCliCommandRunner();
+		const r = await runner.runCommand(["bash", "-c", "echo out1; echo err1 >&2; echo out2; echo err2 >&2"], 5000);
+		expect(r).toEqual({
+			ok: true,
+			value: expect.objectContaining({
+				stdout: "out1\nout2\n",
+				stderr: "err1\nerr2\n",
+				exitCode: 0,
+			}),
+		});
+	});
+
+	// ---- overflow ----
+
+	it("detects stdout overflow (>1 MiB) without deadlock", async () => {
+		const runner = createPrimeCliCommandRunner();
+		const r = await runner.runCommand(["bash", "-c", "dd if=/dev/zero bs=1024 count=2048 2>/dev/null"], 10_000);
+		expect(r).toEqual({ ok: false, code: "OUTPUT_OVERFLOW" });
+	});
+
+	it("detects stderr overflow without deadlock", async () => {
+		const runner = createPrimeCliCommandRunner();
+		const r = await runner.runCommand(["bash", "-c", "dd if=/dev/zero bs=1024 count=2048 1>&2 2>/dev/null"], 10_000);
+		expect(r).toEqual({ ok: false, code: "OUTPUT_OVERFLOW" });
+	});
+
+	it("detects overflow when both streams flood", async () => {
+		const runner = createPrimeCliCommandRunner();
+		const r = await runner.runCommand(
+			[
+				"bash",
+				"-c",
+				"dd if=/dev/zero bs=1024 count=2048 2>/dev/null & dd if=/dev/zero bs=1024 count=2048 1>&2 2>/dev/null & wait",
+			],
+			10_000,
+		);
+		expect(r).toEqual({ ok: false, code: "OUTPUT_OVERFLOW" });
+	});
+
+	// ---- process closes pipes then sleeps ----
+
+	it("timeout kills a process that closed pipes but is still alive", async () => {
+		const runner = createPrimeCliCommandRunner();
+		const r = await runner.runCommand(["bash", "-c", "exec 1>&-; exec 2>&-; sleep 30"], 300);
+		expect(r).toEqual({ ok: false, code: "TIMED_OUT" });
+	});
+
+	// ---- malformed UTF-8 ----
+
+	it("returns STREAM_FAILED for malformed UTF-8 output", async () => {
+		const runner = createPrimeCliCommandRunner();
+		const r = await runner.runCommand(["bash", "-c", "printf '\\xff\\xfe'"], 5000);
+		expect(r).toEqual({ ok: false, code: "STREAM_FAILED" });
+	});
+
+	// ---- injected stream failure ----
+
+	it("returns STREAM_FAILED when stdout read fails", async () => {
+		const spawn: SpawnFn = () => ({
+			stdout: streamError(),
+			stderr: streamFrom(new Uint8Array(0)),
+			exited: Promise.resolve(0),
+			kill() {},
+		});
+		const runner = createPrimeCliCommandRunner(spawn);
+		const r = await runner.runCommand(["echo"], 1000);
+		expect(r).toEqual({ ok: false, code: "STREAM_FAILED" });
+	});
+
+	it("returns STREAM_FAILED when stderr read fails", async () => {
+		const spawn: SpawnFn = () => ({
+			stdout: streamFrom(new Uint8Array(0)),
+			stderr: streamError(),
+			exited: Promise.resolve(0),
+			kill() {},
+		});
+		const runner = createPrimeCliCommandRunner(spawn);
+		const r = await runner.runCommand(["echo"], 1000);
+		expect(r).toEqual({ ok: false, code: "STREAM_FAILED" });
+	});
+
+	it("returns STREAM_FAILED when stdout read fails while stderr never closes", async () => {
+		const spawn: SpawnFn = () => {
+			let stderrCtrl: ReadableStreamDefaultController<Uint8Array> | undefined;
+			let exitResolve: ((code: number) => void) | undefined;
+			return {
+				stdout: streamError(),
+				stderr: new ReadableStream({
+					start(ctrl) {
+						stderrCtrl = ctrl;
+						ctrl.enqueue(new Uint8Array([65]));
+					},
+				}),
+				exited: new Promise<number>((resolve) => {
+					exitResolve = resolve;
+				}),
+				kill() {
+					stderrCtrl?.close();
+					exitResolve?.(0);
+				},
+			};
+		};
+		const runner = createPrimeCliCommandRunner(spawn);
+		const r = await runner.runCommand(["echo"], 1000);
+		expect(r).toEqual({ ok: false, code: "STREAM_FAILED" });
+	});
+
+	// ---- injected PROCESS_UNCERTAIN ----
+
+	it("returns PROCESS_UNCERTAIN when kill throws", async () => {
+		const spawn: SpawnFn = () => ({
+			stdout: streamFrom(new Uint8Array(0)),
+			stderr: streamFrom(new Uint8Array(0)),
+			exited: new Promise<never>(() => {}),
+			kill() {
+				throw new Error("kill failed");
+			},
+		});
+		const runner = createPrimeCliCommandRunner(spawn, 50);
+		const r = await runner.runCommand(["echo"], 100);
+		expect(r).toEqual({ ok: false, code: "PROCESS_UNCERTAIN" });
+	});
+
+	it("returns PROCESS_UNCERTAIN when exited rejects", async () => {
+		const spawn: SpawnFn = () => ({
+			stdout: streamFrom(new Uint8Array(0)),
+			stderr: streamFrom(new Uint8Array(0)),
+			exited: Promise.reject(new Error("waitpid failed")),
+			kill() {},
+		});
+		const runner = createPrimeCliCommandRunner(spawn);
+		const r = await runner.runCommand(["echo"], 1000);
+		expect(r).toEqual({ ok: false, code: "PROCESS_UNCERTAIN" });
+	});
+
+	it("returns PROCESS_UNCERTAIN when exit never settles after kill", async () => {
+		const spawn: SpawnFn = () => ({
+			stdout: streamFrom(new Uint8Array(0)),
+			stderr: streamFrom(new Uint8Array(0)),
+			exited: new Promise<never>(() => {}),
+			kill() {},
+		});
+		const runner = createPrimeCliCommandRunner(spawn, 50);
+		const r = await runner.runCommand(["echo"], 100);
+		expect(r).toEqual({ ok: false, code: "PROCESS_UNCERTAIN" });
+	});
+
+	// ---- exact frozen result ----
+
+	it("returns frozen result objects", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = await runner.runCommand(["echo"], 1000);
+		expect(Object.isFrozen(r)).toBe(true);
+		if (r.ok) {
+			expect(Object.isFrozen(r.value)).toBe(true);
+		}
+	});
+
+	it("returns frozen failure objects", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = await runner.runCommand([], 1000);
+		expect(Object.isFrozen(r)).toBe(true);
+	});
+
+	it("failure result has exactly two keys (ok, code)", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = (await runner.runCommand([], 1000)) as { ok: false; code: string };
+		expect(Object.keys(r).sort()).toEqual(["code", "ok"]);
+	});
+
+	it("success result has exactly two keys (ok, value)", async () => {
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		const r = (await runner.runCommand(["echo"], 1000)) as { ok: true; value: Record<string, unknown> };
+		expect(Object.keys(r).sort()).toEqual(["ok", "value"]);
+		expect(Object.keys(r.value).sort()).toEqual(["durationMs", "exitCode", "stderr", "stdout"]);
+	});
+
+	// ---- opacity ----
+
+	it("failures contain no sensitive data (argv, path, exception)", async () => {
+		const runner = createPrimeCliCommandRunner(() => {
+			throw new Error("/home/user/.secret-key");
+		});
+		const r = await runner.runCommand(["echo"], 1000);
+		expect(r).toEqual({ ok: false, code: "SPAWN_FAILED" });
+		const json = JSON.stringify(r);
+		expect(json).not.toContain("secret");
+		expect(json).not.toContain("home");
+	});
+
+	it("timeout failure contains no output snippets", async () => {
+		let exitResolve: ((code: number) => void) | undefined;
+		const spawn: SpawnFn = () => ({
+			stdout: streamFrom(new TextEncoder().encode("sensitive data")),
+			stderr: streamFrom(new Uint8Array(0)),
+			exited: new Promise<number>((resolve) => {
+				exitResolve = resolve;
+			}),
+			kill() {
+				exitResolve?.(0);
+			},
+		});
+		const runner = createPrimeCliCommandRunner(spawn);
+		const r = await runner.runCommand(["echo"], 100);
+		expect(r).toEqual({ ok: false, code: "TIMED_OUT" });
+		const json = JSON.stringify(r);
+		expect(json).not.toContain("sensitive");
+	});
+
+	// ---- causal dominance ----
+
+	it("stream failure before abort wins over abort", async () => {
+		const spawn: SpawnFn = () => ({
+			stdout: streamFrom(new Uint8Array(0)),
+			stderr: streamError(),
+			exited: Promise.resolve(0),
+			kill() {},
+		});
+		const ctrl = new AbortController();
+		const runner = createPrimeCliCommandRunner(spawn);
+		const promise = runner.runCommand(["echo"], 5000, ctrl.signal);
+		await new Promise((r) => setTimeout(r, 50));
+		ctrl.abort();
+		const result = await promise;
+		expect(result).toEqual({ ok: false, code: "STREAM_FAILED" });
+	});
+
+	it("caller abort beats timeout", async () => {
+		const ctrl = new AbortController();
+		const runner = createPrimeCliCommandRunner();
+		const promise = runner.runCommand(["sleep", "30"], 5000, ctrl.signal);
+		await new Promise((r) => setTimeout(r, 50));
+		ctrl.abort();
+		const r = await promise;
+		expect(r).toEqual({ ok: false, code: "ABORTED" });
+	});
+
+	it("derivative stream error after abort does not overwrite ABORTED", async () => {
+		let exitResolve: ((code: number) => void) | undefined;
+		let stdoutCtrl: ReadableStreamDefaultController<Uint8Array> | undefined;
+		const spawn: SpawnFn = () => {
+			const stdout = new ReadableStream({
+				start(c) {
+					stdoutCtrl = c;
+					c.enqueue(new TextEncoder().encode("hello"));
+				},
+			});
+			return {
+				stdout,
+				stderr: streamFrom(new Uint8Array(0)),
+				exited: new Promise<number>((resolve) => {
+					exitResolve = resolve;
+				}),
+				kill() {
+					stdoutCtrl?.close();
+					exitResolve?.(0);
+				},
+			};
+		};
+		const ctrl = new AbortController();
+		const runner = createPrimeCliCommandRunner(spawn);
+		const promise = runner.runCommand(["echo"], 5000, ctrl.signal);
+		await new Promise((r) => setTimeout(r, 50));
+		ctrl.abort();
+		const r = await promise;
+		// Even if stdout errors during/after cancel, ABORTED dominates
+		expect(r).toEqual({ ok: false, code: "ABORTED" });
+	});
+
+	// ---- listener/timer cleanup ----  // ---- listener/timer cleanup ----
+
+	it("removes abort listener after completion", async () => {
+		const ctrl = new AbortController();
+		const runner = createPrimeCliCommandRunner(() => noopProcess());
+		await runner.runCommand(["echo"], 1000, ctrl.signal);
+		let fireCount = 0;
+		const listener = () => {
+			fireCount++;
+		};
+		ctrl.signal.addEventListener("abort", listener, { once: true });
+		ctrl.abort();
+		expect(fireCount).toBe(1);
+	});
+
+	// ---- no-output timeout ----
+
+	it("no-output process completes within timeout", async () => {
+		const runner = createPrimeCliCommandRunner();
+		const r = await runner.runCommand(["true"], 1000);
+		expect(r).toEqual({
+			ok: true,
+			value: expect.objectContaining({ stdout: "", stderr: "", exitCode: 0 }),
+		});
+	});
+
+	// ---- valid astral argv ----
+
+	it("valid astral-plane character in argv works", async () => {
+		const runner = createPrimeCliCommandRunner();
+		const r = await runner.runCommand(["echo", "\ud83d\ude00"], 5000);
+		expect(r).toEqual({
+			ok: true,
+			value: expect.objectContaining({
+				stdout: "\ud83d\ude00\n",
+			}),
+		});
+	});
+});
+
+// ---- reader-settlement bounded tests ----
+
+it("overflow with throwing kill leads to bounded reader settlement => PROCESS_UNCERTAIN", async () => {
+	const spawn: SpawnFn = () => {
+		let _stdoutCtrl: ReadableStreamDefaultController<Uint8Array> | undefined;
+		// stdout floods
+		const stdout = new ReadableStream({
+			start(c) {
+				_stdoutCtrl = c;
+				// Enqueue just under 1 MiB, then one more chunk to trigger overflow
+				const chunk = new Uint8Array(1024 * 512);
+				c.enqueue(chunk);
+			},
+			pull(c) {
+				c.enqueue(new Uint8Array(1024 * 512));
+			},
+		});
+		// stderr never closes
+		const stderr = new ReadableStream({
+			start(c) {
+				c.enqueue(new Uint8Array([65]));
+			},
+		});
+		return {
+			stdout,
+			stderr,
+			exited: new Promise<never>(() => {}),
+			kill() {
+				throw new Error("kill failed");
+			},
+		};
+	};
+	const runner = createPrimeCliCommandRunner(spawn, 50);
+	const r = await runner.runCommand(["echo"], 5000);
+	// Overflow sets primary, kill throws, bounded readers wait -> killThrew true -> PROC_UNCERTAIN
+	expect(r).toEqual({ ok: false, code: "PROCESS_UNCERTAIN" });
+});
+
+it("timeout killing process closes pipes so both readers settle", async () => {
+	const runner = createPrimeCliCommandRunner();
+	// A process that produces bounded output slowly but outlives timeout
+	const r = await runner.runCommand(["sleep", "10"], 200);
+	expect(r).toEqual({ ok: false, code: "TIMED_OUT" });
+});
+
+it("stream failure with other stream never closing leads to bounded cleanup", async () => {
+	let exitResolve: ((code: number) => void) | undefined;
+	const spawn: SpawnFn = () => {
+		let stderrCtrl: ReadableStreamDefaultController<Uint8Array> | undefined;
+		const stderr = new ReadableStream({
+			start(c) {
+				stderrCtrl = c;
+				c.enqueue(new Uint8Array([65]));
+			},
+		});
+		return {
+			stdout: new ReadableStream({
+				start(c) {
+					c.error(new Error("pipe failed"));
+				},
+			}),
+			stderr,
+			exited: new Promise<number>((resolve) => {
+				exitResolve = resolve;
+			}),
+			kill() {
+				stderrCtrl?.close();
+				exitResolve?.(0);
+			},
+		};
+	};
+	const runner = createPrimeCliCommandRunner(spawn);
+	const r = await runner.runCommand(["echo"], 5000);
+	expect(r).toEqual({ ok: false, code: "STREAM_FAILED" });
+});
+
+it("exit rejection with bounded reader cleanup", async () => {
+	const spawn: SpawnFn = () => {
+		let stderrCtrl: ReadableStreamDefaultController<Uint8Array> | undefined;
+		const stderr = new ReadableStream({
+			start(c) {
+				stderrCtrl = c;
+			},
+		});
+		return {
+			stdout: streamFrom(new Uint8Array(0)),
+			stderr,
+			exited: Promise.reject(new Error("waitpid rejected")),
+			kill() {
+				stderrCtrl?.close();
+			},
+		};
+	};
+	const runner = createPrimeCliCommandRunner(spawn);
+	const r = await runner.runCommand(["echo"], 5000);
+	expect(r).toEqual({ ok: false, code: "PROCESS_UNCERTAIN" });
+});
+
+// ---- closes-pipes-then-exits within timeout (must succeed) ----
+
+it("process closes pipes then exits within timeout (success, not uncertain)", async () => {
+	const runner = createPrimeCliCommandRunner();
+	const r = await runner.runCommand(["bash", "-c", "exec 1>&-; exec 2>&-; sleep 1; exit 0"], 15_000);
+	expect(r).toEqual({
+		ok: true,
+		value: expect.objectContaining({
+			stdout: "",
+			stderr: "",
+			exitCode: 0,
+		}),
+	});
+	// duration must be < 5s (not hitting cleanup timeout)
+	expect(r.ok ? r.value.durationMs : 99999).toBeLessThan(5000);
+});
+
+// ---- abort-during-registration race ----
+
+it("signal aborted exactly between initial check and listener registration", async () => {
+	// Build a signal that aborts synchronously when addEventListener is called
+	// but is NOT aborted when signal.aborted is checked first.
+	// We can do this by aborting from within a proxy or by using
+	// setTimeout(0) in the addEventListener. Simpler: abort first, then pass.
+	// But the pre-abort check returns ABORTED before registration.
+	// So test the recheck path: signal becomes aborted during registration.
+	// Use AbortSignal.timeout(0) which fires immediately.
+	const signal = AbortSignal.timeout(0);
+	// Give the microtask a chance to fire the abort
+	await new Promise((r) => setTimeout(r, 5));
+
+	let spawned = false;
+	const runner = createPrimeCliCommandRunner(() => {
+		spawned = true;
+		return noopProcess();
+	});
+	const r = await runner.runCommand(["echo"], 5000, signal);
+	expect(r).toEqual({ ok: false, code: "ABORTED" });
+	expect(spawned).toBe(false);
+});
+
+it("abort fires exactly during addEventListener (after aborted check)", async () => {
+	// Use a custom AbortController where abort fires during addEventListener
+	const ctrl = new AbortController();
+	const signal = ctrl.signal;
+
+	// Intercept addEventListener to abort the signal during registration
+	const origAddEventListener = signal.addEventListener.bind(signal);
+	let _addEventListenerCalled = false;
+	signal.addEventListener = ((type, listener, options) => {
+		_addEventListenerCalled = true;
+		origAddEventListener(type, listener, options);
+		// Abort synchronously, which will trigger the listener we just registered
+		ctrl.abort();
+	}) as typeof signal.addEventListener;
+
+	let spawned = false;
+	const runner = createPrimeCliCommandRunner(() => {
+		spawned = true;
+		return noopProcess();
+	});
+	const r = await runner.runCommand(["echo"], 5000, signal);
+	expect(r).toEqual({ ok: false, code: "ABORTED" });
+	expect(spawned).toBe(false);
+});
+
+// ---- owned buffer erasure ----
+
+it("erases owned chunks and merged buffers on success", async () => {
+	const originalFill = Uint8Array.prototype.fill;
+	const erased: Uint8Array[] = [];
+	Uint8Array.prototype.fill = function (value, start, end) {
+		const result = originalFill.call(this, value, start, end);
+		if (value === 0 && this.byteLength === 11) erased.push(this);
+		return result;
+	};
+	try {
+		const runner = createPrimeCliCommandRunner(() => ({
+			stdout: streamFrom(new TextEncoder().encode("test-output")),
+			stderr: streamFrom(new Uint8Array(0)),
+			exited: Promise.resolve(0),
+			kill() {},
+		}));
+		const result = await runner.runCommand(["echo"], 5000);
+		expect(result).toEqual({
+			ok: true,
+			value: expect.objectContaining({ stdout: "test-output" }),
+		});
+		expect(erased.length).toBeGreaterThanOrEqual(2);
+		for (const bytes of erased) expect(bytes.every((byte) => byte === 0)).toBe(true);
+	} finally {
+		Uint8Array.prototype.fill = originalFill;
+	}
+});
+
+describe("default spawn (real Bun processes)", () => {
+	it("spawns a real process without injected spawn", async () => {
+		const runner = createPrimeCliCommandRunner();
+		const r = await runner.runCommand(["echo", "hi"], 5000);
+		expect(r.ok).toBe(true);
+	});
+
+	it("handles missing executable as SPAWN_FAILED", async () => {
+		const runner = createPrimeCliCommandRunner();
+		const r = await runner.runCommand(["./nonexistent-binary"], 1000);
+		expect(r).toEqual({ ok: false, code: "SPAWN_FAILED" });
+	});
+});
+
+// ---- focused contract tests ----
+
+describe("focused contract tests", () => {
+	it("invalid kill (non-function) => PROCESS_UNCERTAIN", async () => {
+		const spawn: SpawnFn = () => ({
+			stdout: streamFrom(new Uint8Array(0)),
+			stderr: streamFrom(new Uint8Array(0)),
+			exited: Promise.resolve(0),
+			kill: "not-a-function" as unknown as () => void,
+		});
+		const runner = createPrimeCliCommandRunner(spawn);
+		const r = await runner.runCommand(["echo"], 1000);
+		expect(r).toEqual({ ok: false, code: "PROCESS_UNCERTAIN" });
+	});
+
+	it("getReader not a function => STREAM_FAILED", async () => {
+		const spawn: SpawnFn = () => ({
+			stdout: { getReader: "not-a-function" } as unknown as ReadableStream<Uint8Array>,
+			stderr: streamFrom(new Uint8Array(0)),
+			exited: Promise.resolve(0),
+			kill() {},
+		});
+		const runner = createPrimeCliCommandRunner(spawn);
+		const r = await runner.runCommand(["echo"], 1000);
+		expect(r).toEqual({ ok: false, code: "STREAM_FAILED" });
+	});
+
+	it("getReader throws => STREAM_FAILED", async () => {
+		const spawn: SpawnFn = () => ({
+			stdout: {
+				getReader() {
+					throw new Error("no reader for you");
+				},
+			} as unknown as ReadableStream<Uint8Array>,
+			stderr: streamFrom(new Uint8Array(0)),
+			exited: Promise.resolve(0),
+			kill() {},
+		});
+		const runner = createPrimeCliCommandRunner(spawn);
+		const r = await runner.runCommand(["echo"], 1000);
+		expect(r).toEqual({ ok: false, code: "STREAM_FAILED" });
+	});
+
+	it("synchronous cancel throw observed => reader settles, does not crash", async () => {
+		let cancelCalled = false;
+		let readCount = 0;
+		const faultyReader = {
+			read() {
+				readCount++;
+				if (readCount >= 2) {
+					return Promise.resolve({ done: true, value: undefined });
+				}
+				return Promise.resolve({ done: false, value: new Uint8Array([65]) });
+			},
+			cancel() {
+				cancelCalled = true;
+				throw new Error("cancel throws");
+			},
+			releaseLock() {},
+		};
+		const spawn: SpawnFn = () => ({
+			stdout: {
+				getReader() {
+					return faultyReader;
+				},
+			} as unknown as ReadableStream<Uint8Array>,
+			stderr: streamFrom(new Uint8Array(0)),
+			exited: Promise.resolve(42),
+			kill() {},
+		});
+		const runner = createPrimeCliCommandRunner(spawn);
+		const r = await runner.runCommand(["echo"], 1000);
+		expect(r).toEqual({
+			ok: true,
+			value: expect.objectContaining({ stdout: "A", exitCode: 42 }),
+		});
+		expect(cancelCalled).toBe(false); // cancel not called in normal path
+	});
+
+	it("stream read throws synchronously => STREAM_FAILED", async () => {
+		const spawn: SpawnFn = () => ({
+			stdout: {
+				getReader() {
+					return {
+						read() {
+							throw new Error("sync read throw");
+						},
+						cancel() {
+							return Promise.resolve();
+						},
+						releaseLock() {},
+					};
+				},
+			} as unknown as ReadableStream<Uint8Array>,
+			stderr: streamFrom(new Uint8Array(0)),
+			exited: Promise.resolve(0),
+			kill() {},
+		});
+		const runner = createPrimeCliCommandRunner(spawn);
+		const r = await runner.runCommand(["echo"], 1000);
+		expect(r).toEqual({ ok: false, code: "STREAM_FAILED" });
+	});
+
+	it("stdout accessor is rejected as PROCESS_UNCERTAIN", async () => {
+		let exitResolve: ((code: number) => void) | undefined;
+		const spawn: SpawnFn = () => {
+			const throwOnStdout = {
+				get stdout() {
+					throw new Error("stdout getter fail");
+				},
+				get stderr() {
+					return streamFrom(new Uint8Array(0));
+				},
+				get exited() {
+					return new Promise<number>((resolve) => {
+						exitResolve = resolve;
+					});
+				},
+				kill() {
+					exitResolve?.(0);
+				},
+			} as unknown as SpawnedProcess;
+			return throwOnStdout;
+		};
+		const runner = createPrimeCliCommandRunner(spawn);
+		const r = await runner.runCommand(["echo"], 5000);
+		expect(r).toEqual({ ok: false, code: "PROCESS_UNCERTAIN" });
+	});
+
+	it("structural stdout accessor is rejected as PROCESS_UNCERTAIN", async () => {
+		let exitResolve: ((code: number) => void) | undefined;
+		const spawn: SpawnFn = () => {
+			return {
+				get stdout() {
+					throw new Error("stdout getter fail at capture");
+				},
+				stderr: streamFrom(new Uint8Array(0)),
+				get exited() {
+					return new Promise<number>((resolve) => {
+						exitResolve = resolve;
+					});
+				},
+				kill() {
+					exitResolve?.(0);
+				},
+			} as unknown as SpawnedProcess;
+		};
+		const runner = createPrimeCliCommandRunner(spawn);
+		const r = await runner.runCommand(["echo"], 5000);
+		expect(r).toEqual({ ok: false, code: "PROCESS_UNCERTAIN" });
+	});
+});
+
+// ---- additional contract tests ----
+
+describe("additional contract tests", () => {
+	it("returns STREAM_FAILED when the owned output copy fails", async () => {
+		const originalSet = Uint8Array.prototype.set;
+		let matchingCalls = 0;
+		Uint8Array.prototype.set = function (source, offset) {
+			if (this.byteLength === 4 && source.length === 4) {
+				matchingCalls += 1;
+				throw new Error("copy failed");
+			}
+			return originalSet.call(this, source, offset);
+		};
+		try {
+			const runner = createPrimeCliCommandRunner(() => ({
+				stdout: streamFrom(new Uint8Array([1, 2, 3, 4])),
+				stderr: streamFrom(new Uint8Array(0)),
+				exited: Promise.resolve(0),
+				kill() {},
+			}));
+			const result = await runner.runCommand(["echo"], 1000);
+			expect(result).toEqual({ ok: false, code: "STREAM_FAILED" });
+			expect(matchingCalls).toBe(1);
+		} finally {
+			Uint8Array.prototype.set = originalSet;
+		}
+	});
+
+	it("returns STREAM_FAILED instead of truncating when chunk merge fails", async () => {
+		const originalSet = Uint8Array.prototype.set;
+		let matchingCalls = 0;
+		Uint8Array.prototype.set = function (source, offset) {
+			if (this.byteLength === 4 && source.length === 4) {
+				matchingCalls += 1;
+				if (matchingCalls === 2) throw new Error("merge failed");
+			}
+			return originalSet.call(this, source, offset);
+		};
+		try {
+			const runner = createPrimeCliCommandRunner(() => ({
+				stdout: streamFrom(new Uint8Array([1, 2, 3, 4])),
+				stderr: streamFrom(new Uint8Array(0)),
+				exited: Promise.resolve(0),
+				kill() {},
+			}));
+			const result = await runner.runCommand(["echo"], 1000);
+			expect(result).toEqual({ ok: false, code: "STREAM_FAILED" });
+			expect(matchingCalls).toBe(2);
+		} finally {
+			Uint8Array.prototype.set = originalSet;
+		}
+	});
+
+	it("exit thenable honors only its first callback", async () => {
+		// A thenable that calls both resolve and reject
+		const hostileThen = {
+			// biome-ignore lint/suspicious/noThenProperty: intentional hostile thenable test
+			then(resolve: (v: number) => void, reject: () => void) {
+				resolve(0);
+				reject();
+			},
+		};
+		const spawn: SpawnFn = () => ({
+			stdout: streamFrom(new Uint8Array(0)),
+			stderr: streamFrom(new Uint8Array(0)),
+			exited: hostileThen as Promise<number>,
+			kill() {},
+		});
+		const runner = createPrimeCliCommandRunner(spawn);
+		const r = await runner.runCommand(["echo"], 1000);
+		// Once gate prevents double-callback; should succeed
+		expect(r).toEqual({
+			ok: true,
+			value: expect.objectContaining({ exitCode: 0 }),
+		});
+	});
+
+	it("non-finite exit via hostile thenable => PROCESS_UNCERTAIN", async () => {
+		const hostileThen = {
+			// biome-ignore lint/suspicious/noThenProperty: intentional hostile thenable test
+			then(resolve: (v: number) => void) {
+				resolve(NaN);
+			},
+		};
+		const spawn: SpawnFn = () => ({
+			stdout: streamFrom(new Uint8Array(0)),
+			stderr: streamFrom(new Uint8Array(0)),
+			exited: hostileThen as Promise<number>,
+			kill() {},
+		});
+		const runner = createPrimeCliCommandRunner(spawn);
+		const r = await runner.runCommand(["echo"], 1000);
+		expect(r).toEqual({ ok: false, code: "PROCESS_UNCERTAIN" });
+	});
+
+	it("negative exit code => PROCESS_UNCERTAIN", async () => {
+		const spawn: SpawnFn = () => ({
+			stdout: streamFrom(new Uint8Array(0)),
+			stderr: streamFrom(new Uint8Array(0)),
+			exited: Promise.resolve(-42),
+			kill() {},
+		});
+		const runner = createPrimeCliCommandRunner(spawn);
+		const r = await runner.runCommand(["echo"], 1000);
+		expect(r).toEqual({ ok: false, code: "PROCESS_UNCERTAIN" });
+	});
+
+	it("non-integer exit code => PROCESS_UNCERTAIN", async () => {
+		const spawn: SpawnFn = () => ({
+			stdout: streamFrom(new Uint8Array(0)),
+			stderr: streamFrom(new Uint8Array(0)),
+			exited: Promise.resolve(0.5),
+			kill() {},
+		});
+		const runner = createPrimeCliCommandRunner(spawn);
+		const r = await runner.runCommand(["echo"], 1000);
+		expect(r).toEqual({ ok: false, code: "PROCESS_UNCERTAIN" });
+	});
+
+	it("negative duration via performance.now manipulation => PROCESS_UNCERTAIN", async () => {
+		// Override performance.now to return a negative delta
+		const origNow = performance.now;
+		let callCount = 0;
+		performance.now = () => {
+			callCount++;
+			if (callCount === 1) return 100;
+			return 50; // delta = -50
+		};
+		try {
+			const spawn: SpawnFn = () => ({
+				stdout: streamFrom(new Uint8Array([65])),
+				stderr: streamFrom(new Uint8Array(0)),
+				exited: Promise.resolve(0),
+				kill() {},
+			});
+			const runner = createPrimeCliCommandRunner(spawn);
+			const r = await runner.runCommand(["echo"], 1000);
+			expect(r).toEqual({ ok: false, code: "PROCESS_UNCERTAIN" });
+		} finally {
+			performance.now = origNow;
+		}
+	});
+
+	it("non-finite exit via injected thenable => PROCESS_UNCERTAIN", async () => {
+		// An exit that passes NaN (non-safe-integer) triggers onReject
+		const hostileThen = {
+			// biome-ignore lint/suspicious/noThenProperty: intentional hostile thenable test
+			then(resolve: (v: number) => void) {
+				resolve(NaN);
+			},
+		};
+		const spawn: SpawnFn = () => ({
+			stdout: streamFrom(new Uint8Array([65])),
+			stderr: streamFrom(new Uint8Array(0)),
+			exited: hostileThen as Promise<number>,
+			kill() {},
+		});
+		const runner = createPrimeCliCommandRunner(spawn);
+		const r = await runner.runCommand(["echo"], 1000);
+		// NaN is not a safe integer => onReject called => PROCESS_UNCERTAIN
+		expect(r).toEqual({ ok: false, code: "PROCESS_UNCERTAIN" });
+	});
+
+	it("rejects invalid cleanup configuration without spawning", async () => {
+		let spawned = false;
+		const runner = createPrimeCliCommandRunner(() => {
+			spawned = true;
+			return noopProcess();
+		}, Number.NaN);
+		const result = await runner.runCommand(["echo"], 1000);
+		expect(result).toEqual({ ok: false, code: "INPUT_INVALID" });
+		expect(spawned).toBe(false);
+	});
+
+	it("rejects argv accessors, extra keys, and revoked proxies without spawning", async () => {
+		let spawned = false;
+		const runner = createPrimeCliCommandRunner(() => {
+			spawned = true;
+			return noopProcess();
+		});
+		const accessorArgs = ["echo"];
+		Object.defineProperty(accessorArgs, "0", { get: () => "echo" });
+		const symbolArgs = ["echo"];
+		Reflect.set(symbolArgs, Symbol("extra"), true);
+		const revocable = Proxy.revocable(["echo"], {});
+		revocable.revoke();
+		const invoke = (args: unknown): unknown => Reflect.apply(runner.runCommand, runner, [args, 1000]);
+		expect(await Promise.resolve(invoke(accessorArgs))).toEqual({ ok: false, code: "INPUT_INVALID" });
+		expect(await Promise.resolve(invoke(symbolArgs))).toEqual({ ok: false, code: "INPUT_INVALID" });
+		expect(await Promise.resolve(invoke(revocable.proxy))).toEqual({ ok: false, code: "INPUT_INVALID" });
+		expect(spawned).toBe(false);
+	});
+
+	it("rejects extra process result keys after killing and observing exit", async () => {
+		let killed = false;
+		const spawn = (): SpawnedProcess => {
+			const result = {
+				stdout: streamFrom(new Uint8Array(0)),
+				stderr: streamFrom(new Uint8Array(0)),
+				exited: Promise.resolve(0),
+				kill() {
+					killed = true;
+				},
+				extra: "forbidden",
+			};
+			return result;
+		};
+		const result = await createPrimeCliCommandRunner(spawn).runCommand(["echo"], 1000);
+		expect(result).toEqual({ ok: false, code: "PROCESS_UNCERTAIN" });
+		expect(killed).toBe(true);
+	});
+
+	it("captures each getReader method exactly once", async () => {
+		let stdoutGetterCalls = 0;
+		let stderrGetterCalls = 0;
+		const stdout = streamFrom(new Uint8Array(0));
+		const stderr = streamFrom(new Uint8Array(0));
+		const stdoutGetReader = stdout.getReader.bind(stdout);
+		const stderrGetReader = stderr.getReader.bind(stderr);
+		Object.defineProperty(stdout, "getReader", {
+			get() {
+				stdoutGetterCalls += 1;
+				return stdoutGetReader;
+			},
+		});
+		Object.defineProperty(stderr, "getReader", {
+			get() {
+				stderrGetterCalls += 1;
+				return stderrGetReader;
+			},
+		});
+		const spawn = (): SpawnedProcess => ({
+			stdout,
+			stderr,
+			exited: Promise.resolve(0),
+			kill() {},
+		});
+		const result = await createPrimeCliCommandRunner(spawn).runCommand(["echo"], 1000);
+		expect(result.ok).toBe(true);
+		expect(stdoutGetterCalls).toBe(1);
+		expect(stderrGetterCalls).toBe(1);
+	});
+
+	it("returns PROCESS_UNCERTAIN when a pending cancel operation cannot be observed", async () => {
+		let resolveExit: ((code: number) => void) | undefined;
+		const never = new Promise<never>(() => {});
+		const stream = new ReadableStream<Uint8Array>({
+			pull: () => never,
+			cancel: () => never,
+		});
+		const spawn = (): SpawnedProcess => ({
+			stdout: stream,
+			stderr: streamFrom(new Uint8Array(0)),
+			exited: new Promise<number>((resolve) => {
+				resolveExit = resolve;
+			}),
+			kill() {
+				resolveExit?.(0);
+			},
+		});
+		const runner = createPrimeCliCommandRunner(spawn, 50);
+		const result = await runner.runCommand(["echo"], 100);
+		expect(result).toEqual({ ok: false, code: "PROCESS_UNCERTAIN" });
+	});
+});

--- a/packages/coding-agent/test/fixtures/prime-cli-0.6.21-create-version-fixture.json
+++ b/packages/coding-agent/test/fixtures/prime-cli-0.6.21-create-version-fixture.json
@@ -1,0 +1,7 @@
+{
+  "primePackageVersion": "0.6.21",
+  "versionStdout": "Prime CLI version: 0.6.21\n",
+  "sandboxCommandSourceSha256": "2b7b79dc1296746730db1dd1c0d248524dc81ae129b3a5ac624dcff41bc7412f",
+  "sandboxModelSourceSha256": "1ba393881f9ce103fb0d8f44a44a8a3719724fda15a2b7f35a517cafc48bc1e4",
+  "createPlainStdout": "\nSuccessfully created sandbox sb_abc123\nUse 'prime sandbox get sb_abc123' to check the sandbox status\n"
+}

--- a/packages/coding-agent/test/fixtures/prime-cli-0.6.21-sandbox-json-fixture.json
+++ b/packages/coding-agent/test/fixtures/prime-cli-0.6.21-sandbox-json-fixture.json
@@ -1,0 +1,68 @@
+{
+  "primePackageVersion": "0.6.21",
+  "sandboxCommandSourceSha256": "2b7b79dc1296746730db1dd1c0d248524dc81ae129b3a5ac624dcff41bc7412f",
+  "sandboxModelSourceSha256": "1ba393881f9ce103fb0d8f44a44a8a3719724fda15a2b7f35a517cafc48bc1e4",
+  "timeUtilsSourceSha256": "5cd800696c7088b7d309d3b7d453b29ca052c90c1cd63aabaf683059ed060aa6",
+  "expectedLabel": "prime-agent:lifecycle:0123456789abcdef",
+  "list": {
+    "sandboxes": [
+      {
+        "id": "sb_abc123",
+        "name": "",
+        "image": "ubuntu:24.04",
+        "status": "RUNNING",
+        "resources": "1 CPU, 1GB RAM",
+        "region": null,
+        "labels": [
+          "prime-agent:lifecycle:0123456789abcdef"
+        ],
+        "created_at": "2026-09-04 01:02:03 UTC",
+        "timeout_minutes": 60,
+        "expires_at": "2026-09-04 02:02:03 UTC"
+      }
+    ],
+    "total": 1,
+    "page": 1,
+    "per_page": 100,
+    "has_next": false
+  },
+  "get": {
+    "id": "sb_abc123",
+    "name": "",
+    "type": "Container",
+    "docker_image": "ubuntu:24.04",
+    "start_command": "tail -f /dev/null",
+    "status": "RUNNING",
+    "cpu_cores": 1.0,
+    "memory_gb": 1.0,
+    "disk_size_gb": 5.0,
+    "disk_mount_path": "/workspace",
+    "gpu_count": 0,
+    "gpu_type": null,
+    "vm": false,
+    "network_allowlist": null,
+    "network_denylist": null,
+    "timeout_minutes": 60,
+    "idle_timeout_minutes": null,
+    "termination_reason": null,
+    "labels": [
+      "prime-agent:lifecycle:0123456789abcdef"
+    ],
+    "created_at": "2026-09-04 01:02:03 UTC",
+    "user_id": null,
+    "team_id": null,
+    "region": null,
+    "registry_credentials_id": null,
+    "started_at": "2026-09-04 01:02:04 UTC",
+    "exit_code": 0,
+    "environment_vars": {
+      "VISIBLE": "v***e"
+    },
+    "secrets": {
+      "TOKEN": "***"
+    },
+    "advanced_configs": {
+      "futureFlag": true
+    }
+  }
+}

--- a/packages/coding-agent/test/prime-cli-create-version-codec.test.ts
+++ b/packages/coding-agent/test/prime-cli-create-version-codec.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "bun:test";
+import {
+	parsePrimeCliCreateOutput,
+	parsePrimeCliVersionOutput,
+} from "../src/modes/daemon/sandbox/prime-cli-create-version-codec.js";
+import fixture from "./fixtures/prime-cli-0.6.21-create-version-fixture.json";
+
+const INVALID = Object.freeze({ ok: false, code: "INVALID_OUTPUT" });
+
+function expectOpaqueFailure(result: unknown): void {
+	expect(result).toEqual(INVALID);
+	expect(Object.isFrozen(result)).toBe(true);
+	if (typeof result === "object" && result !== null) {
+		expect(Object.keys(result)).toEqual(["ok", "code"]);
+	}
+}
+
+describe("Prime CLI 0.6.21 version codec", () => {
+	it("accepts only the exact source-backed line", () => {
+		const result = parsePrimeCliVersionOutput(fixture.versionStdout);
+		expect(result).toEqual({ ok: true, value: { version: "0.6.21" } });
+		expect(Object.isFrozen(result)).toBe(true);
+		if (result.ok) expect(Object.isFrozen(result.value)).toBe(true);
+	});
+
+	for (const output of [
+		"Prime CLI version: 0.6.21",
+		"Prime CLI version: 0.6.21\n\n",
+		" Prime CLI version: 0.6.21\n",
+		"Prime CLI version: 0.6.22\n",
+		"warning\nPrime CLI version: 0.6.21\n",
+		"",
+	]) {
+		it(`rejects non-exact output ${JSON.stringify(output)}`, () => {
+			expectOpaqueFailure(parsePrimeCliVersionOutput(output));
+		});
+	}
+});
+
+describe("Prime CLI 0.6.21 create codec", () => {
+	it("accepts the source output with the same ID repeated", () => {
+		const result = parsePrimeCliCreateOutput(fixture.createPlainStdout);
+		expect(result).toEqual({ ok: true, value: { id: "sb_abc123" } });
+		expect(Object.isFrozen(result)).toBe(true);
+		if (result.ok) expect(Object.isFrozen(result.value)).toBe(true);
+	});
+
+	it("accepts one hexadecimal digit without inventing a fixed provider length", () => {
+		expect(parsePrimeCliCreateOutput("Successfully created sandbox sb_a\n")).toEqual({
+			ok: true,
+			value: { id: "sb_a" },
+		});
+	});
+
+	it("accepts a 128-byte total ID", () => {
+		const id = `sb_${"a".repeat(125)}`;
+		expect(parsePrimeCliCreateOutput(`Successfully created sandbox ${id}\n`)).toEqual({
+			ok: true,
+			value: { id },
+		});
+	});
+
+	for (const output of [
+		"",
+		"Successfully created sandbox sb_\n",
+		"Successfully created sandbox sb_xyz\n",
+		"Successfully created sandbox sb_abcg\n",
+		"Successfully created sandbox xsb_abc\n",
+		"Successfully created sandbox sb_abc_extra\n",
+		"Successfully created sandbox sb_abcé\n",
+		"Successfully created sandbox sb_abc-def\n",
+		"Successfully created sandbox sb_abc\nUse 'prime sandbox get sb_def'\n",
+		"Successfully created sandbox sb_abc\nSuccessfully created sandbox sb_abc\n",
+		"Created sandbox sb_abc\n",
+		`Successfully created sandbox sb_${"a".repeat(126)}\n`,
+		"Successfully created sandbox sb_abc\ud800\n",
+	]) {
+		it(`rejects ambiguous or malformed output ${output.length}`, () => {
+			expectOpaqueFailure(parsePrimeCliCreateOutput(output));
+		});
+	}
+
+	it("bounds output by UTF-8 bytes rather than UTF-16 units", () => {
+		const prefix = "Successfully created sandbox sb_a\n";
+		const output = `${prefix}${"é".repeat(524_280)}`;
+		expect(output.length).toBeLessThan(1_048_576);
+		expectOpaqueFailure(parsePrimeCliCreateOutput(output));
+	});
+
+	it("never reflects provider output in failures", () => {
+		const secret = "do-not-reflect-this";
+		const result = parsePrimeCliCreateOutput(`Successfully created sandbox sb_abc\n${secret} sb_def\n`);
+		expectOpaqueFailure(result);
+		expect(JSON.stringify(result)).not.toContain(secret);
+		expect(JSON.stringify(result)).not.toContain("sb_abc");
+	});
+});

--- a/packages/coding-agent/test/prime-cli-json-codec.test.ts
+++ b/packages/coding-agent/test/prime-cli-json-codec.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, it } from "bun:test";
+import {
+	parsePrimeSandboxGetOutput,
+	parsePrimeSandboxListOutput,
+} from "../src/modes/daemon/sandbox/prime-cli-json-codec.js";
+import fixture from "./fixtures/prime-cli-0.6.21-sandbox-json-fixture.json";
+
+function expectFailure(result: unknown, code: "INPUT_INVALID" | "INVALID_OUTPUT" = "INVALID_OUTPUT"): void {
+	expect(result).toEqual({ ok: false, code });
+	expect(Object.isFrozen(result)).toBe(true);
+	if (typeof result === "object" && result !== null) expect(Object.keys(result)).toEqual(["ok", "code"]);
+}
+
+function listOutput(value: unknown = fixture.list): string {
+	return JSON.stringify(value);
+}
+
+function getOutput(value: unknown = fixture.get): string {
+	return JSON.stringify(value);
+}
+
+function mutateListRow(key: string, value: unknown): string {
+	const list = structuredClone(fixture.list);
+	Object.defineProperty(list.sandboxes[0], key, { value, enumerable: true, configurable: true, writable: true });
+	return listOutput(list);
+}
+
+function withoutGetKey(key: string): string {
+	const value = structuredClone(fixture.get);
+	Reflect.deleteProperty(value, key);
+	return getOutput(value);
+}
+
+describe("Prime CLI 0.6.21 list JSON codec", () => {
+	it("accepts the source-derived fixture and freezes exact retained state", () => {
+		const result = parsePrimeSandboxListOutput(listOutput(), fixture.expectedLabel);
+		expect(result).toEqual({
+			ok: true,
+			value: {
+				sandboxes: [{ id: "sb_abc123", status: "RUNNING", labels: [fixture.expectedLabel] }],
+				total: 1,
+				page: 1,
+				perPage: 100,
+				hasNext: false,
+			},
+		});
+		expect(Object.isFrozen(result)).toBe(true);
+		if (result.ok) {
+			expect(Object.isFrozen(result.value)).toBe(true);
+			expect(Object.isFrozen(result.value.sandboxes)).toBe(true);
+			expect(Object.isFrozen(result.value.sandboxes[0])).toBe(true);
+			expect(Object.isFrozen(result.value.sandboxes[0].labels)).toBe(true);
+			expect(Object.keys(result.value.sandboxes[0])).toEqual(["id", "status", "labels"]);
+		}
+	});
+
+	it("accepts all exact known statuses", () => {
+		for (const status of ["PENDING", "PROVISIONING", "RUNNING", "PAUSED", "ERROR", "TERMINATED", "TIMEOUT"]) {
+			const result = parsePrimeSandboxListOutput(mutateListRow("status", status), fixture.expectedLabel);
+			expect(result.ok).toBe(true);
+		}
+	});
+
+	it("accepts an empty page as proven zero matches", () => {
+		const value = { sandboxes: [], total: 0, page: 1, per_page: 100, has_next: false };
+		expect(parsePrimeSandboxListOutput(listOutput(value), fixture.expectedLabel)).toEqual({
+			ok: true,
+			value: { sandboxes: [], total: 0, page: 1, perPage: 100, hasNext: false },
+		});
+	});
+
+	it("tolerates benign unknown keys without retaining them", () => {
+		const value = structuredClone(fixture.list);
+		Object.defineProperty(value, "future", { value: { nested: true }, enumerable: true });
+		Object.defineProperty(value.sandboxes[0], "future", { value: 7, enumerable: true });
+		expect(parsePrimeSandboxListOutput(listOutput(value), fixture.expectedLabel).ok).toBe(true);
+	});
+
+	for (const [name, output] of [
+		["invalid JSON", "{"],
+		["array root", "[]"],
+		["empty input", ""],
+		["zero page", listOutput({ ...fixture.list, page: 0 })],
+		["zero per_page", listOutput({ ...fixture.list, per_page: 0 })],
+		["negative total", listOutput({ ...fixture.list, total: -1 })],
+		["wrong has_next", listOutput({ ...fixture.list, has_next: "false" })],
+		[
+			"rows exceed per_page",
+			listOutput({
+				...fixture.list,
+				per_page: 1,
+				total: 2,
+				sandboxes: [fixture.list.sandboxes[0], fixture.list.sandboxes[0]],
+			}),
+		],
+		["rows exceed total", listOutput({ ...fixture.list, total: 0 })],
+		["impossible has_next", listOutput({ ...fixture.list, total: 100, has_next: true })],
+		["impossible final page", listOutput({ ...fixture.list, total: 101, has_next: false })],
+		[
+			"duplicate IDs",
+			listOutput({
+				...fixture.list,
+				total: 2,
+				sandboxes: [fixture.list.sandboxes[0], fixture.list.sandboxes[0]],
+			}),
+		],
+		["label mismatch", listOutput()],
+	] as const) {
+		it(`rejects ${name}`, () => {
+			const label = name === "label mismatch" ? "other-label" : fixture.expectedLabel;
+			expectFailure(parsePrimeSandboxListOutput(output, label));
+		});
+	}
+
+	for (const [field, value] of [
+		["id", "sb_"],
+		["id", "sb_abcg"],
+		["name", "é".repeat(257)],
+		["image", ""],
+		["resources", ""],
+		["region", 4],
+		["labels", null],
+		["labels", [fixture.expectedLabel, 4]],
+		["created_at", "abcd-ef-gh ij:kl:mn UTC"],
+		["created_at", "2025-02-29 01:02:03 UTC"],
+		["created_at", "0000-01-01 01:02:03 UTC"],
+		["timeout_minutes", 0],
+		["expires_at", "2026-04-31 01:02:03 UTC"],
+	] as const) {
+		it(`rejects malformed row field ${field}`, () => {
+			expectFailure(parsePrimeSandboxListOutput(mutateListRow(field, value), fixture.expectedLabel));
+		});
+	}
+
+	it("rejects every missing required row field including nullable fields", () => {
+		for (const key of [
+			"id",
+			"name",
+			"image",
+			"status",
+			"resources",
+			"region",
+			"labels",
+			"created_at",
+			"timeout_minutes",
+			"expires_at",
+		]) {
+			const value = structuredClone(fixture.list);
+			Reflect.deleteProperty(value.sandboxes[0], key);
+			expectFailure(parsePrimeSandboxListOutput(listOutput(value), fixture.expectedLabel));
+		}
+	});
+
+	it("rejects invalid or secret-bearing expected labels as input", () => {
+		expectFailure(parsePrimeSandboxListOutput(listOutput(), ""), "INPUT_INVALID");
+		expectFailure(parsePrimeSandboxListOutput(listOutput(), "bad\nlabel"), "INPUT_INVALID");
+		expectFailure(parsePrimeSandboxListOutput(listOutput(), "é".repeat(257)), "INPUT_INVALID");
+	});
+
+	it("bounds the raw output by UTF-8 bytes", () => {
+		const output = `${listOutput()}${"é".repeat(524_288)}`;
+		expect(output.length).toBeLessThan(1_048_576);
+		expectFailure(parsePrimeSandboxListOutput(output, fixture.expectedLabel));
+	});
+
+	it("never reflects an ID, label, or raw fragment in failure", () => {
+		const result = parsePrimeSandboxListOutput(mutateListRow("status", "UNKNOWN_SECRET"), fixture.expectedLabel);
+		expectFailure(result);
+		const serialized = JSON.stringify(result);
+		expect(serialized).not.toContain("UNKNOWN_SECRET");
+		expect(serialized).not.toContain("sb_abc123");
+		expect(serialized).not.toContain(fixture.expectedLabel);
+	});
+});
+
+describe("Prime CLI 0.6.21 get JSON codec", () => {
+	it("accepts and retains only lifecycle fields", () => {
+		const result = parsePrimeSandboxGetOutput(getOutput(), "sb_abc123", fixture.expectedLabel);
+		expect(result).toEqual({
+			ok: true,
+			value: { id: "sb_abc123", status: "RUNNING", labels: [fixture.expectedLabel], vm: false, type: "Container" },
+		});
+		expect(Object.isFrozen(result)).toBe(true);
+		if (result.ok) {
+			expect(Object.isFrozen(result.value)).toBe(true);
+			expect(Object.isFrozen(result.value.labels)).toBe(true);
+			expect(Object.keys(result.value)).toEqual(["id", "status", "labels", "vm", "type"]);
+			expect(JSON.stringify(result)).not.toContain("TOKEN");
+			expect(JSON.stringify(result)).not.toContain("VISIBLE");
+		}
+	});
+
+	it("accepts a consistent VM detail structurally", () => {
+		const value = { ...fixture.get, vm: true, type: "VM" };
+		expect(parsePrimeSandboxGetOutput(getOutput(value), "sb_abc123", fixture.expectedLabel).ok).toBe(true);
+	});
+
+	it("rejects expected identity and label mismatches", () => {
+		expectFailure(parsePrimeSandboxGetOutput(getOutput(), "sb_def456", fixture.expectedLabel));
+		expectFailure(parsePrimeSandboxGetOutput(getOutput(), "sb_abc123", "other-label"));
+	});
+
+	it("rejects inconsistent type/vm", () => {
+		expectFailure(
+			parsePrimeSandboxGetOutput(
+				getOutput({ ...fixture.get, vm: true, type: "Container" }),
+				"sb_abc123",
+				fixture.expectedLabel,
+			),
+		);
+		expectFailure(
+			parsePrimeSandboxGetOutput(
+				getOutput({ ...fixture.get, vm: false, type: "VM" }),
+				"sb_abc123",
+				fixture.expectedLabel,
+			),
+		);
+	});
+
+	it("requires every exact known detail field", () => {
+		for (const key of [
+			"id",
+			"name",
+			"type",
+			"docker_image",
+			"start_command",
+			"status",
+			"cpu_cores",
+			"memory_gb",
+			"disk_size_gb",
+			"disk_mount_path",
+			"gpu_count",
+			"gpu_type",
+			"vm",
+			"network_allowlist",
+			"network_denylist",
+			"timeout_minutes",
+			"idle_timeout_minutes",
+			"termination_reason",
+			"labels",
+			"created_at",
+			"user_id",
+			"team_id",
+			"region",
+			"registry_credentials_id",
+		]) {
+			expectFailure(parsePrimeSandboxGetOutput(withoutGetKey(key), "sb_abc123", fixture.expectedLabel));
+		}
+	});
+
+	for (const [key, value] of [
+		["start_command", {}],
+		["cpu_cores", Number.POSITIVE_INFINITY],
+		["memory_gb", -1],
+		["disk_size_gb", "5"],
+		["disk_mount_path", ""],
+		["gpu_count", 0.5],
+		["gpu_type", 4],
+		["network_allowlist", [4]],
+		["network_denylist", "none"],
+		["idle_timeout_minutes", 0],
+		["termination_reason", {}],
+		["registry_credentials_id", {}],
+		["started_at", null],
+		["terminated_at", "2025-02-29 00:00:00 UTC"],
+		["exit_code", 0.5],
+		["environment_vars", []],
+		["environment_vars", { KEY: 4 }],
+		["secrets", { KEY: 4 }],
+		["advanced_configs", []],
+	] as const) {
+		it(`rejects wrong known detail value ${key}`, () => {
+			const valueObject = structuredClone(fixture.get);
+			Object.defineProperty(valueObject, key, { value, enumerable: true, configurable: true, writable: true });
+			expectFailure(parsePrimeSandboxGetOutput(getOutput(valueObject), "sb_abc123", fixture.expectedLabel));
+		});
+	}
+
+	it("rejects overdeep advanced config", () => {
+		const advanced = { a: { b: { c: { d: { e: true } } } } };
+		expectFailure(
+			parsePrimeSandboxGetOutput(
+				getOutput({ ...fixture.get, advanced_configs: advanced }),
+				"sb_abc123",
+				fixture.expectedLabel,
+			),
+		);
+	});
+
+	it("accepts absent optional detail fields", () => {
+		const value = structuredClone(fixture.get);
+		for (const key of ["started_at", "exit_code", "environment_vars", "secrets", "advanced_configs"])
+			Reflect.deleteProperty(value, key);
+		expect(parsePrimeSandboxGetOutput(getOutput(value), "sb_abc123", fixture.expectedLabel).ok).toBe(true);
+	});
+
+	it("rejects invalid expected inputs with opaque fixed results", () => {
+		expectFailure(parsePrimeSandboxGetOutput(getOutput(), "not-an-id", fixture.expectedLabel), "INPUT_INVALID");
+		expectFailure(parsePrimeSandboxGetOutput(getOutput(), "sb_abc123", "bad\nlabel"), "INPUT_INVALID");
+	});
+});

--- a/packages/coding-agent/test/prime-sandbox-lifecycle.test.ts
+++ b/packages/coding-agent/test/prime-sandbox-lifecycle.test.ts
@@ -1,0 +1,937 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type Clock,
+	type CreatePermission,
+	createSandboxLifecycle,
+	type DelayFn,
+	type LifecycleConfig,
+	type RunCommand,
+	type RunnerResult,
+	type SandboxHandle,
+} from "../src/modes/daemon/sandbox/prime-sandbox-lifecycle.js";
+import versionFixture from "./fixtures/prime-cli-0.6.21-create-version-fixture.json";
+import fixture from "./fixtures/prime-cli-0.6.21-sandbox-json-fixture.json";
+
+const EL = fixture.expectedLabel;
+const VS = versionFixture.versionStdout;
+
+function vc(): LifecycleConfig {
+	return Object.freeze({
+		primeCliPath: "/usr/local/bin/prime",
+		label: EL,
+		image: "ubuntu:24.04",
+		name: "test-sandbox",
+		cpuCores: 1,
+		memoryGb: 1,
+		diskSizeGb: 5,
+		sandboxTimeoutMinutes: 60,
+		operationTimeoutMs: 60000,
+		pollIntervalMs: 500,
+	});
+}
+
+function ok(s: string, se = "", ec = 0): RunnerResult {
+	return Object.freeze({ ok: true, value: Object.freeze({ stdout: s, stderr: se, exitCode: ec, durationMs: 100 }) });
+}
+
+function fail(c: string): RunnerResult {
+	return Object.freeze({ ok: false, code: c }) as unknown as RunnerResult;
+}
+
+function mk(a: readonly string[]): string {
+	return a.join("\0");
+}
+
+function emptyJ(): string {
+	return JSON.stringify({ sandboxes: [], total: 0, page: 1, per_page: 100, has_next: false });
+}
+
+function makeGetResponse(overrides: Record<string, unknown>): string {
+	return JSON.stringify({ ...fixture.get, ...overrides });
+}
+
+const VK = mk(["/usr/local/bin/prime", "--version"]);
+const LK = mk([
+	"/usr/local/bin/prime",
+	"--plain",
+	"sandbox",
+	"list",
+	"--label",
+	EL,
+	"--page",
+	"1",
+	"--num",
+	"100",
+	"--output",
+	"json",
+]);
+const GK = mk(["/usr/local/bin/prime", "--plain", "sandbox", "get", "sb_abc123", "--output", "json"]);
+
+function mkR(m: Map<string, RunnerResult>): RunCommand {
+	return (a, _t, _s) => {
+		const k = mk(a);
+		const r = m.get(k);
+		return Promise.resolve(r !== undefined ? r : ok(""));
+	};
+}
+
+const VR = ok(VS);
+
+describe("Construction", () => {
+	it("accepts config + version gate", async () => {
+		const r = await createSandboxLifecycle(mkR(new Map([[VK, VR]])), vc());
+		expect(r.ok).toBe(true);
+		if (r.ok) {
+			expect(Object.isFrozen(r.value)).toBe(true);
+			expect(typeof r.value.lifecycle.inspect).toBe("function");
+			expect(typeof r.value.lifecycle.create).toBe("function");
+			expect(typeof r.value.lifecycle.waitUntilReady).toBe("function");
+			expect(typeof r.value.lifecycle.deleteAndProveAbsent).toBe("function");
+			expect(typeof r.value.proofConsumer.consumeProof).toBe("function");
+		}
+	});
+	it("CONFIG_REJECTED: rel path", async () => {
+		const r = await createSandboxLifecycle(async () => ok(""), { ...vc(), primeCliPath: "x" });
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.code).toBe("CONFIG_REJECTED");
+	});
+	it("CONFIG_REJECTED: empty label", async () => {
+		const r = await createSandboxLifecycle(async () => ok(""), { ...vc(), label: "" });
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.code).toBe("CONFIG_REJECTED");
+	});
+	it("VERSION_MISMATCH: runner fail", async () => {
+		const r = await createSandboxLifecycle(mkR(new Map([[VK, fail("SPAWN_FAILED")]])), vc());
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.code).toBe("VERSION_MISMATCH");
+	});
+	it("VERSION_MISMATCH: nonzero exit", async () => {
+		const r = await createSandboxLifecycle(mkR(new Map([[VK, ok("", "", 1)]])), vc());
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.code).toBe("VERSION_MISMATCH");
+	});
+	it("VERSION_MISMATCH: wrong output", async () => {
+		const r = await createSandboxLifecycle(mkR(new Map([[VK, ok("bad\n")]])), vc());
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.code).toBe("VERSION_MISMATCH");
+	});
+	it("VERSION_MISMATCH: throws", async () => {
+		const r = await createSandboxLifecycle(() => {
+			throw new Error("x");
+		}, vc());
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.code).toBe("VERSION_MISMATCH");
+	});
+	it("CONFIG_REJECTED: clock throws", async () => {
+		const r = await createSandboxLifecycle(mkR(new Map([[VK, VR]])), vc(), {
+			now: () => {
+				throw new Error("x");
+			},
+		});
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.code).toBe("CONFIG_REJECTED");
+	});
+	it("freezes result", async () => {
+		const r = await createSandboxLifecycle(mkR(new Map([[VK, VR]])), vc());
+		expect(Object.isFrozen(r)).toBe(true);
+	});
+});
+
+describe("Inspect", () => {
+	const oneJ = JSON.stringify({
+		sandboxes: [
+			{
+				id: "sb_abc123",
+				name: "",
+				image: "u:1",
+				status: "RUNNING",
+				resources: "1CPU",
+				region: null,
+				labels: [EL],
+				created_at: "2026-09-04 01:02:03 UTC",
+				timeout_minutes: 60,
+				expires_at: null,
+			},
+		],
+		total: 1,
+		page: 1,
+		per_page: 100,
+		has_next: false,
+	});
+
+	it("empty returns permission", async () => {
+		const r = await createSandboxLifecycle(
+			mkR(
+				new Map([
+					[VK, VR],
+					[LK, ok(emptyJ())],
+				]),
+			),
+			vc(),
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const i = await r.value.lifecycle.inspect();
+		expect(i.ok).toBe(true);
+		if (!i.ok) return;
+		expect(i.kind).toBe("empty");
+		expect(Object.keys(i.value)).toEqual([]);
+	});
+	it("single returns handle", async () => {
+		const r = await createSandboxLifecycle(
+			mkR(
+				new Map([
+					[VK, VR],
+					[LK, ok(oneJ)],
+					[GK, ok(JSON.stringify(fixture.get))],
+				]),
+			),
+			vc(),
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const i = await r.value.lifecycle.inspect();
+		expect(i.ok).toBe(true);
+		if (!i.ok) return;
+		expect(i.kind).toBe("single");
+		expect(Object.keys(i.value)).toEqual([]);
+	});
+	it("COLLISION", async () => {
+		const l2 = structuredClone(fixture.list);
+		l2.sandboxes.push({ ...l2.sandboxes[0], id: "sb_02" });
+		l2.total = 2;
+		const r = await createSandboxLifecycle(
+			mkR(
+				new Map([
+					[VK, VR],
+					[LK, ok(JSON.stringify(l2))],
+				]),
+			),
+			vc(),
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const i = await r.value.lifecycle.inspect();
+		expect(i.ok).toBe(false);
+		if (!i.ok) expect(i.code).toBe("COLLISION");
+	});
+	it("ABORTED", async () => {
+		const c = new AbortController();
+		c.abort();
+		const r = await createSandboxLifecycle(mkR(new Map([[VK, VR]])), vc());
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const i = await r.value.lifecycle.inspect(c.signal);
+		expect(i.ok).toBe(false);
+		if (!i.ok) expect(i.code).toBe("ABORTED");
+	});
+});
+
+describe("Create", () => {
+	const CS =
+		"\nSuccessfully created sandbox sb_abc123\nUse 'prime sandbox get sb_abc123' to check the sandbox status\n";
+	const CK = mk([
+		"/usr/local/bin/prime",
+		"--plain",
+		"sandbox",
+		"create",
+		"ubuntu:24.04",
+		"--name",
+		"test-sandbox",
+		"--cpu-cores",
+		"1",
+		"--memory-gb",
+		"1",
+		"--disk-size-gb",
+		"5",
+		"--timeout-minutes",
+		"60",
+		"--label",
+		EL,
+		"--yes",
+	]);
+
+	it("creates and returns handle", async () => {
+		const r = await createSandboxLifecycle(
+			mkR(
+				new Map([
+					[VK, VR],
+					[LK, ok(emptyJ())],
+					[CK, ok(CS)],
+					[GK, ok(JSON.stringify(fixture.get))],
+				]),
+			),
+			vc(),
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const insp = await r.value.lifecycle.inspect();
+		expect(insp.ok).toBe(true);
+		if (!insp.ok || insp.kind !== "empty") return;
+		const cr = await r.value.lifecycle.create(insp.value);
+		expect(cr.ok).toBe(true);
+		if (cr.ok) expect(Object.keys(cr.value)).toEqual([]);
+	});
+	it("TOKEN_CONSUMED", async () => {
+		const r = await createSandboxLifecycle(
+			mkR(
+				new Map([
+					[VK, VR],
+					[LK, ok(emptyJ())],
+					[CK, ok(CS)],
+					[GK, ok(JSON.stringify(fixture.get))],
+				]),
+			),
+			vc(),
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const insp = await r.value.lifecycle.inspect();
+		expect(insp.ok).toBe(true);
+		if (!insp.ok || insp.kind !== "empty") return;
+		await r.value.lifecycle.create(insp.value);
+		const s = await r.value.lifecycle.create(insp.value);
+		expect(s.ok).toBe(false);
+		if (!s.ok) expect(s.code).toBe("TOKEN_CONSUMED");
+	});
+	it("TOKEN_INVALID", async () => {
+		const r = await createSandboxLifecycle(mkR(new Map([[VK, VR]])), vc());
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const cr = await r.value.lifecycle.create(Object.freeze({}) as unknown as CreatePermission);
+		expect(cr.ok).toBe(false);
+		if (!cr.ok) expect(cr.code).toBe("TOKEN_INVALID");
+	});
+	it("RECOVERY_REQUIRED", async () => {
+		const r = await createSandboxLifecycle(
+			mkR(
+				new Map([
+					[VK, VR],
+					[LK, ok(emptyJ())],
+					[CK, ok("bad\n")],
+				]),
+			),
+			vc(),
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const insp = await r.value.lifecycle.inspect();
+		expect(insp.ok).toBe(true);
+		if (!insp.ok || insp.kind !== "empty") return;
+		const cr = await r.value.lifecycle.create(insp.value);
+		expect(cr.ok).toBe(false);
+		if (!cr.ok) expect(cr.code).toBe("RECOVERY_REQUIRED");
+	});
+});
+
+describe("WaitUntilReady", () => {
+	const oneJ = JSON.stringify({
+		sandboxes: [
+			{
+				id: "sb_abc123",
+				name: "",
+				image: "u:1",
+				status: "RUNNING",
+				resources: "1CPU",
+				region: null,
+				labels: [EL],
+				created_at: "2026-09-04 01:02:03 UTC",
+				timeout_minutes: 60,
+				expires_at: null,
+			},
+		],
+		total: 1,
+		page: 1,
+		per_page: 100,
+		has_next: false,
+	});
+
+	it("RUNNING ok", async () => {
+		const r = await createSandboxLifecycle(
+			mkR(
+				new Map([
+					[VK, VR],
+					[LK, ok(oneJ)],
+					[GK, ok(JSON.stringify({ ...fixture.get, status: "RUNNING" }))],
+				]),
+			),
+			vc(),
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const insp = await r.value.lifecycle.inspect();
+		expect(insp.ok).toBe(true);
+		if (!insp.ok || insp.kind !== "single") return;
+		const w = await r.value.lifecycle.waitUntilReady(insp.value);
+		expect(w.ok).toBe(true);
+	});
+	it("ERROR terminal", async () => {
+		const r = await createSandboxLifecycle(
+			mkR(
+				new Map([
+					[VK, VR],
+					[LK, ok(oneJ)],
+					[GK, ok(JSON.stringify({ ...fixture.get, status: "ERROR" }))],
+				]),
+			),
+			vc(),
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const insp = await r.value.lifecycle.inspect();
+		expect(insp.ok).toBe(true);
+		if (!insp.ok || insp.kind !== "single") return;
+		const w = await r.value.lifecycle.waitUntilReady(insp.value);
+		expect(w.ok).toBe(false);
+		if (!w.ok) expect(w.code).toBe("READY_TERMINAL");
+	});
+	it("HANDLE_INVALID", async () => {
+		const r = await createSandboxLifecycle(mkR(new Map([[VK, VR]])), vc());
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const w = await r.value.lifecycle.waitUntilReady(Object.freeze({}) as unknown as SandboxHandle);
+		expect(w.ok).toBe(false);
+		if (!w.ok) expect(w.code).toBe("HANDLE_INVALID");
+	});
+});
+
+describe("DeleteAndProveAbsent", () => {
+	it("HANDLE_INVALID", async () => {
+		const r = await createSandboxLifecycle(mkR(new Map([[VK, VR]])), vc());
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const dr = await r.value.lifecycle.deleteAndProveAbsent(Object.freeze({}) as unknown as SandboxHandle);
+		expect(dr.ok).toBe(false);
+		if (!dr.ok) expect(dr.code).toBe("HANDLE_INVALID");
+	});
+
+	it("malformed absence evidence never mints a proof or reissues delete", async () => {
+		const deleteKey = mk(["/usr/local/bin/prime", "--plain", "sandbox", "delete", "sb_abc123", "--yes"]);
+		let listCalls = 0;
+		let deleteCalls = 0;
+		const runner: RunCommand = (argv) => {
+			const key = mk(argv);
+			if (key === VK) return Promise.resolve(VR);
+			if (key === LK) {
+				listCalls++;
+				return Promise.resolve(ok(listCalls === 1 ? JSON.stringify(fixture.list) : "{"));
+			}
+			if (key === GK) return Promise.resolve(ok(JSON.stringify(fixture.get)));
+			if (key === deleteKey) {
+				deleteCalls++;
+				return Promise.resolve(fail("TIMED_OUT"));
+			}
+			return Promise.resolve(ok(""));
+		};
+		const created = await createSandboxLifecycle(runner, vc());
+		expect(created.ok).toBe(true);
+		if (!created.ok) return;
+		const inspected = await created.value.lifecycle.inspect();
+		expect(inspected.ok).toBe(true);
+		if (!inspected.ok || inspected.kind !== "single") return;
+		const deleted = await created.value.lifecycle.deleteAndProveAbsent(inspected.value);
+		expect(deleted).toEqual({ ok: false, code: "ABSENCE_UNCERTAIN" });
+		expect(deleteCalls).toBe(1);
+		const repeated = await created.value.lifecycle.deleteAndProveAbsent(inspected.value);
+		expect(repeated).toEqual({ ok: false, code: "DUPLICATE_DELETE" });
+		expect(deleteCalls).toBe(1);
+	});
+});
+
+describe("Edge", () => {
+	it("ABORTED propagation", async () => {
+		const r = await createSandboxLifecycle(
+			mkR(
+				new Map([
+					[VK, VR],
+					[LK, fail("ABORTED")],
+				]),
+			),
+			vc(),
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const i = await r.value.lifecycle.inspect();
+		expect(i.ok).toBe(false);
+		if (!i.ok) expect(i.code).toBe("ABORTED");
+	});
+	it("TIMED_OUT -> UNCERTAIN", async () => {
+		const r = await createSandboxLifecycle(
+			mkR(
+				new Map([
+					[VK, VR],
+					[LK, fail("TIMED_OUT")],
+				]),
+			),
+			vc(),
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const i = await r.value.lifecycle.inspect();
+		expect(i.ok).toBe(false);
+		if (!i.ok) expect(i.code).toBe("UNCERTAIN");
+	});
+	it("no private data in errors", async () => {
+		const c = new AbortController();
+		c.abort();
+		const r = await createSandboxLifecycle(mkR(new Map([[VK, VR]])), vc());
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const i = await r.value.lifecycle.inspect(c.signal);
+		const js = JSON.stringify(i);
+		expect(js).not.toContain("sb_");
+		expect(js).not.toContain(EL);
+	});
+	it("foreign handle cross-adapter", async () => {
+		const oneJ = JSON.stringify({
+			sandboxes: [
+				{
+					id: "sb_0a",
+					name: "",
+					image: "u:1",
+					status: "RUNNING",
+					resources: "1CPU",
+					region: null,
+					labels: [EL],
+					created_at: "2026-09-04 01:02:03 UTC",
+					timeout_minutes: 60,
+					expires_at: null,
+				},
+			],
+			total: 1,
+			page: 1,
+			per_page: 100,
+			has_next: false,
+		});
+		const gkx = mk(["/usr/local/bin/prime", "--plain", "sandbox", "get", "sb_0a", "--output", "json"]);
+		const a1 = await createSandboxLifecycle(
+			mkR(
+				new Map([
+					[VK, VR],
+					[LK, ok(oneJ)],
+					[gkx, ok(JSON.stringify({ ...fixture.get, id: "sb_0a" }))],
+				]),
+			),
+			vc(),
+		);
+		expect(a1.ok).toBe(true);
+		if (!a1.ok) return;
+		const insp = await a1.value.lifecycle.inspect();
+		expect(insp.ok).toBe(true);
+		if (!insp.ok || insp.kind !== "single") return;
+		const a2 = await createSandboxLifecycle(mkR(new Map([[VK, VR]])), vc());
+		expect(a2.ok).toBe(true);
+		if (!a2.ok) return;
+		const w = await a2.value.lifecycle.waitUntilReady(insp.value);
+		expect(w.ok).toBe(false);
+		if (!w.ok) expect(w.code).toBe("HANDLE_INVALID");
+	});
+	it("permission cross-adapter", async () => {
+		const a1 = await createSandboxLifecycle(
+			mkR(
+				new Map([
+					[VK, VR],
+					[LK, ok(emptyJ())],
+				]),
+			),
+			vc(),
+		);
+		expect(a1.ok).toBe(true);
+		if (!a1.ok) return;
+		const insp = await a1.value.lifecycle.inspect();
+		expect(insp.ok).toBe(true);
+		if (!insp.ok || insp.kind !== "empty") return;
+		const a2 = await createSandboxLifecycle(mkR(new Map([[VK, VR]])), vc());
+		expect(a2.ok).toBe(true);
+		if (!a2.ok) return;
+		const cr = await a2.value.lifecycle.create(insp.value);
+		expect(cr.ok).toBe(false);
+		if (!cr.ok) expect(cr.code).toBe("TOKEN_INVALID");
+	});
+});
+describe("ProofConsumer", () => {
+	it("full flow: delete produces proof, consume once ok, second fails, foreign rejects", async () => {
+		const oneJ = JSON.stringify({
+			sandboxes: [
+				{
+					id: "sb_0f",
+					name: "",
+					image: "u:1",
+					status: "RUNNING",
+					resources: "1CPU",
+					region: null,
+					labels: [EL],
+					created_at: "2026-09-04 01:02:03 UTC",
+					timeout_minutes: 60,
+					expires_at: null,
+				},
+			],
+			total: 1,
+			page: 1,
+			per_page: 100,
+			has_next: false,
+		});
+		const gk = mk(["/usr/local/bin/prime", "--plain", "sandbox", "get", "sb_0f", "--output", "json"]);
+		const dk = mk(["/usr/local/bin/prime", "--plain", "sandbox", "delete", "sb_0f", "--yes"]);
+		const m = new Map();
+		m.set(VK, VR);
+		m.set(LK, ok(oneJ));
+		m.set(gk, ok(makeGetResponse({ id: "sb_0f" })));
+		m.set(dk, ok("Deleted.\n"));
+		let deleteCalls = 0;
+		const runner = (a: readonly string[], _t: number, _s?: AbortSignal) => {
+			const k = mk(a);
+			const r = m.get(k);
+			if (k === LK) {
+				m.set(LK, ok(emptyJ()));
+			}
+			if (k === dk) deleteCalls++;
+			return Promise.resolve(r !== undefined ? r : ok(""));
+		};
+		const r = await createSandboxLifecycle(runner, vc());
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const bundle = r.value;
+		const insp = await bundle.lifecycle.inspect();
+		expect(insp.ok).toBe(true);
+		if (!insp.ok || insp.kind !== "single") return;
+		const delResult = await bundle.lifecycle.deleteAndProveAbsent(insp.value);
+		expect(deleteCalls).toBe(1);
+		expect(delResult.ok).toBe(true);
+		if (!delResult.ok) return;
+		const proof = delResult.value;
+		const consume1 = bundle.proofConsumer.consumeProof(proof);
+		expect(consume1.ok).toBe(true);
+		const consume2 = bundle.proofConsumer.consumeProof(proof);
+		expect(consume2.ok).toBe(false);
+		if (!consume2.ok) expect(consume2.code).toBe("PROOF_INVALID");
+		const r2 = await createSandboxLifecycle(mkR(new Map([[VK, VR]])), vc());
+		expect(r2.ok).toBe(true);
+		if (!r2.ok) return;
+		const foreignResult = r2.value.proofConsumer.consumeProof(proof);
+		expect(foreignResult.ok).toBe(false);
+		if (!foreignResult.ok) expect(foreignResult.code).toBe("PROOF_INVALID");
+	});
+});
+describe("Delay deadline bound", () => {
+	it("injected hanging delay produces UNCERTAIN under bounded guard", async () => {
+		const hangDelay: DelayFn = () => new Promise(() => {});
+		const shortCfg = { ...vc(), operationTimeoutMs: 200, pollIntervalMs: 1000 };
+		const oneJ = JSON.stringify({
+			sandboxes: [
+				{
+					id: "sb_0c",
+					name: "",
+					image: "u:1",
+					status: "PENDING",
+					resources: "1CPU",
+					region: null,
+					labels: [EL],
+					created_at: "2026-09-04 01:02:03 UTC",
+					timeout_minutes: 60,
+					expires_at: null,
+				},
+			],
+			total: 1,
+			page: 1,
+			per_page: 100,
+			has_next: false,
+		});
+		const gk0c = mk(["/usr/local/bin/prime", "--plain", "sandbox", "get", "sb_0c", "--output", "json"]);
+		const r = await createSandboxLifecycle(
+			mkR(
+				new Map([
+					[VK, VR],
+					[LK, ok(oneJ)],
+					[gk0c, ok(makeGetResponse({ id: "sb_0c", status: "PENDING" }))],
+				]),
+			),
+			shortCfg,
+			undefined,
+			hangDelay,
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const bundle = r.value;
+		const insp = await bundle.lifecycle.inspect();
+		expect(insp.ok).toBe(true);
+		if (!insp.ok || insp.kind !== "single") return;
+		const t0 = Date.now();
+		const w = await bundle.lifecycle.waitUntilReady(insp.value);
+		const elapsed = Date.now() - t0;
+		expect(w.ok).toBe(false);
+		if (!w.ok) expect(w.code).toBe("UNCERTAIN");
+		expect(elapsed).toBeLessThan(5000);
+	});
+
+	it("caller abort beats a hanging injected delay", async () => {
+		const pendingList = JSON.stringify({
+			...fixture.list,
+			sandboxes: fixture.list.sandboxes.map((row) => ({ ...row, status: "PENDING" })),
+		});
+		const hangDelay: DelayFn = () => new Promise(() => {});
+		const r = await createSandboxLifecycle(
+			mkR(
+				new Map([
+					[VK, VR],
+					[LK, ok(pendingList)],
+					[GK, ok(makeGetResponse({ status: "PENDING" }))],
+				]),
+			),
+			{ ...vc(), operationTimeoutMs: 1000, pollIntervalMs: 1000 },
+			undefined,
+			hangDelay,
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const inspected = await r.value.lifecycle.inspect();
+		expect(inspected.ok).toBe(true);
+		if (!inspected.ok || inspected.kind !== "single") return;
+		const controller = new AbortController();
+		setTimeout(() => controller.abort(), 20);
+		const startedAt = Date.now();
+		const result = await r.value.lifecycle.waitUntilReady(inspected.value, controller.signal);
+		expect(result).toEqual({ ok: false, code: "ABORTED" });
+		expect(Date.now() - startedAt).toBeLessThan(500);
+	});
+});
+describe("Strict config validation", () => {
+	it("rejects config with extra keys", async () => {
+		const c = { ...vc(), extraKey: true };
+		const r = await createSandboxLifecycle(async () => ok(""), c);
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.code).toBe("CONFIG_REJECTED");
+	});
+	it("rejects config with missing keys", async () => {
+		const { primeCliPath: _, ...rest } = vc();
+		const r = await createSandboxLifecycle(async () => ok(""), rest as any);
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.code).toBe("CONFIG_REJECTED");
+	});
+	it("rejects config with symbol keys", async () => {
+		const c = Object.assign({}, vc(), { [Symbol("x")]: 1 });
+		const r = await createSandboxLifecycle(async () => ok(""), c);
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.code).toBe("CONFIG_REJECTED");
+	});
+	it("rejects image starting with dash", async () => {
+		const r = await createSandboxLifecycle(async () => ok(""), { ...vc(), image: "-image" });
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.code).toBe("CONFIG_REJECTED");
+	});
+});
+
+describe("Static clock poll limits", () => {
+	it("POLL_LIMIT under static clock", async () => {
+		const staticClock: Clock = { now: () => 1000 };
+		const immediateDelay: DelayFn = async () => "elapsed";
+		const oneJ = JSON.stringify({
+			sandboxes: [
+				{
+					id: "sb_0d",
+					name: "",
+					image: "u:1",
+					status: "PENDING",
+					resources: "1CPU",
+					region: null,
+					labels: [EL],
+					created_at: "2026-09-04 01:02:03 UTC",
+					timeout_minutes: 60,
+					expires_at: null,
+				},
+			],
+			total: 1,
+			page: 1,
+			per_page: 100,
+			has_next: false,
+		});
+		const gk0d = mk(["/usr/local/bin/prime", "--plain", "sandbox", "get", "sb_0d", "--output", "json"]);
+		const r = await createSandboxLifecycle(
+			mkR(
+				new Map([
+					[VK, VR],
+					[LK, ok(oneJ)],
+					[gk0d, ok(makeGetResponse({ id: "sb_0d", status: "PENDING" }))],
+				]),
+			),
+			{ ...vc(), pollIntervalMs: 10 },
+			staticClock,
+			immediateDelay,
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const bundle = r.value;
+		const insp = await bundle.lifecycle.inspect();
+		expect(insp.ok).toBe(true);
+		if (!insp.ok || insp.kind !== "single") return;
+		const w = await bundle.lifecycle.waitUntilReady(insp.value);
+		expect(w.ok).toBe(false);
+		if (!w.ok) expect(w.code).toBe("POLL_LIMIT");
+	});
+	it("infinite pagination blocked by completed flag", async () => {
+		let listCalls = 0;
+		const infRunner: RunCommand = (a, _t, _s) => {
+			if (a[1] === "--version") return Promise.resolve(VR);
+			const pageFlag = a.indexOf("--page");
+			if (pageFlag >= 0) {
+				listCalls++;
+				const page = Number(a[pageFlag + 1]);
+				const first = (page - 1) * 100;
+				const sandboxes = Array.from({ length: 100 }, (_, offset) => ({
+					...fixture.list.sandboxes[0],
+					id: `sb_${(first + offset).toString(16).padStart(8, "0")}`,
+				}));
+				return Promise.resolve(
+					ok(
+						JSON.stringify({
+							sandboxes,
+							total: 100_000,
+							page,
+							per_page: 100,
+							has_next: true,
+						}),
+					),
+				);
+			}
+			return Promise.resolve(ok(""));
+		};
+		const r = await createSandboxLifecycle(infRunner, vc());
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const insp = await r.value.lifecycle.inspect();
+		expect(listCalls).toBe(1000);
+		expect(insp.ok).toBe(false);
+		if (!insp.ok) expect(insp.code).toBe("UNCERTAIN");
+	});
+});
+describe("Container proof in waitUntilReady", () => {
+	it("rejects VM sandbox", async () => {
+		const oneJ = JSON.stringify({
+			sandboxes: [
+				{
+					id: "sb_0e",
+					name: "",
+					image: "u:1",
+					status: "RUNNING",
+					resources: "1CPU",
+					region: null,
+					labels: [EL],
+					created_at: "2026-09-04 01:02:03 UTC",
+					timeout_minutes: 60,
+					expires_at: null,
+				},
+			],
+			total: 1,
+			page: 1,
+			per_page: 100,
+			has_next: false,
+		});
+		const gk0e = mk(["/usr/local/bin/prime", "--plain", "sandbox", "get", "sb_0e", "--output", "json"]);
+		const r = await createSandboxLifecycle(
+			mkR(
+				new Map([
+					[VK, VR],
+					[LK, ok(oneJ)],
+					[gk0e, ok(makeGetResponse({ id: "sb_0e", vm: true, type: "VM" }))],
+				]),
+			),
+			vc(),
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const insp = await r.value.lifecycle.inspect();
+		// inspect already rejects VM, so this should be UNCERTAIN
+		expect(insp.ok).toBe(false);
+	});
+
+	it("runner non-finite exitCode => UNCERTAIN", async () => {
+		const m = new Map([
+			[VK, VR],
+			[LK, { ok: true, value: { stdout: "", stderr: "", exitCode: Infinity, durationMs: 100 } } as any],
+		]);
+		const r = await createSandboxLifecycle(mkR(m), vc());
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const insp = await r.value.lifecycle.inspect();
+		expect(insp.ok).toBe(false);
+		if (!insp.ok) expect(insp.code).toBe("UNCERTAIN");
+	});
+	it("runner unknown failure code => UNCERTAIN", async () => {
+		const m = new Map([
+			[VK, VR],
+			[LK, { ok: false, code: "MYSTERY_FAILURE" } as any],
+		]);
+		const r = await createSandboxLifecycle(mkR(m), vc());
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const insp = await r.value.lifecycle.inspect();
+		expect(insp.ok).toBe(false);
+		if (!insp.ok) expect(insp.code).toBe("UNCERTAIN");
+	});
+	it("Proxy config ownKeys throws => CONFIG_REJECTED", async () => {
+		const proxy = new Proxy(
+			{},
+			{
+				ownKeys() {
+					throw new Error("x");
+				},
+			},
+		);
+		const r = await createSandboxLifecycle(async () => ok(""), proxy as any);
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.code).toBe("CONFIG_REJECTED");
+	});
+	it("Proxy config getOwnPropertyDescriptor throws => CONFIG_REJECTED", async () => {
+		const proxy = new Proxy(
+			{ primeCliPath: "/x" },
+			{
+				getOwnPropertyDescriptor() {
+					throw new Error("x");
+				},
+			},
+		);
+		const r = await createSandboxLifecycle(async () => ok(""), proxy as any);
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.code).toBe("CONFIG_REJECTED");
+	});
+});
+
+describe("Hostile runner result validation", () => {
+	it("runner with extra keys => UNCERTAIN", async () => {
+		const m = new Map([
+			[VK, VR],
+			[LK, { ok: true, value: { stdout: "", stderr: "", exitCode: 0, durationMs: 100 }, extra: true } as any],
+		]);
+		const r = await createSandboxLifecycle(mkR(m), vc());
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const insp = await r.value.lifecycle.inspect();
+		expect(insp.ok).toBe(false);
+		if (!insp.ok) expect(insp.code).toBe("UNCERTAIN");
+	});
+	it("runner with symbol key => UNCERTAIN", async () => {
+		const rv: any = { ok: true, value: { stdout: "", stderr: "", exitCode: 0, durationMs: 100 } };
+		Object.defineProperty(rv, Symbol("x"), { value: 1 });
+		const m = new Map([
+			[VK, VR],
+			[LK, rv],
+		]);
+		const r = await createSandboxLifecycle(mkR(m), vc());
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const insp = await r.value.lifecycle.inspect();
+		expect(insp.ok).toBe(false);
+		if (!insp.ok) expect(insp.code).toBe("UNCERTAIN");
+	});
+
+	it("copies validated runner data without invoking Proxy get traps", async () => {
+		const proxiedVersion = new Proxy(VR, {
+			get: (_target, key) => {
+				if (key === "then") return undefined;
+				throw new Error("runner getter invoked");
+			},
+		});
+		const result = await createSandboxLifecycle(async () => proxiedVersion, vc());
+		expect(result.ok).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/prime-sandbox-lifecycle.test.ts
+++ b/packages/coding-agent/test/prime-sandbox-lifecycle.test.ts
@@ -159,7 +159,7 @@ describe("Inspect", () => {
 		has_next: false,
 	});
 
-	it("empty returns permission", async () => {
+	it("empty returns permission+absenceProof pair", async () => {
 		const r = await createSandboxLifecycle(
 			mkR(
 				new Map([
@@ -175,7 +175,7 @@ describe("Inspect", () => {
 		expect(i.ok).toBe(true);
 		if (!i.ok) return;
 		expect(i.kind).toBe("empty");
-		expect(Object.keys(i.value)).toEqual([]);
+		expect(Object.keys(i.value)).toEqual(["createPermission", "absenceProof"]);
 	});
 	it("single returns handle", async () => {
 		const r = await createSandboxLifecycle(
@@ -268,7 +268,7 @@ describe("Create", () => {
 		const insp = await r.value.lifecycle.inspect();
 		expect(insp.ok).toBe(true);
 		if (!insp.ok || insp.kind !== "empty") return;
-		const cr = await r.value.lifecycle.create(insp.value);
+		const cr = await r.value.lifecycle.create(insp.value.createPermission);
 		expect(cr.ok).toBe(true);
 		if (cr.ok) expect(Object.keys(cr.value)).toEqual([]);
 	});
@@ -289,8 +289,8 @@ describe("Create", () => {
 		const insp = await r.value.lifecycle.inspect();
 		expect(insp.ok).toBe(true);
 		if (!insp.ok || insp.kind !== "empty") return;
-		await r.value.lifecycle.create(insp.value);
-		const s = await r.value.lifecycle.create(insp.value);
+		await r.value.lifecycle.create(insp.value.createPermission);
+		const s = await r.value.lifecycle.create(insp.value.createPermission);
 		expect(s.ok).toBe(false);
 		if (!s.ok) expect(s.code).toBe("TOKEN_CONSUMED");
 	});
@@ -318,7 +318,7 @@ describe("Create", () => {
 		const insp = await r.value.lifecycle.inspect();
 		expect(insp.ok).toBe(true);
 		if (!insp.ok || insp.kind !== "empty") return;
-		const cr = await r.value.lifecycle.create(insp.value);
+		const cr = await r.value.lifecycle.create(insp.value.createPermission);
 		expect(cr.ok).toBe(false);
 		if (!cr.ok) expect(cr.code).toBe("RECOVERY_REQUIRED");
 	});
@@ -544,7 +544,7 @@ describe("Edge", () => {
 		const a2 = await createSandboxLifecycle(mkR(new Map([[VK, VR]])), vc());
 		expect(a2.ok).toBe(true);
 		if (!a2.ok) return;
-		const cr = await a2.value.lifecycle.create(insp.value);
+		const cr = await a2.value.lifecycle.create(insp.value.createPermission);
 		expect(cr.ok).toBe(false);
 		if (!cr.ok) expect(cr.code).toBe("TOKEN_INVALID");
 	});
@@ -933,5 +933,84 @@ describe("Hostile runner result validation", () => {
 		});
 		const result = await createSandboxLifecycle(async () => proxiedVersion, vc());
 		expect(result.ok).toBe(true);
+	});
+});
+
+describe("Inspect empty absence proof", () => {
+	it("is genuine, frozen, one-shot, and factory-bound", async () => {
+		const first = await createSandboxLifecycle(
+			mkR(
+				new Map([
+					[VK, VR],
+					[LK, ok(emptyJ())],
+				]),
+			),
+			vc(),
+		);
+		expect(first.ok).toBe(true);
+		if (!first.ok) return;
+		const inspected = await first.value.lifecycle.inspect();
+		expect(inspected.ok).toBe(true);
+		if (!inspected.ok || inspected.kind !== "empty") return;
+		expect(Object.isFrozen(inspected.value)).toBe(true);
+
+		const second = await createSandboxLifecycle(mkR(new Map([[VK, VR]])), vc());
+		expect(second.ok).toBe(true);
+		if (!second.ok) return;
+		expect(second.value.proofConsumer.consumeProof(inspected.value.absenceProof)).toEqual({
+			ok: false,
+			code: "PROOF_INVALID",
+		});
+		expect(first.value.proofConsumer.consumeProof(inspected.value.absenceProof)).toEqual({ ok: true });
+		expect(first.value.proofConsumer.consumeProof(inspected.value.absenceProof)).toEqual({
+			ok: false,
+			code: "PROOF_INVALID",
+		});
+	});
+
+	it("permission use invalidates its paired proof before a failed create", async () => {
+		const runner: RunCommand = (argv) => {
+			const key = mk(argv);
+			if (key === VK) return Promise.resolve(VR);
+			if (key === LK) return Promise.resolve(ok(emptyJ()));
+			return Promise.resolve(fail("SPAWN_FAILED"));
+		};
+		const created = await createSandboxLifecycle(runner, vc());
+		expect(created.ok).toBe(true);
+		if (!created.ok) return;
+		const inspected = await created.value.lifecycle.inspect();
+		expect(inspected.ok).toBe(true);
+		if (!inspected.ok || inspected.kind !== "empty") return;
+		expect(await created.value.lifecycle.create(inspected.value.createPermission)).toEqual({
+			ok: false,
+			code: "RECOVERY_REQUIRED",
+		});
+		expect(created.value.proofConsumer.consumeProof(inspected.value.absenceProof)).toEqual({
+			ok: false,
+			code: "PROOF_INVALID",
+		});
+	});
+
+	it("proof use invalidates its paired permission before provider effects", async () => {
+		let providerEffects = 0;
+		const runner: RunCommand = (argv) => {
+			const key = mk(argv);
+			if (key === VK) return Promise.resolve(VR);
+			if (key === LK) return Promise.resolve(ok(emptyJ()));
+			providerEffects++;
+			return Promise.resolve(ok(""));
+		};
+		const created = await createSandboxLifecycle(runner, vc());
+		expect(created.ok).toBe(true);
+		if (!created.ok) return;
+		const inspected = await created.value.lifecycle.inspect();
+		expect(inspected.ok).toBe(true);
+		if (!inspected.ok || inspected.kind !== "empty") return;
+		expect(created.value.proofConsumer.consumeProof(inspected.value.absenceProof)).toEqual({ ok: true });
+		expect(await created.value.lifecycle.create(inspected.value.createPermission)).toEqual({
+			ok: false,
+			code: "TOKEN_CONSUMED",
+		});
+		expect(providerEffects).toBe(0);
 	});
 });

--- a/packages/coding-agent/test/sandbox-ownership-deletion-v4.test.ts
+++ b/packages/coding-agent/test/sandbox-ownership-deletion-v4.test.ts
@@ -1,0 +1,719 @@
+import { describe, expect, it } from "bun:test";
+import { chmodSync } from "node:fs";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { LifecycleConfig, RunCommand, RunnerResult } from "../src/modes/daemon/sandbox/prime-sandbox-lifecycle.js";
+import {
+	createOwnershipJournal,
+	createOwnershipJournalWithDeletion,
+	type OwnershipDeletionCode,
+	type OwnershipJournal,
+} from "../src/modes/daemon/sandbox-ownership-journal.js";
+import type { OwnershipIntent } from "../src/modes/daemon/sandbox-ownership-record.js";
+import versionFixture from "./fixtures/prime-cli-0.6.21-create-version-fixture.json";
+import fixture from "./fixtures/prime-cli-0.6.21-sandbox-json-fixture.json";
+
+// ── Fixtures ───────────────────────────────────────────────
+
+const EL = fixture.expectedLabel;
+const VS = versionFixture.versionStdout;
+
+const intent: OwnershipIntent = Object.freeze({
+	lifecycleKey: "life-0123456789abcdef",
+	parentSessionId: "parent-0123456789abcdef",
+	childSessionId: "child-0123456789abcdef",
+});
+
+const t0 = "2026-09-04T01:02:03.004Z";
+const t1 = "2026-09-04T01:02:04.004Z";
+const t2 = "2026-09-04T01:02:05.004Z";
+const t3 = "2026-09-04T01:02:06.004Z";
+const t4 = "2026-09-04T01:02:07.004Z";
+const t5 = "2026-09-04T01:02:08.004Z";
+
+function vc(): LifecycleConfig {
+	return Object.freeze({
+		primeCliPath: "/usr/local/bin/prime",
+		label: EL,
+		image: "ubuntu:24.04",
+		name: "test-sandbox",
+		cpuCores: 1,
+		memoryGb: 1,
+		diskSizeGb: 5,
+		sandboxTimeoutMinutes: 60,
+		operationTimeoutMs: 60000,
+		pollIntervalMs: 500,
+	});
+}
+
+function ok(s: string, se = "", ec = 0): RunnerResult {
+	return Object.freeze({ ok: true, value: Object.freeze({ stdout: s, stderr: se, exitCode: ec, durationMs: 100 }) });
+}
+
+function mk(a: readonly string[]): string {
+	return a.join("\0");
+}
+
+function emptyJ(): string {
+	return JSON.stringify({ sandboxes: [], total: 0, page: 1, per_page: 100, has_next: false });
+}
+
+const VK = mk(["/usr/local/bin/prime", "--version"]);
+const LK = mk([
+	"/usr/local/bin/prime",
+	"--plain",
+	"sandbox",
+	"list",
+	"--label",
+	EL,
+	"--page",
+	"1",
+	"--num",
+	"100",
+	"--output",
+	"json",
+]);
+
+const VR = ok(VS);
+
+function mkR(m: Map<string, RunnerResult>): RunCommand {
+	return (a, _t, _s) => {
+		const k = mk(a);
+		const r = m.get(k);
+		return Promise.resolve(r !== undefined ? r : ok(""));
+	};
+}
+
+// ── Journal helpers ────────────────────────────────────────
+
+async function freshRoot(prefix: string): Promise<{
+	root: string;
+	jDir: string;
+	remove: () => Promise<void>;
+}> {
+	const dir = await mkdtemp(join(tmpdir(), prefix));
+	await chmod(dir, 0o700);
+	return {
+		root: dir,
+		jDir: join(dir, ".sandbox-ownership"),
+		remove: async () => {
+			await rm(dir, { recursive: true, force: true }).catch(() => {});
+		},
+	};
+}
+
+async function mkJournal(root: string): Promise<OwnershipJournal> {
+	const result = await createOwnershipJournal(root);
+	if (!result.ok) throw new Error(`create: ${result.code}`);
+	return result.value;
+}
+
+async function buildFiveChain(
+	root: string,
+	i: OwnershipIntent = intent,
+	ts0 = t0,
+	ts1 = t1,
+	ts2 = t2,
+	ts3 = t3,
+	ts4 = t4,
+): Promise<void> {
+	const j = await mkJournal(root);
+	const a = await j.admit(i, ts0);
+	if (!a.ok) throw new Error(`admit: ${a.code}`);
+	const stages: Array<["creating" | "active" | "delete_intent" | "deleting", string]> = [
+		["creating", ts1],
+		["active", ts2],
+		["delete_intent", ts3],
+		["deleting", ts4],
+	];
+	for (const [stage, ts] of stages) {
+		const r = await j.transition(stage, i, ts);
+		if (!r.ok) throw new Error(`transition ${stage}: ${r.code}`);
+	}
+}
+
+function expectFailure(result: unknown, code: OwnershipDeletionCode): void {
+	expect(Object.isFrozen(result)).toBe(true);
+	expect(result).toEqual({ ok: false, code });
+}
+
+// ── Cross-test: deleted-record encoder ─────────────────────
+
+describe("V4 deleted-record encoder cross-test", () => {
+	it("produces a byte-identical record that decodeOwnershipRecord accepts", async () => {
+		const { root, remove } = await freshRoot("v4-cross-");
+		try {
+			await buildFiveChain(root);
+			const m = new Map<string, RunnerResult>();
+			m.set(VK, VR);
+			m.set(LK, ok(emptyJ()));
+
+			const result = await createOwnershipJournalWithDeletion(root, intent, mkR(m), vc());
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+
+			const insp = await result.value.lifecycle.inspect();
+			expect(insp.ok).toBe(true);
+			if (!insp.ok || insp.kind !== "empty") return;
+
+			const fr = await result.value.finalizeDeleted(insp.value.absenceProof, t5);
+			expect(fr.ok).toBe(true);
+		} finally {
+			await remove();
+		}
+	});
+});
+
+// ── Factory journal validation ─────────────────────────────
+
+describe("V4 factory journal validation", () => {
+	it("rejects missing journal dir - no lifecycle command", async () => {
+		const { root, remove } = await freshRoot("v4-no-j-");
+		try {
+			await rm(join(root, ".sandbox-ownership"), { recursive: true, force: true }).catch(() => {});
+			let ranVersion = false;
+			const runner: RunCommand = () => {
+				ranVersion = true;
+				return Promise.resolve(VR);
+			};
+			const r = await createOwnershipJournalWithDeletion(root, intent, runner, vc());
+			expectFailure(r, "DIRECTORY_UNSAFE");
+			expect(ranVersion).toBe(false);
+		} finally {
+			await remove();
+		}
+	});
+
+	it("rejects empty journal dir with CORRUPT", async () => {
+		const { root, remove } = await freshRoot("v4-empty-");
+		try {
+			await mkdir(join(root, ".sandbox-ownership"), { recursive: false, mode: 0o700 });
+			let ranVersion = false;
+			const runner: RunCommand = () => {
+				ranVersion = true;
+				return Promise.resolve(VR);
+			};
+			const r = await createOwnershipJournalWithDeletion(root, intent, runner, vc());
+			expectFailure(r, "CORRUPT");
+			expect(ranVersion).toBe(false);
+		} finally {
+			await remove();
+		}
+	});
+
+	it("rejects wrong intent - no provider commands", async () => {
+		const { root, remove } = await freshRoot("v4-wint-");
+		try {
+			const wrong: OwnershipIntent = {
+				lifecycleKey: "wrong-key",
+				parentSessionId: "wrong-parent",
+				childSessionId: "wrong-child",
+			};
+			await buildFiveChain(root, wrong);
+			let ranVersion = false;
+			const runner: RunCommand = () => {
+				ranVersion = true;
+				return Promise.resolve(VR);
+			};
+			const r = await createOwnershipJournalWithDeletion(root, intent, runner, vc());
+			expectFailure(r, "CORRUPT");
+			expect(ranVersion).toBe(false);
+		} finally {
+			await remove();
+		}
+	});
+
+	it("rejects wrong stage (not deleting) - no provider commands", async () => {
+		const { root, remove } = await freshRoot("v4-wstg-");
+		try {
+			const j = await mkJournal(root);
+			await j.admit(intent, t0);
+			await j.transition("creating", intent, t1);
+			let ranVersion = false;
+			const runner: RunCommand = () => {
+				ranVersion = true;
+				return Promise.resolve(VR);
+			};
+			const r = await createOwnershipJournalWithDeletion(root, intent, runner, vc());
+			expectFailure(r, "CORRUPT");
+			expect(ranVersion).toBe(false);
+		} finally {
+			await remove();
+		}
+	});
+
+	it("rejects bound intent with accessors", async () => {
+		const { root, remove } = await freshRoot("v4-acc-");
+		try {
+			await buildFiveChain(root);
+			let ranVersion = false;
+			const runner: RunCommand = () => {
+				ranVersion = true;
+				return Promise.resolve(VR);
+			};
+			const hostile = Object.create(Object.prototype);
+			Object.defineProperty(hostile, "lifecycleKey", {
+				enumerable: true,
+				value: "life-0123456789abcdef",
+			});
+			Object.defineProperty(hostile, "parentSessionId", {
+				enumerable: true,
+				value: "parent-0123456789abcdef",
+			});
+			Object.defineProperty(hostile, "childSessionId", {
+				enumerable: true,
+				get: () => {
+					throw new Error("leak");
+				},
+			});
+			const r = await createOwnershipJournalWithDeletion(root, hostile as unknown as OwnershipIntent, runner, vc());
+			expectFailure(r, "INPUT_INVALID");
+			expect(ranVersion).toBe(false);
+		} finally {
+			await remove();
+		}
+	});
+
+	it("rejects non-enumerable bound intent fields before lifecycle construction", async () => {
+		const { root, remove } = await freshRoot("v4-non-enum-");
+		try {
+			await buildFiveChain(root);
+			const hidden = Object.create(Object.prototype);
+			for (const [key, value] of Object.entries(intent)) {
+				Object.defineProperty(hidden, key, { enumerable: false, value });
+			}
+			let ranVersion = false;
+			const runner: RunCommand = () => {
+				ranVersion = true;
+				return Promise.resolve(VR);
+			};
+			const result = await createOwnershipJournalWithDeletion(root, hidden, runner, vc());
+			expectFailure(result, "INPUT_INVALID");
+			expect(ranVersion).toBe(false);
+		} finally {
+			await remove();
+		}
+	});
+});
+
+// ── Full finalization flow ─────────────────────────────────
+
+describe("V4 full finalization flow", () => {
+	it("lifecycle version runs after journal recovery", async () => {
+		const { root, remove } = await freshRoot("v4-ord-");
+		try {
+			await buildFiveChain(root);
+			let versionCount = 0;
+			const runner: RunCommand = (argv) => {
+				if (mk(argv) === VK) {
+					versionCount++;
+					return Promise.resolve(VR);
+				}
+				return Promise.resolve(ok(emptyJ()));
+			};
+			const r = await createOwnershipJournalWithDeletion(root, intent, runner, vc());
+			expect(r.ok).toBe(true);
+			expect(versionCount).toBe(1);
+		} finally {
+			await remove();
+		}
+	});
+
+	it("full success: inspect empty -> finalizeDeleted", async () => {
+		const { root, remove } = await freshRoot("v4-full-");
+		try {
+			await buildFiveChain(root);
+			const m = new Map<string, RunnerResult>();
+			m.set(VK, VR);
+			m.set(LK, ok(emptyJ()));
+
+			const result = await createOwnershipJournalWithDeletion(root, intent, mkR(m), vc());
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(Object.isFrozen(result.value)).toBe(true);
+			expect(typeof result.value.lifecycle.inspect).toBe("function");
+			expect(typeof result.value.finalizeDeleted).toBe("function");
+
+			const insp = await result.value.lifecycle.inspect();
+			expect(insp.ok).toBe(true);
+			if (!insp.ok || insp.kind !== "empty") return;
+
+			const fr = await result.value.finalizeDeleted(insp.value.absenceProof, t5);
+			expect(fr.ok).toBe(true);
+			expect(fr).toEqual({ ok: true });
+
+			const jr = await mkJournal(root);
+			const rec = await jr.recover();
+			expect(rec.ok).toBe(true);
+			if (!rec.ok) return;
+			expect(rec.value.chain.records.length).toBe(6);
+			expect(rec.value.chain.current.stage).toBe("deleted");
+			expect(rec.value.chain.current.sequence).toBe(6);
+
+			const fr2 = await result.value.finalizeDeleted(insp.value.absenceProof, t5);
+			expectFailure(fr2, "PROOF_INVALID");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("foreign proof is rejected", async () => {
+		const { root, remove } = await freshRoot("v4-for-");
+		try {
+			await buildFiveChain(root);
+			const m = new Map<string, RunnerResult>();
+			m.set(VK, VR);
+			m.set(LK, ok(emptyJ()));
+
+			const result = await createOwnershipJournalWithDeletion(root, intent, mkR(m), vc());
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+
+			const fakeProof = Object.freeze({}) as any;
+			const fr = await result.value.finalizeDeleted(fakeProof, t5);
+			expectFailure(fr, "PROOF_INVALID");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("second finalize with same proof after success returns PROOF_INVALID", async () => {
+		const { root, remove } = await freshRoot("v4-double-");
+		try {
+			await buildFiveChain(root);
+			const m = new Map<string, RunnerResult>();
+			m.set(VK, VR);
+			m.set(LK, ok(emptyJ()));
+
+			const result = await createOwnershipJournalWithDeletion(root, intent, mkR(m), vc());
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+
+			const insp = await result.value.lifecycle.inspect();
+			expect(insp.ok).toBe(true);
+			if (!insp.ok || insp.kind !== "empty") return;
+
+			const fr = await result.value.finalizeDeleted(insp.value.absenceProof, t5);
+			expect(fr.ok).toBe(true);
+
+			const fr2 = await result.value.finalizeDeleted(insp.value.absenceProof, t5);
+			expectFailure(fr2, "PROOF_INVALID");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("rejects recordedAt not later than seq5", async () => {
+		const { root, remove } = await freshRoot("v4-time-");
+		try {
+			await buildFiveChain(root);
+			const m = new Map<string, RunnerResult>();
+			m.set(VK, VR);
+			m.set(LK, ok(emptyJ()));
+
+			const result = await createOwnershipJournalWithDeletion(root, intent, mkR(m), vc());
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+
+			const insp = await result.value.lifecycle.inspect();
+			expect(insp.ok).toBe(true);
+			if (!insp.ok || insp.kind !== "empty") return;
+
+			const fr = await result.value.finalizeDeleted(insp.value.absenceProof, t4);
+			expectFailure(fr, "INPUT_INVALID");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("rejects invalid timestamp", async () => {
+		const { root, remove } = await freshRoot("v4-ts-");
+		try {
+			await buildFiveChain(root);
+			const m = new Map<string, RunnerResult>();
+			m.set(VK, VR);
+			m.set(LK, ok(emptyJ()));
+
+			const result = await createOwnershipJournalWithDeletion(root, intent, mkR(m), vc());
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+
+			const insp = await result.value.lifecycle.inspect();
+			expect(insp.ok).toBe(true);
+			if (!insp.ok || insp.kind !== "empty") return;
+
+			const fr = await result.value.finalizeDeleted(insp.value.absenceProof, "not-a-timestamp");
+			expectFailure(fr, "INPUT_INVALID");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("candidate chain validated before proof consumption", async () => {
+		const { root, remove } = await freshRoot("v4-cand-");
+		try {
+			await buildFiveChain(root);
+			const m = new Map<string, RunnerResult>();
+			m.set(VK, VR);
+			m.set(LK, ok(emptyJ()));
+
+			const result = await createOwnershipJournalWithDeletion(root, intent, mkR(m), vc());
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+
+			const insp = await result.value.lifecycle.inspect();
+			expect(insp.ok).toBe(true);
+			if (!insp.ok || insp.kind !== "empty") return;
+
+			// Consume the proof outside finalizeDeleted first to invalidate it
+			// Then finalizeDeleted should fail at proof consumption
+			const fr = await result.value.finalizeDeleted(insp.value.absenceProof, t5);
+			expect(fr.ok).toBe(true);
+
+			// Second attempt with same proof fails (already consumed)
+			const fr2 = await result.value.finalizeDeleted(insp.value.absenceProof, t5);
+			expectFailure(fr2, "PROOF_INVALID");
+		} finally {
+			await remove();
+		}
+	});
+});
+
+// ── Retry after IO_UNCERTAIN ──────────────────────────────
+
+describe("V4 retry after IO_UNCERTAIN", () => {
+	it("retains exact retry authority after a post-consumption publish failure", async () => {
+		const { root, jDir, remove } = await freshRoot("v4-retry-");
+		const originalSet = WeakMap.prototype.set;
+		try {
+			await buildFiveChain(root);
+			const m = new Map<string, RunnerResult>();
+			m.set(VK, VR);
+			m.set(LK, ok(emptyJ()));
+
+			const result = await createOwnershipJournalWithDeletion(root, intent, mkR(m), vc());
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+
+			const insp = await result.value.lifecycle.inspect();
+			expect(insp.ok).toBe(true);
+			if (!insp.ok || insp.kind !== "empty") return;
+			const proof = insp.value.absenceProof;
+			let sabotaged = false;
+			function sabotageAfterAuthorization<K extends WeakKey, V>(
+				this: WeakMap<K, V>,
+				key: K,
+				value: V,
+			): WeakMap<K, V> {
+				const map = originalSet.call(this, key, value);
+				if (!sabotaged && Object.is(key, proof)) {
+					sabotaged = true;
+					chmodSync(jDir, 0o500);
+				}
+				return map;
+			}
+			Object.defineProperty(WeakMap.prototype, "set", {
+				configurable: true,
+				value: sabotageAfterAuthorization,
+				writable: true,
+			});
+
+			const first = await result.value.finalizeDeleted(proof, t5);
+			expect(first.ok).toBe(false);
+			expect(sabotaged).toBe(true);
+			Object.defineProperty(WeakMap.prototype, "set", {
+				configurable: true,
+				value: originalSet,
+				writable: true,
+			});
+			await chmod(jDir, 0o700);
+
+			const changedTimestamp = await result.value.finalizeDeleted(proof, "2026-09-04T01:02:09.004Z");
+			expectFailure(changedTimestamp, "INPUT_INVALID");
+
+			const retry = await result.value.finalizeDeleted(proof, t5);
+			expect(retry.ok).toBe(true);
+			const again = await result.value.finalizeDeleted(proof, t5);
+			expectFailure(again, "PROOF_INVALID");
+		} finally {
+			Object.defineProperty(WeakMap.prototype, "set", {
+				configurable: true,
+				value: originalSet,
+				writable: true,
+			});
+			await chmod(jDir, 0o700).catch(() => {});
+			await remove();
+		}
+	});
+});
+
+// ── Inspect empty token pairing ────────────────────────────
+
+describe("V4 inspect empty token pairing", () => {
+	it("permission use invalidates paired proof", async () => {
+		const { root, remove } = await freshRoot("v4-pair-");
+		try {
+			await buildFiveChain(root);
+			const m = new Map<string, RunnerResult>();
+			m.set(VK, VR);
+			m.set(LK, ok(emptyJ()));
+
+			const result = await createOwnershipJournalWithDeletion(root, intent, mkR(m), vc());
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+
+			const insp = await result.value.lifecycle.inspect();
+			expect(insp.ok).toBe(true);
+			if (!insp.ok || insp.kind !== "empty") return;
+
+			await result.value.lifecycle.create(insp.value.createPermission);
+
+			const fr = await result.value.finalizeDeleted(insp.value.absenceProof, t5);
+			expectFailure(fr, "PROOF_INVALID");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("proof use invalidates paired permission", async () => {
+		const { root, remove } = await freshRoot("v4-pair2-");
+		try {
+			await buildFiveChain(root);
+			const m = new Map<string, RunnerResult>();
+			m.set(VK, VR);
+			m.set(LK, ok(emptyJ()));
+
+			const result = await createOwnershipJournalWithDeletion(root, intent, mkR(m), vc());
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+
+			const insp = await result.value.lifecycle.inspect();
+			expect(insp.ok).toBe(true);
+			if (!insp.ok || insp.kind !== "empty") return;
+
+			await result.value.finalizeDeleted(insp.value.absenceProof, t5);
+
+			const cr = await result.value.lifecycle.create(insp.value.createPermission);
+			expect(cr.ok).toBe(false);
+		} finally {
+			await remove();
+		}
+	});
+});
+
+// ── Crash restart recovery ─────────────────────────────────
+
+describe("V4 crash restart recovery", () => {
+	it("recovers from seq5 after lost auth, obtains new empty proof, finalizes", async () => {
+		const { root, remove } = await freshRoot("v4-crash-");
+		try {
+			await buildFiveChain(root);
+
+			const m = new Map<string, RunnerResult>();
+			m.set(VK, VR);
+			m.set(LK, ok(emptyJ()));
+
+			const result1 = await createOwnershipJournalWithDeletion(root, intent, mkR(m), vc());
+			expect(result1.ok).toBe(true);
+			if (!result1.ok) return;
+
+			// Crash: discard result1
+			const result2 = await createOwnershipJournalWithDeletion(root, intent, mkR(m), vc());
+			expect(result2.ok).toBe(true);
+			if (!result2.ok) return;
+
+			const insp = await result2.value.lifecycle.inspect();
+			expect(insp.ok).toBe(true);
+			if (!insp.ok || insp.kind !== "empty") return;
+
+			const fr = await result2.value.finalizeDeleted(insp.value.absenceProof, t5);
+			expect(fr.ok).toBe(true);
+
+			const jr = await mkJournal(root);
+			const rec = await jr.recover();
+			expect(rec.ok).toBe(true);
+			if (!rec.ok) return;
+			expect(rec.value.chain.current.stage).toBe("deleted");
+		} finally {
+			await remove();
+		}
+	});
+});
+
+// ── Hostile filesystem injection ───────────────────────────
+
+describe("V4 hostile filesystem injection", () => {
+	it("corrupted journal between factory and finalize fails", async () => {
+		const { root, jDir, remove } = await freshRoot("v4-hf-");
+		try {
+			await buildFiveChain(root);
+			const m = new Map<string, RunnerResult>();
+			m.set(VK, VR);
+			m.set(LK, ok(emptyJ()));
+
+			const result = await createOwnershipJournalWithDeletion(root, intent, mkR(m), vc());
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+
+			const insp = await result.value.lifecycle.inspect();
+			expect(insp.ok).toBe(true);
+			if (!insp.ok || insp.kind !== "empty") return;
+
+			// Remove seq5 to corrupt the journal
+			await rm(join(jDir, "0005.ownership-v1"));
+
+			const fr = await result.value.finalizeDeleted(insp.value.absenceProof, t5);
+			expectFailure(fr, "CORRUPT");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("modified seq5 content causes CORRUPT", async () => {
+		const { root, jDir, remove } = await freshRoot("v4-mod-");
+		try {
+			await buildFiveChain(root);
+			const m = new Map<string, RunnerResult>();
+			m.set(VK, VR);
+			m.set(LK, ok(emptyJ()));
+
+			const result = await createOwnershipJournalWithDeletion(root, intent, mkR(m), vc());
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+
+			const insp = await result.value.lifecycle.inspect();
+			expect(insp.ok).toBe(true);
+			if (!insp.ok || insp.kind !== "empty") return;
+
+			// Tamper with seq5 content
+			const p5 = join(jDir, "0005.ownership-v1");
+			const buf = await readFile(p5);
+			const modified = Buffer.concat([buf.slice(0, -1), Buffer.from("x")]);
+			await writeFile(p5, modified, { mode: 0o600 });
+
+			const fr = await result.value.finalizeDeleted(insp.value.absenceProof, t5);
+			expectFailure(fr, "CORRUPT");
+		} finally {
+			await remove();
+		}
+	});
+});
+
+// ── Error DTO safety ───────────────────────────────────────
+
+describe("V4 error DTO safety", () => {
+	it("error values contain no path, intent, proof, or provider material", async () => {
+		const { remove } = await freshRoot("v4-safe-");
+		try {
+			// Use nonexistent root
+			const badRoot = `/nonexistent-v4-safe-${String(Math.random())}`;
+			const r = await createOwnershipJournalWithDeletion(badRoot, intent, async () => Promise.resolve(VR), vc());
+			const json = JSON.stringify(r);
+			expect(json).not.toContain("life-0123456789abcdef");
+			expect(json).not.toContain("/");
+		} finally {
+			await remove();
+		}
+	});
+});

--- a/packages/coding-agent/test/sandbox-ownership-journal.test.ts
+++ b/packages/coding-agent/test/sandbox-ownership-journal.test.ts
@@ -1,0 +1,579 @@
+import { describe, expect, it } from "bun:test";
+import { chmod, link, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	createOwnershipJournal,
+	type OwnershipJournal,
+	type OwnershipJournalCode,
+} from "../src/modes/daemon/sandbox-ownership-journal.js";
+import type { NonDeletedTransitionStage, OwnershipIntent } from "../src/modes/daemon/sandbox-ownership-record.js";
+
+// ── Helpers ────────────────────────────────────────────────
+
+const intent: OwnershipIntent = Object.freeze({
+	lifecycleKey: "life-0123456789abcdef",
+	parentSessionId: "parent-0123456789abcdef",
+	childSessionId: "child-0123456789abcdef",
+});
+const altIntent: OwnershipIntent = Object.freeze({
+	lifecycleKey: "alt-lifecycle",
+	parentSessionId: "alt-parent",
+	childSessionId: "alt-child",
+});
+const t0 = "2026-09-04T01:02:03.004Z";
+
+function expectFrozenTree(value: unknown): void {
+	expect(Object.isFrozen(value)).toBe(true);
+	if (typeof value !== "object" || value === null || value instanceof Uint8Array) return;
+	for (const nested of Object.values(value)) {
+		if (typeof nested === "object" && nested !== null) expectFrozenTree(nested);
+	}
+}
+
+function expectFailure(result: unknown, code: OwnershipJournalCode): void {
+	expect(Object.isFrozen(result)).toBe(true);
+	expect(result).toEqual({ ok: false, code });
+}
+
+function expectOk(result: unknown): asserts result is { ok: true; value: unknown } {
+	expect(result).toHaveProperty("ok", true);
+}
+
+async function freshRoot(prefix: string): Promise<{ root: string; jDir: string; remove: () => Promise<void> }> {
+	const dir = await mkdtemp(join(tmpdir(), prefix));
+	await chmod(dir, 0o700);
+	return {
+		root: dir,
+		jDir: join(dir, ".sandbox-ownership"),
+		remove: async () => {
+			await rm(dir, { recursive: true, force: true }).catch(() => {});
+		},
+	};
+}
+
+async function mkJournal(root: string): Promise<OwnershipJournal> {
+	const result = await createOwnershipJournal(root);
+	if (!result.ok) throw new Error(`create: ${result.code}`);
+	return result.value;
+}
+
+async function setup(
+	prefix: string,
+): Promise<{ root: string; jDir: string; journal: OwnershipJournal; remove: () => Promise<void> }> {
+	const { root, jDir, remove } = await freshRoot(prefix);
+	const journal = await mkJournal(root);
+	return { root, jDir, journal, remove };
+}
+
+// ── Factory ────────────────────────────────────────────────
+
+describe("factory", () => {
+	it("creates journal dir and returns frozen capability", async () => {
+		const { root, remove } = await freshRoot("fac-ok-");
+		try {
+			const r = await createOwnershipJournal(root);
+			expect(r.ok).toBe(true);
+			if (!r.ok) return;
+			expectFrozenTree(r);
+			expect(typeof r.value.admit).toBe("function");
+			expect(typeof r.value.recover).toBe("function");
+			expect(typeof r.value.transition).toBe("function");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("rejects empty/relative/control root", async () => {
+		expectFailure(await createOwnershipJournal(""), "INPUT_INVALID");
+		expectFailure(await createOwnershipJournal("relative"), "INPUT_INVALID");
+		expectFailure(await createOwnershipJournal(`/${String.fromCharCode(10)}root`), "INPUT_INVALID");
+	});
+
+	it("rejects wrong-mode root", async () => {
+		const { root, remove } = await freshRoot("fac-mode-");
+		try {
+			await chmod(root, 0o755);
+			expectFailure(await createOwnershipJournal(root), "DIRECTORY_UNSAFE");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("rejects symlinked root", async () => {
+		const { root, remove } = await freshRoot("fac-sym-");
+		try {
+			const linkPath = join(root, `../sym-${Date.now()}`);
+			await symlink(root, linkPath);
+			try {
+				expectFailure(await createOwnershipJournal(linkPath), "DIRECTORY_UNSAFE");
+			} finally {
+				await rm(linkPath).catch(() => {});
+			}
+		} finally {
+			await remove();
+		}
+	});
+
+	it("rejects existing empty journal dir as CORRUPT", async () => {
+		const { root, jDir, journal: j, remove } = await setup("fac-empty-");
+		try {
+			await j.admit(intent, t0);
+			await rm(join(jDir, "0001.ownership-v1")).catch(() => {});
+			expectFailure(await createOwnershipJournal(root), "CORRUPT");
+		} finally {
+			await remove();
+		}
+	});
+});
+
+// ── Admit & recover ────────────────────────────────────────
+
+describe("admit and recover", () => {
+	it("admits pre_admit and recovers", async () => {
+		const { journal: j, remove } = await setup("ar-");
+		try {
+			const a = await j.admit(intent, t0);
+			expect(a.ok).toBe(true);
+			if (!a.ok) return;
+			expectFrozenTree(a);
+			expect(Object.keys(a.value)).toEqual(["chain"]);
+			expect(a.value.chain.current.stage).toBe("pre_admit");
+
+			const r = await j.recover();
+			expect(r.ok).toBe(true);
+			if (!r.ok) return;
+			expectFrozenTree(r);
+			expect(r.value.chain.current.stage).toBe("pre_admit");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("idempotent admit", async () => {
+		const { journal: j, remove } = await setup("ar-idem-");
+		try {
+			expectOk(await j.admit(intent, t0));
+			const a2 = await j.admit(intent, t0);
+			expectOk(a2);
+			expect(Object.keys(a2.value)).toEqual(["chain"]);
+		} finally {
+			await remove();
+		}
+	});
+
+	it("rejects different intent conflict", async () => {
+		const { journal: j, remove } = await setup("ar-conflict-");
+		try {
+			await j.admit(intent, t0);
+			expectFailure(await j.admit(altIntent, t0), "CONFLICT");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("recovers across factory restart", async () => {
+		const { root, journal: j1, remove } = await setup("ar-restart-");
+		try {
+			await j1.admit(intent, t0);
+			const j2 = await mkJournal(root);
+			const r = await j2.recover();
+			expect(r.ok).toBe(true);
+			if (!r.ok) return;
+			expect(r.value.chain.current.stage).toBe("pre_admit");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("public recover on fresh empty returns CORRUPT", async () => {
+		const { journal: j, remove } = await setup("ar-empty-");
+		try {
+			expectFailure(await j.recover(), "CORRUPT");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("rejects empty/bad intent", async () => {
+		const { journal: j, remove } = await setup("ar-bad-");
+		try {
+			const bad: OwnershipIntent = { lifecycleKey: "", parentSessionId: "p", childSessionId: "c" };
+			expectFailure(await j.admit(bad, t0), "INPUT_INVALID");
+		} finally {
+			await remove();
+		}
+	});
+});
+
+// ── Transitions ────────────────────────────────────────────
+
+describe("transitions", () => {
+	it("walks full chain", async () => {
+		const { journal: j, remove } = await setup("t-full-");
+		try {
+			await j.admit(intent, t0);
+			const cases: [NonDeletedTransitionStage, string][] = [
+				["creating", "2026-09-04T01:02:04.004Z"],
+				["active", "2026-09-04T01:02:05.004Z"],
+				["delete_intent", "2026-09-04T01:02:06.004Z"],
+				["deleting", "2026-09-04T01:02:07.004Z"],
+			];
+			for (const [st, ts] of cases) {
+				const t = await j.transition(st, intent, ts);
+				expect(t.ok).toBe(true);
+				if (!t.ok) return;
+				expect(t.value.chain.current.stage).toBe(st);
+			}
+		} finally {
+			await remove();
+		}
+	});
+
+	it("creating->delete_intent shortcut", async () => {
+		const { journal: j, remove } = await setup("t-short-");
+		try {
+			await j.admit(intent, t0);
+			await j.transition("creating", intent, "2026-09-04T01:02:04.004Z");
+			const r = await j.transition("delete_intent", intent, "2026-09-04T01:02:05.004Z");
+			if (!r.ok) throw new Error(`transition: ${r.code}`);
+			expect(r.value.chain.current.stage).toBe("delete_intent");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("idempotent transition", async () => {
+		const { journal: j, remove } = await setup("t-idem-");
+		try {
+			await j.admit(intent, t0);
+			await j.transition("creating", intent, "2026-09-04T01:02:04.004Z");
+			const t2 = await j.transition("creating", intent, "2026-09-04T01:02:05.004Z");
+			expectOk(t2);
+			expect(Object.keys(t2.value)).toEqual(["chain"]);
+		} finally {
+			await remove();
+		}
+	});
+
+	it("rejects invalid edge pre_admit->active", async () => {
+		const { journal: j, remove } = await setup("t-edge-");
+		try {
+			await j.admit(intent, t0);
+			expectFailure(await j.transition("active", intent, "2026-09-04T01:02:04.004Z"), "INVALID_TRANSITION");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("rejects wrong intent during transition", async () => {
+		const { journal: j, remove } = await setup("t-wint-");
+		try {
+			await j.admit(intent, t0);
+			expectFailure(await j.transition("creating", altIntent, "2026-09-04T01:02:04.004Z"), "CONFLICT");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("restarts after every stage", async () => {
+		const { root, journal: j, remove } = await setup("t-recv-");
+		try {
+			await j.admit(intent, t0);
+			const cases: [NonDeletedTransitionStage, string][] = [
+				["creating", "2026-09-04T01:02:04.004Z"],
+				["active", "2026-09-04T01:02:05.004Z"],
+				["delete_intent", "2026-09-04T01:02:06.004Z"],
+				["deleting", "2026-09-04T01:02:07.004Z"],
+			];
+			for (const [st, ts] of cases) {
+				await j.transition(st, intent, ts);
+				const j2 = await mkJournal(root);
+				const r = await j2.recover();
+				expect(r.ok).toBe(true);
+				if (!r.ok) return;
+				expect(r.value.chain.current.stage).toBe(st);
+			}
+		} finally {
+			await remove();
+		}
+	});
+});
+
+// ── Hostile filesystem ─────────────────────────────────────
+
+describe("hostile filesystem", () => {
+	for (const { name, mutate, code } of [
+		{
+			name: "symlink record path",
+			code: "CORRUPT" as OwnershipJournalCode,
+			mutate: async (jd: string) => {
+				const r1 = join(jd, "0001.ownership-v1");
+				await rm(r1);
+				const target = join(jd, "../evil-target");
+				await writeFile(target, "x", { mode: 0o600 });
+				await symlink(target, r1);
+			},
+		},
+		{
+			name: "directory record path",
+			code: "CORRUPT" as OwnershipJournalCode,
+			mutate: async (jd: string) => {
+				const r1 = join(jd, "0001.ownership-v1");
+				await rm(r1);
+				await mkdir(r1, { recursive: false, mode: 0o700 });
+			},
+		},
+		{
+			name: "hardlink record (nlink>1)",
+			code: "CORRUPT" as OwnershipJournalCode,
+			mutate: async (jd: string) => {
+				const r1 = join(jd, "0001.ownership-v1");
+				const hp = join(jd, "../hardlink-dup");
+				await link(r1, hp);
+			},
+		},
+		{
+			name: "zero-size record",
+			code: "CORRUPT" as OwnershipJournalCode,
+			mutate: async (jd: string) => {
+				await rm(join(jd, "0001.ownership-v1"));
+				await writeFile(join(jd, "0001.ownership-v1"), "", { mode: 0o600 });
+			},
+		},
+		{
+			name: "oversize record",
+			code: "CORRUPT" as OwnershipJournalCode,
+			mutate: async (jd: string) => {
+				await rm(join(jd, "0001.ownership-v1"));
+				await writeFile(join(jd, "0001.ownership-v1"), "x".repeat(5000), { mode: 0o600 });
+			},
+		},
+		{
+			name: "partially truncated record",
+			code: "CORRUPT" as OwnershipJournalCode,
+			mutate: async (jd: string) => {
+				const buf = await readFile(join(jd, "0001.ownership-v1"));
+				await writeFile(join(jd, "0001.ownership-v1"), buf.slice(0, Math.floor(buf.length / 2)), { mode: 0o600 });
+			},
+		},
+		{
+			name: "malformed JSON record",
+			code: "CORRUPT" as OwnershipJournalCode,
+			mutate: async (jd: string) => {
+				await rm(join(jd, "0001.ownership-v1"));
+				await writeFile(join(jd, "0001.ownership-v1"), "not-json-here", { mode: 0o600 });
+			},
+		},
+	]) {
+		it(`rejects ${name}`, async () => {
+			const { jDir, journal: j, remove } = await setup("hf-rec-");
+			try {
+				await j.admit(intent, t0);
+				await mutate(jDir);
+				const r = await j.recover();
+				expectFailure(r, code);
+			} finally {
+				try {
+					await rm(join(jDir, "../evil-target")).catch(() => {});
+				} catch {}
+				try {
+					await rm(join(jDir, "../hardlink-dup")).catch(() => {});
+				} catch {}
+				await remove();
+			}
+		});
+	}
+
+	for (const { name, corrupt, expectedCode } of [
+		{
+			name: "extra unknown file",
+			expectedCode: "CORRUPT" as OwnershipJournalCode,
+			corrupt: async (jd: string) => {
+				await writeFile(join(jd, "evil.txt"), "bad", { mode: 0o600 });
+			},
+		},
+		{
+			name: "symlinked journal dir on reopen",
+			expectedCode: "DIRECTORY_UNSAFE" as OwnershipJournalCode,
+			corrupt: async (jd: string) => {
+				await rm(jd, { recursive: true, force: true });
+				const fakeDir = await mkdtemp(join(tmpdir(), "fake-"));
+				await chmod(fakeDir, 0o700);
+				await rm(fakeDir, { recursive: true, force: true });
+				await symlink(fakeDir, jd);
+			},
+		},
+		{
+			name: "wrong-mode journal dir",
+			expectedCode: "DIRECTORY_UNSAFE" as OwnershipJournalCode,
+			corrupt: async (jd: string) => {
+				await chmod(jd, 0o755);
+			},
+		},
+	]) {
+		it(`rejects ${name}`, async () => {
+			const { root, jDir, journal: j, remove } = await setup("hf-dir-");
+			try {
+				await j.admit(intent, t0);
+				await corrupt(jDir);
+				expectFailure(await createOwnershipJournal(root), expectedCode);
+			} finally {
+				await remove();
+			}
+		});
+	}
+
+	it("collision safe: no double sequence-1", async () => {
+		const { journal: j, remove } = await setup("hf-coll-");
+		try {
+			const a1 = await j.admit(intent, t0);
+			expect(a1.ok).toBe(true);
+			const a2 = await j.admit(intent, t0);
+			expectOk(a2);
+			expect(Object.keys(a2.value)).toEqual(["chain"]);
+		} finally {
+			await remove();
+		}
+	});
+
+	it("getter-bearing intent is rejected safely", async () => {
+		const { journal: j, remove } = await setup("hf-gett-");
+		try {
+			const hostile = { lifecycleKey: "x", parentSessionId: "y", childSessionId: "z" };
+			Object.defineProperty(hostile, "lifecycleKey", {
+				get: () => {
+					throw new Error("leak");
+				},
+			});
+			expectFailure(await j.admit(hostile as unknown as OwnershipIntent, t0), "INPUT_INVALID");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("O_EXCL append collision cannot corrupt existing records", async () => {
+		const { root, journal: j1, remove } = await setup("hf-append-");
+		try {
+			await j1.admit(intent, t0);
+			await j1.transition("creating", intent, "2026-09-04T01:02:04.004Z");
+			const j2 = await mkJournal(root);
+			const r = await j2.recover();
+			expect(r.ok).toBe(true);
+			if (!r.ok) return;
+			expect(r.value.chain.current.stage).toBe("creating");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("second factory on fresh empty dir cannot admit", async () => {
+		const { root, journal: j1, remove } = await setup("hf-2fac-");
+		try {
+			// First admits
+			const a1 = await j1.admit(intent, t0);
+			expect(a1.ok).toBe(true);
+
+			// Second factory on same dir has createdByUs=false, oneShot.used=true
+			// It can recover but cannot admit
+			const j2 = await mkJournal(root);
+			const r2 = await j2.recover();
+			expect(r2.ok).toBe(true);
+			if (!r2.ok) return;
+			expect(r2.value.chain.current.stage).toBe("pre_admit");
+
+			// Admit from j2 should be idempotent (existing chain)
+			const a2 = await j2.admit(intent, t0);
+			expectOk(a2);
+			expect(Object.keys(a2.value)).toEqual(["chain"]);
+		} finally {
+			await remove();
+		}
+	});
+
+	it("second factory on empty dir cannot create sequence-1", async () => {
+		const { root, remove } = await freshRoot("hf-2empty-");
+		try {
+			const j1 = await mkJournal(root);
+			const a1 = await j1.admit(intent, t0);
+			expect(a1.ok).toBe(true);
+			const jDir = join(root, ".sandbox-ownership");
+			await rm(join(jDir, "0001.ownership-v1")).catch(() => {});
+			const j2result = await createOwnershipJournal(root);
+			expectFailure(j2result, "CORRUPT");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("concurrent Promise.all admits - only one publishes sequence-1", async () => {
+		const { root, remove } = await freshRoot("hf-conc-admit-");
+		try {
+			const j = await mkJournal(root);
+			const results = await Promise.all([j.admit(intent, t0), j.admit(intent, t0), j.admit(intent, t0)]);
+			const successCount = results.filter((r) => r.ok).length;
+			expect(successCount).toBeGreaterThanOrEqual(1);
+			expect(successCount).toBeLessThanOrEqual(3);
+			for (const r of results) {
+				if (!r.ok) {
+					expect(r.code).toMatch(/^(IO_UNCERTAIN|CORRUPT)$/);
+				}
+			}
+			const rec = await j.recover();
+			expect(rec.ok).toBe(true);
+			if (!rec.ok) return;
+			expect(rec.value.chain.current.sequence).toBe(1);
+			expect(rec.value.chain.current.stage).toBe("pre_admit");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("concurrent Promise.all transitions - only one publishes each", async () => {
+		const { root, remove } = await freshRoot("hf-conc-trans-");
+		try {
+			const j = await mkJournal(root);
+			await j.admit(intent, t0);
+			const results = await Promise.all([
+				j.transition("creating", intent, "2026-09-04T01:02:04.004Z"),
+				j.transition("creating", intent, "2026-09-04T01:02:04.004Z"),
+				j.transition("creating", intent, "2026-09-04T01:02:04.004Z"),
+			]);
+			const successCount = results.filter((r) => r.ok).length;
+			expect(successCount).toBeGreaterThanOrEqual(1);
+			const rec = await j.recover();
+			expect(rec.ok).toBe(true);
+			if (!rec.ok) return;
+			expect(rec.value.chain.current.sequence).toBe(2);
+			expect(rec.value.chain.current.stage).toBe("creating");
+			expect(rec.value.chain.records.length).toBe(2);
+		} finally {
+			await remove();
+		}
+	});
+
+	it("rejects record file with special mode bits (sticky)", async () => {
+		const { jDir, journal: j, remove } = await setup("hf-chmod-rec-");
+		try {
+			await j.admit(intent, t0);
+			const recPath = join(jDir, "0001.ownership-v1");
+			await chmod(recPath, 0o1600);
+			const r = await j.recover();
+			expectFailure(r, "CORRUPT");
+		} finally {
+			await remove();
+		}
+	});
+
+	it("rejects journal dir with special mode bits", async () => {
+		const { root, jDir, journal: j, remove } = await setup("hf-chmod-dir-");
+		try {
+			await j.admit(intent, t0);
+			await chmod(jDir, 0o2700);
+			const j2r = await createOwnershipJournal(root);
+			expectFailure(j2r, "DIRECTORY_UNSAFE");
+		} finally {
+			await remove();
+		}
+	});
+});

--- a/packages/coding-agent/test/sandbox-ownership-record.test.ts
+++ b/packages/coding-agent/test/sandbox-ownership-record.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+	createPreAdmitOwnershipRecord,
+	decideNonDeletedOwnershipTransition,
+	decodeOwnershipRecord,
+	type OwnershipIntent,
+	type OwnershipRecord,
+	type OwnershipSequence,
+	type OwnershipStage,
+	validateOwnershipChain,
+} from "../src/modes/daemon/sandbox-ownership-record.js";
+
+const intent: OwnershipIntent = Object.freeze({
+	lifecycleKey: "life-0123456789abcdef",
+	parentSessionId: "parent-0123456789abcdef",
+	childSessionId: "child-0123456789abcdef",
+});
+const t0 = "2026-09-04T01:02:03.004Z";
+
+function expectFrozenTree(value: unknown): void {
+	expect(Object.isFrozen(value)).toBe(true);
+	if (typeof value !== "object" || value === null || value instanceof Uint8Array) return;
+	for (const nested of Object.values(value)) {
+		if (typeof nested === "object" && nested !== null) expectFrozenTree(nested);
+	}
+}
+
+function expectFailure(result: unknown, code: string): void {
+	expect(result).toEqual({ ok: false, code });
+	expect(Object.isFrozen(result)).toBe(true);
+	if (typeof result === "object" && result !== null) expect(Object.keys(result)).toEqual(["ok", "code"]);
+}
+
+function takeBytes(result: ReturnType<typeof createPreAdmitOwnershipRecord>): Uint8Array {
+	if (!result.ok) throw new Error("test setup failed");
+	const bytes = result.value.payload.take();
+	if (bytes === undefined) throw new Error("payload already consumed");
+	return bytes;
+}
+
+function createdRecord(result: ReturnType<typeof createPreAdmitOwnershipRecord>): OwnershipRecord {
+	if (!result.ok) throw new Error("test setup failed");
+	return result.value.record;
+}
+
+function buildFixtureRecord(
+	sequence: OwnershipSequence,
+	stage: OwnershipStage,
+	previousDigest: string | null,
+	recordedAt: string,
+): OwnershipRecord {
+	const prefix = `{"version":1,"sequence":${sequence},"stage":${JSON.stringify(stage)},"lifecycleKey":${JSON.stringify(intent.lifecycleKey)},"parentSessionId":${JSON.stringify(intent.parentSessionId)},"childSessionId":${JSON.stringify(intent.childSessionId)},"recordedAt":${JSON.stringify(recordedAt)},"previousDigest":${previousDigest === null ? "null" : JSON.stringify(previousDigest)}`;
+	const digest = createHash("sha256").update(new TextEncoder().encode(prefix)).digest("hex");
+	return Object.freeze({
+		version: 1,
+		sequence,
+		stage,
+		lifecycleKey: intent.lifecycleKey,
+		parentSessionId: intent.parentSessionId,
+		childSessionId: intent.childSessionId,
+		recordedAt,
+		previousDigest,
+		contentDigest: digest,
+	});
+}
+
+function chainOf(records: readonly OwnershipRecord[]) {
+	const result = validateOwnershipChain(records);
+	if (!result.ok) throw new Error("test chain invalid");
+	return result.value;
+}
+
+function advance(
+	records: OwnershipRecord[],
+	target: "creating" | "active" | "delete_intent" | "deleting",
+	timestamp: string,
+): void {
+	const result = decideNonDeletedOwnershipTransition(chainOf(records), target, intent, timestamp);
+	if (!result.ok || result.idempotent) throw new Error("test transition failed");
+	records.push(result.value.record);
+	expect(result.value.payload.discard()).toBe(true);
+}
+
+describe("ownership canonical record", () => {
+	it("creates one frozen pre-admission record and one owned payload", () => {
+		const result = createPreAdmitOwnershipRecord(intent, t0);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expectFrozenTree(result);
+		expect(result.value.record.sequence).toBe(1);
+		expect(result.value.record.stage).toBe("pre_admit");
+		expect(result.value.record.previousDigest).toBeNull();
+		expect(result.value.record.contentDigest).toMatch(/^[0-9a-f]{64}$/);
+		const first = result.value.payload.take();
+		expect(first).toBeInstanceOf(Uint8Array);
+		expect(result.value.payload.take()).toBeUndefined();
+		expect(result.value.payload.discard()).toBe(true);
+	});
+
+	it("matches the independently calculated canonical vector", () => {
+		const result = createPreAdmitOwnershipRecord(intent, t0);
+		if (!result.ok) throw new Error("test setup failed");
+		const bytes = result.value.payload.take();
+		if (bytes === undefined) throw new Error("payload unavailable");
+		expect(new TextDecoder().decode(bytes)).toBe(
+			`{"version":1,"sequence":1,"stage":"pre_admit","lifecycleKey":"life-0123456789abcdef","parentSessionId":"parent-0123456789abcdef","childSessionId":"child-0123456789abcdef","recordedAt":"2026-09-04T01:02:03.004Z","previousDigest":null,"contentDigest":"7655040da904f69ebd2e7e30dd83100102320f7540473985e982017517b514bf"}`,
+		);
+		bytes.fill(0);
+	});
+
+	it("discards an untaken payload by erasing its private bytes", () => {
+		const result = createPreAdmitOwnershipRecord(intent, t0);
+		if (!result.ok) throw new Error("test setup failed");
+		expect(result.value.payload.discard()).toBe(true);
+		expect(result.value.payload.take()).toBeUndefined();
+	});
+
+	for (const badIntent of [
+		{ ...intent, lifecycleKey: "" },
+		{ ...intent, lifecycleKey: "bad\nkey" },
+		{ ...intent, lifecycleKey: "bad\u007fkey" },
+		{ ...intent, lifecycleKey: "\ud800" },
+		{ ...intent, lifecycleKey: "é".repeat(129) },
+	]) {
+		it("rejects an invalid intent", () => {
+			expectFailure(createPreAdmitOwnershipRecord(badIntent, t0), "INPUT_INVALID");
+		});
+	}
+
+	for (const timestamp of [
+		"2026-09-04T01:02:03Z",
+		"2025-02-29T01:02:03.004Z",
+		"2026-13-04T01:02:03.004Z",
+		"not-a-time",
+	]) {
+		it(`rejects invalid timestamp ${timestamp}`, () => {
+			expectFailure(createPreAdmitOwnershipRecord(intent, timestamp), "INPUT_INVALID");
+		});
+	}
+});
+
+describe("ownership record decoder", () => {
+	it("decodes exact canonical bytes and erases the caller buffer", () => {
+		const created = createPreAdmitOwnershipRecord(intent, t0);
+		const bytes = takeBytes(created);
+		const expected = createdRecord(created);
+		const result = decodeOwnershipRecord(bytes);
+		expect(result).toEqual({ ok: true, value: expected });
+		expect(bytes.every((value) => value === 0)).toBe(true);
+		expectFrozenTree(result);
+	});
+
+	for (const mutate of [
+		(text: string) => ` ${text}`,
+		(text: string) => text.replace('{"version":1', '{"sequence":1,"version":1').replace(',"sequence":1', ""),
+		(text: string) => text.replace('{"version":1', '{"version":1,"version":1'),
+		(text: string) => text.replace('"pre_admit"', '"pre_admit\\u0022"'),
+		(text: string) => text.slice(0, -1),
+		(text: string) => text.replace(/.$/, "x"),
+	]) {
+		it("rejects noncanonical or corrupt JSON and erases input", () => {
+			const bytes = takeBytes(createPreAdmitOwnershipRecord(intent, t0));
+			const mutated = new TextEncoder().encode(mutate(new TextDecoder().decode(bytes)));
+			bytes.fill(0);
+			expectFailure(decodeOwnershipRecord(mutated), "CORRUPT");
+			expect(mutated.every((value) => value === 0)).toBe(true);
+		});
+	}
+
+	it("rejects malformed UTF-8 and erases it", () => {
+		const bytes = new Uint8Array([0xc3, 0x28]);
+		expectFailure(decodeOwnershipRecord(bytes), "CORRUPT");
+		expect(bytes).toEqual(new Uint8Array([0, 0]));
+	});
+
+	it("rejects empty and oversized input", () => {
+		const empty = new Uint8Array(0);
+		expectFailure(decodeOwnershipRecord(empty), "CORRUPT");
+		const large = new Uint8Array(4097).fill(1);
+		expectFailure(decodeOwnershipRecord(large), "CORRUPT");
+		expect(large.every((value) => value === 0)).toBe(true);
+	});
+});
+
+describe("ownership chain validation and transition", () => {
+	it("validates a complete non-deleted chain and freezes copies", () => {
+		const records = [createdRecord(createPreAdmitOwnershipRecord(intent, t0))];
+		advance(records, "creating", "2026-09-04T01:02:04.004Z");
+		advance(records, "active", "2026-09-04T01:02:05.004Z");
+		advance(records, "delete_intent", "2026-09-04T01:02:06.004Z");
+		advance(records, "deleting", "2026-09-04T01:02:07.004Z");
+		const result = validateOwnershipChain(records);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.current.stage).toBe("deleting");
+			expectFrozenTree(result);
+			expect(result.value.records[0]).not.toBe(records[0]);
+		}
+	});
+
+	it("accepts all three authorized deleted shortcut shapes during recovery", () => {
+		const pre = createdRecord(createPreAdmitOwnershipRecord(intent, t0));
+		const directDeleted = buildFixtureRecord(2, "deleted", pre.contentDigest, "2026-09-04T01:02:04.004Z");
+		expect(validateOwnershipChain([pre, directDeleted]).ok).toBe(true);
+
+		const records = [pre];
+		advance(records, "creating", "2026-09-04T01:02:04.004Z");
+		advance(records, "delete_intent", "2026-09-04T01:02:05.004Z");
+		const fromIntent = buildFixtureRecord(4, "deleted", records[2].contentDigest, "2026-09-04T01:02:06.004Z");
+		expect(validateOwnershipChain([...records, fromIntent]).ok).toBe(true);
+		advance(records, "deleting", "2026-09-04T01:02:06.004Z");
+		const fromDeleting = buildFixtureRecord(5, "deleted", records[3].contentDigest, "2026-09-04T01:02:07.004Z");
+		expect(validateOwnershipChain([...records, fromDeleting]).ok).toBe(true);
+	});
+
+	it("rejects gaps, inconsistent intent, broken digest, edge, link, and time", () => {
+		const pre = createdRecord(createPreAdmitOwnershipRecord(intent, t0));
+		const creating = buildFixtureRecord(2, "creating", pre.contentDigest, "2026-09-04T01:02:04.004Z");
+		const active = buildFixtureRecord(3, "active", creating.contentDigest, "2026-09-04T01:02:05.004Z");
+		expectFailure(validateOwnershipChain([pre, active]), "CORRUPT");
+		expectFailure(validateOwnershipChain([pre, Object.freeze({ ...creating, lifecycleKey: "other" })]), "CORRUPT");
+		expectFailure(
+			validateOwnershipChain([pre, Object.freeze({ ...creating, contentDigest: "0".repeat(64) })]),
+			"CORRUPT",
+		);
+		expectFailure(
+			validateOwnershipChain([pre, buildFixtureRecord(2, "active", pre.contentDigest, "2026-09-04T01:02:04.004Z")]),
+			"CORRUPT",
+		);
+		expectFailure(
+			validateOwnershipChain([pre, buildFixtureRecord(2, "creating", "0".repeat(64), "2026-09-04T01:02:04.004Z")]),
+			"CORRUPT",
+		);
+		expectFailure(
+			validateOwnershipChain([
+				pre,
+				buildFixtureRecord(2, "creating", pre.contentDigest, "2026-09-04T01:02:02.004Z"),
+			]),
+			"CORRUPT",
+		);
+	});
+
+	it("rejects mutable or accessor-bearing caller records without invoking getters", () => {
+		const pre = createdRecord(createPreAdmitOwnershipRecord(intent, t0));
+		const mutable = { ...pre };
+		expectFailure(validateOwnershipChain([mutable]), "CORRUPT");
+		let invoked = false;
+		const hostile = Object.create(Object.prototype);
+		Object.defineProperty(hostile, "version", {
+			enumerable: true,
+			get: () => {
+				invoked = true;
+				throw new Error("secret");
+			},
+		});
+		expectFailure(Reflect.apply(validateOwnershipChain, undefined, [[hostile]]), "CORRUPT");
+		expect(invoked).toBe(false);
+	});
+
+	it("accepts idempotence only for an exact existing stage and returns current", () => {
+		const records = [createdRecord(createPreAdmitOwnershipRecord(intent, t0))];
+		advance(records, "creating", "2026-09-04T01:02:04.004Z");
+		advance(records, "delete_intent", "2026-09-04T01:02:05.004Z");
+		const result = decideNonDeletedOwnershipTransition(
+			chainOf(records),
+			"creating",
+			intent,
+			"2026-09-04T01:02:06.004Z",
+		);
+		expect(result).toEqual({ ok: true, idempotent: true, value: records[2] });
+		expectFrozenTree(result);
+		expectFailure(
+			decideNonDeletedOwnershipTransition(chainOf(records), "active", intent, "2026-09-04T01:02:06.004Z"),
+			"INVALID_TRANSITION",
+		);
+	});
+
+	it("rejects structurally forged validated chains", () => {
+		const pre = createdRecord(createPreAdmitOwnershipRecord(intent, t0));
+		const forged = { records: [pre], current: pre, intent };
+		expectFailure(
+			Reflect.apply(decideNonDeletedOwnershipTransition, undefined, [forged, "creating", intent, t0]),
+			"CORRUPT",
+		);
+	});
+
+	it("does not expose a production deleted-record creator", () => {
+		const chain = chainOf([createdRecord(createPreAdmitOwnershipRecord(intent, t0))]);
+		expectFailure(
+			Reflect.apply(decideNonDeletedOwnershipTransition, undefined, [chain, "deleted", intent, t0]),
+			"INPUT_INVALID",
+		);
+	});
+
+	it("rejects conflicting intent and regressing time", () => {
+		const records = [createdRecord(createPreAdmitOwnershipRecord(intent, t0))];
+		const chain = chainOf(records);
+		expectFailure(
+			decideNonDeletedOwnershipTransition(chain, "creating", { ...intent, childSessionId: "other" }, t0),
+			"CONFLICT",
+		);
+		expectFailure(
+			decideNonDeletedOwnershipTransition(chain, "creating", intent, "2026-09-04T01:02:02.004Z"),
+			"INPUT_INVALID",
+		);
+	});
+});

--- a/prime-agent-runtime/src/rlm/sandbox_release_archive.py
+++ b/prime-agent-runtime/src/rlm/sandbox_release_archive.py
@@ -700,10 +700,35 @@ def _parent_path(path: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
+class _TarSink:
+    """Synchronous bounded sink used by the shared archive parser."""
+
+    def compressed_data(self, chunk: memoryview) -> ArchiveErrorCode | None:
+        return None
+
+    def directory(self, path: str, mode: int, entry: ManifestEntry) -> ArchiveErrorCode | None:
+        return None
+
+    def begin_file(
+        self, path: str, mode: int, size: int, entry: ManifestEntry
+    ) -> ArchiveErrorCode | None:
+        return None
+
+    def write_file(self, chunk: memoryview) -> ArchiveErrorCode | None:
+        return None
+
+    def finish_file(self) -> ArchiveErrorCode | None:
+        return None
+
+    def finish_archive(self) -> ArchiveErrorCode | None:
+        return None
+
+
 def _verify_streaming(
     fd: int,
     compressed_limit: int,
     manifest: Manifest,
+    sink: _TarSink | None = None,
 ) -> ArchiveErrorCode | None:
     """Incremental preadv -> zlib -> tar verifier.
 
@@ -750,6 +775,19 @@ def _verify_streaming(
     zc = 0                      # consecutive zero block count
     past = False                # end-of-tar marker passed
 
+    def _finish_file() -> ArchiveErrorCode | None:
+        nonlocal fin, h
+        dig = h.hexdigest()
+        if dig != fsha:
+            return ArchiveErrorCode.FILE_SHA_MISMATCH
+        if sink is not None:
+            sink_error = sink.finish_file()
+            if sink_error is not None:
+                return sink_error
+        h = hashlib.sha256()
+        fin = False
+        return None
+
     def _process_data(data: bytes) -> ArchiveErrorCode | None:
         nonlocal fin, fres, fsha, fpad, h
         nonlocal mc, fc, dc, tfb, dtot
@@ -760,24 +798,28 @@ def _verify_streaming(
             if fin:
                 # Zero-length file guard: finalize immediately if no content
                 if fres == 0:
-                    dig = h.hexdigest()
-                    if dig != fsha:
-                        return ArchiveErrorCode.FILE_SHA_MISMATCH
-                    h = hashlib.sha256()
-                    fin = False
+                    finish_error = _finish_file()
+                    if finish_error is not None:
+                        return finish_error
                     continue
 
                 hash_avail = min(fres, len(data) - pos)
                 if hash_avail > 0:
-                    h.update(data[pos:pos + hash_avail])
+                    chunk_view = memoryview(data)[pos:pos + hash_avail]
+                    try:
+                        if sink is not None:
+                            sink_error = sink.write_file(chunk_view)
+                            if sink_error is not None:
+                                return sink_error
+                        h.update(chunk_view)
+                    finally:
+                        chunk_view.release()
                     pos += hash_avail
                     fres -= hash_avail
                     if fres == 0:
-                        dig = h.hexdigest()
-                        if dig != fsha:
-                            return ArchiveErrorCode.FILE_SHA_MISMATCH
-                        h = hashlib.sha256()
-                        fin = False
+                        finish_error = _finish_file()
+                        if finish_error is not None:
+                            return finish_error
                 if fin:
                     continue
 
@@ -901,6 +943,10 @@ def _verify_streaming(
                 if dc > MAX_DIRECTORIES:
                     return ArchiveErrorCode.TOO_MANY_DIRS
                 dirs.add(norm_path)
+                if sink is not None:
+                    sink_error = sink.directory(norm_path, mode_val, mentry)
+                    if sink_error is not None:
+                        return sink_error
             else:
                 fc += 1
                 if fc > MAX_REGULAR_FILES:
@@ -913,6 +959,10 @@ def _verify_streaming(
                 total_data = ((size_val + _TAR_BLOCK - 1) // _TAR_BLOCK) * _TAR_BLOCK
                 fpad = total_data - size_val
                 fsha = mentry.sha256 if mentry.sha256 is not None else ""
+                if sink is not None:
+                    sink_error = sink.begin_file(norm_path, mode_val, size_val, mentry)
+                    if sink_error is not None:
+                        return sink_error
                 fin = True
 
         return None
@@ -955,6 +1005,10 @@ def _verify_streaming(
                 comp_offset += count
                 input_view = memoryview(compressed_buffer)[:count]
                 try:
+                    if sink is not None:
+                        sink_error = sink.compressed_data(input_view)
+                        if sink_error is not None:
+                            return sink_error
                     try:
                         output = decomp.decompress(input_view, _D_BUF)
                     except zlib.error:
@@ -1016,6 +1070,10 @@ def _verify_streaming(
         if dtot % _TAR_BLOCK != 0:
             return ArchiveErrorCode.TOTAL_NOT_MULTIPLE_512
 
+        if sink is not None:
+            sink_error = sink.finish_archive()
+            if sink_error is not None:
+                return sink_error
         return None
 
     finally:

--- a/prime-agent-runtime/src/rlm/sandbox_release_archive.py
+++ b/prime-agent-runtime/src/rlm/sandbox_release_archive.py
@@ -1,0 +1,1086 @@
+"""Phase 1: streaming verify/parse a sandbox official-release archive.
+
+Pure-Python-3.11-stdlib incremental preadv -> zlib -> tar state machine.
+Bounded fixed-size buffers: no full-archive allocation.
+Fixed StrEnum error codes; all types validated strictly before fd access.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import hashlib
+import os
+import re
+import stat
+import types
+import zlib
+from typing import Final
+
+# ---------------------------------------------------------------------------
+# Safety ceilings
+# ---------------------------------------------------------------------------
+
+MAX_COMPRESSED_BYTES: Final[int] = 96 * 1024 * 1024
+MAX_DECOMPRESSED_TAR: Final[int] = 256 * 1024 * 1024
+MAX_MEMBERS: Final[int] = 1024
+MAX_REGULAR_FILES: Final[int] = 512
+MAX_DIRECTORIES: Final[int] = 512
+MAX_PER_FILE_BYTES: Final[int] = 192 * 1024 * 1024
+MAX_TOTAL_FILE_BYTES: Final[int] = 224 * 1024 * 1024
+MAX_PATH_UTF8_BYTES: Final[int] = 512
+MAX_COMPONENT_UTF8_BYTES: Final[int] = 255
+
+_VALID_FILE_MODES: Final[tuple[int, ...]] = (0o644, 0o755)
+_VALID_DIR_MODE: Final[int] = 0o755
+
+_USTAR_MAGIC: Final[bytes] = b"ustar\x00"
+_USTAR_VERSION: Final[bytes] = b"00"
+
+_TAR_BLOCK: Final[int] = 512
+_MIN_ZERO_BLOCKS: Final[int] = 2
+
+_CHAR_BLACKLIST: Final[bytes] = bytes(list(range(0x00, 0x20)))
+
+_HEX64_RE: Final = re.compile(r"^[0-9a-f]{64}$")
+_MODE_OCTAL_RE: Final = re.compile(r"^0[0-7]{3,4}$")
+
+_C_BUF: Final[int] = 65536
+_D_BUF: Final[int] = 65536
+_PREADV_BUF: Final[int] = 1048576
+
+# Zero-length file sentinel SHA-256 (hash of empty bytes)
+_EMPTY_SHA256: Final[str] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+
+# ---------------------------------------------------------------------------
+# Fixed error codes
+# ---------------------------------------------------------------------------
+
+
+class ArchiveErrorCode(enum.StrEnum):
+    """Every possible failure code emitted by verify_archive."""
+
+    # Identity/manifest validation (before fd)
+    BAD_IDENTITY_FIELD = "bad_identity_field"
+    BAD_MANIFEST_FIELD = "bad_manifest_field"
+
+    # fd validation
+    BAD_FD_FIELD = "bad_fd_field"
+    FD_STAT_FAILED = "fd_stat_failed"
+    FD_NOT_REGULAR = "fd_not_regular"
+    FD_BAD_MODE = "fd_bad_mode"
+    FD_NOT_READABLE = "fd_not_readable"
+    FD_NOT_OWNER = "fd_not_owner"
+    FD_BAD_NLINK = "fd_bad_nlink"
+    FD_TOO_SMALL = "fd_too_small"
+    FD_TOO_LARGE = "fd_too_large"
+    FD_IDENTITY_CHANGED = "fd_identity_changed"
+    FD_SIZE_CHANGED = "fd_size_changed"
+
+    # Compressed hash
+    PREAD_ERROR = "pread_error"
+    COMPRESSED_TRUNCATED = "compressed_truncated"
+    COMPRESSED_TRAILING = "compressed_trailing"
+    DIGEST_MISMATCH = "digest_mismatch"
+
+    # Numeric field parsing
+    BAD_NUMERIC_FIELD = "bad_numeric_field"
+
+    # Tar header parsing
+    BAD_BLOCK_SIZE = "bad_block_size"
+    CHECKSUM_ERROR = "checksum_error"
+    BAD_MAGIC = "bad_magic"
+    BAD_VERSION = "bad_version"
+    BAD_TYPE = "bad_type"
+    BAD_NAME = "bad_name"
+    BAD_LINK = "bad_link"
+    BAD_DEVICE = "bad_device"
+    BAD_MODE = "bad_mode"
+    BAD_SIZE = "bad_size"
+    BAD_MTIME = "bad_mtime"
+    BAD_UID = "bad_uid"
+    BAD_GID = "bad_gid"
+    BAD_HEADER = "bad_header"
+    BAD_CSTRING_PADDING = "bad_cstring_padding"
+    BAD_TRAILING_SLASH = "bad_trailing_slash"
+    BAD_ROOT_SPELLING = "bad_root_spelling"
+
+    # Path validation
+    BAD_PATH = "bad_path"
+
+    # Streaming verify
+    FILE_SHA_MISMATCH = "file_sha_mismatch"
+    NON_ZERO_PADDING = "non_zero_padding"
+    TAIL_NONZERO = "tail_nonzero"
+    UNPAIRED_ZERO_BLOCK = "unpaired_zero_block"
+    SECOND_TAR = "second_tar"
+    DUPLICATE_PATH = "duplicate_path"
+    PARENT_MISSING = "parent_missing"
+    FILE_TOO_LARGE = "file_too_large"
+    DIR_SIZE_MISMATCH = "dir_size_mismatch"
+    ENTRY_NOT_IN_MANIFEST = "entry_not_in_manifest"
+    ENTRY_TYPE_MISMATCH = "entry_type_mismatch"
+    ENTRY_MODE_MISMATCH = "entry_mode_mismatch"
+    ENTRY_SIZE_MISMATCH = "entry_size_mismatch"
+    TOO_MANY_MEMBERS = "too_many_members"
+    TOO_MANY_DIRS = "too_many_dirs"
+    TOO_MANY_FILES = "too_many_files"
+    TOTAL_BYTES_EXCEEDED = "total_bytes_exceeded"
+    DECOMPRESSED_TOO_LARGE = "decompressed_too_large"
+    GZIP_ERROR = "gzip_error"
+    GZIP_TRAILING_DATA = "gzip_trailing_data"
+    NO_ZERO_BLOCKS = "no_zero_blocks"
+    MEMBER_COUNT_MISMATCH = "member_count_mismatch"
+    FILE_COUNT_MISMATCH = "file_count_mismatch"
+    DIR_COUNT_MISMATCH = "dir_count_mismatch"
+    TOTAL_BYTES_MISMATCH = "total_bytes_mismatch"
+    DECOMPRESSED_SIZE_MISMATCH = "decompressed_size_mismatch"
+
+    # General
+    INTERNAL_ERROR = "internal_error"
+    NO_PROGRESS = "no_progress"
+    GZIP_EOF_PREMATURE = "gzip_eof_premature"
+    GZIP_UNUSED_DATA = "gzip_unused_data"
+    ACTIVE_FILE_INCOMPLETE = "active_file_incomplete"
+    ZERO_BLOCK_PARTIAL_HEADER = "zero_block_partial_header"
+    TOTAL_NOT_MULTIPLE_512 = "total_not_multiple_512"
+    ONE_ZERO_BLOCK = "one_zero_block"
+
+    # Dataclass type validation
+    BAD_DATACLASS_TYPE = "bad_dataclass_type"
+    BAD_DATACLASS_KEY = "bad_dataclass_key"
+    BAD_PRIMITIVE_TYPE = "bad_primitive_type"
+    IDENTITY_MISMATCH = "identity_mismatch"
+    PREADV_EXTRA = "preadv_extra"
+
+    # Manifest structure
+    ROOT_ENTRY_MISSING = "root_entry_missing"
+    PARENT_ORDER = "parent_order"
+    ZERO_LENGTH_EMPTY_SHA = "zero_length_empty_sha"
+
+
+# Convenience alias: every error code str.
+ErrorCode = ArchiveErrorCode  # shorthand
+
+
+# ---------------------------------------------------------------------------
+# Strict dataclass type validation helpers
+# ---------------------------------------------------------------------------
+
+def _check_strict_dataclass(
+    obj: object,
+    expected_keys: dict[str, type | types.UnionType],
+    expected_class: type | None = None,
+) -> str | None:
+    """Validate exact instance storage without invoking instance attribute hooks."""
+    try:
+        if expected_class is not None and type(obj) is not expected_class:
+            return "bad_dataclass_type"
+        if expected_class is None and not hasattr(type(obj), "__dataclass_fields__"):
+            return "bad_dataclass_type"
+        values = object.__getattribute__(obj, "__dict__")
+        if type(values) is not dict or set(values) != set(expected_keys):
+            return "bad_dataclass_key"
+        for key, expected_type in expected_keys.items():
+            value = values[key]
+            if isinstance(expected_type, types.UnionType):
+                if not any(type(value) is member for member in expected_type.__args__):
+                    return "bad_primitive_type"
+            elif expected_type is type(None):
+                if value is not None:
+                    return "bad_primitive_type"
+            elif type(value) is not expected_type:
+                return "bad_primitive_type"
+        return None
+    except Exception:
+        return "bad_dataclass_type"
+
+
+# ---------------------------------------------------------------------------
+# Immutable input types
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class ArchiveIdentity:
+    compressed_sha256: str
+    compressed_bytes: int
+
+
+@dataclasses.dataclass(frozen=True)
+class ManifestEntry:
+    path: str
+    type: str
+    mode: str
+    size: int
+    sha256: str | None
+
+
+@dataclasses.dataclass(frozen=True)
+class Manifest:
+    identity: ArchiveIdentity
+    entries: tuple[ManifestEntry, ...]
+    total_regular_bytes: int
+    decompressed_tar_bytes: int
+
+
+# ---------------------------------------------------------------------------
+# Immutable result types (fixed codes only)
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class VerifyArchiveSuccess:
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
+class VerifyArchiveFailure:
+    code: ArchiveErrorCode
+
+    def __post_init__(self) -> None:
+        if type(self.code) is not ArchiveErrorCode:
+            raise ValueError("invalid archive error code")
+
+
+VerifyResult = VerifyArchiveSuccess | VerifyArchiveFailure
+
+
+# ---------------------------------------------------------------------------
+# Field validation (before any fd access)
+# ---------------------------------------------------------------------------
+
+
+def _validate_identity(identity: ArchiveIdentity) -> ArchiveErrorCode | None:
+    # Strict dataclass check
+    err = _check_strict_dataclass(identity, {
+        "compressed_sha256": str,
+        "compressed_bytes": int,
+    }, ArchiveIdentity)
+    if err is not None:
+        return ArchiveErrorCode(err)
+
+    sha = identity.compressed_sha256
+    csize = identity.compressed_bytes
+
+    if not isinstance(sha, str) or not _HEX64_RE.match(sha):
+        return ArchiveErrorCode.BAD_IDENTITY_FIELD
+    if not isinstance(csize, int) or csize <= 0 or csize > MAX_COMPRESSED_BYTES:
+        return ArchiveErrorCode.BAD_IDENTITY_FIELD
+    return None
+
+
+def _validate_manifest(
+    manifest: Manifest,
+    identity: ArchiveIdentity | None = None,
+) -> ArchiveErrorCode | None:
+    err = _check_strict_dataclass(manifest, {
+        "identity": ArchiveIdentity,
+        "entries": tuple,
+        "total_regular_bytes": int,
+        "decompressed_tar_bytes": int,
+    }, Manifest)
+    if err is not None:
+        return ArchiveErrorCode(err)
+
+    entries = manifest.identity
+    identity_error = _validate_identity(entries)
+    if identity_error is not None:
+        return identity_error
+    if identity is not None and (
+        entries.compressed_sha256 != identity.compressed_sha256
+        or entries.compressed_bytes != identity.compressed_bytes
+    ):
+        return ArchiveErrorCode.IDENTITY_MISMATCH
+
+    manifest_entries = manifest.entries
+    total_regular = manifest.total_regular_bytes
+    decompressed_bytes = manifest.decompressed_tar_bytes
+    if len(manifest_entries) == 0 or len(manifest_entries) > MAX_MEMBERS:
+        return ArchiveErrorCode.BAD_MANIFEST_FIELD
+    if total_regular < 0 or total_regular > MAX_TOTAL_FILE_BYTES:
+        return ArchiveErrorCode.BAD_MANIFEST_FIELD
+    if (
+        decompressed_bytes <= 0
+        or decompressed_bytes > MAX_DECOMPRESSED_TAR
+        or decompressed_bytes % _TAR_BLOCK != 0
+    ):
+        return ArchiveErrorCode.BAD_MANIFEST_FIELD
+
+    seen: set[str] = set()
+    directories: set[str] = set()
+    file_count = 0
+    directory_count = 0
+    counted_bytes = 0
+    paths: list[str] = []
+    for index, entry in enumerate(manifest_entries):
+        entry_error = _validate_entry(entry, seen)
+        if entry_error is not None:
+            return entry_error
+        path = entry.path
+        paths.append(path)
+        if index == 0:
+            if path != "." or entry.type != "directory":
+                return ArchiveErrorCode.ROOT_ENTRY_MISSING
+        elif path == ".":
+            return ArchiveErrorCode.BAD_MANIFEST_FIELD
+
+        parent = _parent_path(path)
+        if parent is not None and parent not in directories:
+            parent_exists_later = any(
+                type(candidate) is ManifestEntry
+                and candidate.path == parent
+                and candidate.type == "directory"
+                for candidate in manifest_entries[index + 1:]
+            )
+            return ArchiveErrorCode.PARENT_ORDER if parent_exists_later else ArchiveErrorCode.BAD_MANIFEST_FIELD
+
+        if entry.type == "file":
+            file_count += 1
+            counted_bytes += entry.size
+        else:
+            directory_count += 1
+            directories.add(path)
+
+    if paths != sorted(paths, key=lambda path: path.encode("utf-8")):
+        return ArchiveErrorCode.PARENT_ORDER
+    if file_count > MAX_REGULAR_FILES or directory_count > MAX_DIRECTORIES:
+        return ArchiveErrorCode.BAD_MANIFEST_FIELD
+    if counted_bytes != total_regular:
+        return ArchiveErrorCode.BAD_MANIFEST_FIELD
+    return None
+
+
+def _validate_entry(entry: ManifestEntry, seen: set[str]) -> ArchiveErrorCode | None:
+    err = _check_strict_dataclass(entry, {
+        "path": str,
+        "type": str,
+        "mode": str,
+        "size": int,
+        "sha256": type(None) | str,
+    }, ManifestEntry)
+    if err is not None:
+        return ArchiveErrorCode(err)
+
+    path = entry.path
+    entry_type = entry.type
+    mode = entry.mode
+    size = entry.size
+    digest = entry.sha256
+    try:
+        raw_path = path.encode("utf-8")
+    except UnicodeEncodeError:
+        return ArchiveErrorCode.BAD_MANIFEST_FIELD
+    normalized, path_error = _validate_path(raw_path)
+    if path_error is not None or normalized != path or path.endswith("/"):
+        return ArchiveErrorCode.BAD_MANIFEST_FIELD
+    if path in seen:
+        return ArchiveErrorCode.BAD_MANIFEST_FIELD
+    if entry_type not in ("file", "directory"):
+        return ArchiveErrorCode.BAD_MANIFEST_FIELD
+    if entry_type == "directory":
+        if mode != "0755" or size != 0 or digest is not None:
+            return ArchiveErrorCode.BAD_MANIFEST_FIELD
+    else:
+        if mode not in ("0644", "0755"):
+            return ArchiveErrorCode.BAD_MANIFEST_FIELD
+        if size < 0 or size > MAX_PER_FILE_BYTES:
+            return ArchiveErrorCode.BAD_MANIFEST_FIELD
+        if type(digest) is not str or _HEX64_RE.fullmatch(digest) is None:
+            return ArchiveErrorCode.BAD_MANIFEST_FIELD
+        if size == 0 and digest != _EMPTY_SHA256:
+            return ArchiveErrorCode.ZERO_LENGTH_EMPTY_SHA
+    seen.add(path)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# fd validation
+# ---------------------------------------------------------------------------
+
+
+class _Snap:
+    __slots__ = ("dev", "ino", "uid", "size", "mode")
+
+
+def _fstat_validate(fd: int, expected_size: int) -> tuple[_Snap | None, ArchiveErrorCode | None]:
+    try:
+        st = os.fstat(fd)
+    except OSError:
+        return (None, ArchiveErrorCode.FD_STAT_FAILED)
+    if not stat.S_ISREG(st.st_mode):
+        return (None, ArchiveErrorCode.FD_NOT_REGULAR)
+    mb = stat.S_IMODE(st.st_mode)
+    if mb & 0o7022:
+        return (None, ArchiveErrorCode.FD_BAD_MODE)
+    if not (mb & 0o400):
+        return (None, ArchiveErrorCode.FD_NOT_READABLE)
+    uid = os.getuid()
+    if st.st_uid != uid:
+        return (None, ArchiveErrorCode.FD_NOT_OWNER)
+    if st.st_nlink != 1:
+        return (None, ArchiveErrorCode.FD_BAD_NLINK)
+    sz = st.st_size
+    if sz < expected_size:
+        return (None, ArchiveErrorCode.FD_TOO_SMALL)
+    if sz > MAX_COMPRESSED_BYTES:
+        return (None, ArchiveErrorCode.FD_TOO_LARGE)
+    snap = _Snap()
+    snap.dev = st.st_dev
+    snap.ino = st.st_ino
+    snap.uid = uid
+    snap.size = sz
+    snap.mode = st.st_mode
+    return (snap, None)
+
+
+def _fstat_unchanged(fd: int, snap: _Snap) -> ArchiveErrorCode | None:
+    try:
+        st = os.fstat(fd)
+    except OSError:
+        return ArchiveErrorCode.FD_STAT_FAILED
+    if st.st_dev != snap.dev or st.st_ino != snap.ino or st.st_uid != snap.uid:
+        return ArchiveErrorCode.FD_IDENTITY_CHANGED
+    if st.st_nlink != 1:
+        return ArchiveErrorCode.FD_BAD_NLINK
+    if st.st_mode != snap.mode:
+        return ArchiveErrorCode.FD_IDENTITY_CHANGED
+    if st.st_size != snap.size:
+        return ArchiveErrorCode.FD_SIZE_CHANGED
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Compressed hash (os.preadv into mutable buffer)
+# ---------------------------------------------------------------------------
+
+
+def _hash_compressed(fd: int, expected_size: int, expected_digest: str) -> ArchiveErrorCode | None:
+    digest = hashlib.sha256()
+    buffer = bytearray(_PREADV_BUF)
+    extra = bytearray(1)
+    try:
+        offset = 0
+        while offset < expected_size:
+            requested = min(len(buffer), expected_size - offset)
+            view = memoryview(buffer)[:requested]
+            try:
+                count = os.preadv(fd, [view], offset)
+            except OSError:
+                return ArchiveErrorCode.PREAD_ERROR
+            finally:
+                view.release()
+            if count == 0:
+                return ArchiveErrorCode.COMPRESSED_TRUNCATED
+            if count < 0 or count > requested:
+                return ArchiveErrorCode.PREADV_EXTRA
+            digest.update(memoryview(buffer)[:count])
+            for index in range(count):
+                buffer[index] = 0
+            offset += count
+        try:
+            extra_count = os.preadv(fd, [extra], expected_size)
+        except OSError:
+            return ArchiveErrorCode.PREAD_ERROR
+        if extra_count != 0:
+            return ArchiveErrorCode.COMPRESSED_TRAILING
+        if digest.hexdigest() != expected_digest:
+            return ArchiveErrorCode.DIGEST_MISMATCH
+        return None
+    finally:
+        for index in range(len(buffer)):
+            buffer[index] = 0
+        extra[0] = 0
+
+
+# ---------------------------------------------------------------------------
+# Octal field parsing
+# ---------------------------------------------------------------------------
+
+
+def _octal_to_int(field: bytes) -> tuple[int, ArchiveErrorCode | None]:
+    try:
+        if len(field) == 0 or (field[0] & 0x80):
+            return (0, ArchiveErrorCode.BAD_NUMERIC_FIELD)
+        cleaned = field.rstrip(b"\x00 ")
+        if len(cleaned) == 0:
+            return (0, None)
+        for bc in cleaned:
+            if bc < 0x30 or bc > 0x37:
+                return (0, ArchiveErrorCode.BAD_NUMERIC_FIELD)
+        val = int(cleaned.decode("ascii"), 8)
+        return (val, None) if val >= 0 else (0, ArchiveErrorCode.BAD_NUMERIC_FIELD)
+    except (ValueError, UnicodeDecodeError):
+        return (0, ArchiveErrorCode.BAD_NUMERIC_FIELD)
+
+
+# ---------------------------------------------------------------------------
+# Cstring validation helper
+# ---------------------------------------------------------------------------
+
+
+def _validate_cstring(field: bytes) -> ArchiveErrorCode | None:
+    """Ensure *field* is a valid null-terminated string with zero padding only after null.
+
+    Returns None if valid, error code otherwise.
+    """
+    null_idx = field.find(b"\x00")
+    if null_idx == -1:
+        # No null at all — must pad with nulls; some tar implementations
+        # allow full-field names without null if exact length.
+        # Strict: require null within field.
+        return ArchiveErrorCode.BAD_CSTRING_PADDING
+    if null_idx == 0 and field.rstrip(b"\x00"):
+        # Leading null with non-null after — invalid
+        return ArchiveErrorCode.BAD_CSTRING_PADDING
+    # Everything after the first null must be null
+    for b in field[null_idx + 1:]:
+        if b != 0:
+            return ArchiveErrorCode.BAD_CSTRING_PADDING
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tar header parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_tar_header(block: bytes) -> tuple[dict[str, object] | None, ArchiveErrorCode | None]:
+    try:
+        if len(block) != _TAR_BLOCK:
+            return (None, ArchiveErrorCode.BAD_BLOCK_SIZE)
+        raw_chk = block[148:156]
+        computed = sum(block[:148]) + (32 * 8) + sum(block[156:])
+        chk_v, chk_e = _octal_to_int(raw_chk)
+        if chk_e is not None or chk_v != computed:
+            return (None, ArchiveErrorCode.CHECKSUM_ERROR)
+        if block[257:263] != _USTAR_MAGIC:
+            return (None, ArchiveErrorCode.BAD_MAGIC)
+        if block[263:265] != _USTAR_VERSION:
+            return (None, ArchiveErrorCode.BAD_VERSION)
+        tf = block[156:157]
+        if tf not in (b"0", b"5"):
+            return (None, ArchiveErrorCode.BAD_TYPE)
+
+        # --- Cstring padding checks ---
+        err = _validate_cstring(block[0:100])
+        if err is not None:
+            return (None, err)
+        err = _validate_cstring(block[345:500])
+        if err is not None:
+            return (None, err)
+        err = _validate_cstring(block[157:257])
+        if err is not None:
+            return (None, err)
+        err = _validate_cstring(block[265:297])
+        if err is not None:
+            return (None, err)
+        err = _validate_cstring(block[297:329])
+        if err is not None:
+            return (None, err)
+
+        raw_name = block[0:100]
+        prefix_raw = block[345:500]
+        name_part = raw_name.rstrip(b"\x00")
+        prefix_part = prefix_raw.rstrip(b"\x00")
+
+        full_name = prefix_part + b"/" + name_part if prefix_part else name_part
+
+        if b"\x00" in full_name:
+            return (None, ArchiveErrorCode.BAD_NAME)
+
+        # Check link field is all zeros
+        if block[157:257].rstrip(b"\x00"):
+            return (None, ArchiveErrorCode.BAD_LINK)
+
+        # Device major/minor
+        dm_v, dm_e = _octal_to_int(block[329:337])
+        if dm_e is not None:
+            return (None, ArchiveErrorCode.BAD_DEVICE)
+        dn_v, dn_e = _octal_to_int(block[337:345])
+        if dn_e is not None:
+            return (None, ArchiveErrorCode.BAD_DEVICE)
+        if dm_v != 0 or dn_v != 0:
+            return (None, ArchiveErrorCode.BAD_DEVICE)
+
+        # Numeric fields including all standard ones
+        md_v, md_e = _octal_to_int(block[100:108])
+        if md_e is not None:
+            return (None, ArchiveErrorCode.BAD_MODE)
+        sz_v, sz_e = _octal_to_int(block[124:136])
+        if sz_e is not None:
+            return (None, ArchiveErrorCode.BAD_SIZE)
+        _, mt_e = _octal_to_int(block[136:148])
+        if mt_e is not None:
+            return (None, ArchiveErrorCode.BAD_MTIME)
+        _, uid_e = _octal_to_int(block[108:116])
+        if uid_e is not None:
+            return (None, ArchiveErrorCode.BAD_UID)
+        _, gid_e = _octal_to_int(block[116:124])
+        if gid_e is not None:
+            return (None, ArchiveErrorCode.BAD_GID)
+
+        if any(block[500:512]):
+            return (None, ArchiveErrorCode.BAD_HEADER)
+        if full_name in (b".", b"./"):
+            if full_name != b"./" or tf != b"5":
+                return (None, ArchiveErrorCode.BAD_ROOT_SPELLING)
+        elif tf == b"5" and not full_name.endswith(b"/"):
+            return (None, ArchiveErrorCode.BAD_TRAILING_SLASH)
+        elif tf == b"0" and full_name.endswith(b"/"):
+            return (None, ArchiveErrorCode.BAD_TRAILING_SLASH)
+
+        fields: dict[str, object] = {
+            "name": full_name,
+            "mode": md_v,
+            "size": sz_v,
+            "typeflag": tf,
+        }
+        return (fields, None)
+    except (IndexError, ValueError):
+        return (None, ArchiveErrorCode.BAD_HEADER)
+
+
+# ---------------------------------------------------------------------------
+# Path validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_path(raw_path: bytes) -> tuple[str, ArchiveErrorCode | None]:
+    try:
+        if len(raw_path) == 0 or b"\x00" in raw_path or b"\\" in raw_path:
+            return ("", ArchiveErrorCode.BAD_PATH)
+        for bc in raw_path:
+            if bc in _CHAR_BLACKLIST or bc == 0x7f:
+                return ("", ArchiveErrorCode.BAD_PATH)
+        try:
+            raw_path.decode("utf-8")
+        except UnicodeDecodeError:
+            return ("", ArchiveErrorCode.BAD_PATH)
+        if len(raw_path) > MAX_PATH_UTF8_BYTES:
+            return ("", ArchiveErrorCode.BAD_PATH)
+        path_str = raw_path.decode("utf-8")
+        if path_str.startswith("/"):
+            return ("", ArchiveErrorCode.BAD_PATH)
+        if path_str.startswith("././") or path_str.startswith("./.."):
+            return ("", ArchiveErrorCode.BAD_PATH)
+        if path_str.startswith("./"):
+            path_str = path_str[2:]
+        if path_str.endswith("//"):
+            return ("", ArchiveErrorCode.BAD_PATH)
+        path_str = path_str.rstrip("/")
+        if path_str == "":
+            path_str = "."
+        if path_str == ".":
+            return (".", None)
+        components = path_str.split("/")
+        for comp in components:
+            if comp in ("..", "", "."):
+                return ("", ArchiveErrorCode.BAD_PATH)
+            if len(comp.encode("utf-8")) > MAX_COMPONENT_UTF8_BYTES:
+                return ("", ArchiveErrorCode.BAD_PATH)
+        return (path_str, None)
+    except Exception:
+        return ("", ArchiveErrorCode.BAD_PATH)
+
+
+def _parent_path(path: str) -> str | None:
+    if path == ".":
+        return None
+    idx = path.rfind("/")
+    if idx == -1:
+        return "."
+    parent = path[:idx]
+    return "." if parent == "" else parent
+
+
+# ---------------------------------------------------------------------------
+# Streaming tar state machine
+# ---------------------------------------------------------------------------
+
+
+def _verify_streaming(
+    fd: int,
+    compressed_limit: int,
+    manifest: Manifest,
+) -> ArchiveErrorCode | None:
+    """Incremental preadv -> zlib -> tar verifier.
+
+    Bounded architecture:
+    - Fixed-size compressed input buffer (64 KB) with carryover for
+      zlib unconsumed tail.  Never allocates the full compressed archive.
+    - zlib.decompress with max_length=65536 for bounded output chunks.
+    - State machine that holds at most one 512-byte header buffer plus
+      counters and a single SHA-256 hasher.
+    - File content is streamed through the hasher incrementally; padding
+      bytes are skipped without buffering.
+    - Absolute preadv offset is never decremented and data is never reread.
+    - Zero-length files finalize immediately (no infinite loop).
+    - Final checks reject active/incomplete file, remaining padding,
+      partial header, total non-512, and one zero block.
+
+    Returns error code or None on success.
+    """
+    by_path: dict[str, ManifestEntry] = {}
+    for e in manifest.entries:
+        by_path[e.path] = e
+    mfc = sum(1 for e in manifest.entries if e.type == "file")
+    mdc = sum(1 for e in manifest.entries if e.type == "directory")
+
+    decomp = zlib.decompressobj(wbits=31)
+    compressed_buffer = bytearray(_C_BUF)
+    carryover = bytearray()
+    comp_offset = 0
+
+    # Decompressed-data state machine
+    hdr = bytearray()          # header accumulation buf (< 512 bytes)
+    fin = False                 # file-content-hashing mode active
+    fres = 0                    # remaining file content bytes to hash
+    fsha = ""                   # expected file sha256
+    fpad = 0                    # remaining padding bytes to skip
+    h = hashlib.sha256()
+    mc = 0                      # member count
+    fc = 0                      # file count
+    dc = 0                      # dir count
+    tfb = 0                     # total file bytes
+    dtot = 0                    # total decompressed bytes
+    seen: set[str] = set()
+    dirs: set[str] = set()
+    zc = 0                      # consecutive zero block count
+    past = False                # end-of-tar marker passed
+
+    def _process_data(data: bytes) -> ArchiveErrorCode | None:
+        nonlocal fin, fres, fsha, fpad, h
+        nonlocal mc, fc, dc, tfb, dtot
+        nonlocal zc, past
+        pos = 0
+
+        while pos < len(data):
+            if fin:
+                # Zero-length file guard: finalize immediately if no content
+                if fres == 0:
+                    dig = h.hexdigest()
+                    if dig != fsha:
+                        return ArchiveErrorCode.FILE_SHA_MISMATCH
+                    h = hashlib.sha256()
+                    fin = False
+                    continue
+
+                hash_avail = min(fres, len(data) - pos)
+                if hash_avail > 0:
+                    h.update(data[pos:pos + hash_avail])
+                    pos += hash_avail
+                    fres -= hash_avail
+                    if fres == 0:
+                        dig = h.hexdigest()
+                        if dig != fsha:
+                            return ArchiveErrorCode.FILE_SHA_MISMATCH
+                        h = hashlib.sha256()
+                        fin = False
+                if fin:
+                    continue
+
+            if fpad > 0:
+                skip = min(fpad, len(data) - pos)
+                for b in data[pos:pos + skip]:
+                    if b != 0:
+                        return ArchiveErrorCode.NON_ZERO_PADDING
+                pos += skip
+                fpad -= skip
+                if fpad > 0:
+                    break
+                continue
+
+            if past:
+                for b in data[pos:]:
+                    if b != 0:
+                        return ArchiveErrorCode.TAIL_NONZERO
+                pos = len(data)
+                break
+
+            need = _TAR_BLOCK - len(hdr)
+            take = min(need, len(data) - pos)
+            hdr.extend(data[pos:pos + take])
+            pos += take
+
+            if len(hdr) < _TAR_BLOCK:
+                break
+
+            block = bytes(hdr)
+            hdr.clear()
+
+            zero = True
+            for bc in block:
+                if bc != 0:
+                    zero = False
+                    break
+
+            if zero:
+                zc += 1
+                if zc >= _MIN_ZERO_BLOCKS:
+                    past = True
+                continue
+            elif zc == 1:
+                return ArchiveErrorCode.UNPAIRED_ZERO_BLOCK
+            elif zc > 1:
+                if past:
+                    return ArchiveErrorCode.TAIL_NONZERO
+                return ArchiveErrorCode.SECOND_TAR
+
+            fields, hdr_err = _parse_tar_header(block)
+            if hdr_err is not None:
+                return hdr_err
+            if not isinstance(fields, dict):
+                return ArchiveErrorCode.BAD_HEADER
+
+            tf_raw = fields.get("typeflag")
+            if not isinstance(tf_raw, bytes) or len(tf_raw) == 0:
+                return ArchiveErrorCode.BAD_HEADER
+            raw_name = fields.get("name")
+            if not isinstance(raw_name, bytes):
+                return ArchiveErrorCode.BAD_HEADER
+            mode_val = fields.get("mode", 0)
+            if not isinstance(mode_val, int):
+                return ArchiveErrorCode.BAD_HEADER
+            size_val = fields.get("size", 0)
+            if not isinstance(size_val, int):
+                return ArchiveErrorCode.BAD_HEADER
+
+            norm_path, path_err = _validate_path(raw_name)
+            if path_err is not None:
+                return path_err
+
+            typeflag = tf_raw[0]
+            if typeflag == ord("5"):
+                etype = "directory"
+            elif typeflag == ord("0"):
+                etype = "file"
+            else:
+                return ArchiveErrorCode.BAD_TYPE
+
+            if etype == "file":
+                if mode_val not in _VALID_FILE_MODES:
+                    return ArchiveErrorCode.BAD_MODE
+            else:
+                if mode_val != _VALID_DIR_MODE:
+                    return ArchiveErrorCode.BAD_MODE
+
+            if mc == 0 and norm_path != ".":
+                return ArchiveErrorCode.PARENT_MISSING
+            if norm_path in seen:
+                return ArchiveErrorCode.DUPLICATE_PATH
+            seen.add(norm_path)
+
+            if norm_path != ".":
+                p = _parent_path(norm_path)
+                if p is not None and p != "." and p not in dirs:
+                    return ArchiveErrorCode.PARENT_MISSING
+
+            if size_val > MAX_PER_FILE_BYTES:
+                return ArchiveErrorCode.FILE_TOO_LARGE
+            if etype == "directory" and size_val != 0:
+                return ArchiveErrorCode.DIR_SIZE_MISMATCH
+
+            mentry = by_path.get(norm_path)
+            if mentry is None:
+                return ArchiveErrorCode.ENTRY_NOT_IN_MANIFEST
+            if mentry.type != etype:
+                return ArchiveErrorCode.ENTRY_TYPE_MISMATCH
+            if int(mentry.mode, 8) != mode_val:
+                return ArchiveErrorCode.ENTRY_MODE_MISMATCH
+            if mentry.size != size_val:
+                return ArchiveErrorCode.ENTRY_SIZE_MISMATCH
+
+            mc += 1
+            if mc > MAX_MEMBERS:
+                return ArchiveErrorCode.TOO_MANY_MEMBERS
+
+            if etype == "directory":
+                dc += 1
+                if dc > MAX_DIRECTORIES:
+                    return ArchiveErrorCode.TOO_MANY_DIRS
+                dirs.add(norm_path)
+            else:
+                fc += 1
+                if fc > MAX_REGULAR_FILES:
+                    return ArchiveErrorCode.TOO_MANY_FILES
+                tfb += size_val
+                if tfb > MAX_TOTAL_FILE_BYTES:
+                    return ArchiveErrorCode.TOTAL_BYTES_EXCEEDED
+
+                fres = size_val
+                total_data = ((size_val + _TAR_BLOCK - 1) // _TAR_BLOCK) * _TAR_BLOCK
+                fpad = total_data - size_val
+                fsha = mentry.sha256 if mentry.sha256 is not None else ""
+                fin = True
+
+        return None
+
+    try:
+        while not decomp.eof:
+            if carryover:
+                input_size = len(carryover)
+                input_view = memoryview(carryover)
+                try:
+                    try:
+                        output = decomp.decompress(input_view, _D_BUF)
+                    except zlib.error:
+                        return ArchiveErrorCode.GZIP_ERROR
+                finally:
+                    input_view.release()
+                unconsumed = decomp.unconsumed_tail
+                for index in range(len(carryover)):
+                    carryover[index] = 0
+                carryover.clear()
+                carryover.extend(unconsumed)
+                if not output and len(carryover) >= input_size and not decomp.eof:
+                    return ArchiveErrorCode.NO_PROGRESS
+            else:
+                if comp_offset >= compressed_limit:
+                    return ArchiveErrorCode.COMPRESSED_TRUNCATED
+                requested = min(_C_BUF, compressed_limit - comp_offset)
+                read_view = memoryview(compressed_buffer)[:requested]
+                try:
+                    try:
+                        count = os.preadv(fd, [read_view], comp_offset)
+                    except OSError:
+                        return ArchiveErrorCode.PREAD_ERROR
+                finally:
+                    read_view.release()
+                if count == 0:
+                    return ArchiveErrorCode.COMPRESSED_TRUNCATED
+                if count < 0 or count > requested:
+                    return ArchiveErrorCode.PREADV_EXTRA
+                comp_offset += count
+                input_view = memoryview(compressed_buffer)[:count]
+                try:
+                    try:
+                        output = decomp.decompress(input_view, _D_BUF)
+                    except zlib.error:
+                        return ArchiveErrorCode.GZIP_ERROR
+                finally:
+                    input_view.release()
+                unconsumed = decomp.unconsumed_tail
+                carryover.extend(unconsumed)
+                for index in range(count):
+                    compressed_buffer[index] = 0
+
+            if output:
+                dtot += len(output)
+                if dtot > MAX_DECOMPRESSED_TAR:
+                    return ArchiveErrorCode.DECOMPRESSED_TOO_LARGE
+                process_error = _process_data(output)
+                if process_error is not None:
+                    return process_error
+
+        if decomp.unused_data:
+            return ArchiveErrorCode.GZIP_TRAILING_DATA
+        if carryover:
+            return ArchiveErrorCode.GZIP_UNUSED_DATA
+        if comp_offset != compressed_limit:
+            return ArchiveErrorCode.GZIP_EOF_PREMATURE
+
+        # ---- Process remaining header buffer at EOF -----------------------
+        if hdr:
+            if zc == 1 and any(hdr):
+                return ArchiveErrorCode.UNPAIRED_ZERO_BLOCK
+            if past and any(hdr):
+                return ArchiveErrorCode.TAIL_NONZERO
+            return ArchiveErrorCode.ZERO_BLOCK_PARTIAL_HEADER
+
+        # ---- Final checks -------------------------------------------------
+        if zc == 1:
+            return ArchiveErrorCode.ONE_ZERO_BLOCK
+        if not past:
+            return ArchiveErrorCode.NO_ZERO_BLOCKS
+
+        # Reject if still mid-file (active/incomplete file)
+        if fin:
+            return ArchiveErrorCode.ACTIVE_FILE_INCOMPLETE
+        if fpad > 0:
+            return ArchiveErrorCode.NON_ZERO_PADDING
+
+        if mc != len(manifest.entries):
+            return ArchiveErrorCode.MEMBER_COUNT_MISMATCH
+        if fc != mfc:
+            return ArchiveErrorCode.FILE_COUNT_MISMATCH
+        if dc != mdc:
+            return ArchiveErrorCode.DIR_COUNT_MISMATCH
+        if tfb != manifest.total_regular_bytes:
+            return ArchiveErrorCode.TOTAL_BYTES_MISMATCH
+        if dtot != manifest.decompressed_tar_bytes:
+            return ArchiveErrorCode.DECOMPRESSED_SIZE_MISMATCH
+
+        # Total decompressed bytes must be multiple of 512
+        if dtot % _TAR_BLOCK != 0:
+            return ArchiveErrorCode.TOTAL_NOT_MULTIPLE_512
+
+        return None
+
+    finally:
+        for index in range(len(compressed_buffer)):
+            compressed_buffer[index] = 0
+        for index in range(len(carryover)):
+            carryover[index] = 0
+        for index in range(len(hdr)):
+            hdr[index] = 0
+        carryover.clear()
+        hdr.clear()
+        h = hashlib.sha256()
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def verify_archive(
+    fd: int,
+    identity: ArchiveIdentity,
+    manifest: Manifest,
+) -> VerifyResult:
+    """Phase 1: verify a sandbox official-release archive.
+
+    True streaming: incremental preadv -> zlib -> tar state machine.
+    Never allocates the full compressed archive or decompressed tar.
+    Never closes caller fd.  Bounded fixed-size buffers.
+    Returns frozen result with fixed error codes only.
+    """
+    err = _validate_identity(identity)
+    if err is not None:
+        return VerifyArchiveFailure(code=err)
+    err = _validate_manifest(manifest, identity)
+    if err is not None:
+        return VerifyArchiveFailure(code=err)
+    if type(fd) is not int or fd < 0:
+        return VerifyArchiveFailure(code=ArchiveErrorCode.BAD_FD_FIELD)
+
+    try:
+        snap, err = _fstat_validate(fd, identity.compressed_bytes)
+        if err is not None:
+            return VerifyArchiveFailure(code=err)
+
+        err = _hash_compressed(fd, identity.compressed_bytes, identity.compressed_sha256)
+        if err is not None:
+            return VerifyArchiveFailure(code=err)
+
+        err = _fstat_unchanged(fd, snap)
+        if err is not None:
+            return VerifyArchiveFailure(code=err)
+
+        try:
+            tar_err = _verify_streaming(fd, identity.compressed_bytes, manifest)
+        except Exception:
+            return VerifyArchiveFailure(code=ArchiveErrorCode.INTERNAL_ERROR)
+
+        if tar_err is not None:
+            return VerifyArchiveFailure(code=tar_err)
+
+        err = _fstat_unchanged(fd, snap)
+        if err is not None:
+            return VerifyArchiveFailure(code=err)
+
+        return VerifyArchiveSuccess()
+    finally:
+        pass

--- a/prime-agent-runtime/src/rlm/sandbox_release_extract.py
+++ b/prime-agent-runtime/src/rlm/sandbox_release_extract.py
@@ -1,0 +1,941 @@
+"""Phase 2: fd-relative extraction of a verified official release.
+
+The archive parser remains single-source in ``sandbox_release_archive``.  This
+module supplies a synchronous sink that writes only beneath a freshly claimed,
+caller-owned directory.  Python 3.11 has fd-relative ``os.open``/``os.mkdir``
+operations but no ``os.openat``/``os.mkdirat`` names.
+
+Residual: a hostile process with the same uid can race names inside a directory
+that it can write.  Production must keep the supplied parent directory private
+and exact mode 0700 for the complete invocation.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import hashlib
+import os
+import re
+import stat
+from collections.abc import Callable
+from typing import Final
+
+from .sandbox_release_archive import (
+    ArchiveErrorCode,
+    ArchiveIdentity,
+    Manifest,
+    ManifestEntry,
+    VerifyArchiveFailure,
+    _fstat_unchanged,
+    _fstat_validate,
+    _parent_path,
+    _TarSink,
+    _validate_identity,
+    _validate_manifest,
+    _verify_streaming,
+    verify_archive,
+)
+
+_CANDIDATE_RE: Final = re.compile(r"^[a-z][a-z0-9-]{15,63}$")
+_REQUIRED_FILES: Final[dict[str, int]] = {
+    "prime-agent": 0o755,
+    "package.json": 0o644,
+    "install.sh": 0o755,
+    "photon_rs_bg.wasm": 0o644,
+    "prime-agent-runtime/pyproject.toml": 0o644,
+}
+_REQUIRED_SKILLS: Final[tuple[str, ...]] = (
+    "agent-message",
+    "agent-observe",
+    "compact",
+    "goal",
+    "refine",
+    "rlm-heartbeat",
+)
+_ELF_PREFIX_BYTES: Final[int] = 64
+_ROOT_CAPABILITY_TOKEN: Final[object] = object()
+
+
+class ExtractErrorCode(enum.StrEnum):
+    BAD_PARENT_FD = "bad_parent_fd"
+    PARENT_STAT_FAILED = "parent_stat_failed"
+    PARENT_NOT_DIRECTORY = "parent_not_directory"
+    PARENT_NOT_OWNER = "parent_not_owner"
+    PARENT_BAD_MODE = "parent_bad_mode"
+    PARENT_CHANGED = "parent_changed"
+    BAD_CANDIDATE = "bad_candidate"
+    REQUIRED_ENTRY_MISSING = "required_entry_missing"
+    REQUIRED_ENTRY_INVALID = "required_entry_invalid"
+    CANDIDATE_EXISTS = "candidate_exists"
+    ENTRY_EXISTS = "entry_exists"
+    DIRECTORY_CREATE_FAILED = "directory_create_failed"
+    DIRECTORY_OPEN_FAILED = "directory_open_failed"
+    DIRECTORY_IDENTITY_CHANGED = "directory_identity_changed"
+    FILE_CREATE_FAILED = "file_create_failed"
+    FILE_WRITE_FAILED = "file_write_failed"
+    FILE_IDENTITY_CHANGED = "file_identity_changed"
+    FILE_CLOSE_FAILED = "file_close_failed"
+    MODE_APPLY_FAILED = "mode_apply_failed"
+    SYNC_FAILED = "sync_failed"
+    ELF_INVALID = "elf_invalid"
+    CLEANUP_UNCERTAIN = "cleanup_uncertain"
+    INTERNAL_ERROR = "internal_error"
+
+
+@dataclasses.dataclass(frozen=True)
+class ExtractArchiveFailure:
+    code: ArchiveErrorCode | ExtractErrorCode
+
+    def __post_init__(self) -> None:
+        if type(self.code) not in (ArchiveErrorCode, ExtractErrorCode):
+            raise ValueError("invalid extraction error code")
+
+
+class RuntimeRootCapability:
+    """Nominal root authority.  It never reveals the fd or path."""
+
+    __slots__ = ("__close", "__verify")
+
+    def __init__(
+        self,
+        token: object,
+        verify: Callable[[], bool],
+        close: Callable[[], bool],
+    ) -> None:
+        if token is not _ROOT_CAPABILITY_TOKEN or not callable(verify) or not callable(close):
+            raise ValueError("invalid runtime root capability")
+        self.__verify = verify
+        self.__close = close
+
+    def verify(self) -> bool:
+        return self.__verify()
+
+    def close(self) -> bool:
+        return self.__close()
+
+
+@dataclasses.dataclass(frozen=True)
+class ExtractArchiveSuccess:
+    root: RuntimeRootCapability
+
+    def __post_init__(self) -> None:
+        if type(self.root) is not RuntimeRootCapability:
+            raise ValueError("invalid runtime root capability")
+
+
+ExtractResult = ExtractArchiveSuccess | ExtractArchiveFailure
+
+
+@dataclasses.dataclass(frozen=True)
+class _DirIdentity:
+    dev: int
+    ino: int
+    uid: int
+
+
+@dataclasses.dataclass
+class _DirRecord:
+    path: str
+    parent_path: str | None
+    name: str
+    fd: int
+    identity: _DirIdentity
+    mode: int
+    nlink: int | None
+
+
+@dataclasses.dataclass
+class _FileRecord:
+    path: str
+    parent_path: str
+    name: str
+    fd: int
+    identity: _DirIdentity
+    expected_mode: int
+    expected_size: int
+    expected_sha256: str
+    offset: int
+    hasher: object
+    elf_prefix: bytearray
+
+
+class _ExtractAbort(Exception):
+    __slots__ = ("code",)
+
+    def __init__(self, code: ExtractErrorCode) -> None:
+        super().__init__(code.value)
+        self.code = code
+
+
+def _mode_exact(mode: int, expected: int) -> bool:
+    return stat.S_IMODE(mode) == expected and (mode & 0o7000) == 0
+
+
+def _stat_identity(value: os.stat_result) -> _DirIdentity | None:
+    try:
+        if type(value.st_dev) is not int or type(value.st_ino) is not int or type(value.st_uid) is not int:
+            return None
+        if value.st_dev < 0 or value.st_ino <= 0 or value.st_uid < 0:
+            return None
+        return _DirIdentity(value.st_dev, value.st_ino, value.st_uid)
+    except Exception:
+        return None
+
+
+def _same_identity(left: _DirIdentity, right: _DirIdentity) -> bool:
+    return left.dev == right.dev and left.ino == right.ino and left.uid == right.uid
+
+
+def _current_uid() -> int | None:
+    try:
+        uid = os.getuid()
+    except Exception:
+        return None
+    if type(uid) is not int or uid < 0:
+        return None
+    return uid
+
+
+def _safe_close(fd: int) -> bool:
+    try:
+        os.close(fd)
+        return True
+    except Exception:
+        return False
+
+
+def _validate_parent(fd: int) -> tuple[_DirIdentity | None, ExtractErrorCode | None]:
+    if type(fd) is not int or fd < 0:
+        return None, ExtractErrorCode.BAD_PARENT_FD
+    try:
+        value = os.fstat(fd)
+    except Exception:
+        return None, ExtractErrorCode.PARENT_STAT_FAILED
+    identity = _stat_identity(value)
+    if identity is None:
+        return None, ExtractErrorCode.PARENT_STAT_FAILED
+    if not stat.S_ISDIR(value.st_mode):
+        return None, ExtractErrorCode.PARENT_NOT_DIRECTORY
+    uid = _current_uid()
+    if uid is None:
+        return None, ExtractErrorCode.PARENT_STAT_FAILED
+    if identity.uid != uid:
+        return None, ExtractErrorCode.PARENT_NOT_OWNER
+    if not _mode_exact(value.st_mode, 0o700):
+        return None, ExtractErrorCode.PARENT_BAD_MODE
+    return identity, None
+
+
+def _parent_unchanged(fd: int, expected: _DirIdentity) -> ExtractErrorCode | None:
+    current, error = _validate_parent(fd)
+    if error is not None:
+        return ExtractErrorCode.PARENT_CHANGED
+    if current is None or not _same_identity(current, expected):
+        return ExtractErrorCode.PARENT_CHANGED
+    return None
+
+
+def _validate_required_manifest(manifest: Manifest) -> ExtractErrorCode | None:
+    by_path = {entry.path: entry for entry in manifest.entries}
+    for path, mode in _REQUIRED_FILES.items():
+        entry = by_path.get(path)
+        if entry is None:
+            return ExtractErrorCode.REQUIRED_ENTRY_MISSING
+        if (
+            entry.type != "file"
+            or entry.mode != f"0{mode:o}"
+            or entry.sha256 is None
+            or entry.size == 0
+        ):
+            return ExtractErrorCode.REQUIRED_ENTRY_INVALID
+        if path == "prime-agent" and entry.size < _ELF_PREFIX_BYTES:
+            return ExtractErrorCode.REQUIRED_ENTRY_INVALID
+    skills = by_path.get("skills")
+    if skills is None or skills.type != "directory" or skills.mode != "0755":
+        return ExtractErrorCode.REQUIRED_ENTRY_MISSING
+    for name in _REQUIRED_SKILLS:
+        directory = by_path.get(f"skills/{name}")
+        skill = by_path.get(f"skills/{name}/SKILL.md")
+        if directory is None or directory.type != "directory" or directory.mode != "0755":
+            return ExtractErrorCode.REQUIRED_ENTRY_MISSING
+        if skill is None or skill.type != "file" or skill.mode != "0644" or skill.sha256 is None or skill.size == 0:
+            return ExtractErrorCode.REQUIRED_ENTRY_INVALID
+    return None
+
+
+def _verify_elf(prefix: bytearray) -> bool:
+    if len(prefix) < _ELF_PREFIX_BYTES:
+        return False
+    if bytes(prefix[0:4]) != b"\x7fELF":
+        return False
+    if prefix[4] != 2 or prefix[5] != 1 or prefix[6] != 1:
+        return False
+    if prefix[7] not in (0, 3):
+        return False
+    if int.from_bytes(prefix[16:18], "little") not in (2, 3):
+        return False
+    if int.from_bytes(prefix[18:20], "little") != 62:
+        return False
+    if int.from_bytes(prefix[20:24], "little") != 1:
+        return False
+    return True
+
+
+class _ExtractionSink(_TarSink):
+    def __init__(
+        self,
+        parent_fd: int,
+        parent_identity: _DirIdentity,
+        candidate: str,
+        root_fd: int,
+        root_identity: _DirIdentity,
+    ) -> None:
+        self.parent_fd = parent_fd
+        self.parent_identity = parent_identity
+        self.candidate = candidate
+        self.directories: dict[str, _DirRecord] = {
+            ".": _DirRecord(".", None, candidate, root_fd, root_identity, 0o700, None)
+        }
+        self.files: list[_FileRecord] = []
+        self.current: _FileRecord | None = None
+        self.tree_synced = False
+        self.finalized = False
+        self.compressed_hasher = hashlib.sha256()
+
+    def compressed_data(self, chunk: memoryview) -> ArchiveErrorCode | None:
+        self.compressed_hasher.update(chunk)
+        return None
+
+    def compressed_matches(self, expected: str) -> bool:
+        return self.compressed_hasher.hexdigest() == expected
+
+    def _abort(self, code: ExtractErrorCode) -> None:
+        raise _ExtractAbort(code)
+
+    def _directory_stable(
+        self,
+        record: _DirRecord,
+        expected_mode: int,
+        *,
+        freeze_nlink: bool = False,
+        refresh_nlink: bool = False,
+    ) -> bool:
+        try:
+            by_fd = os.fstat(record.fd)
+            fd_identity = _stat_identity(by_fd)
+            if fd_identity is None or not _same_identity(fd_identity, record.identity):
+                return False
+            if not stat.S_ISDIR(by_fd.st_mode) or by_fd.st_uid != _current_uid():
+                return False
+            if not _mode_exact(by_fd.st_mode, expected_mode):
+                return False
+            if record.parent_path is None:
+                parent_fd = self.parent_fd
+            else:
+                parent = self.directories.get(record.parent_path)
+                if parent is None:
+                    return False
+                parent_fd = parent.fd
+            by_name = os.stat(record.name, dir_fd=parent_fd, follow_symlinks=False)
+            named_identity = _stat_identity(by_name)
+            stable = (
+                named_identity is not None
+                and _same_identity(named_identity, record.identity)
+                and stat.S_ISDIR(by_name.st_mode)
+                and _mode_exact(by_name.st_mode, expected_mode)
+                and type(by_fd.st_nlink) is int
+                and type(by_name.st_nlink) is int
+                and by_fd.st_nlink >= 2
+                and by_fd.st_nlink == by_name.st_nlink
+                and (
+                    refresh_nlink
+                    or record.nlink is None
+                    or by_fd.st_nlink == record.nlink
+                )
+            )
+            if stable and (freeze_nlink or refresh_nlink):
+                record.nlink = by_fd.st_nlink
+            return stable
+        except Exception:
+            return False
+
+    def _file_stable(self, record: _FileRecord, expected_mode: int) -> bool:
+        parent = self.directories.get(record.parent_path)
+        if parent is None:
+            return False
+        try:
+            by_fd = os.fstat(record.fd)
+            fd_identity = _stat_identity(by_fd)
+            by_name = os.stat(record.name, dir_fd=parent.fd, follow_symlinks=False)
+            named_identity = _stat_identity(by_name)
+            return (
+                fd_identity is not None
+                and named_identity is not None
+                and _same_identity(fd_identity, record.identity)
+                and _same_identity(named_identity, record.identity)
+                and stat.S_ISREG(by_fd.st_mode)
+                and stat.S_ISREG(by_name.st_mode)
+                and by_fd.st_uid == _current_uid()
+                and by_name.st_uid == _current_uid()
+                and by_fd.st_nlink == 1
+                and by_name.st_nlink == 1
+                and by_fd.st_size == record.expected_size
+                and by_name.st_size == record.expected_size
+                and _mode_exact(by_fd.st_mode, expected_mode)
+                and _mode_exact(by_name.st_mode, expected_mode)
+            )
+        except Exception:
+            return False
+
+    def directory(self, path: str, mode: int, entry: ManifestEntry) -> ArchiveErrorCode | None:
+        if path == ".":
+            root = self.directories["."]
+            if not self._directory_stable(root, 0o700):
+                self._abort(ExtractErrorCode.DIRECTORY_IDENTITY_CHANGED)
+            return None
+        parent_path = _parent_path(path)
+        if parent_path is None:
+            self._abort(ExtractErrorCode.INTERNAL_ERROR)
+        parent = self.directories.get(parent_path)
+        if parent is None:
+            self._abort(ExtractErrorCode.DIRECTORY_IDENTITY_CHANGED)
+        name = path.rsplit("/", 1)[-1]
+        try:
+            os.mkdir(name, 0o700, dir_fd=parent.fd)
+        except FileExistsError:
+            self._abort(ExtractErrorCode.ENTRY_EXISTS)
+        except Exception:
+            self._abort(ExtractErrorCode.DIRECTORY_CREATE_FAILED)
+        try:
+            child_fd = os.open(
+                name,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+                dir_fd=parent.fd,
+            )
+        except Exception:
+            self._abort(ExtractErrorCode.DIRECTORY_OPEN_FAILED)
+        try:
+            value = os.fstat(child_fd)
+            named = os.stat(name, dir_fd=parent.fd, follow_symlinks=False)
+            identity = _stat_identity(value)
+            named_identity = _stat_identity(named)
+            if (
+                identity is None
+                or named_identity is None
+                or not _same_identity(identity, named_identity)
+                or not stat.S_ISDIR(value.st_mode)
+                or not _mode_exact(value.st_mode, 0o700)
+                or value.st_uid != _current_uid()
+            ):
+                self._abort(ExtractErrorCode.DIRECTORY_IDENTITY_CHANGED)
+            self.directories[path] = _DirRecord(path, parent_path, name, child_fd, identity, 0o700, None)
+        except _ExtractAbort:
+            _safe_close(child_fd)
+            raise
+        except Exception:
+            _safe_close(child_fd)
+            self._abort(ExtractErrorCode.DIRECTORY_IDENTITY_CHANGED)
+        return None
+
+    def begin_file(
+        self, path: str, mode: int, size: int, entry: ManifestEntry
+    ) -> ArchiveErrorCode | None:
+        if self.current is not None:
+            self._abort(ExtractErrorCode.INTERNAL_ERROR)
+        parent_path = _parent_path(path)
+        if parent_path is None:
+            self._abort(ExtractErrorCode.INTERNAL_ERROR)
+        parent = self.directories.get(parent_path)
+        if parent is None:
+            self._abort(ExtractErrorCode.DIRECTORY_IDENTITY_CHANGED)
+        name = path.rsplit("/", 1)[-1]
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC
+        try:
+            file_fd = os.open(name, flags, 0o600, dir_fd=parent.fd)
+        except FileExistsError:
+            self._abort(ExtractErrorCode.ENTRY_EXISTS)
+        except Exception:
+            self._abort(ExtractErrorCode.FILE_CREATE_FAILED)
+        try:
+            value = os.fstat(file_fd)
+            named = os.stat(name, dir_fd=parent.fd, follow_symlinks=False)
+            identity = _stat_identity(value)
+            named_identity = _stat_identity(named)
+            expected_sha = entry.sha256
+            if (
+                identity is None
+                or named_identity is None
+                or not _same_identity(identity, named_identity)
+                or expected_sha is None
+                or not stat.S_ISREG(value.st_mode)
+                or value.st_uid != _current_uid()
+                or value.st_nlink != 1
+                or value.st_size != 0
+                or not _mode_exact(value.st_mode, 0o600)
+            ):
+                self._abort(ExtractErrorCode.FILE_IDENTITY_CHANGED)
+            record = _FileRecord(
+                path,
+                parent_path,
+                name,
+                file_fd,
+                identity,
+                mode,
+                size,
+                expected_sha,
+                0,
+                hashlib.sha256(),
+                bytearray(),
+            )
+            self.files.append(record)
+            self.current = record
+        except _ExtractAbort:
+            _safe_close(file_fd)
+            raise
+        except Exception:
+            _safe_close(file_fd)
+            self._abort(ExtractErrorCode.FILE_IDENTITY_CHANGED)
+        return None
+
+    def write_file(self, chunk: memoryview) -> ArchiveErrorCode | None:
+        record = self.current
+        if record is None:
+            self._abort(ExtractErrorCode.INTERNAL_ERROR)
+        position = 0
+        while position < len(chunk):
+            try:
+                written = os.pwrite(record.fd, chunk[position:], record.offset)
+            except Exception:
+                self._abort(ExtractErrorCode.FILE_WRITE_FAILED)
+            if type(written) is not int or written <= 0 or written > len(chunk) - position:
+                self._abort(ExtractErrorCode.FILE_WRITE_FAILED)
+            piece = chunk[position:position + written]
+            try:
+                record.hasher.update(piece)
+                if record.path == "prime-agent" and len(record.elf_prefix) < _ELF_PREFIX_BYTES:
+                    wanted = min(_ELF_PREFIX_BYTES - len(record.elf_prefix), len(piece))
+                    record.elf_prefix.extend(piece[:wanted])
+            finally:
+                piece.release()
+            record.offset += written
+            position += written
+        if record.offset > record.expected_size:
+            self._abort(ExtractErrorCode.FILE_WRITE_FAILED)
+        return None
+
+    def finish_file(self) -> ArchiveErrorCode | None:
+        record = self.current
+        if record is None:
+            self._abort(ExtractErrorCode.INTERNAL_ERROR)
+        if record.offset != record.expected_size or record.hasher.hexdigest() != record.expected_sha256:
+            self._abort(ExtractErrorCode.FILE_IDENTITY_CHANGED)
+        if record.path == "prime-agent" and not _verify_elf(record.elf_prefix):
+            self._abort(ExtractErrorCode.ELF_INVALID)
+        try:
+            os.fchmod(record.fd, record.expected_mode)
+        except Exception:
+            self._abort(ExtractErrorCode.MODE_APPLY_FAILED)
+        try:
+            os.fsync(record.fd)
+        except Exception:
+            self._abort(ExtractErrorCode.SYNC_FAILED)
+        if not self._file_stable(record, record.expected_mode):
+            self._abort(ExtractErrorCode.FILE_IDENTITY_CHANGED)
+        for index in range(len(record.elf_prefix)):
+            record.elf_prefix[index] = 0
+        if not _safe_close(record.fd):
+            self._abort(ExtractErrorCode.FILE_CLOSE_FAILED)
+        record.fd = -1
+        self.current = None
+        return None
+
+    def finish_archive(self) -> ArchiveErrorCode | None:
+        if self.current is not None:
+            self._abort(ExtractErrorCode.INTERNAL_ERROR)
+        ordered = sorted(
+            (record for path, record in self.directories.items() if path != "."),
+            key=lambda record: record.path.count("/"),
+            reverse=True,
+        )
+        for record in ordered:
+            try:
+                os.fchmod(record.fd, 0o755)
+                record.mode = 0o755
+            except Exception:
+                self._abort(ExtractErrorCode.MODE_APPLY_FAILED)
+            try:
+                os.fsync(record.fd)
+            except Exception:
+                self._abort(ExtractErrorCode.SYNC_FAILED)
+            if not self._directory_stable(record, 0o755, freeze_nlink=True):
+                self._abort(ExtractErrorCode.DIRECTORY_IDENTITY_CHANGED)
+        root = self.directories["."]
+        try:
+            os.fchmod(root.fd, 0o700)
+            os.fsync(root.fd)
+            os.fsync(self.parent_fd)
+        except Exception:
+            self._abort(ExtractErrorCode.SYNC_FAILED)
+        if not self._directory_stable(root, 0o700, freeze_nlink=True):
+            self._abort(ExtractErrorCode.DIRECTORY_IDENTITY_CHANGED)
+        if _parent_unchanged(self.parent_fd, self.parent_identity) is not None:
+            self._abort(ExtractErrorCode.PARENT_CHANGED)
+        self.tree_synced = True
+        return None
+
+    def seal_success(self) -> None:
+        if not self.tree_synced or self.current is not None:
+            self._abort(ExtractErrorCode.INTERNAL_ERROR)
+        ordered = sorted(
+            (record for path, record in self.directories.items() if path != "."),
+            key=lambda record: record.path.count("/"),
+            reverse=True,
+        )
+        for record in ordered:
+            if not self._directory_stable(record, 0o755):
+                self._abort(ExtractErrorCode.DIRECTORY_IDENTITY_CHANGED)
+        root = self.directories["."]
+        if not self._directory_stable(root, 0o700):
+            self._abort(ExtractErrorCode.DIRECTORY_IDENTITY_CHANGED)
+        if _parent_unchanged(self.parent_fd, self.parent_identity) is not None:
+            self._abort(ExtractErrorCode.PARENT_CHANGED)
+        self.finalized = True
+
+    def cleanup(self) -> bool:
+        ok = True
+        current = self.current
+        if current is not None and current.fd >= 0:
+            if not _safe_close(current.fd):
+                ok = False
+            current.fd = -1
+        self.current = None
+        for record in self.files:
+            for index in range(len(record.elf_prefix)):
+                record.elf_prefix[index] = 0
+            if record.fd >= 0:
+                if not _safe_close(record.fd):
+                    ok = False
+                record.fd = -1
+        if not ok:
+            return False
+        for record in self.directories.values():
+            if record.fd >= 0:
+                if not self._directory_stable(record, record.mode):
+                    return False
+                try:
+                    os.fchmod(record.fd, 0o700)
+                    record.mode = 0o700
+                except Exception:
+                    return False
+                if not self._directory_stable(record, 0o700):
+                    return False
+        for record in reversed(self.files):
+            parent = self.directories.get(record.parent_path)
+            if parent is None:
+                return False
+            try:
+                value = os.stat(record.name, dir_fd=parent.fd, follow_symlinks=False)
+                identity = _stat_identity(value)
+                if (
+                    identity is None
+                    or not _same_identity(identity, record.identity)
+                    or not stat.S_ISREG(value.st_mode)
+                    or value.st_nlink != 1
+                    or value.st_uid != _current_uid()
+                    or not self._directory_stable(parent, 0o700)
+                ):
+                    return False
+                os.unlink(record.name, dir_fd=parent.fd)
+                if not self._directory_stable(
+                    parent, 0o700, refresh_nlink=True
+                ):
+                    return False
+            except Exception:
+                return False
+        ordered = sorted(
+            (record for path, record in self.directories.items() if path != "."),
+            key=lambda record: record.path.count("/"),
+            reverse=True,
+        )
+        for record in ordered:
+            parent = self.directories.get(record.parent_path or "")
+            if parent is None or not self._directory_stable(record, 0o700):
+                return False
+            if not _safe_close(record.fd):
+                return False
+            record.fd = -1
+            try:
+                named = os.stat(record.name, dir_fd=parent.fd, follow_symlinks=False)
+                named_identity = _stat_identity(named)
+                if (
+                    named_identity is None
+                    or not _same_identity(named_identity, record.identity)
+                    or not stat.S_ISDIR(named.st_mode)
+                    or not _mode_exact(named.st_mode, 0o700)
+                ):
+                    return False
+                os.rmdir(record.name, dir_fd=parent.fd)
+                if not self._directory_stable(
+                    parent, 0o700, refresh_nlink=True
+                ):
+                    return False
+            except Exception:
+                return False
+        root = self.directories["."]
+        if not self._directory_stable(root, 0o700):
+            return False
+        if _parent_unchanged(self.parent_fd, self.parent_identity) is not None:
+            return False
+        if not _safe_close(root.fd):
+            return False
+        root.fd = -1
+        try:
+            named = os.stat(self.candidate, dir_fd=self.parent_fd, follow_symlinks=False)
+            named_identity = _stat_identity(named)
+            if (
+                named_identity is None
+                or not _same_identity(named_identity, root.identity)
+                or not stat.S_ISDIR(named.st_mode)
+                or not _mode_exact(named.st_mode, 0o700)
+            ):
+                return False
+            os.rmdir(self.candidate, dir_fd=self.parent_fd)
+            os.fsync(self.parent_fd)
+        except Exception:
+            return False
+        return _parent_unchanged(self.parent_fd, self.parent_identity) is None
+
+    def make_capability(self) -> RuntimeRootCapability:
+        if not self.finalized:
+            self._abort(ExtractErrorCode.INTERNAL_ERROR)
+        records = tuple(self.directories.values())
+        state = {"closed": False}
+
+        def verify() -> bool:
+            if state["closed"]:
+                return False
+            for record in records:
+                try:
+                    value = os.fstat(record.fd)
+                    current = _stat_identity(value)
+                    if (
+                        current is None
+                        or not _same_identity(current, record.identity)
+                        or not stat.S_ISDIR(value.st_mode)
+                        or value.st_uid != _current_uid()
+                        or type(value.st_nlink) is not int
+                        or record.nlink is None
+                        or value.st_nlink != record.nlink
+                        or not _mode_exact(value.st_mode, record.mode)
+                    ):
+                        return False
+                except Exception:
+                    return False
+            return True
+
+        def close() -> bool:
+            if state["closed"]:
+                return True
+            ok = True
+            for record in records:
+                if record.fd >= 0:
+                    if _safe_close(record.fd):
+                        record.fd = -1
+                    else:
+                        ok = False
+            state["closed"] = ok
+            return ok
+
+        return RuntimeRootCapability(_ROOT_CAPABILITY_TOKEN, verify, close)
+
+
+def _cleanup_safely(sink: _ExtractionSink) -> bool:
+    try:
+        return sink.cleanup()
+    except Exception:
+        return False
+
+
+def _remove_named_empty_claim(
+    parent_fd: int, candidate: str, identity: _DirIdentity
+) -> bool:
+    try:
+        named = os.stat(candidate, dir_fd=parent_fd, follow_symlinks=False)
+        named_identity = _stat_identity(named)
+        if (
+            named_identity is None
+            or not _same_identity(named_identity, identity)
+            or not stat.S_ISDIR(named.st_mode)
+            or named.st_uid != _current_uid()
+            or not _mode_exact(named.st_mode, 0o700)
+        ):
+            return False
+        os.rmdir(candidate, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+        return True
+    except Exception:
+        return False
+
+
+def _remove_empty_claim(
+    parent_fd: int,
+    candidate: str,
+    root_fd: int,
+    identity: _DirIdentity,
+    claimed_identity: _DirIdentity,
+) -> bool:
+    try:
+        by_fd = os.fstat(root_fd)
+        by_name = os.stat(candidate, dir_fd=parent_fd, follow_symlinks=False)
+        fd_identity = _stat_identity(by_fd)
+        named_identity = _stat_identity(by_name)
+        if (
+            fd_identity is None
+            or named_identity is None
+            or not _same_identity(fd_identity, identity)
+            or not _same_identity(named_identity, identity)
+            or not _same_identity(identity, claimed_identity)
+            or not stat.S_ISDIR(by_fd.st_mode)
+        ):
+            return False
+        if not _safe_close(root_fd):
+            return False
+        named_after_close = os.stat(candidate, dir_fd=parent_fd, follow_symlinks=False)
+        after_identity = _stat_identity(named_after_close)
+        if (
+            after_identity is None
+            or not _same_identity(after_identity, identity)
+            or not stat.S_ISDIR(named_after_close.st_mode)
+        ):
+            return False
+        os.rmdir(candidate, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except Exception:
+        return False
+    return True
+
+
+def extract_verified_archive(
+    archive_fd: int,
+    parent_fd: int,
+    candidate_name: str,
+    identity: ArchiveIdentity,
+    manifest: Manifest,
+) -> ExtractResult:
+    """Verify, claim, and extract without ever returning a path or raw fd."""
+    identity_error = _validate_identity(identity)
+    if identity_error is not None:
+        return ExtractArchiveFailure(identity_error)
+    manifest_error = _validate_manifest(manifest, identity)
+    if manifest_error is not None:
+        return ExtractArchiveFailure(manifest_error)
+    if type(candidate_name) is not str or _CANDIDATE_RE.fullmatch(candidate_name) is None:
+        return ExtractArchiveFailure(ExtractErrorCode.BAD_CANDIDATE)
+    required_error = _validate_required_manifest(manifest)
+    if required_error is not None:
+        return ExtractArchiveFailure(required_error)
+    if type(archive_fd) is not int or archive_fd < 0:
+        return ExtractArchiveFailure(ArchiveErrorCode.BAD_FD_FIELD)
+    parent_identity, parent_error = _validate_parent(parent_fd)
+    if parent_error is not None:
+        return ExtractArchiveFailure(parent_error)
+    if parent_identity is None:
+        return ExtractArchiveFailure(ExtractErrorCode.PARENT_STAT_FAILED)
+
+    verified = verify_archive(archive_fd, identity, manifest)
+    if type(verified) is VerifyArchiveFailure:
+        return ExtractArchiveFailure(verified.code)
+    if _parent_unchanged(parent_fd, parent_identity) is not None:
+        return ExtractArchiveFailure(ExtractErrorCode.PARENT_CHANGED)
+    archive_snap, archive_error = _fstat_validate(archive_fd, identity.compressed_bytes)
+    if archive_error is not None or archive_snap is None:
+        return ExtractArchiveFailure(archive_error or ArchiveErrorCode.FD_STAT_FAILED)
+
+    try:
+        os.mkdir(candidate_name, 0o700, dir_fd=parent_fd)
+    except FileExistsError:
+        return ExtractArchiveFailure(ExtractErrorCode.CANDIDATE_EXISTS)
+    except Exception:
+        return ExtractArchiveFailure(ExtractErrorCode.DIRECTORY_CREATE_FAILED)
+    try:
+        claimed_value = os.stat(candidate_name, dir_fd=parent_fd, follow_symlinks=False)
+        claimed_identity = _stat_identity(claimed_value)
+        if (
+            claimed_identity is None
+            or not stat.S_ISDIR(claimed_value.st_mode)
+            or claimed_value.st_uid != _current_uid()
+            or not _mode_exact(claimed_value.st_mode, 0o700)
+        ):
+            return ExtractArchiveFailure(ExtractErrorCode.CLEANUP_UNCERTAIN)
+    except Exception:
+        return ExtractArchiveFailure(ExtractErrorCode.CLEANUP_UNCERTAIN)
+    try:
+        root_fd = os.open(
+            candidate_name,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=parent_fd,
+        )
+    except Exception:
+        if not _remove_named_empty_claim(parent_fd, candidate_name, claimed_identity):
+            return ExtractArchiveFailure(ExtractErrorCode.CLEANUP_UNCERTAIN)
+        return ExtractArchiveFailure(ExtractErrorCode.DIRECTORY_OPEN_FAILED)
+    try:
+        root_value = os.fstat(root_fd)
+        root_named = os.stat(candidate_name, dir_fd=parent_fd, follow_symlinks=False)
+        root_identity = _stat_identity(root_value)
+        root_named_identity = _stat_identity(root_named)
+        if (
+            root_identity is None
+            or root_named_identity is None
+            or not _same_identity(root_identity, root_named_identity)
+            or not _same_identity(root_identity, claimed_identity)
+            or not stat.S_ISDIR(root_value.st_mode)
+            or root_value.st_uid != _current_uid()
+            or not _mode_exact(root_value.st_mode, 0o700)
+        ):
+            if root_identity is None or not _remove_empty_claim(
+                parent_fd, candidate_name, root_fd, root_identity, claimed_identity
+            ):
+                return ExtractArchiveFailure(ExtractErrorCode.CLEANUP_UNCERTAIN)
+            return ExtractArchiveFailure(ExtractErrorCode.DIRECTORY_IDENTITY_CHANGED)
+    except Exception:
+        _safe_close(root_fd)
+        return ExtractArchiveFailure(ExtractErrorCode.CLEANUP_UNCERTAIN)
+
+    sink = _ExtractionSink(parent_fd, parent_identity, candidate_name, root_fd, root_identity)
+    failure: ArchiveErrorCode | ExtractErrorCode | None = None
+    try:
+        stream_error = _verify_streaming(archive_fd, identity.compressed_bytes, manifest, sink)
+        if stream_error is not None:
+            failure = stream_error
+        elif not sink.compressed_matches(identity.compressed_sha256):
+            failure = ArchiveErrorCode.DIGEST_MISMATCH
+        else:
+            stable_error = _fstat_unchanged(archive_fd, archive_snap)
+            if stable_error is not None:
+                failure = stable_error
+            elif _parent_unchanged(parent_fd, parent_identity) is not None:
+                failure = ExtractErrorCode.PARENT_CHANGED
+            else:
+                sink.seal_success()
+    except _ExtractAbort as error:
+        failure = error.code
+    except Exception:
+        failure = ExtractErrorCode.INTERNAL_ERROR
+
+    if failure is not None:
+        if not _cleanup_safely(sink):
+            return ExtractArchiveFailure(ExtractErrorCode.CLEANUP_UNCERTAIN)
+        return ExtractArchiveFailure(failure)
+    if not sink.finalized:
+        if not _cleanup_safely(sink):
+            return ExtractArchiveFailure(ExtractErrorCode.CLEANUP_UNCERTAIN)
+        return ExtractArchiveFailure(ExtractErrorCode.INTERNAL_ERROR)
+    try:
+        capability = sink.make_capability()
+    except Exception:
+        if not _cleanup_safely(sink):
+            return ExtractArchiveFailure(ExtractErrorCode.CLEANUP_UNCERTAIN)
+        return ExtractArchiveFailure(ExtractErrorCode.INTERNAL_ERROR)
+    return ExtractArchiveSuccess(capability)

--- a/prime-agent-runtime/test/test_sandbox_release_archive.py
+++ b/prime-agent-runtime/test/test_sandbox_release_archive.py
@@ -1,0 +1,1292 @@
+"""Adversarial tests for sandbox_release_archive Phase 1 (streaming).
+
+Verifies incremental preadv->zlib->tar state machine, bounded buffers,
+fixed error codes (StrEnum), fd ownership, and all failure families.
+No test constructs arbitrary error codes.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import gzip
+import hashlib
+import io
+import os
+import tempfile
+import tarfile
+import unittest
+import zlib
+
+from unittest.mock import patch
+
+from rlm.sandbox_release_archive import (
+    MAX_COMPRESSED_BYTES,
+    MAX_DECOMPRESSED_TAR,
+    MAX_PER_FILE_BYTES,
+    _TAR_BLOCK,
+    ArchiveIdentity,
+    Manifest,
+    ManifestEntry,
+    VerifyArchiveSuccess,
+    VerifyArchiveFailure,
+    ArchiveErrorCode,
+    verify_archive,
+    _fstat_validate,
+    _fstat_unchanged,
+    _hash_compressed,
+    _octal_to_int,
+    _parse_tar_header,
+    _validate_path,
+    _validate_identity,
+    _validate_manifest,
+    _validate_entry,
+    _check_strict_dataclass,
+    _validate_cstring,
+    _verify_streaming,
+    _PREADV_BUF,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _gzip_compress(data: bytes) -> bytes:
+    buf = io.BytesIO()
+    with gzip.GzipFile(fileobj=buf, mode="wb") as f:
+        f.write(data)
+    return buf.getvalue()
+
+
+def _build_ustar_gz(entries, /):
+    """Return (gz_bytes, sha256, uncompressed_tar_bytes, manifest_dicts)."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz", format=tarfile.USTAR_FORMAT) as tf:
+        for entry in entries:
+            if entry["type"] == "dir":
+                directory_name = "./" if entry["name"] == "." else entry["name"].rstrip("/") + "/"
+                ti = tarfile.TarInfo(directory_name)
+                ti.type = tarfile.DIRTYPE
+                ti.mode = entry.get("mode", 0o755)
+                tf.addfile(ti)
+            else:
+                ti = tarfile.TarInfo(entry["name"])
+                ti.type = tarfile.REGTYPE
+                ti.mode = entry.get("mode", 0o644)
+                c = entry.get("content", b"")
+                ti.size = len(c)
+                tf.addfile(ti, io.BytesIO(c))
+    gz = buf.getvalue()
+    decomp = zlib.decompressobj(wbits=31)
+    tar_b = decomp.decompress(gz)
+    if not decomp.eof:
+        tar_b += decomp.flush()
+    sha = hashlib.sha256(gz).hexdigest()
+    mds = []
+    for e in entries:
+        if e["type"] == "dir":
+            manifest_path = "." if e["name"] in (".", "./") else e["name"].rstrip("/")
+            mds.append({"path": manifest_path, "type": "directory",
+                        "mode": oct(e.get("mode", 0o755))[2:].zfill(4),
+                        "size": 0, "sha256": None})
+        else:
+            c = e.get("content", b"")
+            cs = hashlib.sha256(c).hexdigest()
+            mds.append({"path": e["name"], "type": "file",
+                        "mode": oct(e.get("mode", 0o644))[2:].zfill(4),
+                        "size": len(c), "sha256": cs})
+    return gz, sha, tar_b, mds
+
+
+def _mkentry(d, /):
+    return ManifestEntry(path=d["path"], type=d["type"],
+                         mode=d["mode"], size=d["size"], sha256=d.get("sha256"))
+
+
+def _write_temp(data: bytes, /):
+    """Write data to temp file, return (read_fd, path)."""
+    fd, path = tempfile.mkstemp()
+    os.write(fd, data)
+    os.close(fd)
+    rfd = os.open(path, os.O_RDONLY)
+    return rfd, path
+
+
+def _build_valid_block():
+    """Build a valid 512-byte ustar directory header for '.' root."""
+    b = bytearray(512)
+    b[0:3] = b"./\x00"
+    b[100:108] = b"0000755\x00"
+    b[108:116] = b"0000000\x00"
+    b[116:124] = b"0000000\x00"
+    b[124:136] = b"00000000000\x00"
+    b[136:148] = b"00000000000\x00"
+    b[148:156] = b" " * 8
+    b[156:157] = b"5"
+    b[257:263] = b"ustar\x00"
+    b[263:265] = b"00"
+    b[329:337] = b"0000000\x00"
+    b[337:345] = b"0000000\x00"
+    # Uname/gname (cstrings)
+    b[265:297] = b"\x00" * 32
+    b[297:329] = b"\x00" * 32
+    computed = sum(b[:148]) + (32 * 8) + sum(b[156:])
+    chk = f"{computed:06o}\x00 ".encode()[:8].ljust(8, b"\x00")
+    b[148:156] = chk[:8]
+    return b
+
+
+def _rebuild_checksum(b: bytearray) -> None:
+    computed = sum(b[:148]) + (32 * 8) + sum(b[156:])
+    chk = f"{computed:06o}\x00 ".encode()[:8].ljust(8, b"\x00")
+    b[148:156] = chk[:8]
+
+
+# ===================================================================
+# Strict dataclass validation
+# ===================================================================
+
+class TestStrictDataclass(unittest.TestCase):
+    def test_valid_identity(self) -> None:
+        id_ = ArchiveIdentity(compressed_sha256="a" * 64, compressed_bytes=512)
+        err = _check_strict_dataclass(id_, {"compressed_sha256": str, "compressed_bytes": int})
+        self.assertIsNone(err)
+
+    def test_wrong_key(self) -> None:
+        id_ = ArchiveIdentity(compressed_sha256="a" * 64, compressed_bytes=512)
+        err = _check_strict_dataclass(id_, {"compressed_sha256": str, "compressed_bytes": int, "extra": str})
+        self.assertEqual(err, "bad_dataclass_key")
+
+    def test_subclass_type(self) -> None:
+        """bool is a subclass of int and must be rejected."""
+        id_ = ArchiveIdentity(compressed_sha256="a" * 64, compressed_bytes=True)
+        err = _check_strict_dataclass(id_, {"compressed_sha256": str, "compressed_bytes": int})
+        self.assertEqual(err, "bad_primitive_type")
+
+    def test_none_field(self) -> None:
+        @dataclasses.dataclass(frozen=True)
+        class Fake:
+            x: str | None = None
+        obj = Fake(x=None)
+        err = _check_strict_dataclass(obj, {"x": type(None)})
+        self.assertIsNone(err)
+
+
+# ===================================================================
+# Error code StrEnum
+# ===================================================================
+
+class TestErrorCodes(unittest.TestCase):
+    def test_code_is_enum(self) -> None:
+        self.assertIsInstance(ArchiveErrorCode.FD_BAD_MODE, ArchiveErrorCode)
+
+    def test_enum_values_are_strs(self) -> None:
+        # StrEnum values are comparable to str
+        self.assertEqual(ArchiveErrorCode.FD_BAD_MODE.value, "fd_bad_mode")
+
+    def test_no_arbitrary_codes(self) -> None:
+        """VerifyArchiveFailure only accepts ArchiveErrorCode, not arbitrary str."""
+        f = VerifyArchiveFailure(code=ArchiveErrorCode.DIGEST_MISMATCH)
+        self.assertIs(f.code, ArchiveErrorCode.DIGEST_MISMATCH)
+
+    def test_success_frozen(self) -> None:
+        s = VerifyArchiveSuccess()
+        with self.assertRaises(AttributeError):
+            s.new_attr = 1
+
+    def test_failure_frozen(self) -> None:
+        f = VerifyArchiveFailure(code=ArchiveErrorCode.BAD_PATH)
+        with self.assertRaises(AttributeError):
+            f.code = ArchiveErrorCode.BAD_TYPE
+
+
+# ===================================================================
+# Input validation
+# ===================================================================
+
+class TestValidateIdentity(unittest.TestCase):
+    def test_valid(self) -> None:
+        id_ = ArchiveIdentity(compressed_sha256="a" * 64, compressed_bytes=512)
+        self.assertIsNone(_validate_identity(id_))
+
+    def test_bad_sha_length(self) -> None:
+        id_ = ArchiveIdentity(compressed_sha256="abc", compressed_bytes=512)
+        self.assertEqual(_validate_identity(id_), ArchiveErrorCode.BAD_IDENTITY_FIELD)
+
+    def test_bad_sha_uppercase(self) -> None:
+        id_ = ArchiveIdentity(compressed_sha256="A" * 64, compressed_bytes=512)
+        self.assertEqual(_validate_identity(id_), ArchiveErrorCode.BAD_IDENTITY_FIELD)
+
+    def test_negative_size(self) -> None:
+        id_ = ArchiveIdentity(compressed_sha256="a" * 64, compressed_bytes=-1)
+        self.assertEqual(_validate_identity(id_), ArchiveErrorCode.BAD_IDENTITY_FIELD)
+
+    def test_zero_size(self) -> None:
+        id_ = ArchiveIdentity(compressed_sha256="a" * 64, compressed_bytes=0)
+        self.assertEqual(_validate_identity(id_), ArchiveErrorCode.BAD_IDENTITY_FIELD)
+
+    def test_overlarge(self) -> None:
+        id_ = ArchiveIdentity(compressed_sha256="a" * 64,
+                              compressed_bytes=MAX_COMPRESSED_BYTES + 1)
+        self.assertEqual(_validate_identity(id_), ArchiveErrorCode.BAD_IDENTITY_FIELD)
+
+
+
+    def test_bool_as_size(self) -> None:
+        """bool subclass of int must be rejected."""
+        id_ = ArchiveIdentity(compressed_sha256="a" * 64, compressed_bytes=True)
+        r = _validate_identity(id_)
+        # _check_strict_dataclass catches bool first
+        self.assertIn(r, (ArchiveErrorCode.BAD_PRIMITIVE_TYPE, ArchiveErrorCode.BAD_IDENTITY_FIELD))
+
+
+class TestValidateManifest(unittest.TestCase):
+    def test_valid(self) -> None:
+        e = ManifestEntry(path=".", type="directory", mode="0755", size=0, sha256=None)
+        m = Manifest(identity=ArchiveIdentity("a" * 64, 512),
+                     entries=(e,), total_regular_bytes=0, decompressed_tar_bytes=512)
+        self.assertIsNone(_validate_manifest(m))
+
+    def test_bad_entry_type(self) -> None:
+        e = ManifestEntry(path=".", type="symlink", mode="0755", size=0, sha256=None)
+        m = Manifest(identity=ArchiveIdentity("a" * 64, 512),
+                     entries=(e,), total_regular_bytes=0, decompressed_tar_bytes=512)
+        self.assertEqual(_validate_manifest(m), ArchiveErrorCode.BAD_MANIFEST_FIELD)
+
+    def test_dir_with_sha256(self) -> None:
+        e = ManifestEntry(path=".", type="directory", mode="0755", size=0, sha256="a" * 64)
+        m = Manifest(identity=ArchiveIdentity("a" * 64, 512),
+                     entries=(e,), total_regular_bytes=0, decompressed_tar_bytes=512)
+        self.assertEqual(_validate_manifest(m), ArchiveErrorCode.BAD_MANIFEST_FIELD)
+
+    def test_file_without_sha256(self) -> None:
+        e = ManifestEntry(path="f", type="file", mode="0644", size=5, sha256=None)
+        m = Manifest(identity=ArchiveIdentity("a" * 64, 512),
+                     entries=(e,), total_regular_bytes=5, decompressed_tar_bytes=512)
+        self.assertEqual(_validate_manifest(m), ArchiveErrorCode.BAD_MANIFEST_FIELD)
+
+    def test_total_bytes_mismatch(self) -> None:
+        e = ManifestEntry(path="f", type="file", mode="0644", size=5,
+                          sha256="a" * 64)
+        root = ManifestEntry(path=".", type="directory", mode="0755", size=0, sha256=None)
+        m = Manifest(identity=ArchiveIdentity("a" * 64, 512),
+                     entries=(root, e), total_regular_bytes=999,
+                     decompressed_tar_bytes=512)
+        self.assertEqual(_validate_manifest(m), ArchiveErrorCode.BAD_MANIFEST_FIELD)
+
+    def test_empty_entries(self) -> None:
+        m = Manifest(identity=ArchiveIdentity("a" * 64, 512),
+                     entries=(), total_regular_bytes=0, decompressed_tar_bytes=512)
+        self.assertEqual(_validate_manifest(m), ArchiveErrorCode.BAD_MANIFEST_FIELD)
+
+    def test_duplicate_path(self) -> None:
+        e1 = ManifestEntry(path="f", type="file", mode="0644", size=5,
+                           sha256="a" * 64)
+        e2 = ManifestEntry(path="f", type="file", mode="0644", size=5,
+                           sha256="a" * 64)
+        root = ManifestEntry(path=".", type="directory", mode="0755", size=0, sha256=None)
+        m = Manifest(identity=ArchiveIdentity("a" * 64, 512),
+                     entries=(root, e1, e2), total_regular_bytes=10,
+                     decompressed_tar_bytes=512)
+        self.assertEqual(_validate_manifest(m), ArchiveErrorCode.BAD_MANIFEST_FIELD)
+
+    def test_no_root_entry(self) -> None:
+        e = ManifestEntry(path="sub", type="directory", mode="0755", size=0, sha256=None)
+        m = Manifest(identity=ArchiveIdentity("a" * 64, 512),
+                     entries=(e,), total_regular_bytes=0, decompressed_tar_bytes=512)
+        self.assertEqual(_validate_manifest(m), ArchiveErrorCode.ROOT_ENTRY_MISSING)
+
+    def test_parent_before_child(self) -> None:
+        # child "sub/file" before parent "sub" should fail PARENT_ORDER
+        e1 = ManifestEntry(path="sub/file", type="file", mode="0644", size=5,
+                           sha256="a" * 64)
+        e2 = ManifestEntry(path="sub", type="directory", mode="0755", size=0, sha256=None)
+        root = ManifestEntry(path=".", type="directory", mode="0755", size=0, sha256=None)
+        m = Manifest(identity=ArchiveIdentity("a" * 64, 512),
+                     entries=(root, e1, e2), total_regular_bytes=5,
+                     decompressed_tar_bytes=512)
+        self.assertEqual(_validate_manifest(m), ArchiveErrorCode.PARENT_ORDER)
+
+    def test_decompressed_not_multiple_512(self) -> None:
+        e = ManifestEntry(path=".", type="directory", mode="0755", size=0, sha256=None)
+        m = Manifest(identity=ArchiveIdentity("a" * 64, 512),
+                     entries=(e,), total_regular_bytes=0, decompressed_tar_bytes=100)
+        self.assertEqual(_validate_manifest(m), ArchiveErrorCode.BAD_MANIFEST_FIELD)
+
+    def test_zero_length_file_empty_sha(self) -> None:
+        """Zero-length files must have SHA-256 of empty content."""
+        e = ManifestEntry(path="f", type="file", mode="0644", size=0,
+                          sha256="a" * 64)
+        root = ManifestEntry(path=".", type="directory", mode="0755", size=0, sha256=None)
+        m = Manifest(identity=ArchiveIdentity("a" * 64, 512),
+                     entries=(root, e), total_regular_bytes=0, decompressed_tar_bytes=512)
+        self.assertEqual(_validate_manifest(m), ArchiveErrorCode.ZERO_LENGTH_EMPTY_SHA)
+
+
+# ===================================================================
+# _fstat_validate / _fstat_unchanged
+# ===================================================================
+
+class TestFstatValidate(unittest.TestCase):
+    def test_regular_ok(self) -> None:
+        fd, path = _write_temp(b"data")
+        _, err = _fstat_validate(fd, 0)
+        os.close(fd)
+        os.unlink(path)
+        self.assertIsNone(err)
+
+    def test_pipe_rejected(self) -> None:
+        r, w = os.pipe()
+        _, err = _fstat_validate(r, 0)
+        os.close(r)
+        os.close(w)
+        self.assertEqual(err, ArchiveErrorCode.FD_NOT_REGULAR)
+
+
+class TestFstatUnchanged(unittest.TestCase):
+    def test_ok(self) -> None:
+        fd, path = _write_temp(b"data")
+        snap, err = _fstat_validate(fd, 0)
+        self.assertIsNone(err)
+        err2 = _fstat_unchanged(fd, snap)
+        os.close(fd)
+        os.unlink(path)
+        self.assertIsNone(err2)
+
+    def test_bad_fd(self) -> None:
+        from rlm.sandbox_release_archive import _Snap
+        s = _Snap()
+        s.dev = 0
+        s.ino = 0
+        s.uid = 0
+        s.size = 0
+        s.mode = 0
+        self.assertEqual(_fstat_unchanged(999999, s), ArchiveErrorCode.FD_STAT_FAILED)
+
+
+# ===================================================================
+# _hash_compressed (preadv-based)
+# ===================================================================
+
+class TestHashCompressed(unittest.TestCase):
+    def test_ok(self) -> None:
+        data = b"test data"
+        sha = hashlib.sha256(data).hexdigest()
+        fd, path = _write_temp(data)
+        err = _hash_compressed(fd, len(data), sha)
+        os.close(fd)
+        os.unlink(path)
+        self.assertIsNone(err)
+
+    def test_mismatch(self) -> None:
+        data = b"test data"
+        fd, path = _write_temp(data)
+        err = _hash_compressed(fd, len(data), "0" * 64)
+        os.close(fd)
+        os.unlink(path)
+        self.assertEqual(err, ArchiveErrorCode.DIGEST_MISMATCH)
+
+    def test_truncated(self) -> None:
+        data = b"small"
+        fd, path = _write_temp(data)
+        err = _hash_compressed(fd, len(data) + 100, "0" * 64)
+        os.close(fd)
+        os.unlink(path)
+        self.assertEqual(err, ArchiveErrorCode.COMPRESSED_TRUNCATED)
+
+
+# ===================================================================
+# _octal_to_int
+# ===================================================================
+
+class TestOctalToInt(unittest.TestCase):
+    def test_basic(self) -> None:
+        v, e = _octal_to_int(b"0000755\x00")
+        self.assertIsNone(e)
+        self.assertEqual(v, 0o755)
+
+    def test_base256(self) -> None:
+        v, e = _octal_to_int(bytes([0x80, 0x00, 0x00]))
+        self.assertEqual(e, ArchiveErrorCode.BAD_NUMERIC_FIELD)
+
+    def test_bad_digit(self) -> None:
+        v, e = _octal_to_int(b"0000A00\x00")
+        self.assertEqual(e, ArchiveErrorCode.BAD_NUMERIC_FIELD)
+
+    def test_empty(self) -> None:
+        v, e = _octal_to_int(b"")
+        self.assertEqual(e, ArchiveErrorCode.BAD_NUMERIC_FIELD)
+
+    def test_all_spaces(self) -> None:
+        v, e = _octal_to_int(b" " * 8)
+        self.assertIsNone(e)
+        self.assertEqual(v, 0)
+
+
+# ===================================================================
+# _parse_tar_header (with cstring validation)
+# ===================================================================
+
+class TestParseTarHeader(unittest.TestCase):
+    def test_valid_directory(self) -> None:
+        b = _build_valid_block()
+        f, e = _parse_tar_header(bytes(b))
+        self.assertIsNone(e)
+        self.assertIsNotNone(f)
+
+    def test_valid_file(self) -> None:
+        b = _build_valid_block()
+        b[0:7] = b"myfile\x00"
+        b[156] = ord("0")
+        b[124:136] = b"00000000100\x00"
+        _rebuild_checksum(b)
+        f, e = _parse_tar_header(bytes(b))
+        self.assertIsNone(e)
+        self.assertIsNotNone(f)
+    def test_bad_magic(self) -> None:
+        b = _build_valid_block()
+        b[257:263] = b"xxxxxx"
+        _rebuild_checksum(b)
+        f, e = _parse_tar_header(bytes(b))
+        self.assertEqual(e, ArchiveErrorCode.BAD_MAGIC)
+
+    def test_bad_version(self) -> None:
+        b = _build_valid_block()
+        b[263:265] = b"xx"
+        _rebuild_checksum(b)
+        f, e = _parse_tar_header(bytes(b))
+        self.assertEqual(e, ArchiveErrorCode.BAD_VERSION)
+
+    def test_checksum_error(self) -> None:
+        b = _build_valid_block()
+        b[0] = 0xEF
+        _rebuild_checksum(b)
+        # After changing b[0], checksum won't match
+        b[148:156] = b"0000000\x00"
+        f, e = _parse_tar_header(bytes(b))
+        self.assertEqual(e, ArchiveErrorCode.CHECKSUM_ERROR)
+
+    def test_bad_type(self) -> None:
+        b = _build_valid_block()
+        b[156] = ord("x")
+        _rebuild_checksum(b)
+        f, e = _parse_tar_header(bytes(b))
+        self.assertEqual(e, ArchiveErrorCode.BAD_TYPE)
+
+    def test_forbidden_type_L(self) -> None:
+        b = _build_valid_block()
+        b[156] = ord("L")
+        _rebuild_checksum(b)
+        f, e = _parse_tar_header(bytes(b))
+        self.assertEqual(e, ArchiveErrorCode.BAD_TYPE)
+
+    def test_nonempty_linkname(self) -> None:
+        b = _build_valid_block()
+        b[157:157 + 12] = b"some_target\x00"
+        _rebuild_checksum(b)
+        f, e = _parse_tar_header(bytes(b))
+        self.assertEqual(e, ArchiveErrorCode.BAD_LINK)
+
+    def test_nonzero_device(self) -> None:
+        b = _build_valid_block()
+        b[329:329 + 8] = b"0000001\x00"
+        _rebuild_checksum(b)
+        f, e = _parse_tar_header(bytes(b))
+        self.assertEqual(e, ArchiveErrorCode.BAD_DEVICE)
+
+    def test_base256_mode(self) -> None:
+        b = _build_valid_block()
+        b[100] = 0x80
+        _rebuild_checksum(b)
+        f, e = _parse_tar_header(bytes(b))
+        self.assertEqual(e, ArchiveErrorCode.BAD_MODE)
+
+    def test_cstring_padding_name(self) -> None:
+        """Non-null bytes after the first null in name field should fail."""
+        b = _build_valid_block()
+        b[0:3] = b".\x00X"  # null at pos 1, then X at pos 2
+        _rebuild_checksum(b)
+        f, e = _parse_tar_header(bytes(b))
+        self.assertEqual(e, ArchiveErrorCode.BAD_CSTRING_PADDING)
+
+    def test_root_directory_trailing_slash(self) -> None:
+        """Root entry './' as directory with type '5' is required."""
+        b = _build_valid_block()
+        b[0:3] = b"./\x00"
+        b[156] = ord("5")
+        _rebuild_checksum(b)
+        f, e = _parse_tar_header(bytes(b))
+        self.assertIsNone(e, f"root dir should pass, got {e}")
+
+    def test_non_root_dir_needs_trailing_slash(self) -> None:
+        """Non-root directory without trailing slash should fail."""
+        b = _build_valid_block()
+        b[0:5] = b"subd\x00"
+        b[156] = ord("5")
+        _rebuild_checksum(b)
+        f, e = _parse_tar_header(bytes(b))
+        self.assertEqual(e, ArchiveErrorCode.BAD_TRAILING_SLASH)
+
+    def test_non_root_dir_with_trailing_slash(self) -> None:
+        """Non-root directory with trailing slash should pass."""
+        b = _build_valid_block()
+        b[0:6] = b"subd/\x00"
+        b[156] = ord("5")
+        _rebuild_checksum(b)
+        f, e = _parse_tar_header(bytes(b))
+        self.assertIsNone(e)
+
+
+# ===================================================================
+# _validate_cstring
+# ===================================================================
+
+class TestValidateCstring(unittest.TestCase):
+    def test_ok_null_terminated(self) -> None:
+        self.assertIsNone(_validate_cstring(b"hello\x00" + b"\x00" * 10))
+
+    def test_no_null(self) -> None:
+        self.assertEqual(_validate_cstring(b"hello"), ArchiveErrorCode.BAD_CSTRING_PADDING)
+
+    def test_trailing_nonnull_after_null(self) -> None:
+        self.assertEqual(_validate_cstring(b"h\x00i"), ArchiveErrorCode.BAD_CSTRING_PADDING)
+
+
+# ===================================================================
+# _validate_path
+# ===================================================================
+
+class TestValidatePath(unittest.TestCase):
+    def test_normal(self) -> None:
+        n, e = _validate_path(b"hello.txt")
+        self.assertIsNone(e)
+        self.assertEqual(n, "hello.txt")
+
+    def test_root_dot(self) -> None:
+        n, e = _validate_path(b".")
+        self.assertIsNone(e)
+        self.assertEqual(n, ".")
+
+    def test_leading_dot_slash(self) -> None:
+        n, e = _validate_path(b"./hello.txt")
+        self.assertIsNone(e)
+        self.assertEqual(n, "hello.txt")
+
+    def test_absolute_rejected(self) -> None:
+        n, e = _validate_path(b"/etc/passwd")
+        self.assertEqual(e, ArchiveErrorCode.BAD_PATH)
+
+    def test_dotdot_rejected(self) -> None:
+        n, e = _validate_path(b"../escape")
+        self.assertEqual(e, ArchiveErrorCode.BAD_PATH)
+
+    def test_nul_rejected(self) -> None:
+        n, e = _validate_path(b"bad\x00name")
+        self.assertEqual(e, ArchiveErrorCode.BAD_PATH)
+
+    def test_backslash_rejected(self) -> None:
+        n, e = _validate_path(b"bad\\name")
+        self.assertEqual(e, ArchiveErrorCode.BAD_PATH)
+
+    def test_control_char(self) -> None:
+        n, e = _validate_path(b"bad\x01name")
+        self.assertEqual(e, ArchiveErrorCode.BAD_PATH)
+
+    def test_invalid_utf8(self) -> None:
+        n, e = _validate_path(b"bad\xffname")
+        self.assertEqual(e, ArchiveErrorCode.BAD_PATH)
+
+    def test_empty(self) -> None:
+        n, e = _validate_path(b"")
+        self.assertEqual(e, ArchiveErrorCode.BAD_PATH)
+
+    def test_empty_component(self) -> None:
+        n, e = _validate_path(b"a//b")
+        self.assertEqual(e, ArchiveErrorCode.BAD_PATH)
+
+    def test_dot_component(self) -> None:
+        n, e = _validate_path(b"a/./b")
+        self.assertEqual(e, ArchiveErrorCode.BAD_PATH)
+
+    def test_multiple_leading_dot_slash(self) -> None:
+        n, e = _validate_path(b"././f")
+        self.assertEqual(e, ArchiveErrorCode.BAD_PATH)
+
+    def test_trailing_double_slash(self) -> None:
+        n, e = _validate_path(b"d//")
+        self.assertEqual(e, ArchiveErrorCode.BAD_PATH)
+
+
+# ===================================================================
+# Full success
+# ===================================================================
+
+class TestVerifySuccess(unittest.TestCase):
+    def test_small_archive(self) -> None:
+        entries = [
+            {"name": ".", "type": "dir", "mode": 0o755},
+            {"name": "a.txt", "type": "file", "mode": 0o644, "content": b"alpha"},
+            {"name": "sub", "type": "dir", "mode": 0o755},
+            {"name": "sub/b.txt", "type": "file", "mode": 0o644, "content": b"beta"},
+        ]
+        gz, sha, tar_b, mds = _build_ustar_gz(entries)
+        id_ = ArchiveIdentity(compressed_sha256=sha, compressed_bytes=len(gz))
+        m = Manifest(identity=id_, entries=tuple(_mkentry(d) for d in mds),
+                     total_regular_bytes=sum(d["size"] for d in mds if d["type"] == "file"),
+                     decompressed_tar_bytes=len(tar_b))
+        fd, path = _write_temp(gz)
+        r = verify_archive(fd, id_, m)
+        os.close(fd)
+        os.unlink(path)
+        self.assertIsInstance(r, VerifyArchiveSuccess)
+
+    def test_single_file(self) -> None:
+        entries = [
+            {"name": ".", "type": "dir", "mode": 0o755},
+            {"name": "f.bin", "type": "file", "mode": 0o644, "content": b"x" * 1000},
+        ]
+        gz, sha, tar_b, mds = _build_ustar_gz(entries)
+        id_ = ArchiveIdentity(compressed_sha256=sha, compressed_bytes=len(gz))
+        m = Manifest(identity=id_, entries=tuple(_mkentry(d) for d in mds),
+                     total_regular_bytes=1000, decompressed_tar_bytes=len(tar_b))
+        fd, path = _write_temp(gz)
+        r = verify_archive(fd, id_, m)
+        os.close(fd)
+        os.unlink(path)
+        self.assertIsInstance(r, VerifyArchiveSuccess)
+
+    def test_zero_length_file(self) -> None:
+        """Zero-length files must verify without infinite loop."""
+        entries = [
+            {"name": ".", "type": "dir", "mode": 0o755},
+            {"name": "empty", "type": "file", "mode": 0o644, "content": b""},
+        ]
+        gz, sha, tar_b, mds = _build_ustar_gz(entries)
+        id_ = ArchiveIdentity(compressed_sha256=sha, compressed_bytes=len(gz))
+        m = Manifest(identity=id_, entries=tuple(_mkentry(d) for d in mds),
+                     total_regular_bytes=0, decompressed_tar_bytes=len(tar_b))
+        fd, path = _write_temp(gz)
+        try:
+            r = verify_archive(fd, id_, m)
+        finally:
+            os.close(fd)
+            os.unlink(path)
+        self.assertIsInstance(r, VerifyArchiveSuccess)
+
+
+# ===================================================================
+# Failure families
+# ===================================================================
+
+class TestVerifyFailures(unittest.TestCase):
+    def _run(self, entries, identity, manifest):
+        gz, sha, tar_b, mds = _build_ustar_gz(entries)
+        fd, path = _write_temp(gz)
+        r = verify_archive(fd, identity, manifest)
+        os.close(fd)
+        os.unlink(path)
+        return r
+
+    def test_digest_mismatch(self) -> None:
+        entries = [{"name": ".", "type": "dir", "mode": 0o755}]
+        gz, sha, tar_b, mds = _build_ustar_gz(entries)
+        wrong_id = ArchiveIdentity(compressed_sha256="0" * 64, compressed_bytes=len(gz))
+        m = Manifest(identity=wrong_id, entries=tuple(_mkentry(d) for d in mds),
+                     total_regular_bytes=0, decompressed_tar_bytes=len(tar_b))
+        r = self._run(entries, wrong_id, m)
+        self.assertIsInstance(r, VerifyArchiveFailure)
+        if isinstance(r, VerifyArchiveFailure):
+            self.assertEqual(r.code, ArchiveErrorCode.DIGEST_MISMATCH)
+
+    def test_total_bytes_mismatch(self) -> None:
+        """Manifest with wrong total_regular_bytes caught by validation."""
+        entries = [{"name": ".", "type": "dir", "mode": 0o755},
+                   {"name": "f", "type": "file", "mode": 0o644, "content": b"hello"}]
+        gz, sha, tar_b, mds = _build_ustar_gz(entries)
+        id_ = ArchiveIdentity(compressed_sha256=sha, compressed_bytes=len(gz))
+        m = Manifest(identity=id_, entries=tuple(_mkentry(d) for d in mds),
+                     total_regular_bytes=9999, decompressed_tar_bytes=len(tar_b))
+        r = self._run(entries, id_, m)
+        self.assertIsInstance(r, VerifyArchiveFailure)
+        if isinstance(r, VerifyArchiveFailure):
+            self.assertEqual(r.code, ArchiveErrorCode.BAD_MANIFEST_FIELD)
+
+    def test_decompressed_size_mismatch(self) -> None:
+        entries = [{"name": ".", "type": "dir", "mode": 0o755}]
+        gz, sha, tar_b, mds = _build_ustar_gz(entries)
+        id_ = ArchiveIdentity(compressed_sha256=sha, compressed_bytes=len(gz))
+        # Use a valid multiple-of-512 but wrong decompressed size (tar_b is 10240)
+        wrong_dtot = 512  # valid multiple of 512, but != 10240
+        m = Manifest(identity=id_, entries=tuple(_mkentry(d) for d in mds),
+                     total_regular_bytes=0, decompressed_tar_bytes=wrong_dtot)
+        fd, path = _write_temp(gz)
+        r = verify_archive(fd, id_, m)
+        os.close(fd)
+        os.unlink(path)
+        self.assertIsInstance(r, VerifyArchiveFailure)
+        if isinstance(r, VerifyArchiveFailure):
+            self.assertEqual(r.code, ArchiveErrorCode.DECOMPRESSED_SIZE_MISMATCH)
+
+
+# ===================================================================
+# Tar structure failures (through _verify_streaming)
+# ===================================================================
+
+class TestTarStructure(unittest.TestCase):
+    """Test streaming verifier directly with constructed tar.gz data."""
+
+    def _verify_gz(self, gz: bytes, manifest: Manifest) -> ArchiveErrorCode | None:
+        fd, path = _write_temp(gz)
+        try:
+            return _verify_streaming(fd, len(gz), manifest)
+        finally:
+            os.close(fd)
+            os.unlink(path)
+
+    def test_missing_zero_blocks(self) -> None:
+        entries = [{"name": ".", "type": "dir", "mode": 0o755}]
+        _, _, tar_b, mds = _build_ustar_gz(entries)
+        header_only = tar_b[:_TAR_BLOCK]
+        gz = _gzip_compress(header_only)
+        m = Manifest(identity=ArchiveIdentity("a" * 64, len(gz)),
+                     entries=tuple(_mkentry(d) for d in mds),
+                     total_regular_bytes=0, decompressed_tar_bytes=len(header_only))
+        e = self._verify_gz(gz, m)
+        self.assertEqual(e, ArchiveErrorCode.NO_ZERO_BLOCKS)
+
+    def test_unpaired_zero_block(self) -> None:
+        entries = [{"name": ".", "type": "dir", "mode": 0o755}]
+        _, _, tar_b, mds = _build_ustar_gz(entries)
+        # One zero block followed by non-zero data = unpaired
+        tainted = tar_b[:_TAR_BLOCK] + bytearray(512) + b"NONZERO"
+        gz = _gzip_compress(bytes(tainted))
+        m = Manifest(identity=ArchiveIdentity("a" * 64, len(gz)),
+                     entries=tuple(_mkentry(d) for d in mds),
+                     total_regular_bytes=0, decompressed_tar_bytes=len(bytes(tainted)))
+        e = self._verify_gz(gz, m)
+        self.assertEqual(e, ArchiveErrorCode.UNPAIRED_ZERO_BLOCK)
+
+    def test_second_tar(self) -> None:
+        """Two zero blocks followed by second tar: trailing non-zero data."""
+        entries = [{"name": ".", "type": "dir", "mode": 0o755}]
+        _, _, tar_b, mds = _build_ustar_gz(entries)
+        entries2 = [{"name": "x", "type": "file", "mode": 0o644, "content": b"x"}]
+        _, _, tar2, _ = _build_ustar_gz(entries2)
+        combined = tar_b + tar2
+        gz = _gzip_compress(combined)
+        m = Manifest(identity=ArchiveIdentity("a" * 64, len(gz)),
+                     entries=tuple(_mkentry(d) for d in mds),
+                     total_regular_bytes=0, decompressed_tar_bytes=len(combined))
+        e = self._verify_gz(gz, m)
+        self.assertEqual(e, ArchiveErrorCode.TAIL_NONZERO)
+
+    def test_sha_mismatch(self) -> None:
+        entries = [{"name": ".", "type": "dir", "mode": 0o755},
+                   {"name": "f", "type": "file", "mode": 0o644, "content": b"hello"}]
+        _, _, tar_b, mds = _build_ustar_gz(entries)
+        wrong_mds = [{"path": ".", "type": "directory", "mode": "0755", "size": 0, "sha256": None},
+                     {"path": "f", "type": "file", "mode": "0644", "size": 5, "sha256": "0" * 64}]
+        gz = _gzip_compress(tar_b)
+        m = Manifest(identity=ArchiveIdentity("a" * 64, len(gz)),
+                     entries=tuple(_mkentry(d) for d in wrong_mds),
+                     total_regular_bytes=5, decompressed_tar_bytes=len(tar_b))
+        e = self._verify_gz(gz, m)
+        self.assertEqual(e, ArchiveErrorCode.FILE_SHA_MISMATCH)
+
+    def test_forbidden_type(self) -> None:
+        entries = [{"name": ".", "type": "dir", "mode": 0o755}]
+        _, _, tar_b, mds = _build_ustar_gz(entries)
+        modified = bytearray(tar_b)
+        modified[156] = ord("L")
+        _rebuild_checksum(modified)
+        gz = _gzip_compress(bytes(modified))
+        m = Manifest(identity=ArchiveIdentity("a" * 64, len(gz)),
+                     entries=tuple(_mkentry(d) for d in mds),
+                     total_regular_bytes=0, decompressed_tar_bytes=len(bytes(modified)))
+        e = self._verify_gz(gz, m)
+        self.assertEqual(e, ArchiveErrorCode.BAD_TYPE)
+
+    def test_tail_nonzero(self) -> None:
+        entries = [{"name": ".", "type": "dir", "mode": 0o755}]
+        _, _, tar_b, mds = _build_ustar_gz(entries)
+        tainted = tar_b + b"NONZERO"
+        gz = _gzip_compress(tainted)
+        m = Manifest(identity=ArchiveIdentity("a" * 64, len(gz)),
+                     entries=tuple(_mkentry(d) for d in mds),
+                     total_regular_bytes=0, decompressed_tar_bytes=len(tainted))
+        e = self._verify_gz(gz, m)
+        self.assertEqual(e, ArchiveErrorCode.TAIL_NONZERO)
+
+    def test_non_zero_padding(self) -> None:
+        entries = [{"name": ".", "type": "dir", "mode": 0o755},
+                   {"name": "f", "type": "file", "mode": 0o644, "content": b"hello"}]
+        _, _, tar_b, mds = _build_ustar_gz(entries)
+        modified = bytearray(tar_b)
+        # Find padding region after file content (offset 512+512=1024, padding at 512+5=517)
+        # file "f" with 5 bytes: 1 block = 512, padding = 507 bytes at offset 1024
+        modified[1030] = 0x01  # non-zero in file padding (byte 6 of content block = padding byte 1)
+        gz = _gzip_compress(bytes(modified))
+        m = Manifest(identity=ArchiveIdentity("a" * 64, len(gz)),
+                     entries=tuple(_mkentry(d) for d in mds),
+                     total_regular_bytes=5, decompressed_tar_bytes=len(tar_b))
+        e = self._verify_gz(gz, m)
+        self.assertEqual(e, ArchiveErrorCode.NON_ZERO_PADDING)
+
+    def test_zero_block_info_partial_header(self) -> None:
+        """Partial zero block (only 1 of 2 required) should fail ONE_ZERO_BLOCK."""
+        # Build a minimal tar: header block + 1 zero block (not the required 2)
+        # Create an uncompressed tar with just header + 1 zero block
+        b = io.BytesIO()
+        with tarfile.open(fileobj=b, mode="w:", format=tarfile.USTAR_FORMAT) as tf:
+            ti = tarfile.TarInfo(".")
+            ti.type = tarfile.DIRTYPE
+            ti.mode = 0o755
+            tf.addfile(ti)
+        raw_tar = b.getvalue()
+        # Find where the zero blocks start (after valid tar data)
+        # raw_tar ends with many zero blocks. Take only 2 blocks: header + 1 zero
+        one_zero = raw_tar[:_TAR_BLOCK] + b"\x00" * 512
+        gz = _gzip_compress(one_zero)
+        mds = [{"path": ".", "type": "directory", "mode": "0755", "size": 0, "sha256": None}]
+        m = Manifest(identity=ArchiveIdentity("a" * 64, len(gz)),
+                     entries=tuple(_mkentry(d) for d in mds),
+                     total_regular_bytes=0, decompressed_tar_bytes=len(one_zero))
+        e = self._verify_gz(gz, m)
+        self.assertEqual(e, ArchiveErrorCode.ONE_ZERO_BLOCK)
+
+
+# ===================================================================
+# Gzip failures
+# ===================================================================
+
+class TestGzipFailures(unittest.TestCase):
+    def test_trailing_data(self) -> None:
+        entries = [{"name": ".", "type": "dir", "mode": 0o755}]
+        gz, sha, tar_b, mds = _build_ustar_gz(entries)
+        extra = _gzip_compress(b"extra")
+        gz2 = gz + extra
+        id_ = ArchiveIdentity(compressed_sha256=hashlib.sha256(gz2).hexdigest(),
+                              compressed_bytes=len(gz2))
+        m = Manifest(identity=id_, entries=tuple(_mkentry(d) for d in mds),
+                     total_regular_bytes=0, decompressed_tar_bytes=len(tar_b))
+        fd, path = _write_temp(gz2)
+        r = verify_archive(fd, id_, m)
+        os.close(fd)
+        os.unlink(path)
+        self.assertIsInstance(r, VerifyArchiveFailure)
+        if isinstance(r, VerifyArchiveFailure):
+            self.assertEqual(r.code, ArchiveErrorCode.GZIP_TRAILING_DATA)
+
+    def test_corrupted(self) -> None:
+        gz = b"\x1f\x8b\x08" + b"\x00" * 100
+        id_ = ArchiveIdentity(compressed_sha256=hashlib.sha256(gz).hexdigest(),
+                              compressed_bytes=len(gz))
+        m = Manifest(identity=id_, entries=(ManifestEntry(path=".", type="directory",
+                                                          mode="0755", size=0, sha256=None),),
+                     total_regular_bytes=0, decompressed_tar_bytes=512)
+        fd, path = _write_temp(gz)
+        r = verify_archive(fd, id_, m)
+        os.close(fd)
+        os.unlink(path)
+        self.assertIsInstance(r, VerifyArchiveFailure)
+        if isinstance(r, VerifyArchiveFailure):
+            self.assertEqual(r.code, ArchiveErrorCode.GZIP_ERROR)
+
+    def test_gzip_eof_before_compressed_limit(self) -> None:
+        """Gzip stream ends before compressed_limit is reached."""
+        entries = [{"name": ".", "type": "dir", "mode": 0o755}]
+        gz, sha, tar_b, mds = _build_ustar_gz(entries)
+        # Pad the gzip with zeros after the valid gzip so compressed_limit is larger
+        gz_padded = gz + b"\x00" * 100
+        padded_sha = hashlib.sha256(gz_padded).hexdigest()
+        id_ = ArchiveIdentity(compressed_sha256=padded_sha,
+                              compressed_bytes=len(gz_padded))
+        m = Manifest(identity=id_, entries=tuple(_mkentry(d) for d in mds),
+                     total_regular_bytes=0, decompressed_tar_bytes=len(tar_b))
+        fd, path = _write_temp(gz_padded)
+        r = verify_archive(fd, id_, m)
+        os.close(fd)
+        os.unlink(path)
+        self.assertIsInstance(r, VerifyArchiveFailure)
+        if isinstance(r, VerifyArchiveFailure):
+            self.assertIn(r.code, (
+                ArchiveErrorCode.GZIP_EOF_PREMATURE,
+                ArchiveErrorCode.GZIP_TRAILING_DATA,
+            ))
+
+
+# ===================================================================
+# fd ownership / bounded reads
+# ===================================================================
+
+class TestFdOwnership(unittest.TestCase):
+    def test_caller_fd_stays_open(self) -> None:
+        entries = [{"name": ".", "type": "dir", "mode": 0o755}]
+        gz, sha, tar_b, mds = _build_ustar_gz(entries)
+        id_ = ArchiveIdentity(compressed_sha256=sha, compressed_bytes=len(gz))
+        m = Manifest(identity=id_, entries=tuple(_mkentry(d) for d in mds),
+                     total_regular_bytes=0, decompressed_tar_bytes=len(tar_b))
+        fd, path = _write_temp(gz)
+        r = verify_archive(fd, id_, m)
+        try:
+            os.fstat(fd)
+            alive = True
+        except OSError:
+            alive = False
+        os.close(fd)
+        os.unlink(path)
+        self.assertTrue(alive, "caller fd was closed")
+
+
+class TestBoundedReads(unittest.TestCase):
+    def test_offset_unchanged(self) -> None:
+        data = b"offset test data prefix"
+        sha = hashlib.sha256(data).hexdigest()
+        fd, path = _write_temp(data)
+        pre = os.read(fd, 10)
+        self.assertEqual(pre, data[:10])
+        err = _hash_compressed(fd, len(data), sha)
+        self.assertIsNone(err)
+        post = os.read(fd, 5)
+        self.assertEqual(post, data[10:15])
+        os.close(fd)
+        os.unlink(path)
+
+
+# ===================================================================
+# Bad identity before fd access
+# ===================================================================
+
+class TestBadIdentityBeforeFd(unittest.TestCase):
+    def test_zero_compressed_bytes(self) -> None:
+        id_ = ArchiveIdentity(compressed_sha256="a" * 64, compressed_bytes=0)
+        self.assertIsNotNone(_validate_identity(id_))
+
+    def test_none_identity_fails(self) -> None:
+        # _validate_identity catches type errors via strict check
+        # Create a non-dataclass object
+        r = _validate_identity(None)
+        self.assertIsNotNone(r)
+
+
+# ===================================================================
+# Streaming large bomb (>192 MiB) with zlib.compressobj and instrumented bounds
+# ===================================================================
+
+class TestLargeBombStreaming(unittest.TestCase):
+    @staticmethod
+    def _zero_digest(size: int) -> str:
+        digest = hashlib.sha256()
+        chunk = bytes(65536)
+        remaining = size
+        while remaining > 0:
+            count = min(len(chunk), remaining)
+            digest.update(memoryview(chunk)[:count])
+            remaining -= count
+        return digest.hexdigest()
+
+    @staticmethod
+    def _file_header(name: str, size: int) -> bytes:
+        block = bytearray(512)
+        encoded = name.encode("ascii")
+        block[:len(encoded)] = encoded
+        block[len(encoded)] = 0
+        block[100:108] = b"0000644\x00"
+        block[108:116] = b"0000000\x00"
+        block[116:124] = b"0000000\x00"
+        block[124:136] = f"{size:011o}\x00".encode("ascii")
+        block[136:148] = b"00000000000\x00"
+        block[148:156] = b" " * 8
+        block[156:157] = b"0"
+        block[257:263] = b"ustar\x00"
+        block[263:265] = b"00"
+        block[265:345] = bytes(80)
+        checksum = sum(block[:148]) + (32 * 8) + sum(block[156:])
+        block[148:156] = f"{checksum:06o}\x00 ".encode("ascii")
+        return bytes(block)
+
+    def test_oversized_file_manifest_fails_before_fd_access(self) -> None:
+        target = MAX_PER_FILE_BYTES + 512
+        identity = ArchiveIdentity(compressed_sha256="a" * 64, compressed_bytes=1)
+        manifest = Manifest(
+            identity=identity,
+            entries=(
+                ManifestEntry(path=".", type="directory", mode="0755", size=0, sha256=None),
+                ManifestEntry(
+                    path="bigfile",
+                    type="file",
+                    mode="0644",
+                    size=target,
+                    sha256=self._zero_digest(target),
+                ),
+            ),
+            total_regular_bytes=target,
+            decompressed_tar_bytes=512,
+        )
+        result = verify_archive(-1, identity, manifest)
+        self.assertIsInstance(result, VerifyArchiveFailure)
+        if isinstance(result, VerifyArchiveFailure):
+            self.assertEqual(result.code, ArchiveErrorCode.BAD_MANIFEST_FIELD)
+
+    def test_bomb_exceeds_decompressed_limit_during_streaming(self) -> None:
+        sizes = (64, 64, 64, 32)
+        sizes = tuple(size * 1024 * 1024 for size in sizes)
+        chunk = bytes(65536)
+        raw_fd, path = tempfile.mkstemp()
+        os.close(raw_fd)
+        try:
+            with open(path, "wb") as output:
+                with gzip.GzipFile(fileobj=output, mode="wb", compresslevel=1, mtime=0) as archive:
+                    archive.write(bytes(_build_valid_block()))
+                    for index, size in enumerate(sizes):
+                        archive.write(self._file_header(f"f{index}.bin", size))
+                        remaining = size
+                        while remaining > 0:
+                            count = min(len(chunk), remaining)
+                            archive.write(memoryview(chunk)[:count])
+                            remaining -= count
+                    archive.write(bytes(1024))
+                    trailing_zeros = 40 * 1024 * 1024
+                    while trailing_zeros > 0:
+                        count = min(len(chunk), trailing_zeros)
+                        archive.write(memoryview(chunk)[:count])
+                        trailing_zeros -= count
+
+            compressed_size = os.stat(path).st_size
+            identity = ArchiveIdentity(compressed_sha256="a" * 64, compressed_bytes=compressed_size)
+            entries = [ManifestEntry(path=".", type="directory", mode="0755", size=0, sha256=None)]
+            for index, size in enumerate(sizes):
+                entries.append(ManifestEntry(
+                    path=f"f{index}.bin",
+                    type="file",
+                    mode="0644",
+                    size=size,
+                    sha256=self._zero_digest(size),
+                ))
+            manifest = Manifest(
+                identity=identity,
+                entries=tuple(entries),
+                total_regular_bytes=sum(sizes),
+                decompressed_tar_bytes=MAX_DECOMPRESSED_TAR,
+            )
+            fd = os.open(path, os.O_RDONLY)
+            try:
+                error = _verify_streaming(fd, compressed_size, manifest)
+            finally:
+                os.close(fd)
+            self.assertEqual(error, ArchiveErrorCode.DECOMPRESSED_TOO_LARGE)
+        finally:
+            os.unlink(path)
+
+
+# ===================================================================
+# preadv buffer behavior
+# ===================================================================
+
+class TestPreadvBehavior(unittest.TestCase):
+    def test_preadv_into_buffer(self) -> None:
+        """Verify _hash_compressed uses preadv into mutable buffer, not pread returning new bytes."""
+        data = b"X" * 1000
+        sha = hashlib.sha256(data).hexdigest()
+        fd, path = _write_temp(data)
+
+        # Use the module's _hash_compressed which should use preadv internally
+        err = _hash_compressed(fd, len(data), sha)
+        os.close(fd)
+        os.unlink(path)
+        self.assertIsNone(err)
+
+    def test_preadv_buffer_erased(self) -> None:
+        """Every mutable hash buffer is zero or empty after return."""
+        data = b"Y" * 2000
+        sha = hashlib.sha256(data).hexdigest()
+        fd, path = _write_temp(data)
+        original_bytearray = bytearray
+        captured: list[bytearray] = []
+
+        def recording_bytearray(value: int = 0) -> bytearray:
+            buffer = original_bytearray(value)
+            captured.append(buffer)
+            return buffer
+
+        try:
+            with patch("builtins.bytearray", new=recording_bytearray):
+                error = _hash_compressed(fd, len(data), sha)
+            self.assertIsNone(error)
+            self.assertEqual([len(buffer) for buffer in captured], [_PREADV_BUF, 1])
+            self.assertTrue(all(not any(buffer) for buffer in captured))
+        finally:
+            os.close(fd)
+            os.unlink(path)
+
+
+# ===================================================================
+# Manifest.identity exact reference equality test
+# ===================================================================
+
+class TestIdentityExactEquality(unittest.TestCase):
+    def test_identity_values_match(self) -> None:
+        """Equal identity values may be carried by a distinct frozen object."""
+        id1 = ArchiveIdentity(compressed_sha256="a" * 64, compressed_bytes=512)
+        id2 = ArchiveIdentity(compressed_sha256="a" * 64, compressed_bytes=512)
+        e = ManifestEntry(path=".", type="directory", mode="0755", size=0, sha256=None)
+        m = Manifest(identity=id1, entries=(e,), total_regular_bytes=0, decompressed_tar_bytes=512)
+        # _validate_manifest should pass because id1 validates fine
+        err = _validate_manifest(m)
+        self.assertIsNone(err)
+
+
+# ===================================================================
+# _validate_entry
+# ===================================================================
+
+class TestValidateEntry(unittest.TestCase):
+    def test_valid_dir(self) -> None:
+        e = ManifestEntry(path="sub", type="directory", mode="0755", size=0, sha256=None)
+        seen: set[str] = set()
+        self.assertIsNone(_validate_entry(e, seen))
+        self.assertIn("sub", seen)
+
+    def test_valid_file(self) -> None:
+        e = ManifestEntry(path="f", type="file", mode="0644", size=10, sha256="a" * 64)
+        seen: set[str] = set()
+        self.assertIsNone(_validate_entry(e, seen))
+
+    def test_duplicate(self) -> None:
+        e = ManifestEntry(path="f", type="file", mode="0644", size=10, sha256="a" * 64)
+        seen: set[str] = {"f"}
+        self.assertEqual(_validate_entry(e, seen), ArchiveErrorCode.BAD_MANIFEST_FIELD)
+
+    def test_bad_mode_format(self) -> None:
+        # 6-digit mode is too long for regex: ^0[0-7]{3,4}$
+        e = ManifestEntry(path="f", type="file", mode="064400", size=10, sha256="a" * 64)
+        seen: set[str] = set()
+        self.assertEqual(_validate_entry(e, seen), ArchiveErrorCode.BAD_MANIFEST_FIELD)
+
+    def test_file_exceeds_max(self) -> None:
+        e = ManifestEntry(path="f", type="file", mode="0644",
+                          size=MAX_PER_FILE_BYTES + 1, sha256="a" * 64)
+        seen: set[str] = set()
+        self.assertEqual(_validate_entry(e, seen), ArchiveErrorCode.BAD_MANIFEST_FIELD)
+
+    def test_zero_length_file_needs_empty_sha(self) -> None:
+        e = ManifestEntry(path="f", type="file", mode="0644", size=0, sha256="a" * 64)
+        seen: set[str] = set()
+        self.assertEqual(_validate_entry(e, seen), ArchiveErrorCode.ZERO_LENGTH_EMPTY_SHA)
+
+class TestParentAuditStrictBoundaries(unittest.TestCase):
+    def test_exact_dataclass_type_and_storage(self) -> None:
+        @dataclasses.dataclass(frozen=True)
+        class DerivedIdentity(ArchiveIdentity):
+            pass
+
+        derived = DerivedIdentity(compressed_sha256="a" * 64, compressed_bytes=512)
+        self.assertEqual(_validate_identity(derived), ArchiveErrorCode.BAD_DATACLASS_TYPE)
+        identity = ArchiveIdentity(compressed_sha256="a" * 64, compressed_bytes=512)
+        object.__setattr__(identity, "unexpected", "value")
+        self.assertEqual(_validate_identity(identity), ArchiveErrorCode.BAD_DATACLASS_KEY)
+
+    def test_failure_rejects_arbitrary_runtime_code(self) -> None:
+        with self.assertRaisesRegex(ValueError, "invalid archive error code"):
+            VerifyArchiveFailure(code="arbitrary")
+
+    def test_manifest_identity_mismatch_precedes_fd_access(self) -> None:
+        selected = ArchiveIdentity(compressed_sha256="a" * 64, compressed_bytes=512)
+        other = ArchiveIdentity(compressed_sha256="b" * 64, compressed_bytes=512)
+        root = ManifestEntry(path=".", type="directory", mode="0755", size=0, sha256=None)
+        manifest = Manifest(identity=other, entries=(root,), total_regular_bytes=0, decompressed_tar_bytes=512)
+        result = verify_archive(-1, selected, manifest)
+        self.assertIsInstance(result, VerifyArchiveFailure)
+        if isinstance(result, VerifyArchiveFailure):
+            self.assertEqual(result.code, ArchiveErrorCode.IDENTITY_MISMATCH)
+
+    def test_manifest_rejects_unsafe_path_mode_and_file_parent(self) -> None:
+        identity = ArchiveIdentity(compressed_sha256="a" * 64, compressed_bytes=512)
+        root = ManifestEntry(path=".", type="directory", mode="0755", size=0, sha256=None)
+        unsafe = ManifestEntry(path="../escape", type="file", mode="0644", size=1, sha256="a" * 64)
+        manifest = Manifest(identity=identity, entries=(root, unsafe), total_regular_bytes=1, decompressed_tar_bytes=512)
+        self.assertEqual(_validate_manifest(manifest), ArchiveErrorCode.BAD_MANIFEST_FIELD)
+
+        bad_mode = ManifestEntry(path="file", type="file", mode="0777", size=1, sha256="a" * 64)
+        manifest = Manifest(identity=identity, entries=(root, bad_mode), total_regular_bytes=1, decompressed_tar_bytes=512)
+        self.assertEqual(_validate_manifest(manifest), ArchiveErrorCode.BAD_MANIFEST_FIELD)
+
+        parent_file = ManifestEntry(path="parent", type="file", mode="0644", size=1, sha256="a" * 64)
+        child = ManifestEntry(path="parent/child", type="file", mode="0644", size=1, sha256="b" * 64)
+        manifest = Manifest(identity=identity, entries=(root, parent_file, child), total_regular_bytes=2, decompressed_tar_bytes=512)
+        self.assertEqual(_validate_manifest(manifest), ArchiveErrorCode.BAD_MANIFEST_FIELD)
+
+    def test_header_rejects_root_without_slash_file_slash_and_reserved_bytes(self) -> None:
+        root_without_slash = _build_valid_block()
+        root_without_slash[0:3] = b".\x00\x00"
+        _rebuild_checksum(root_without_slash)
+        _, error = _parse_tar_header(bytes(root_without_slash))
+        self.assertEqual(error, ArchiveErrorCode.BAD_ROOT_SPELLING)
+
+        file_slash = _build_valid_block()
+        file_slash[0:6] = b"file/\x00"
+        file_slash[156] = ord("0")
+        _rebuild_checksum(file_slash)
+        _, error = _parse_tar_header(bytes(file_slash))
+        self.assertEqual(error, ArchiveErrorCode.BAD_TRAILING_SLASH)
+
+        reserved = _build_valid_block()
+        reserved[500] = 1
+        _rebuild_checksum(reserved)
+        _, error = _parse_tar_header(bytes(reserved))
+        self.assertEqual(error, ArchiveErrorCode.BAD_HEADER)
+
+    def test_fd_mode_change_is_detected(self) -> None:
+        fd, path = _write_temp(b"x")
+        try:
+            snapshot, error = _fstat_validate(fd, 1)
+            self.assertIsNone(error)
+            self.assertIsNotNone(snapshot)
+            os.chmod(path, 0o400)
+            if snapshot is not None:
+                self.assertEqual(_fstat_unchanged(fd, snapshot), ArchiveErrorCode.FD_IDENTITY_CHANGED)
+        finally:
+            os.close(fd)
+            os.unlink(path)
+
+    def test_streaming_pass_uses_bounded_preadv_only(self) -> None:
+        entries = [
+            {"name": ".", "type": "dir", "mode": 0o755},
+            {"name": "file", "type": "file", "mode": 0o644, "content": b"content"},
+        ]
+        compressed, _, tar_bytes, manifest_dicts = _build_ustar_gz(entries)
+        identity = ArchiveIdentity(compressed_sha256="a" * 64, compressed_bytes=len(compressed))
+        manifest = Manifest(
+            identity=identity,
+            entries=tuple(_mkentry(entry) for entry in manifest_dicts),
+            total_regular_bytes=7,
+            decompressed_tar_bytes=len(tar_bytes),
+        )
+        fd, path = _write_temp(compressed)
+        requested_sizes: list[int] = []
+        captured: list[bytearray] = []
+        original_preadv = os.preadv
+        original_bytearray = bytearray
+
+        def observing_preadv(observed_fd: int, buffers: list[memoryview], offset: int) -> int:
+            requested_sizes.append(sum(buffer.nbytes for buffer in buffers))
+            return original_preadv(observed_fd, buffers, offset)
+
+        def recording_bytearray(value: int = 0) -> bytearray:
+            buffer = original_bytearray(value)
+            captured.append(buffer)
+            return buffer
+
+        try:
+            with patch("builtins.bytearray", new=recording_bytearray):
+                with patch.object(os, "preadv", side_effect=observing_preadv):
+                    error = _verify_streaming(fd, len(compressed), manifest)
+            self.assertIsNone(error)
+            self.assertTrue(requested_sizes)
+            self.assertLessEqual(max(requested_sizes), 65536)
+            self.assertTrue(captured)
+            self.assertTrue(all(not any(buffer) for buffer in captured))
+        finally:
+            os.close(fd)
+            os.unlink(path)

--- a/prime-agent-runtime/test/test_sandbox_release_extract.py
+++ b/prime-agent-runtime/test/test_sandbox_release_extract.py
@@ -1,0 +1,571 @@
+"""Adversarial Phase 2 extraction tests."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import shutil
+import stat
+import tarfile
+import tempfile
+import unittest
+import zlib
+from unittest.mock import patch
+
+from rlm.sandbox_release_archive import (
+    ArchiveErrorCode,
+    ArchiveIdentity,
+    Manifest,
+    ManifestEntry,
+    verify_archive,
+)
+from rlm.sandbox_release_extract import (
+    ExtractArchiveFailure,
+    ExtractArchiveSuccess,
+    ExtractErrorCode,
+    RuntimeRootCapability,
+    _ExtractionSink,
+    extract_verified_archive,
+)
+
+_CANDIDATE = "runtime-0123456789abcdef"
+_SKILLS = ("agent-message", "agent-observe", "compact", "goal", "refine", "rlm-heartbeat")
+
+
+def _elf() -> bytes:
+    value = bytearray(64)
+    value[0:4] = b"\x7fELF"
+    value[4:8] = bytes((2, 1, 1, 0))
+    value[16:18] = (3).to_bytes(2, "little")
+    value[18:20] = (62).to_bytes(2, "little")
+    value[20:24] = (1).to_bytes(4, "little")
+    return bytes(value) + b"runtime"
+
+
+def _release_entries(
+    *, bad_elf: bool = False, missing: str | None = None, package_content: bytes = b"{}\n"
+):
+    entries = [
+        {"name": ".", "type": "dir", "mode": 0o755},
+        {"name": "install.sh", "type": "file", "mode": 0o755, "content": b"#!/bin/sh\n"},
+        {"name": "package.json", "type": "file", "mode": 0o644, "content": package_content},
+        {"name": "photon_rs_bg.wasm", "type": "file", "mode": 0o644, "content": b"wasm"},
+        {"name": "prime-agent", "type": "file", "mode": 0o755, "content": b"bad" * 30 if bad_elf else _elf()},
+        {"name": "prime-agent-runtime", "type": "dir", "mode": 0o755},
+        {"name": "prime-agent-runtime/pyproject.toml", "type": "file", "mode": 0o644, "content": b"[project]\n"},
+        {"name": "skills", "type": "dir", "mode": 0o755},
+    ]
+    for name in _SKILLS:
+        entries.append({"name": f"skills/{name}", "type": "dir", "mode": 0o755})
+        entries.append({"name": f"skills/{name}/SKILL.md", "type": "file", "mode": 0o644, "content": b"# Skill\n"})
+    entries = [entry for entry in entries if entry["name"] != missing]
+    root = entries[0]
+    return [root, *sorted(entries[1:], key=lambda entry: entry["name"].encode("utf-8"))]
+
+
+def _build(entries):
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w:gz", format=tarfile.USTAR_FORMAT) as archive:
+        for entry in entries:
+            if entry["type"] == "dir":
+                name = "./" if entry["name"] == "." else entry["name"] + "/"
+                info = tarfile.TarInfo(name)
+                info.type = tarfile.DIRTYPE
+                info.mode = entry["mode"]
+                archive.addfile(info)
+            else:
+                content = entry["content"]
+                info = tarfile.TarInfo(entry["name"])
+                info.type = tarfile.REGTYPE
+                info.mode = entry["mode"]
+                info.size = len(content)
+                archive.addfile(info, io.BytesIO(content))
+    compressed = raw.getvalue()
+    inflater = zlib.decompressobj(wbits=31)
+    tar_bytes = inflater.decompress(compressed) + inflater.flush()
+    identity = ArchiveIdentity(hashlib.sha256(compressed).hexdigest(), len(compressed))
+    manifest_entries = []
+    total = 0
+    for entry in entries:
+        if entry["type"] == "dir":
+            manifest_entries.append(ManifestEntry(entry["name"], "directory", "0755", 0, None))
+        else:
+            content = entry["content"]
+            total += len(content)
+            manifest_entries.append(ManifestEntry(
+                entry["name"], "file", f"0{entry['mode']:o}", len(content), hashlib.sha256(content).hexdigest()
+            ))
+    manifest = Manifest(identity, tuple(manifest_entries), total, len(tar_bytes))
+    return compressed, identity, manifest
+
+
+class ExtractionCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.mkdtemp(prefix="release-extract-")
+        os.chmod(self.temp, 0o700)
+        self.parent_fd = os.open(self.temp, os.O_RDONLY | os.O_DIRECTORY)
+        self.archive_path = os.path.join(self.temp, "archive.tar.gz")
+
+    def tearDown(self) -> None:
+        try:
+            os.close(self.parent_fd)
+        except OSError:
+            pass
+        shutil.rmtree(self.temp, ignore_errors=True)
+
+    def fixture(self, **kwargs):
+        compressed, identity, manifest = _build(_release_entries(**kwargs))
+        with open(self.archive_path, "wb") as target:
+            target.write(compressed)
+        os.chmod(self.archive_path, 0o600)
+        archive_fd = os.open(self.archive_path, os.O_RDONLY)
+        return archive_fd, identity, manifest
+
+    def extract(self, **kwargs):
+        archive_fd, identity, manifest = self.fixture(**kwargs)
+        try:
+            return extract_verified_archive(archive_fd, self.parent_fd, _CANDIDATE, identity, manifest)
+        finally:
+            os.close(archive_fd)
+
+    def test_success_exact_tree_modes_and_capability(self) -> None:
+        result = self.extract()
+        self.assertIs(type(result), ExtractArchiveSuccess)
+        self.assertIs(type(result.root), RuntimeRootCapability)
+        self.assertTrue(result.root.verify())
+        root = os.path.join(self.temp, _CANDIDATE)
+        self.assertEqual(stat.S_IMODE(os.lstat(root).st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE(os.lstat(os.path.join(root, "prime-agent")).st_mode), 0o755)
+        self.assertEqual(stat.S_IMODE(os.lstat(os.path.join(root, "package.json")).st_mode), 0o644)
+        with open(os.path.join(root, "package.json"), "rb") as package_file:
+            self.assertEqual(package_file.read(), b"{}\n")
+        self.assertTrue(result.root.close())
+        self.assertFalse(result.root.verify())
+        self.assertTrue(result.root.close())
+
+    def test_required_entry_missing_rejects_before_claim(self) -> None:
+        result = self.extract(missing="package.json")
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.REQUIRED_ENTRY_MISSING))
+        self.assertFalse(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_bad_elf_is_removed(self) -> None:
+        result = self.extract(bad_elf=True)
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.ELF_INVALID))
+        self.assertFalse(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_candidate_collision_is_preserved(self) -> None:
+        target = os.path.join(self.temp, _CANDIDATE)
+        os.mkdir(target, 0o700)
+        marker = os.path.join(target, "marker")
+        with open(marker, "wb") as target_file:
+            target_file.write(b"preserve")
+        result = self.extract()
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.CANDIDATE_EXISTS))
+        with open(marker, "rb") as target_file:
+            self.assertEqual(target_file.read(), b"preserve")
+
+    def test_parent_mode_rejected(self) -> None:
+        os.chmod(self.temp, 0o755)
+        result = self.extract()
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.PARENT_BAD_MODE))
+        self.assertFalse(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_short_pwrite_loops_to_completion(self) -> None:
+        real = os.pwrite
+        calls = 0
+        def short(fd, data, offset):
+            nonlocal calls
+            calls += 1
+            return real(fd, data[:3], offset)
+        with patch("rlm.sandbox_release_extract.os.pwrite", side_effect=short):
+            result = self.extract()
+        self.assertIs(type(result), ExtractArchiveSuccess)
+        self.assertGreater(calls, 10)
+        self.assertTrue(result.root.close())
+
+    def test_zero_pwrite_fails_and_cleans(self) -> None:
+        with patch("rlm.sandbox_release_extract.os.pwrite", return_value=0):
+            result = self.extract()
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.FILE_WRITE_FAILED))
+        self.assertFalse(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_oversize_pwrite_fails_and_cleans(self) -> None:
+        with patch("rlm.sandbox_release_extract.os.pwrite", side_effect=lambda fd, data, offset: len(data) + 1):
+            result = self.extract()
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.FILE_WRITE_FAILED))
+        self.assertFalse(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_throwing_pwrite_fails_and_cleans(self) -> None:
+        with patch("rlm.sandbox_release_extract.os.pwrite", side_effect=RuntimeError("private")):
+            result = self.extract()
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.FILE_WRITE_FAILED))
+        self.assertFalse(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_fchmod_fault_makes_cleanup_uncertain(self) -> None:
+        with patch("rlm.sandbox_release_extract.os.fchmod", side_effect=OSError("private")):
+            result = self.extract()
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.CLEANUP_UNCERTAIN))
+        self.assertTrue(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_fsync_fault_makes_cleanup_uncertain(self) -> None:
+        real = os.fsync
+        calls = 0
+        def fail_once(fd):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise OSError("private")
+            return real(fd)
+        with patch("rlm.sandbox_release_extract.os.fsync", side_effect=fail_once):
+            result = self.extract()
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.SYNC_FAILED))
+        self.assertFalse(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_file_name_swap_refuses_cleanup(self) -> None:
+        real = os.pwrite
+        swapped = False
+        def swap(fd, data, offset):
+            nonlocal swapped
+            if not swapped:
+                swapped = True
+                root = os.path.join(self.temp, _CANDIDATE)
+                path = os.path.join(root, "install.sh")
+                moved = os.path.join(root, "moved")
+                os.rename(path, moved)
+                os.symlink("moved", path)
+            return real(fd, data, offset)
+        with patch("rlm.sandbox_release_extract.os.pwrite", side_effect=swap):
+            result = self.extract()
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.CLEANUP_UNCERTAIN))
+        self.assertTrue(os.path.islink(os.path.join(self.temp, _CANDIDATE, "install.sh")))
+
+    def test_elf_prefix_buffer_is_erased(self) -> None:
+        captured = []
+        from rlm import sandbox_release_extract as module
+        real = module._verify_elf
+        def capture(prefix):
+            captured.append(prefix)
+            return real(prefix)
+        with patch("rlm.sandbox_release_extract._verify_elf", side_effect=capture):
+            result = self.extract()
+        self.assertIs(type(result), ExtractArchiveSuccess)
+        self.assertTrue(captured)
+        self.assertTrue(all(value == 0 for value in captured[0]))
+        self.assertTrue(result.root.close())
+
+    def test_never_uses_immutable_pread(self) -> None:
+        with patch("rlm.sandbox_release_archive.os.pread", side_effect=AssertionError("forbidden"), create=True):
+            result = self.extract()
+        self.assertIs(type(result), ExtractArchiveSuccess)
+        self.assertTrue(result.root.close())
+
+    def test_second_pass_rejects_compressed_identity_swap(self) -> None:
+        archive_fd, identity, manifest = self.fixture()
+        mutated = False
+        def verify_then_mutate(fd, selected, selected_manifest):
+            nonlocal mutated
+            result = verify_archive(fd, selected, selected_manifest)
+            writable = os.open(self.archive_path, os.O_WRONLY)
+            try:
+                written = os.pwrite(writable, b"\x01", 4)
+                self.assertEqual(written, 1)
+            finally:
+                os.close(writable)
+            mutated = True
+            return result
+        try:
+            with patch(
+                "rlm.sandbox_release_extract.verify_archive",
+                side_effect=verify_then_mutate,
+            ):
+                result = extract_verified_archive(
+                    archive_fd, self.parent_fd, _CANDIDATE, identity, manifest
+                )
+        finally:
+            os.close(archive_fd)
+        self.assertTrue(mutated)
+        self.assertEqual(result, ExtractArchiveFailure(ArchiveErrorCode.DIGEST_MISMATCH))
+        self.assertFalse(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_seal_revalidates_each_child_directory(self) -> None:
+        real = _ExtractionSink._directory_stable
+        skill_checks = 0
+        def fail_final_skill_check(sink, record, expected_mode, **kwargs):
+            nonlocal skill_checks
+            result = real(sink, record, expected_mode, **kwargs)
+            if record.path == "skills":
+                skill_checks += 1
+                if skill_checks == 2:
+                    return False
+            return result
+        with patch.object(
+            _ExtractionSink,
+            "_directory_stable",
+            new=fail_final_skill_check,
+        ):
+            result = self.extract()
+        self.assertEqual(
+            result,
+            ExtractArchiveFailure(ExtractErrorCode.DIRECTORY_IDENTITY_CHANGED),
+        )
+        self.assertFalse(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_late_archive_failure_still_cleans_with_open_directory_fds(self) -> None:
+        from rlm import sandbox_release_extract as module
+        with patch(
+            "rlm.sandbox_release_extract._fstat_unchanged",
+            return_value=module.ArchiveErrorCode.FD_IDENTITY_CHANGED,
+        ):
+            result = self.extract()
+        self.assertEqual(result, ExtractArchiveFailure(module.ArchiveErrorCode.FD_IDENTITY_CHANGED))
+        self.assertFalse(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_capability_owns_all_directory_fds_until_close(self) -> None:
+        archive_fd, identity, manifest = self.fixture()
+        real_open = os.open
+        captured = []
+        def capture_open(*args, **kwargs):
+            fd = real_open(*args, **kwargs)
+            captured.append(fd)
+            return fd
+        try:
+            with patch("rlm.sandbox_release_extract.os.open", side_effect=capture_open):
+                result = extract_verified_archive(archive_fd, self.parent_fd, _CANDIDATE, identity, manifest)
+        finally:
+            os.close(archive_fd)
+        self.assertIs(type(result), ExtractArchiveSuccess)
+        open_fds = []
+        for fd in set(captured):
+            try:
+                os.fstat(fd)
+                open_fds.append(fd)
+            except OSError:
+                pass
+        self.assertGreater(len(open_fds), 2)
+        self.assertTrue(result.root.close())
+        for fd in set(captured):
+            with self.assertRaises(OSError):
+                os.fstat(fd)
+
+    def test_capability_close_retains_failed_fd_for_retry(self) -> None:
+        archive_fd, identity, manifest = self.fixture()
+        real_open = os.open
+        captured = []
+        def capture_open(*args, **kwargs):
+            fd = real_open(*args, **kwargs)
+            captured.append(fd)
+            return fd
+        try:
+            with patch("rlm.sandbox_release_extract.os.open", side_effect=capture_open):
+                result = extract_verified_archive(
+                    archive_fd, self.parent_fd, _CANDIDATE, identity, manifest
+                )
+        finally:
+            os.close(archive_fd)
+        self.assertIs(type(result), ExtractArchiveSuccess)
+        target = captured[0]
+        real_close = os.close
+        failed = False
+        def fail_once(fd):
+            nonlocal failed
+            if fd == target and not failed:
+                failed = True
+                raise OSError("private")
+            return real_close(fd)
+        with patch("rlm.sandbox_release_extract.os.close", side_effect=fail_once):
+            self.assertFalse(result.root.close())
+        os.fstat(target)
+        self.assertFalse(result.root.verify())
+        self.assertTrue(result.root.close())
+        with self.assertRaises(OSError):
+            os.fstat(target)
+
+    def test_large_file_is_written_in_bounded_chunks(self) -> None:
+        real = os.pwrite
+        largest = 0
+        def observe(fd, data, offset):
+            nonlocal largest
+            largest = max(largest, len(data))
+            return real(fd, data, offset)
+        archive_fd, identity, manifest = self.fixture(package_content=b"x" * 200_000)
+        try:
+            with patch("rlm.sandbox_release_extract.os.pwrite", side_effect=observe):
+                result = extract_verified_archive(archive_fd, self.parent_fd, _CANDIDATE, identity, manifest)
+        finally:
+            os.close(archive_fd)
+        self.assertIs(type(result), ExtractArchiveSuccess)
+        self.assertLessEqual(largest, 65536)
+        self.assertTrue(result.root.close())
+
+    def test_root_mkdir_failure_has_no_claim(self) -> None:
+        with patch("rlm.sandbox_release_extract.os.mkdir", side_effect=OSError("private")):
+            result = self.extract()
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.DIRECTORY_CREATE_FAILED))
+        self.assertFalse(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_root_open_failure_removes_empty_claim(self) -> None:
+        archive_fd, identity, manifest = self.fixture()
+        try:
+            with patch("rlm.sandbox_release_extract.os.open", side_effect=OSError("private")):
+                result = extract_verified_archive(archive_fd, self.parent_fd, _CANDIDATE, identity, manifest)
+        finally:
+            os.close(archive_fd)
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.DIRECTORY_OPEN_FAILED))
+        self.assertFalse(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_first_file_open_failure_cleans(self) -> None:
+        real = os.open
+        calls = 0
+        def fail_file(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise OSError("private")
+            return real(*args, **kwargs)
+        archive_fd, identity, manifest = self.fixture()
+        try:
+            with patch("rlm.sandbox_release_extract.os.open", side_effect=fail_file):
+                result = extract_verified_archive(archive_fd, self.parent_fd, _CANDIDATE, identity, manifest)
+        finally:
+            os.close(archive_fd)
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.FILE_CREATE_FAILED))
+        self.assertFalse(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_one_close_fault_is_retried_during_cleanup(self) -> None:
+        real = os.close
+        calls = 0
+        def fail_once(fd):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise OSError("private")
+            return real(fd)
+        with patch("rlm.sandbox_release_extract.os.close", side_effect=fail_once):
+            result = self.extract()
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.FILE_CLOSE_FAILED))
+        self.assertFalse(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_persistent_close_fault_is_cleanup_uncertain(self) -> None:
+        archive_fd, identity, manifest = self.fixture()
+        try:
+            with patch("rlm.sandbox_release_extract.os.close", side_effect=OSError("private")):
+                result = extract_verified_archive(archive_fd, self.parent_fd, _CANDIDATE, identity, manifest)
+        finally:
+            os.close(archive_fd)
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.CLEANUP_UNCERTAIN))
+        self.assertTrue(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_parent_mode_swap_dominates_cleanup(self) -> None:
+        real = os.pwrite
+        changed = False
+        def change_parent(fd, data, offset):
+            nonlocal changed
+            if not changed:
+                changed = True
+                os.chmod(self.temp, 0o755)
+            return real(fd, data, offset)
+        with patch("rlm.sandbox_release_extract.os.pwrite", side_effect=change_parent):
+            result = self.extract()
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.CLEANUP_UNCERTAIN))
+        self.assertTrue(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+        os.chmod(self.temp, 0o700)
+
+    def test_hardlink_swap_refuses_cleanup(self) -> None:
+        real = os.pwrite
+        linked = False
+        def add_link(fd, data, offset):
+            nonlocal linked
+            if not linked:
+                linked = True
+                root = os.path.join(self.temp, _CANDIDATE)
+                os.link(os.path.join(root, "install.sh"), os.path.join(root, "extra-link"))
+            return real(fd, data, offset)
+        with patch("rlm.sandbox_release_extract.os.pwrite", side_effect=add_link):
+            result = self.extract()
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.CLEANUP_UNCERTAIN))
+        self.assertTrue(os.path.exists(os.path.join(self.temp, _CANDIDATE, "extra-link")))
+
+    def test_required_mode_rejects_before_claim(self) -> None:
+        entries = _release_entries()
+        for entry in entries:
+            if entry["name"] == "install.sh":
+                entry["mode"] = 0o644
+        compressed, identity, manifest = _build(entries)
+        with open(self.archive_path, "wb") as target:
+            target.write(compressed)
+        os.chmod(self.archive_path, 0o600)
+        archive_fd = os.open(self.archive_path, os.O_RDONLY)
+        try:
+            result = extract_verified_archive(archive_fd, self.parent_fd, _CANDIDATE, identity, manifest)
+        finally:
+            os.close(archive_fd)
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.REQUIRED_ENTRY_INVALID))
+        self.assertFalse(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_stat_failure_after_root_claim_leaves_for_home(self) -> None:
+        real = os.stat
+        calls = 0
+        def fail_claim(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise OSError("private")
+            return real(*args, **kwargs)
+        with patch("rlm.sandbox_release_extract.os.stat", side_effect=fail_claim):
+            result = self.extract()
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.CLEANUP_UNCERTAIN))
+        self.assertTrue(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_child_directory_symlink_swap_is_cleanup_uncertain(self) -> None:
+        real = os.mkdir
+        swapped = False
+        def swap_after_mkdir(*args, **kwargs):
+            nonlocal swapped
+            result = real(*args, **kwargs)
+            name = args[0]
+            if name == "prime-agent-runtime" and not swapped:
+                swapped = True
+                root = os.path.join(self.temp, _CANDIDATE)
+                original = os.path.join(root, name)
+                moved = os.path.join(root, "moved-directory")
+                os.rename(original, moved)
+                os.symlink("moved-directory", original)
+            return result
+        with patch("rlm.sandbox_release_extract.os.mkdir", side_effect=swap_after_mkdir):
+            result = self.extract()
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.CLEANUP_UNCERTAIN))
+        self.assertTrue(os.path.islink(os.path.join(self.temp, _CANDIDATE, "prime-agent-runtime")))
+
+    def test_exact_cleanup_closes_all_extraction_fds(self) -> None:
+        archive_fd, identity, manifest = self.fixture()
+        real_open = os.open
+        captured = []
+        def capture_open(*args, **kwargs):
+            fd = real_open(*args, **kwargs)
+            captured.append(fd)
+            return fd
+        try:
+            with patch("rlm.sandbox_release_extract.os.open", side_effect=capture_open):
+                with patch("rlm.sandbox_release_extract.os.pwrite", return_value=0):
+                    result = extract_verified_archive(archive_fd, self.parent_fd, _CANDIDATE, identity, manifest)
+        finally:
+            os.close(archive_fd)
+        self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.FILE_WRITE_FAILED))
+        for fd in captured:
+            with self.assertRaises(OSError):
+                os.fstat(fd)
+        self.assertFalse(os.path.lexists(os.path.join(self.temp, _CANDIDATE)))
+
+    def test_bad_candidate_rejects_without_claim(self) -> None:
+        archive_fd, identity, manifest = self.fixture()
+        try:
+            for candidate in ("runtime", "../runtime-0123456789", "Runtime-0123456789abcdef", "a" * 65):
+                result = extract_verified_archive(archive_fd, self.parent_fd, candidate, identity, manifest)
+                self.assertEqual(result, ExtractArchiveFailure(ExtractErrorCode.BAD_CANDIDATE))
+        finally:
+            os.close(archive_fd)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/assemble-release-archives.mjs
+++ b/scripts/assemble-release-archives.mjs
@@ -38,13 +38,17 @@
 import { createHash } from "node:crypto";
 import {
 	chmodSync,
+	closeSync,
 	cpSync,
 	existsSync,
 	lstatSync,
 	mkdirSync,
+	openSync,
+	readSync,
 	readFileSync,
 	readdirSync,
 	rmSync,
+	statSync,
 	writeFileSync,
 } from "node:fs";
 import { spawnSync } from "node:child_process";
@@ -220,19 +224,234 @@ function assertSafeOutputDir(outDir) {
 	}
 }
 
-function sha256File(path) {
-	const hash = createHash("sha256");
-	hash.update(readFileSync(path));
-	return hash.digest("hex");
+const MANIFEST_VERSION = 1;
+const MAX_ARCHIVE_BYTES = 96 * 1024 * 1024;
+const MAX_DECOMPRESSED_TAR_BYTES = 256 * 1024 * 1024;
+const MAX_MANIFEST_BYTES = 1024 * 1024;
+const MAX_MEMBERS = 1024;
+const MAX_REGULAR_FILES = 512;
+const MAX_DIRECTORIES = 512;
+const MAX_PER_FILE_BYTES = 192 * 1024 * 1024;
+const MAX_TOTAL_FILE_BYTES = 224 * 1024 * 1024;
+const MAX_PATH_UTF8_BYTES = 512;
+const MAX_COMPONENT_UTF8_BYTES = 255;
+
+function sha256FileBounded(path) {
+	const fd = openSync(path, "r");
+	try {
+		const hash = createHash("sha256");
+		const buf = Buffer.alloc(1048576);
+		let bytesRead;
+		while ((bytesRead = readSync(fd, buf, 0, buf.length, null)) > 0) {
+			if (bytesRead < buf.length) {
+				hash.update(buf.subarray(0, bytesRead));
+			} else {
+				hash.update(buf);
+			}
+		}
+		return hash.digest("hex");
+	} finally {
+		closeSync(fd);
+	}
+}
+
+function sha256Bytes(data) {
+	return createHash("sha256").update(data).digest("hex");
+}
+
+function buildEntryManifest(stagingDir, version, platform, archiveName) {
+	const entries = [];
+	const seenPaths = new Set();
+	let totalFiles = 0;
+	let totalDirectories = 0;
+	let totalSize = 0;
+	const rootStat = lstatSync(stagingDir);
+	if (!rootStat.isDirectory()) throw new Error(`Staging root is not a directory: ${stagingDir}`);
+
+	// Root directory entry
+	entries.push({
+		path: ".",
+		type: "directory",
+		mode: "0755",
+		size: 0,
+	});
+	seenPaths.add(".");
+	totalDirectories++;
+	chmodSync(stagingDir, 0o755);
+
+	function walk(currentDir, relativePath) {
+		const dirEntries = readdirSync(currentDir, { withFileTypes: true }).sort((a, b) => bytewiseCompare(a.name, b.name));
+		for (const entry of dirEntries) {
+			const childPath = join(currentDir, entry.name);
+			const childRelative = relativePath === "" ? entry.name : `${relativePath}/${entry.name}`;
+
+			if (seenPaths.has(childRelative)) throw new Error(`Path collision: ${childRelative}`);
+			// Reject links and special files (lstat to detect symlinks)
+			const rawStat = lstatSync(childPath);
+			if (rawStat.isSymbolicLink()) throw new Error(`Refusing to package symlink: ${childRelative}`);
+			if (!rawStat.isFile() && !rawStat.isDirectory()) throw new Error(`Refusing to package special file: ${childRelative}`);
+
+			if (rawStat.isDirectory()) {
+				chmodSync(childPath, 0o755);
+				entries.push({
+					path: childRelative,
+					type: "directory",
+					mode: "0755",
+					size: 0,
+				});
+				seenPaths.add(childRelative);
+				totalDirectories++;
+				walk(childPath, childRelative);
+			} else {
+				const isExecutable = (rawStat.mode & 0o111) !== 0;
+				const normalizedMode = isExecutable ? "0755" : "0644";
+				const modeNum = isExecutable ? 0o755 : 0o644;
+				chmodSync(childPath, modeNum);
+				const preStat = lstatSync(childPath);
+				const sha256 = sha256FileBounded(childPath);
+				const postStat = lstatSync(childPath);
+				if (
+					!preStat.isFile() ||
+					!postStat.isFile() ||
+					preStat.nlink !== 1 ||
+					postStat.nlink !== 1 ||
+					(preStat.mode & 0o7777) !== modeNum ||
+					(postStat.mode & 0o7777) !== modeNum ||
+					preStat.dev !== postStat.dev ||
+					preStat.ino !== postStat.ino ||
+					preStat.size !== postStat.size ||
+					preStat.mtimeMs !== postStat.mtimeMs
+				) {
+					throw new Error(`File changed during hashing: ${childRelative}`);
+				}
+				const fileStat = postStat;
+
+				entries.push({
+					path: childRelative,
+					type: "file",
+					mode: normalizedMode,
+					size: fileStat.size,
+					sha256,
+				});
+				seenPaths.add(childRelative);
+				totalFiles++;
+				totalSize += fileStat.size;
+			}
+		}
+	}
+
+	walk(stagingDir, "");
+	entries.sort((a, b) => bytewiseCompare(a.path, b.path));
+
+	return {
+		manifestVersion: MANIFEST_VERSION,
+		version,
+		platform,
+		archive: archiveName,
+		totalFiles,
+		totalDirectories,
+		totalSize,
+		entries,
+	};
+}
+
+function bytewiseCompare(a, b) {
+	return Buffer.compare(Buffer.from(a, "utf8"), Buffer.from(b, "utf8"));
+}
+
+function validateManifestPath(path) {
+	if (typeof path !== "string" || path.length === 0 || path.startsWith("/") || path.includes("\\")) {
+		throw new Error("Invalid release manifest path");
+	}
+	const encoded = Buffer.from(path, "utf8");
+	if (encoded.toString("utf8") !== path || encoded.byteLength > MAX_PATH_UTF8_BYTES) {
+		throw new Error("Invalid release manifest path");
+	}
+	if (path === ".") return;
+	for (const component of path.split("/")) {
+		if (
+			component.length === 0 ||
+			component === "." ||
+			component === ".." ||
+			Buffer.byteLength(component, "utf8") > MAX_COMPONENT_UTF8_BYTES ||
+			/[\u0000-\u001f\u007f]/.test(component)
+		) {
+			throw new Error("Invalid release manifest path");
+		}
+	}
+}
+
+function verifyEntryManifest(manifest) {
+	const { totalFiles, totalDirectories, totalSize, entries } = manifest;
+	if (!Array.isArray(entries) || entries.length === 0 || entries.length > MAX_MEMBERS) {
+		throw new Error("Invalid release manifest member count");
+	}
+	if (entries[0]?.path !== "." || entries[0]?.type !== "directory") {
+		throw new Error("Release manifest root must be first");
+	}
+	const seen = new Set();
+	const directories = new Set();
+	let countedFiles = 0;
+	let countedDirectories = 0;
+	let countedSize = 0;
+	let previousPath;
+	for (const entry of entries) {
+		validateManifestPath(entry.path);
+		if (seen.has(entry.path)) throw new Error("Duplicate release manifest path");
+		if (previousPath !== undefined && bytewiseCompare(previousPath, entry.path) >= 0) {
+			throw new Error("Release manifest paths are not in bytewise order");
+		}
+		previousPath = entry.path;
+		seen.add(entry.path);
+		if (entry.path !== ".") {
+			const slash = entry.path.lastIndexOf("/");
+			const parent = slash < 0 ? "." : entry.path.slice(0, slash);
+			if (!directories.has(parent)) throw new Error("Release manifest parent is missing or out of order");
+		}
+		if (entry.type === "file") {
+			countedFiles++;
+			if (
+				(entry.mode !== "0644" && entry.mode !== "0755") ||
+				!Number.isSafeInteger(entry.size) ||
+				entry.size < 0 ||
+				entry.size > MAX_PER_FILE_BYTES ||
+				typeof entry.sha256 !== "string" ||
+				!/^[a-f0-9]{64}$/.test(entry.sha256)
+			) {
+				throw new Error("Invalid release manifest file entry");
+			}
+			countedSize += entry.size;
+		} else if (entry.type === "directory") {
+			countedDirectories++;
+			if (entry.mode !== "0755" || entry.sha256 !== undefined || entry.size !== 0) {
+				throw new Error("Invalid release manifest directory entry");
+			}
+			directories.add(entry.path);
+		} else {
+			throw new Error("Invalid release manifest entry type");
+		}
+	}
+	if (
+		countedFiles !== totalFiles ||
+		countedDirectories !== totalDirectories ||
+		countedSize !== totalSize ||
+		countedFiles > MAX_REGULAR_FILES ||
+		countedDirectories > MAX_DIRECTORIES ||
+		countedSize > MAX_TOTAL_FILE_BYTES
+	) {
+		throw new Error("Release manifest totals are invalid");
+	}
+	return manifest;
 }
 
 function createArchive(sourceDir, archivePath) {
-	const result = spawnSync("tar", ["-czf", archivePath, "-C", sourceDir, "."], {
+	const result = spawnSync("tar", ["--format=ustar", "-czf", archivePath, "-C", sourceDir, "."], {
 		stdio: "pipe",
 		encoding: "utf8",
 	});
 	if (result.status !== 0) throw new Error(`tar failed: ${result.stderr || result.stdout}`);
 }
+
 
 function validateSidecars(sidecarDir) {
 	const missingFiles = REQUIRED_SIDECAR_FILES.filter((name) => {
@@ -246,14 +465,24 @@ function validateSidecars(sidecarDir) {
 	return [...missingFiles, ...missingDirectories];
 }
 
-const FORBIDDEN_RELEASE_DIRECTORIES = new Set(["node_modules", ".venv", "__pycache__", ".pytest_cache"]);
 
-function findForbiddenReleaseDirectory(root, relativePath = "") {
-	for (const entry of readdirSync(join(root, relativePath), { withFileTypes: true })) {
-		const child = join(relativePath, entry.name);
-		if (FORBIDDEN_RELEASE_DIRECTORIES.has(entry.name)) return child;
-		if (entry.isDirectory()) {
-			const found = findForbiddenReleaseDirectory(root, child);
+function validateStagingDir(root, relativePath) {
+	const dirEntries = readdirSync(join(root, relativePath), { withFileTypes: true });
+	for (const entry of dirEntries) {
+		const child = relativePath === "" ? entry.name : `${relativePath}/${entry.name}`;
+		const fullPath = join(root, child);
+		const stat = lstatSync(fullPath);
+		if (stat.isSymbolicLink()) {
+			return { kind: "symlink", path: child };
+		}
+		if (!stat.isFile() && !stat.isDirectory()) {
+			return { kind: "special", path: child };
+		}
+		if (entry.name === "node_modules" || entry.name === ".venv" || entry.name === "__pycache__" || entry.name === ".pytest_cache") {
+			return { kind: "forbidden", path: child };
+		}
+		if (stat.isDirectory()) {
+			const found = validateStagingDir(root, child);
 			if (found) return found;
 		}
 	}
@@ -280,6 +509,35 @@ function renderInstaller(path, baseUrl, channel) {
 	chmodSync(path, 0o755);
 }
 
+function readGzipUncompressedSize(path) {
+	const archiveStat = statSync(path);
+	if (archiveStat.size < 18) throw new Error("Archive is too small for gzip");
+	const fd = openSync(path, "r");
+	try {
+		const buffer = Buffer.alloc(4);
+		let completed = 0;
+		while (completed < buffer.byteLength) {
+			const count = readSync(
+				fd,
+				buffer,
+				completed,
+				buffer.byteLength - completed,
+				archiveStat.size - buffer.byteLength + completed,
+			);
+			if (count <= 0) throw new Error("Short read while reading gzip ISIZE");
+			completed += count;
+		}
+		const isize = buffer.readUInt32LE(0);
+		if (isize === 0 || isize > MAX_DECOMPRESSED_TAR_BYTES || isize % 512 !== 0) {
+			throw new Error("Gzip ISIZE is outside release safety bounds");
+		}
+		return isize;
+	} finally {
+		closeSync(fd);
+	}
+}
+
+
 function main() {
 	const args = parseArgs(process.argv.slice(2));
 	const outDir = resolve(args.outDir);
@@ -292,9 +550,15 @@ function main() {
 			`Run "bun run copy-binary-assets" first.`,
 		);
 	}
-	const forbiddenDirectory = findForbiddenReleaseDirectory(args.sidecarDir);
-	if (forbiddenDirectory) {
-		throw new Error(`Release sidecars contain a forbidden dependency or cache directory: ${forbiddenDirectory}`);
+	const preflight = validateStagingDir(args.sidecarDir, "");
+	if (preflight) {
+		if (preflight.kind === "symlink") {
+			throw new Error(`Release sidecars contain a symlink: ${preflight.path}`);
+		}
+		if (preflight.kind === "special") {
+			throw new Error(`Release sidecars contain a special file: ${preflight.path}`);
+		}
+		throw new Error(`Release sidecars contain a forbidden dependency or cache directory: ${preflight.path}`);
 	}
 
 	const binarySources = new Map();
@@ -302,6 +566,14 @@ function main() {
 		const binarySource = join(args.binaryDir, platform, "pi");
 		if (!existsSync(binarySource)) {
 			throw new Error(`Binary not found for platform ${platform}: ${binarySource}`);
+		}
+		// Reject symlinks in binary source path; require regular file
+		const binStat = lstatSync(binarySource);
+		if (binStat.isSymbolicLink()) {
+			throw new Error(`Binary for ${platform} is a symlink: ${binarySource}`);
+		}
+		if (!binStat.isFile()) {
+			throw new Error(`Binary for ${platform} is not a regular file: ${binarySource}`);
 		}
 		binarySources.set(platform, binarySource);
 	}
@@ -330,26 +602,60 @@ function main() {
 		renderInstaller(join(stagingDir, "install.sh"), args.baseUrl, args.channel);
 
 		const archiveName = `prime-agent-${args.version}-${platform}.tar.gz`;
+		const manifestName = `prime-agent-${args.version}-${platform}.manifest.json`;
+
+		const rawManifest = buildEntryManifest(stagingDir, args.version, platform, archiveName);
+		const verifiedManifest = verifyEntryManifest(rawManifest);
 		const archivePath = join(versionDir, archiveName);
 		createArchive(stagingDir, archivePath);
 
-		const sha256 = sha256File(archivePath);
-		archives.push({ platform, file: archiveName, sha256 });
+		const archiveByteSize = statSync(archivePath).size;
+		if (archiveByteSize <= 0 || archiveByteSize > MAX_ARCHIVE_BYTES) {
+			throw new Error("Archive is outside release safety bounds");
+		}
+		const archiveSha256 = sha256FileBounded(archivePath);
+		const decompressedTarBytes = readGzipUncompressedSize(archivePath);
+		verifiedManifest.decompressedTarBytes = decompressedTarBytes;
+		const finalManifestContent = `${JSON.stringify(verifiedManifest, null, 2)}\n`;
+		const manifestByteSize = Buffer.byteLength(finalManifestContent, "utf8");
+		if (manifestByteSize <= 0 || manifestByteSize > MAX_MANIFEST_BYTES) {
+			throw new Error("Entry manifest is outside release safety bounds");
+		}
+		const manifestPath = join(versionDir, manifestName);
+		writeFileSync(manifestPath, finalManifestContent);
+		const finalManifestSha256 = sha256Bytes(finalManifestContent);
+		archives.push({
+			platform,
+			file: archiveName,
+			sha256: archiveSha256,
+			byteSize: archiveByteSize,
+			decompressedTarBytes,
+			manifestFile: manifestName,
+			manifestSha256: finalManifestSha256,
+			manifestByteSize,
+		});
 		console.log(`Created ${archivePath}`);
+		console.log(`Created ${manifestPath} (${verifiedManifest.totalFiles} files, ${verifiedManifest.totalDirectories} dirs, ${verifiedManifest.totalSize} bytes, ${decompressedTarBytes} decompressed)`);
 
 		rmSync(join(outDir, "staging"), { force: true, recursive: true });
 	}
 
 	if (archives.length === 0) throw new Error("No platform archives created");
 
-	archives.sort((a, b) => a.file.localeCompare(b.file));
-	const sumsContent = archives.map((a) => `${a.sha256}  ${a.file}`).join("\n") + "\n";
+	archives.sort((a, b) => { if (a.file < b.file) return -1; if (a.file > b.file) return 1; return 0; });
+	const sumsEntries = [];
+	for (const a of archives) {
+		sumsEntries.push({ sha256: a.sha256, file: a.file });
+		sumsEntries.push({ sha256: a.manifestSha256, file: a.manifestFile });
+	}
+	sumsEntries.sort((a, b) => { if (a.file < b.file) return -1; if (a.file > b.file) return 1; return 0; });
+	const sumsContent = sumsEntries.map((e) => `${e.sha256}  ${e.file}`).join("\n") + "\n";
 	writeFileSync(join(versionDir, "SHA256SUMS"), sumsContent);
 	writeFileSync(join(versionDir, args.channel), `v${args.version}\n`);
 
-	const manifestName = args.channel === "stable" ? "latest.json" : "beta.json";
+	const channelManifestName = args.channel === "stable" ? "latest.json" : "beta.json";
 	writeFileSync(
-		join(versionDir, manifestName),
+		join(versionDir, channelManifestName),
 		JSON.stringify(
 			{
 				version: `v${args.version}`,
@@ -358,6 +664,11 @@ function main() {
 					platform: a.platform,
 					file: a.file,
 					sha256: a.sha256,
+					byteSize: a.byteSize,
+					decompressedTarBytes: a.decompressedTarBytes,
+					manifestFile: a.manifestFile,
+					manifestSha256: a.manifestSha256,
+					manifestByteSize: a.manifestByteSize,
 				})),
 				baseUrl: `${args.baseUrl}/releases/v${args.version}`,
 			},
@@ -367,7 +678,7 @@ function main() {
 	);
 
 	console.log(`\nSHA256SUMS -> ${join(versionDir, "SHA256SUMS")}`);
-	console.log(`${manifestName} -> ${join(versionDir, manifestName)}`);
+	console.log(`${channelManifestName} -> ${join(versionDir, channelManifestName)}`);
 }
 
 try {


### PR DESCRIPTION
## Stack

Depends on #1970. This clean sandbox-sessions stack replaces the implementation direction archived in #2025.

Linear: https://linear.app/primeintellect/issue/RES-1264

## Accepted layers

- approved clean execution plan;
- exact Prime CLI 0.6.21 create/version/list/get codecs and source-derived fixtures;
- canonical ownership records and hostile-filesystem journal;
- Home-private four-method lifecycle with mutually exclusive one-shot create/absence authorities;
- bounded direct Prime CLI process runner;
- journal-internal deletion finalization with closure-private post-proof retry authority;
- strict Python 3.11 streaming official-release verifier using bounded `preadv -> zlib -> tar`;
- canonical ustar release entry manifests, producer/parser safety limits, and pre-upload archive/manifest pair guards;
- public `sandbox: boolean` parsing and an exact early fail-closed dispatch boundary;
- fd-relative official-release extraction into an owned private root with second-pass archive hashing, durable bottom-up sync, identity-aware cleanup, and a nominal runtime-root capability.

## Safety state

- omitted or `sandbox: false` keeps local behavior;
- `sandbox: true` still returns exactly `Sandbox execution is not available for this session` before child or provider effects;
- `sandbox_sessions` is not advertised;
- no provider credential adapter, runtime launch, network exposure, authenticated transport, relay, workspace sync, or production sandbox factory is enabled;
- no paid or remote resource was created.

## Current validation

Using pinned Bun 1.4.0 and Python 3.11:

- provider/runner/lifecycle/ownership integration: 295 passed, 0 failed, 993 expectations;
- RLM recursion/resident/daemon fail-closed integration: 331 passed, 0 failed, 1,375 expectations;
- release archive producer suite: 24 passed, 0 failed, 560 expectations;
- Phase 1 verifier plus Phase 2 extractor: 141 passed, 0 failed under `ResourceWarning`-as-error;
- a fresh official Linux x64 producer-to-extractor run passed all 308 entries and 164,906,190 regular-file bytes;
- the full Python runtime suite passed 409 tests, with one pre-existing macOS platform-emulation failure reproduced unchanged on the parent commit;
- `bun run check`, Python `py_compile`, workflow YAML parsing, publication `sh -n`/`dash -n`, and `git diff --check` pass.

The complete coding-agent suite passed all 364 test files on the current head.

## Next layers

1. pinned in-memory direct HTTPS auth/upload/exec/expose adapters without the SDK plaintext cache or whole-file upload;
2. fixed extraction/launcher commands, native TCP exposure, and mutually authenticated application transport;
3. real runtime FD3 authority, READY proof, Home relay, and one Home-proxied model request;
4. messaging, observation, PAWS sync, restart recovery, controlled live validation, and capability activation.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add sandbox lifecycle, ownership journal, and Prime CLI codec foundation
> - Adds `createSandboxLifecycle` factory with `inspect`, `create`, `waitUntilReady`, `deleteAndProveAbsent`, and `consumeProof` operations, gated by an exact Prime CLI 0.6.21 version check and driven by an injected command runner
> - Adds ownership record codec, chain validator, and durable filesystem journal (`createOwnershipJournal`) with hostile-filesystem defenses, crash-recovery, and one-shot token model for permissions and proofs
> - Adds Prime CLI create-output and JSON-output decoders with strict field validation, UTF-8 bounds, control-character rejection, and opaque frozen failure results
> - Adds `command-runner.ts` with argv/timeout validation, lone-surrogate rejection, abort-signal handling, and Bun spawn adapter
> - Behavioral Change: all lifecycle, codec, and journal results are frozen; handles/permissions/proofs carry no serializable IDs and are valid only within the creating adapter; rejected CLI output returns fixed `INVALID_OUTPUT` or `INPUT_INVALID` codes without reflecting provider data
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84a30ce. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
