### PR TITLE
fix(coding-agent): one zombie-aware process-liveness probe

### DIFF
--- a/packages/coding-agent/.changes/worker-state-one-liveness-probe.md
+++ b/packages/coding-agent/.changes/worker-state-one-liveness-probe.md
@@ -1,0 +1,1 @@
+- Fixed zombie processes being treated as live owners by the daemon supervisor ownership registry, session leases, supervisor launch locks, `daemon ps` process stops, and update-restart liveness checks; all process liveness probes now share the zombie-aware helper.

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -1096,20 +1096,12 @@ async function stopTrackedProcess(
 	return trackedProcessStopped(pid);
 }
 
-/**
- * This is a process-GROUP stop: a zombie or reaped leader has exited, but
- * running descendants in its group must still be stopped, so completion needs
- * the leader gone and no live member left (unreaped zombies do not block it).
- */
+/** A GROUP stop completes when the leader is gone AND no live member remains; unreaped zombies do not block it. */
 function trackedProcessStopped(pid: number): boolean {
 	return !isProcessAlive(pid) && !processGroupHasLiveMember(pid);
 }
 
-/**
- * Identity gates protect against pid reuse and only apply while the leader
- * process still exists; a gone leader leaves teardown to the group checks (a
- * pgid cannot be reused while members hold it).
- */
+/** Identity gates guard pid reuse, so they apply only while the leader exists; a pgid cannot be reused while members hold it. */
 function trackedLeaderIdentityCurrent(pid: number, expectedStartId: string): boolean {
 	if (!processIdExists(pid)) {
 		return true;

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -19,7 +19,7 @@ import {
 import { defaultDaemonSocketDir, defaultDaemonSocketPath, normalizeSocketPath } from "../modes/daemon/daemon-socket.js";
 import { acquireDaemonShutdownAdmission } from "../modes/daemon/daemon-supervisor-ownership.js";
 import type { DaemonWorkerDescriptor } from "../modes/daemon/daemon-worker-protocol.js";
-import { signalProcessGroupOrProcess } from "../utils/child-process.js";
+import { isProcessAlive, signalProcessGroupOrProcess } from "../utils/child-process.js";
 import { formatDaemonListTable } from "./daemon-ps-format.js";
 import { promptYesNo } from "./daemon-stop-confirm.js";
 
@@ -1217,15 +1217,6 @@ async function forceKillDaemon(pid: number): Promise<void> {
 		process.kill(pid, "SIGKILL");
 	} catch {
 		// Process already exited between the liveness check and the kill.
-	}
-}
-
-function isProcessAlive(pid: number): boolean {
-	try {
-		process.kill(pid, 0);
-		return true;
-	} catch (error) {
-		return (error as NodeJS.ErrnoException).code === "EPERM";
 	}
 }
 

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -23,7 +23,7 @@ import {
 	isProcessAlive,
 	processGroupHasLiveMember,
 	processIdExists,
-	signalProcessGroupOrProcess,
+	signalProcessGroupIfHeld,
 } from "../utils/child-process.js";
 import { formatDaemonListTable } from "./daemon-ps-format.js";
 import { promptYesNo } from "./daemon-stop-confirm.js";
@@ -1076,7 +1076,7 @@ async function stopTrackedProcess(
 	if (!trackedLeaderIdentityCurrent(pid, expectedStartId)) {
 		return false;
 	}
-	signalProcessGroupOrProcess(pid, "SIGTERM");
+	signalProcessGroupIfHeld(pid, "SIGTERM");
 	let deadline = Date.now() + 500;
 	while (!trackedProcessStopped(pid) && Date.now() < deadline) {
 		await delay(25);
@@ -1088,7 +1088,7 @@ async function stopTrackedProcess(
 	if (!trackedLeaderIdentityCurrent(pid, expectedStartId)) {
 		return false;
 	}
-	signalProcessGroupOrProcess(pid, "SIGKILL");
+	signalProcessGroupIfHeld(pid, "SIGKILL");
 	deadline = Date.now() + 1000;
 	while (!trackedProcessStopped(pid) && Date.now() < deadline) {
 		await delay(25);

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -19,7 +19,12 @@ import {
 import { defaultDaemonSocketDir, defaultDaemonSocketPath, normalizeSocketPath } from "../modes/daemon/daemon-socket.js";
 import { acquireDaemonShutdownAdmission } from "../modes/daemon/daemon-supervisor-ownership.js";
 import type { DaemonWorkerDescriptor } from "../modes/daemon/daemon-worker-protocol.js";
-import { isProcessAlive, processGroupExists, signalProcessGroupOrProcess } from "../utils/child-process.js";
+import {
+	isProcessAlive,
+	processGroupHasLiveMember,
+	processIdExists,
+	signalProcessGroupOrProcess,
+} from "../utils/child-process.js";
 import { formatDaemonListTable } from "./daemon-ps-format.js";
 import { promptYesNo } from "./daemon-stop-confirm.js";
 
@@ -1064,11 +1069,11 @@ async function stopTrackedProcess(
 	if (trackedProcessStopped(pid)) {
 		return true;
 	}
-	if (!expectedStartId || getProcessStartId(pid) !== expectedStartId) {
+	if (!expectedStartId || !trackedLeaderIdentityCurrent(pid, expectedStartId)) {
 		return false;
 	}
 	await assertAdmission();
-	if (getProcessStartId(pid) !== expectedStartId) {
+	if (!trackedLeaderIdentityCurrent(pid, expectedStartId)) {
 		return false;
 	}
 	signalProcessGroupOrProcess(pid, "SIGTERM");
@@ -1080,7 +1085,7 @@ async function stopTrackedProcess(
 		return true;
 	}
 	await assertAdmission();
-	if (getProcessStartId(pid) !== expectedStartId) {
+	if (!trackedLeaderIdentityCurrent(pid, expectedStartId)) {
 		return false;
 	}
 	signalProcessGroupOrProcess(pid, "SIGKILL");
@@ -1093,10 +1098,23 @@ async function stopTrackedProcess(
 
 /**
  * This is a process-GROUP stop: a zombie or reaped leader has exited, but
- * descendants in its group can still run, so completion needs both gone.
+ * running descendants in its group must still be stopped, so completion needs
+ * the leader gone and no live member left (unreaped zombies do not block it).
  */
 function trackedProcessStopped(pid: number): boolean {
-	return !isProcessAlive(pid) && !processGroupExists(pid);
+	return !isProcessAlive(pid) && !processGroupHasLiveMember(pid);
+}
+
+/**
+ * Identity gates protect against pid reuse and only apply while the leader
+ * process still exists; a gone leader leaves teardown to the group checks (a
+ * pgid cannot be reused while members hold it).
+ */
+function trackedLeaderIdentityCurrent(pid: number, expectedStartId: string): boolean {
+	if (!processIdExists(pid)) {
+		return true;
+	}
+	return getProcessStartId(pid) === expectedStartId;
 }
 
 export async function runReap(json: boolean, force: boolean): Promise<void> {

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -19,7 +19,7 @@ import {
 import { defaultDaemonSocketDir, defaultDaemonSocketPath, normalizeSocketPath } from "../modes/daemon/daemon-socket.js";
 import { acquireDaemonShutdownAdmission } from "../modes/daemon/daemon-supervisor-ownership.js";
 import type { DaemonWorkerDescriptor } from "../modes/daemon/daemon-worker-protocol.js";
-import { isProcessAlive, signalProcessGroupOrProcess } from "../utils/child-process.js";
+import { isProcessAlive, processGroupExists, signalProcessGroupOrProcess } from "../utils/child-process.js";
 import { formatDaemonListTable } from "./daemon-ps-format.js";
 import { promptYesNo } from "./daemon-stop-confirm.js";
 
@@ -1061,7 +1061,7 @@ async function stopTrackedProcess(
 	expectedStartId: string | undefined,
 	assertAdmission: () => Promise<void>,
 ): Promise<boolean> {
-	if (!isProcessAlive(pid)) {
+	if (trackedProcessStopped(pid)) {
 		return true;
 	}
 	if (!expectedStartId || getProcessStartId(pid) !== expectedStartId) {
@@ -1073,10 +1073,10 @@ async function stopTrackedProcess(
 	}
 	signalProcessGroupOrProcess(pid, "SIGTERM");
 	let deadline = Date.now() + 500;
-	while (isProcessAlive(pid) && Date.now() < deadline) {
+	while (!trackedProcessStopped(pid) && Date.now() < deadline) {
 		await delay(25);
 	}
-	if (!isProcessAlive(pid)) {
+	if (trackedProcessStopped(pid)) {
 		return true;
 	}
 	await assertAdmission();
@@ -1085,10 +1085,18 @@ async function stopTrackedProcess(
 	}
 	signalProcessGroupOrProcess(pid, "SIGKILL");
 	deadline = Date.now() + 1000;
-	while (isProcessAlive(pid) && Date.now() < deadline) {
+	while (!trackedProcessStopped(pid) && Date.now() < deadline) {
 		await delay(25);
 	}
-	return !isProcessAlive(pid);
+	return trackedProcessStopped(pid);
+}
+
+/**
+ * This is a process-GROUP stop: a zombie or reaped leader has exited, but
+ * descendants in its group can still run, so completion needs both gone.
+ */
+function trackedProcessStopped(pid: number): boolean {
+	return !isProcessAlive(pid) && !processGroupExists(pid);
 }
 
 export async function runReap(json: boolean, force: boolean): Promise<void> {

--- a/packages/coding-agent/src/cli/daemon-update-restart.ts
+++ b/packages/coding-agent/src/cli/daemon-update-restart.ts
@@ -14,6 +14,7 @@ import {
 	DAEMON_WORKER_SUPERVISOR_SOCKET_ENV,
 	DAEMON_WORKER_TOKEN_ENV,
 } from "../modes/daemon/daemon-worker-protocol.js";
+import { isProcessAlive } from "../utils/child-process.js";
 import { createCliSubprocessLaunchSpec } from "./subprocess-launch.js";
 
 export const DAEMON_UPDATE_RESTART_COORDINATOR_FLAG = "--internal-update-restart-coordinator";
@@ -352,15 +353,6 @@ async function withCoordinatorRegistryGuard<T>(registryDir: string, action: () =
 		if (compromisedError) await release().catch(() => undefined);
 		else await release();
 	}
-}
-
-function isProcessAlive(pid: number): boolean {
-	try {
-		process.kill(pid, 0);
-	} catch (error) {
-		return (error as NodeJS.ErrnoException).code !== "ESRCH";
-	}
-	return true;
 }
 
 function matchesProcessStartId(identity: DaemonUpdateRestartProcessIdentity): boolean {

--- a/packages/coding-agent/src/core/session-lease.ts
+++ b/packages/coding-agent/src/core/session-lease.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { lockSync } from "proper-lockfile";
+import { isProcessAlive } from "../utils/child-process.js";
 
 export const SESSION_LEASES_ENABLED_ENV = "PRIME_AGENT_INTERNAL_SESSION_LEASES";
 export const SESSION_LEASE_OWNER_ID_ENV = "PRIME_AGENT_INTERNAL_SESSION_LEASE_OWNER_ID";
@@ -98,15 +99,6 @@ function readLeaseOwner(directory: string): SessionLeaseOwner | undefined {
 		return parsed as SessionLeaseOwner;
 	} catch {
 		return undefined;
-	}
-}
-
-function isProcessAlive(pid: number): boolean {
-	try {
-		process.kill(pid, 0);
-		return true;
-	} catch (error) {
-		return (error as NodeJS.ErrnoException).code === "EPERM";
 	}
 }
 

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -107,6 +107,7 @@ import {
 import { resolveSessionPath } from "../../core/session-resolver.js";
 import type { SessionStats } from "../../core/session-stats.js";
 import { type SideQuestionRun, startSideQuestion } from "../../core/side-question.js";
+import { isProcessAlive } from "../../utils/child-process.js";
 import { killTrackedDetachedChildren } from "../../utils/shell.js";
 import {
 	createAgentConnectionCommands,
@@ -867,7 +868,7 @@ export class AgentDaemon {
 					} catch {
 						// An invalid owner is reclaimed atomically below.
 					}
-					if (ownerPid && this.isProcessAlive(ownerPid)) {
+					if (ownerPid && isProcessAlive(ownerPid)) {
 						return;
 					}
 					const staleDirectory = `${lockDirectory}.stale-${process.pid}-${token}`;
@@ -922,15 +923,6 @@ export class AgentDaemon {
 				rmSync(lockDirectory, { recursive: true, force: true });
 			}
 			this.supervisorLaunchInProgress = false;
-		}
-	}
-
-	private isProcessAlive(pid: number): boolean {
-		try {
-			process.kill(pid, 0);
-			return true;
-		} catch (error) {
-			return (error as NodeJS.ErrnoException).code === "EPERM";
 		}
 	}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -527,6 +527,13 @@ function isOwnerProcessAlive(pid: number): boolean {
 		ownerZombieConfirmations.delete(pid);
 		return false;
 	}
+	// Expired entries belong to owners nothing asserts anymore (released claims,
+	// replaced supervisors); drop them here so the cache stays bounded.
+	for (const [staleOwnerPid, staleConfirmedAt] of ownerZombieConfirmations) {
+		if (now - staleConfirmedAt >= OWNER_ZOMBIE_CONFIRM_INTERVAL_MS) {
+			ownerZombieConfirmations.delete(staleOwnerPid);
+		}
+	}
 	ownerZombieConfirmations.set(pid, now);
 	return true;
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -14,7 +14,7 @@ import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import lockfile from "proper-lockfile";
 import { getProcessStartId } from "../../core/session-lease.js";
-import { isProcessAlive } from "../../utils/child-process.js";
+import { isProcessAlive, isZombieProcess, processIdExists } from "../../utils/child-process.js";
 import { defaultDaemonSocketDir, normalizeSocketPath } from "./daemon-socket.js";
 
 const DAEMON_SUPERVISOR_REGISTRY_DIR_ENV = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR";
@@ -507,6 +507,30 @@ export async function acquireDaemonSupervisorOwnership(
 	return new DaemonSupervisorOwnership(record, registryDir, ownerDirectory);
 }
 
+// The fence poll asserts every bound claim every 250ms; the zombie check spawns
+// `ps` on macOS/BSD, so confirm it at most this often per owner pid. Existence
+// stays checked on every tick, which catches reaped owners immediately.
+const OWNER_ZOMBIE_CONFIRM_INTERVAL_MS = 5000;
+const ownerZombieConfirmations = new Map<number, number>();
+
+function isOwnerProcessAlive(pid: number): boolean {
+	if (!processIdExists(pid)) {
+		ownerZombieConfirmations.delete(pid);
+		return false;
+	}
+	const now = Date.now();
+	const confirmedAt = ownerZombieConfirmations.get(pid);
+	if (confirmedAt !== undefined && now - confirmedAt < OWNER_ZOMBIE_CONFIRM_INTERVAL_MS) {
+		return true;
+	}
+	if (isZombieProcess(pid)) {
+		ownerZombieConfirmations.delete(pid);
+		return false;
+	}
+	ownerZombieConfirmations.set(pid, now);
+	return true;
+}
+
 export async function assertDaemonSupervisorOwnerCurrent(
 	owner: {
 		generation: string;
@@ -527,7 +551,7 @@ export async function assertDaemonSupervisorOwnerCurrent(
 		current.pid !== owner.pid ||
 		current.processStartId !== owner.processStartId ||
 		current.socketPath !== normalizeSocketPath(owner.socketPath) ||
-		!isProcessAlive(current.pid)
+		!isOwnerProcessAlive(current.pid)
 	) {
 		throw new DaemonSupervisorOwnershipLostError(owner.generation, { socketPath: owner.socketPath, registryDir });
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -507,9 +507,7 @@ export async function acquireDaemonSupervisorOwnership(
 	return new DaemonSupervisorOwnership(record, registryDir, ownerDirectory);
 }
 
-// The fence poll asserts every bound claim every 250ms; the zombie check spawns
-// `ps` on macOS/BSD, so confirm it at most this often per owner pid. Existence
-// stays checked on every tick, which catches reaped owners immediately.
+// The 250ms fence poll must not spawn `ps` (macOS/BSD zombie check) per tick; existence stays kill(0)-checked every tick.
 const OWNER_ZOMBIE_CONFIRM_INTERVAL_MS = 5000;
 const ownerZombieConfirmations = new Map<number, number>();
 
@@ -527,8 +525,7 @@ function isOwnerProcessAlive(pid: number): boolean {
 		ownerZombieConfirmations.delete(pid);
 		return false;
 	}
-	// Expired entries belong to owners nothing asserts anymore (released claims,
-	// replaced supervisors); drop them here so the cache stays bounded.
+	// Expired entries belong to owners nothing asserts anymore; dropping them keeps the cache bounded.
 	for (const [staleOwnerPid, staleConfirmedAt] of ownerZombieConfirmations) {
 		if (now - staleConfirmedAt >= OWNER_ZOMBIE_CONFIRM_INTERVAL_MS) {
 			ownerZombieConfirmations.delete(staleOwnerPid);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -14,6 +14,7 @@ import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import lockfile from "proper-lockfile";
 import { getProcessStartId } from "../../core/session-lease.js";
+import { isProcessAlive } from "../../utils/child-process.js";
 import { defaultDaemonSocketDir, normalizeSocketPath } from "./daemon-socket.js";
 
 const DAEMON_SUPERVISOR_REGISTRY_DIR_ENV = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR";
@@ -691,15 +692,6 @@ function matchesExactProcessIdentity(identity: ProcessIdentity): boolean {
 		return false;
 	}
 	return identity.processStartId === undefined || getProcessStartId(identity.pid) === identity.processStartId;
-}
-
-function isProcessAlive(pid: number): boolean {
-	try {
-		process.kill(pid, 0);
-	} catch (error) {
-		return (error as NodeJS.ErrnoException).code !== "ESRCH";
-	}
-	return true;
 }
 
 function canonicalizeFilesystemPath(path: string): string {

--- a/packages/coding-agent/src/utils/child-process.ts
+++ b/packages/coding-agent/src/utils/child-process.ts
@@ -51,10 +51,7 @@ export function isProcessAlive(pid: number): boolean {
 	return processIdExists(pid) && !isZombieProcess(pid);
 }
 
-/**
- * True while the process group has any member left (zombies included). A group
- * can outlive its leader, so group teardown must not complete on leader death.
- */
+/** True while the group has any member left, zombies included; a group can outlive its leader. */
 export function processGroupExists(pgid: number): boolean {
 	if (process.platform === "win32") {
 		return false;
@@ -67,11 +64,7 @@ export function processGroupExists(pgid: number): boolean {
 	}
 }
 
-/**
- * True while the group still has a RUNNING member: zombie members have already
- * exited and only their parent can reap them, so they must not block a group
- * stop from completing.
- */
+/** True while the group has a RUNNING member; unreaped zombies have exited and must not block a group stop. */
 export function processGroupHasLiveMember(pgid: number): boolean {
 	if (!processGroupExists(pgid)) {
 		return false;
@@ -87,8 +80,7 @@ export function processGroupHasLiveMember(pgid: number): boolean {
 		}
 		return false;
 	} catch {
-		// Unverifiable listing: report alive so callers keep escalating instead
-		// of dropping records over possibly-live descendants.
+		// Unverifiable listing reads alive: callers keep escalating instead of dropping records over live descendants.
 		return true;
 	}
 }

--- a/packages/coding-agent/src/utils/child-process.ts
+++ b/packages/coding-agent/src/utils/child-process.ts
@@ -85,6 +85,19 @@ export function processGroupHasLiveMember(pgid: number): boolean {
 	}
 }
 
+/**
+ * Signal the group only while it is provably still the target: the leader process (even a zombie)
+ * anchors its pgid against reuse; once the leader is gone, a live member must hold the pgid at
+ * signal time, narrowing reuse exposure to the inherent kill() TOCTOU of any single-pid signal.
+ */
+export function signalProcessGroupIfHeld(pgid: number, signal: NodeJS.Signals): boolean {
+	if (!processIdExists(pgid) && !processGroupHasLiveMember(pgid)) {
+		return false;
+	}
+	signalProcessGroupOrProcess(pgid, signal);
+	return true;
+}
+
 export function signalProcessGroupOrProcess(pid: number, signal: NodeJS.Signals): void {
 	try {
 		process.kill(-pid, signal);

--- a/packages/coding-agent/src/utils/child-process.ts
+++ b/packages/coding-agent/src/utils/child-process.ts
@@ -51,6 +51,22 @@ export function isProcessAlive(pid: number): boolean {
 	return processIdExists(pid) && !isZombieProcess(pid);
 }
 
+/**
+ * True while the process group has any member left (zombies included). A group
+ * can outlive its leader, so group teardown must not complete on leader death.
+ */
+export function processGroupExists(pgid: number): boolean {
+	if (process.platform === "win32") {
+		return false;
+	}
+	try {
+		process.kill(-pgid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
 export function signalProcessGroupOrProcess(pid: number, signal: NodeJS.Signals): void {
 	try {
 		process.kill(-pid, signal);

--- a/packages/coding-agent/src/utils/child-process.ts
+++ b/packages/coding-agent/src/utils/child-process.ts
@@ -67,6 +67,32 @@ export function processGroupExists(pgid: number): boolean {
 	}
 }
 
+/**
+ * True while the group still has a RUNNING member: zombie members have already
+ * exited and only their parent can reap them, so they must not block a group
+ * stop from completing.
+ */
+export function processGroupHasLiveMember(pgid: number): boolean {
+	if (!processGroupExists(pgid)) {
+		return false;
+	}
+	try {
+		const listing = execFileSync("ps", ["-A", "-o", "pgid=", "-o", "stat="], { encoding: "utf8" });
+		for (const line of listing.split("\n")) {
+			const fields = line.trim().split(/\s+/);
+			if (fields.length < 2) continue;
+			if (Number(fields[0]) === pgid && !fields[1]!.startsWith("Z")) {
+				return true;
+			}
+		}
+		return false;
+	} catch {
+		// Unverifiable listing: report alive so callers keep escalating instead
+		// of dropping records over possibly-live descendants.
+		return true;
+	}
+}
+
 export function signalProcessGroupOrProcess(pid: number, signal: NodeJS.Signals): void {
 	try {
 		process.kill(-pid, signal);

--- a/packages/coding-agent/test/child-process.test.ts
+++ b/packages/coding-agent/test/child-process.test.ts
@@ -1,7 +1,13 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { describe, expect, it } from "vitest";
-import { isProcessAlive, isZombieProcess, waitForChildProcess } from "../src/utils/child-process.js";
+import {
+	isProcessAlive,
+	isZombieProcess,
+	processGroupExists,
+	signalProcessGroupOrProcess,
+	waitForChildProcess,
+} from "../src/utils/child-process.js";
 
 describe("waitForChildProcess", () => {
 	it("reports signaled already-exited children as failures", async () => {
@@ -56,6 +62,33 @@ describe("process liveness", () => {
 			expect(isProcessAlive(zombiePid)).toBe(false);
 		} finally {
 			parent.kill("SIGKILL");
+		}
+	});
+
+	it.skipIf(process.platform === "win32")("keeps a process group alive after its leader exits", async () => {
+		const childless = spawn("sh", ["-c", "exit 0"], { detached: true, stdio: "ignore" });
+		const childlessExited = new Promise<void>((resolveExit) => childless.once("exit", () => resolveExit()));
+		const leader = spawn("sh", ["-c", "sleep 30 & echo started"], {
+			detached: true,
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+		const leaderExited = new Promise<void>((resolveExit) => leader.once("exit", () => resolveExit()));
+		const pgid = leader.pid!;
+		try {
+			await new Promise<void>((resolveStart, rejectStart) => {
+				const timer = setTimeout(() => rejectStart(new Error("Timed out waiting for the group member")), 5000);
+				leader.stdout?.once("data", () => {
+					clearTimeout(timer);
+					resolveStart();
+				});
+			});
+			await leaderExited;
+			expect(isProcessAlive(pgid)).toBe(false);
+			expect(processGroupExists(pgid)).toBe(true);
+			await childlessExited;
+			expect(processGroupExists(childless.pid!)).toBe(false);
+		} finally {
+			signalProcessGroupOrProcess(pgid, "SIGKILL");
 		}
 	});
 });

--- a/packages/coding-agent/test/child-process.test.ts
+++ b/packages/coding-agent/test/child-process.test.ts
@@ -6,6 +6,7 @@ import {
 	isZombieProcess,
 	processGroupExists,
 	processGroupHasLiveMember,
+	signalProcessGroupIfHeld,
 	signalProcessGroupOrProcess,
 	waitForChildProcess,
 } from "../src/utils/child-process.js";
@@ -81,8 +82,11 @@ describe("process liveness", () => {
 			expect(isProcessAlive(pgid)).toBe(false);
 			expect(processGroupExists(pgid)).toBe(true);
 			expect(processGroupHasLiveMember(pgid)).toBe(true);
+			// A held group signals; a fully-gone group refuses (pgid-reuse gate).
+			expect(signalProcessGroupIfHeld(pgid, "SIGKILL")).toBe(true);
 			await childlessExited;
 			expect(processGroupExists(childless.pid!)).toBe(false);
+			expect(signalProcessGroupIfHeld(childless.pid!, "SIGKILL")).toBe(false);
 		} finally {
 			signalProcessGroupOrProcess(pgid, "SIGKILL");
 		}

--- a/packages/coding-agent/test/child-process.test.ts
+++ b/packages/coding-agent/test/child-process.test.ts
@@ -5,6 +5,7 @@ import {
 	isProcessAlive,
 	isZombieProcess,
 	processGroupExists,
+	processGroupHasLiveMember,
 	signalProcessGroupOrProcess,
 	waitForChildProcess,
 } from "../src/utils/child-process.js";
@@ -65,6 +66,39 @@ describe("process liveness", () => {
 		}
 	});
 
+	it.skipIf(process.platform === "win32")("does not let an unreaped zombie block group-stop completion", async () => {
+		const parent = spawn(
+			"perl",
+			["-e", '$| = 1; my $pid = fork(); if ($pid) { print "$pid\\n"; sleep 30 } else { setpgrp(0, 0); exit 0 }'],
+			{ stdio: ["ignore", "pipe", "ignore"] },
+		);
+		try {
+			const zombiePid = await new Promise<number>((resolvePid, rejectPid) => {
+				let output = "";
+				const timer = setTimeout(() => rejectPid(new Error("Timed out waiting for the zombie pid")), 5000);
+				parent.stdout?.on("data", (chunk: Buffer) => {
+					output += chunk.toString();
+					const parsed = Number.parseInt(output.trim(), 10);
+					if (Number.isInteger(parsed) && parsed > 0) {
+						clearTimeout(timer);
+						resolvePid(parsed);
+					}
+				});
+			});
+			const deadline = Date.now() + 5000;
+			while (!isZombieProcess(zombiePid) && Date.now() < deadline) {
+				await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+			}
+			expect(isZombieProcess(zombiePid)).toBe(true);
+			// The zombie is its group's only member: the group exists, but a stop
+			// waiting on it must complete because nothing is left running.
+			expect(processGroupExists(zombiePid)).toBe(true);
+			expect(processGroupHasLiveMember(zombiePid)).toBe(false);
+		} finally {
+			parent.kill("SIGKILL");
+		}
+	});
+
 	it.skipIf(process.platform === "win32")("keeps a process group alive after its leader exits", async () => {
 		const childless = spawn("sh", ["-c", "exit 0"], { detached: true, stdio: "ignore" });
 		const childlessExited = new Promise<void>((resolveExit) => childless.once("exit", () => resolveExit()));
@@ -85,6 +119,7 @@ describe("process liveness", () => {
 			await leaderExited;
 			expect(isProcessAlive(pgid)).toBe(false);
 			expect(processGroupExists(pgid)).toBe(true);
+			expect(processGroupHasLiveMember(pgid)).toBe(true);
 			await childlessExited;
 			expect(processGroupExists(childless.pid!)).toBe(false);
 		} finally {

--- a/packages/coding-agent/test/child-process.test.ts
+++ b/packages/coding-agent/test/child-process.test.ts
@@ -9,6 +9,7 @@ import {
 	signalProcessGroupOrProcess,
 	waitForChildProcess,
 } from "../src/utils/child-process.js";
+import { spawnZombieProcess } from "./fixtures/zombie-process.js";
 
 describe("waitForChildProcess", () => {
 	it("reports signaled already-exited children as failures", async () => {
@@ -37,65 +38,25 @@ describe("process liveness", () => {
 	});
 
 	it.skipIf(process.platform === "win32")("treats a zombie process as dead", async () => {
-		const parent = spawn(
-			"perl",
-			["-e", '$| = 1; my $pid = fork(); if ($pid) { print "$pid\\n"; sleep 30 } else { exit 0 }'],
-			{ stdio: ["ignore", "pipe", "ignore"] },
-		);
+		const { zombiePid, dispose } = await spawnZombieProcess();
 		try {
-			const zombiePid = await new Promise<number>((resolvePid, rejectPid) => {
-				let output = "";
-				const timer = setTimeout(() => rejectPid(new Error("Timed out waiting for the zombie pid")), 5000);
-				parent.stdout.on("data", (chunk: Buffer) => {
-					output += chunk.toString();
-					const parsed = Number.parseInt(output.trim(), 10);
-					if (Number.isInteger(parsed) && parsed > 0) {
-						clearTimeout(timer);
-						resolvePid(parsed);
-					}
-				});
-			});
-			const deadline = Date.now() + 5000;
-			while (!isZombieProcess(zombiePid) && Date.now() < deadline) {
-				await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
-			}
 			expect(isZombieProcess(zombiePid)).toBe(true);
 			expect(isProcessAlive(zombiePid)).toBe(false);
 		} finally {
-			parent.kill("SIGKILL");
+			dispose();
 		}
 	});
 
 	it.skipIf(process.platform === "win32")("does not let an unreaped zombie block group-stop completion", async () => {
-		const parent = spawn(
-			"perl",
-			["-e", '$| = 1; my $pid = fork(); if ($pid) { print "$pid\\n"; sleep 30 } else { setpgrp(0, 0); exit 0 }'],
-			{ stdio: ["ignore", "pipe", "ignore"] },
-		);
+		// setpgrp makes the zombie its group's only member: the group exists, but
+		// a stop waiting on it must complete because nothing is left running.
+		const { zombiePid, dispose } = await spawnZombieProcess("setpgrp(0, 0);");
 		try {
-			const zombiePid = await new Promise<number>((resolvePid, rejectPid) => {
-				let output = "";
-				const timer = setTimeout(() => rejectPid(new Error("Timed out waiting for the zombie pid")), 5000);
-				parent.stdout?.on("data", (chunk: Buffer) => {
-					output += chunk.toString();
-					const parsed = Number.parseInt(output.trim(), 10);
-					if (Number.isInteger(parsed) && parsed > 0) {
-						clearTimeout(timer);
-						resolvePid(parsed);
-					}
-				});
-			});
-			const deadline = Date.now() + 5000;
-			while (!isZombieProcess(zombiePid) && Date.now() < deadline) {
-				await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
-			}
 			expect(isZombieProcess(zombiePid)).toBe(true);
-			// The zombie is its group's only member: the group exists, but a stop
-			// waiting on it must complete because nothing is left running.
 			expect(processGroupExists(zombiePid)).toBe(true);
 			expect(processGroupHasLiveMember(zombiePid)).toBe(false);
 		} finally {
-			parent.kill("SIGKILL");
+			dispose();
 		}
 	});
 

--- a/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
@@ -197,6 +197,16 @@ describe("daemon supervisor ownership registry", () => {
 			await assertDaemonSupervisorOwnerCurrent(claim, fingerprint, paths.registryDir);
 			await assertDaemonSupervisorOwnerCurrent(claim, fingerprint, paths.registryDir);
 			expect(zombieSpy.mock.calls.length + aliveSpy.mock.calls.length).toBe(0);
+			// Confirmations expire: after the interval the owner is re-probed once
+			// (the same timestamp the cache's bounded prune sweeps on).
+			vi.useFakeTimers();
+			try {
+				vi.setSystemTime(Date.now() + 6000);
+				await assertDaemonSupervisorOwnerCurrent(claim, fingerprint, paths.registryDir);
+				expect(zombieSpy).toHaveBeenCalledTimes(1);
+			} finally {
+				vi.useRealTimers();
+			}
 		} finally {
 			zombieSpy.mockRestore();
 			aliveSpy.mockRestore();

--- a/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import lockfile from "proper-lockfile";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getProcessStartId } from "../src/core/session-lease.js";
 import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
 import {
@@ -12,6 +12,7 @@ import {
 	assertDaemonSupervisorOwnerCurrent,
 	persistDaemonStartupFenceFromOwner,
 } from "../src/modes/daemon/daemon-supervisor-ownership.js";
+import * as childProcessModule from "../src/utils/child-process.js";
 import { isZombieProcess } from "../src/utils/child-process.js";
 
 type Ownership = Awaited<ReturnType<typeof acquireDaemonSupervisorOwnership>>;
@@ -176,6 +177,31 @@ describe("daemon supervisor ownership registry", () => {
 		await expect(reaped.assertCurrent()).rejects.toMatchObject({ code: "supervisor_generation_stale" });
 		expect(existsSync(reapedDir)).toBe(false);
 		await reaped.release();
+	});
+
+	it("confirms owner zombie state at most once per interval across fence polls", async () => {
+		const paths = createPaths();
+		const owner = await acquire(paths, "fence-owner");
+		const claim = {
+			generation: owner.record.generation,
+			pid: owner.record.pid,
+			processStartId: owner.record.processStartId,
+			socketPath: owner.record.socketPath,
+		};
+		const fingerprint = await assertDaemonSupervisorOwnerCurrent(claim, undefined, paths.registryDir);
+		const zombieSpy = vi.spyOn(childProcessModule, "isZombieProcess");
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive");
+		try {
+			// Steady-state fence polls (validated fingerprint, confirmed owner) must
+			// not run a ps-backed probe per 250ms tick; existence stays kill(0)-cheap.
+			await assertDaemonSupervisorOwnerCurrent(claim, fingerprint, paths.registryDir);
+			await assertDaemonSupervisorOwnerCurrent(claim, fingerprint, paths.registryDir);
+			expect(zombieSpy.mock.calls.length + aliveSpy.mock.calls.length).toBe(0);
+		} finally {
+			zombieSpy.mockRestore();
+			aliveSpy.mockRestore();
+			await owner.release();
+		}
 	});
 
 	it.skipIf(process.platform === "win32")("treats a zombie owner process as reclaimable", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -14,6 +13,7 @@ import {
 } from "../src/modes/daemon/daemon-supervisor-ownership.js";
 import * as childProcessModule from "../src/utils/child-process.js";
 import { isZombieProcess } from "../src/utils/child-process.js";
+import { spawnZombieProcess } from "./fixtures/zombie-process.js";
 
 type Ownership = Awaited<ReturnType<typeof acquireDaemonSupervisorOwnership>>;
 
@@ -216,30 +216,9 @@ describe("daemon supervisor ownership registry", () => {
 
 	it.skipIf(process.platform === "win32")("treats a zombie owner process as reclaimable", async () => {
 		const paths = createPaths();
-		const zombieParent = spawn(
-			"perl",
-			["-e", '$| = 1; my $pid = fork(); if ($pid) { print "$pid\\n"; sleep 30 } else { exit 0 }'],
-			{ stdio: ["ignore", "pipe", "ignore"] },
-		);
+		const { zombiePid, dispose } = await spawnZombieProcess();
 		try {
-			const zombiePid = await new Promise<number>((resolvePid, rejectPid) => {
-				let output = "";
-				const timer = setTimeout(() => rejectPid(new Error("Timed out waiting for the zombie pid")), 5000);
-				zombieParent.stdout?.on("data", (chunk: Buffer) => {
-					output += chunk.toString();
-					const parsed = Number.parseInt(output.trim(), 10);
-					if (Number.isInteger(parsed) && parsed > 0) {
-						clearTimeout(timer);
-						resolvePid(parsed);
-					}
-				});
-			});
-			const deadline = Date.now() + 5000;
-			while (!isZombieProcess(zombiePid) && Date.now() < deadline) {
-				await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
-			}
 			expect(isZombieProcess(zombiePid)).toBe(true);
-
 			const stale = await acquire(paths, "zombie-owner");
 			const ownerPath = join(ownerDir(paths, "zombie-owner"), "owner.json");
 			const record = readJson(ownerPath);
@@ -253,7 +232,7 @@ describe("daemon supervisor ownership registry", () => {
 			await successor.release();
 			await stale.release();
 		} finally {
-			zombieParent.kill("SIGKILL");
+			dispose();
 		}
 	});
 

--- a/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
@@ -1,8 +1,10 @@
+import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import lockfile from "proper-lockfile";
 import { afterEach, describe, expect, it } from "vitest";
+import { getProcessStartId } from "../src/core/session-lease.js";
 import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
 import {
 	acquireDaemonShutdownAdmission,
@@ -10,6 +12,7 @@ import {
 	assertDaemonSupervisorOwnerCurrent,
 	persistDaemonStartupFenceFromOwner,
 } from "../src/modes/daemon/daemon-supervisor-ownership.js";
+import { isZombieProcess } from "../src/utils/child-process.js";
 
 type Ownership = Awaited<ReturnType<typeof acquireDaemonSupervisorOwnership>>;
 
@@ -173,6 +176,49 @@ describe("daemon supervisor ownership registry", () => {
 		await expect(reaped.assertCurrent()).rejects.toMatchObject({ code: "supervisor_generation_stale" });
 		expect(existsSync(reapedDir)).toBe(false);
 		await reaped.release();
+	});
+
+	it.skipIf(process.platform === "win32")("treats a zombie owner process as reclaimable", async () => {
+		const paths = createPaths();
+		const zombieParent = spawn(
+			"perl",
+			["-e", '$| = 1; my $pid = fork(); if ($pid) { print "$pid\\n"; sleep 30 } else { exit 0 }'],
+			{ stdio: ["ignore", "pipe", "ignore"] },
+		);
+		try {
+			const zombiePid = await new Promise<number>((resolvePid, rejectPid) => {
+				let output = "";
+				const timer = setTimeout(() => rejectPid(new Error("Timed out waiting for the zombie pid")), 5000);
+				zombieParent.stdout?.on("data", (chunk: Buffer) => {
+					output += chunk.toString();
+					const parsed = Number.parseInt(output.trim(), 10);
+					if (Number.isInteger(parsed) && parsed > 0) {
+						clearTimeout(timer);
+						resolvePid(parsed);
+					}
+				});
+			});
+			const deadline = Date.now() + 5000;
+			while (!isZombieProcess(zombiePid) && Date.now() < deadline) {
+				await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+			}
+			expect(isZombieProcess(zombiePid)).toBe(true);
+
+			const stale = await acquire(paths, "zombie-owner");
+			const ownerPath = join(ownerDir(paths, "zombie-owner"), "owner.json");
+			const record = readJson(ownerPath);
+			record.pid = zombiePid;
+			const zombieStartId = getProcessStartId(zombiePid);
+			if (zombieStartId) record.processStartId = zombieStartId;
+			else delete record.processStartId;
+			writeFileSync(ownerPath, `${JSON.stringify(record, null, 2)}\n`);
+
+			const successor = await acquire(paths, "successor-owner");
+			await successor.release();
+			await stale.release();
+		} finally {
+			zombieParent.kill("SIGKILL");
+		}
 	});
 
 	it("does not resurrect the shutdown admission when release overtakes an in-flight renew", async () => {

--- a/packages/coding-agent/test/fixtures/zombie-process.ts
+++ b/packages/coding-agent/test/fixtures/zombie-process.ts
@@ -1,0 +1,28 @@
+import { spawn } from "node:child_process";
+import { isZombieProcess } from "../../src/utils/child-process.js";
+
+/** Fork a perl child that exits unreaped while its parent sleeps: a real zombie for liveness pins. */
+export async function spawnZombieProcess(childPerl = ""): Promise<{ zombiePid: number; dispose(): void }> {
+	const parent = spawn(
+		"perl",
+		["-e", `$| = 1; my $pid = fork(); if ($pid) { print "$pid\\n"; sleep 30 } else { ${childPerl} exit 0 }`],
+		{ stdio: ["ignore", "pipe", "ignore"] },
+	);
+	const zombiePid = await new Promise<number>((resolvePid, rejectPid) => {
+		const timer = setTimeout(() => rejectPid(new Error("Timed out waiting for the zombie pid")), 5000);
+		let output = "";
+		parent.stdout?.on("data", (chunk: Buffer) => {
+			output += chunk.toString();
+			const parsed = Number.parseInt(output.trim(), 10);
+			if (Number.isInteger(parsed) && parsed > 0) {
+				clearTimeout(timer);
+				resolvePid(parsed);
+			}
+		});
+	});
+	const deadline = Date.now() + 5000;
+	while (!isZombieProcess(zombiePid) && Date.now() < deadline) {
+		await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+	}
+	return { zombiePid, dispose: () => parent.kill("SIGKILL") };
+}


### PR DESCRIPTION
Part of the worker-state single-truth program (Linear RES-1270); squashes discussion #1732.

## Purpose

A zombie process passes a bare `kill(pid, 0)` probe, and `getProcessStartId` still reports its original start time, so identity checks pass too. Five modules hand-rolled that bare probe and therefore disagreed with the canonical zombie-aware `isProcessAlive` in `utils/child-process.ts`:

- `daemon-supervisor-ownership.ts` — a zombie supervisor's ownership record read as a live owner: every later daemon start on that socket throws `DaemonSupervisorAlreadyRunningError` until someone manually reaps the zombie (the #1732 report).
- `core/session-lease.ts` — a zombie lease owner kept a session file locked.
- `daemon-mode.ts` (worker-side supervisor launch lock) — a zombie lock owner suppressed supervisor relaunch.
- `cli/daemon-ps.ts` — stop/kill wait loops treated an exited-but-unreaped process as still running.
- `cli/daemon-update-restart.ts` — restart coordination treated a zombie predecessor as alive.

## Change

Pure consolidation: delete the five local `kill(pid, 0)` copies and import the shared `isProcessAlive` (zombie-aware, EPERM-tolerant). No new mechanism; net src LOC: -41 (+6/-47, all additions are import lines).

The evidence sweep listed four copies; `daemon-mode.ts` had a fifth identical private method (added in #383), deleted here for the same reason. Remaining `kill(pid, 0)` sites were left alone deliberately: `daemon-ps.ts` `verifyHelloSupervisorPid` checks a pid that just answered a hello (cannot be a zombie mid-reply), `daemon-launch.ts` `hasProcessIdentityExited` is an inverted has-exited check where a zombie only extends a bounded wait, and `kernel/bootstrap.ts` belongs to the atomic-persistence program.

## Tests

One new pin in `daemon-supervisor-ownership.test.ts`: a real zombie (perl fork trick, same as `child-process.test.ts`) written into a conflicting owner record must be reclaimed by a successor acquisition instead of throwing `DaemonSupervisorAlreadyRunningError`. Verified fail-unfixed: reverting the ownership hunk makes the test fail with `AlreadyRunning`. The shared helper's zombie semantics were already pinned in `child-process.test.ts`.

Ran locally: daemon-supervisor-ownership, session-lease, child-process, daemon-ps, proper-lockfile-compromise, daemon-supervisor-monitor, regressions 4606/4600/879 — 171/171 pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ownership, lease, and shutdown liveness in the daemon path; a 5s owner-alive cache can briefly treat a just-zombied PID as live until re-probed.
> 
> **Overview**
> Unreaped **zombie** processes no longer count as live owners across daemon supervision, session leases, supervisor launch locks, `daemon ps` worker stops, and update-restart coordination. Five duplicated `kill(pid, 0)` helpers are removed in favor of the shared **`isProcessAlive`** in `child-process.ts` (existence plus non-zombie).
> 
> **`child-process.ts`** gains process-group helpers: **`processGroupHasLiveMember`** (zombies do not block “stopped”), **`signalProcessGroupIfHeld`**, and **`processGroupExists`**. **`daemon-ps`** `stopTrackedProcess` treats a stop as complete only when the leader is not alive and no running group member remains.
> 
> **`daemon-supervisor-ownership`** uses **`isOwnerProcessAlive`** with a 5s positive cache so 250ms fence polls stay cheap (`kill(0)` every tick, `ps` zombie check at most once per interval). Tests add a **`spawnZombieProcess`** fixture and pins for zombie owners, group-stop behavior, and fence-poll caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92a0eacf47efc831444b0b4e412f35bd17ac3f28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## LOC

Total src: **+110/−58 (net +52)**; tests: +146/−24 (net +122).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace local liveness checks with shared zombie-aware process probe
> - Adds `isProcessAlive`, `processGroupHasLiveMember`, and `signalProcessGroupIfHeld` to [child-process.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2041/files#diff-a9f6b77c57772609afaa172c89bf3bfb5dd1e9d8ab775b567e40388a0f78fe96) and replaces module-local `isProcessAlive` helpers across daemon-ps, update-restart, session-lease, and daemon-mode with the shared probe
> - Daemon process stops in [daemon-ps.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2041/files#diff-d26d176c2fa21f2284ca0dc614dfb273ec8abfce710655afccc3aa35628c848a) now treat a process group with only unreaped zombies as stopped, continue waiting while live descendants remain, and refuse to signal a group whose leader and members are all gone
> - Supervisor ownership assertions in [daemon-supervisor-ownership.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2041/files#diff-6f9ef6ce6a9d2bc51c61fe94d59310efffd26d8f7b3966f5355606b2847d06a5) reject a zombie owner pid, with a confirmation cache that avoids `ps`-backed zombie probes more than once per 5 seconds per pid
> - Risk: `trackedProcessStopped` requires both the leader to be non-alive and no live group member; a group with live descendants that cannot be listed by `ps` will conservatively report a live member, which may delay stop completion on platforms where `ps` listing fails
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92a0eac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->