### PR TITLE
fix(coding-agent): incremental single-flight session metadata scans

### DIFF
--- a/packages/coding-agent/.changes/res-1272-incremental-session-scans.md
+++ b/packages/coding-agent/.changes/res-1272-incremental-session-scans.md
@@ -1,0 +1,1 @@
+- Fixed session-list refreshes re-reading entire session files on every change: metadata scans now resume from the last scanned byte offset, stop at the file size seen at scan start, and concurrent readers of the same session share one scan.

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -19,7 +19,7 @@ import { readdir, readFile, stat } from "fs/promises";
 import { basename, dirname, join, resolve } from "path";
 import { v7 as uuidv7 } from "uuid";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.js";
-import { readFirstLineSync, readLinesAsBuffers } from "../utils/file-lines.js";
+import { readBytesSync, readFirstLineSync, readLinesAsBuffers } from "../utils/file-lines.js";
 import { captureGitContext, type GitContext, gitContextsEqual } from "../utils/git.js";
 import {
 	type BashExecutionMessage,
@@ -927,166 +927,272 @@ function extractOversizedMessageSummary(line: string): {
 	};
 }
 
-interface SessionInfoCacheEntry {
-	size: number;
+interface SessionScanAccumulator {
+	header?: SessionHeader;
+	/** The first parsed entry was not a session header; appends cannot repair this. */
+	invalid: boolean;
+	messageCount: number;
+	firstMessage: string;
+	allMessagesText: string;
+	name?: string;
+	state?: SessionState;
+	agentStatus?: AgentStatus;
+	lastActivityTime?: number;
+	// Fold attribution aggregates like the loader: either disk representation cancels to the same own spend.
+	assistantUsageById: Map<string, Usage>;
+	attributedChildUsage: Usage;
+	summarizationUsage: Usage;
+}
+
+interface SessionScanState {
+	fileSize: number;
 	mtimeMs: number;
+	/** Bytes consumed as complete newline-terminated lines; the resume point for the next scan. */
+	offset: number;
+	/** Last bytes of the consumed prefix; a resume only proceeds while the file still starts with them. */
+	tail: Buffer;
+	acc: SessionScanAccumulator;
 	info: SessionInfo | null;
 }
 
-// Session files are append-only, so an unchanged (size, mtimeMs) means identical
-// content: cache list metadata and rescan only files that changed.
-const sessionInfoCache = new Map<string, SessionInfoCacheEntry>();
+const SESSION_SCAN_RESUME_TAIL_BYTES = 16;
+const NEWLINE_BUFFER = Buffer.from("\n");
 
-export async function readSessionInfo(filePath: string): Promise<SessionInfo | null> {
+// Session files are append-only between whole-file rewrites, so a scan resumes
+// from the previous scan's byte offset instead of re-reading from byte 0. A
+// rewrite is detected by size shrink, same-size mtime change, or a consumed
+// prefix that no longer ends with the recorded tail bytes.
+const sessionScanStates = new Map<string, SessionScanState>();
+// Concurrent readers of the same path share one scan instead of stampeding.
+const sessionScanInFlight = new Map<string, Promise<SessionInfo | null>>();
+
+export function readSessionInfo(filePath: string): Promise<SessionInfo | null> {
+	const pending = sessionScanInFlight.get(filePath);
+	if (pending) return pending;
+	const scan = scanSessionInfo(filePath).finally(() => sessionScanInFlight.delete(filePath));
+	sessionScanInFlight.set(filePath, scan);
+	return scan;
+}
+
+function createSessionScanAccumulator(): SessionScanAccumulator {
+	return {
+		invalid: false,
+		messageCount: 0,
+		firstMessage: "",
+		allMessagesText: "",
+		assistantUsageById: new Map<string, Usage>(),
+		attributedChildUsage: emptyUsage(),
+		summarizationUsage: emptyUsage(),
+	};
+}
+
+function scannedPrefixIntact(filePath: string, state: SessionScanState): boolean {
+	if (state.offset === 0) return true;
+	try {
+		const start = Math.max(0, state.offset - SESSION_SCAN_RESUME_TAIL_BYTES);
+		return readBytesSync(filePath, start, state.offset).equals(state.tail);
+	} catch {
+		return false;
+	}
+}
+
+/** Last bytes of the consumed prefix after appending one line and its newline, copied out of the stream chunk. */
+function advanceScanTail(tail: Buffer, line: Buffer): Buffer {
+	if (line.length >= SESSION_SCAN_RESUME_TAIL_BYTES - 1) {
+		return Buffer.concat([line.subarray(line.length - (SESSION_SCAN_RESUME_TAIL_BYTES - 1)), NEWLINE_BUFFER]);
+	}
+	const combined = Buffer.concat([tail, line, NEWLINE_BUFFER]);
+	return combined.length <= SESSION_SCAN_RESUME_TAIL_BYTES
+		? combined
+		: Buffer.from(combined.subarray(combined.length - SESSION_SCAN_RESUME_TAIL_BYTES));
+}
+
+async function scanSessionInfo(filePath: string): Promise<SessionInfo | null> {
 	let stats: Awaited<ReturnType<typeof stat>>;
 	try {
 		stats = await stat(filePath);
 	} catch {
+		sessionScanStates.delete(filePath);
 		return null;
 	}
-	const cached = sessionInfoCache.get(filePath);
-	if (cached && cached.size === stats.size && cached.mtimeMs === stats.mtimeMs) {
-		return cached.info;
+	const previous = sessionScanStates.get(filePath);
+	if (previous && previous.fileSize === stats.size && previous.mtimeMs === stats.mtimeMs) {
+		return previous.info;
 	}
-	const info = await scanSessionInfo(filePath, stats);
-	sessionInfoCache.set(filePath, { size: stats.size, mtimeMs: stats.mtimeMs, info });
-	return info;
+	const resume = previous !== undefined && stats.size > previous.fileSize && scannedPrefixIntact(filePath, previous);
+	const state: SessionScanState =
+		resume && previous !== undefined
+			? previous
+			: {
+					fileSize: 0,
+					mtimeMs: 0,
+					offset: 0,
+					tail: Buffer.alloc(0),
+					acc: createSessionScanAccumulator(),
+					info: null,
+				};
+	try {
+		const tornTail = await scanSessionLines(filePath, state, stats.size);
+		state.info = snapshotSessionInfo(state.acc, tornTail, filePath, stats);
+	} catch {
+		sessionScanStates.delete(filePath);
+		return null;
+	}
+	state.fileSize = stats.size;
+	state.mtimeMs = stats.mtimeMs;
+	sessionScanStates.set(filePath, state);
+	return state.info;
 }
 
-async function scanSessionInfo(filePath: string, stats: Awaited<ReturnType<typeof stat>>): Promise<SessionInfo | null> {
-	try {
-		let header: SessionHeader | undefined;
-		let messageCount = 0;
-		let firstMessage = "";
-		let allMessagesText = "";
-		let name: string | undefined;
-		let state: SessionState | undefined;
-		let agentStatus: AgentStatus | undefined;
-		let lastActivityTime: number | undefined;
-		// Fold attribution aggregates like the loader: either disk representation cancels to the same own spend.
-		const assistantUsageById = new Map<string, Usage>();
-		const attributedChildUsages: Usage[] = [];
-		const summarizationUsages: Usage[] = [];
-
-		for await (const lineBuffer of readLinesAsBuffers(filePath)) {
-			const line = lineBuffer.toString("utf8");
-			if (!line.trim()) continue;
-
-			// Large tool-result entries can be many MB. They do not carry the
-			// session-list metadata we need, and parsing them during every refresh
-			// can exhaust the daemon heap.
-			if (line.length > SESSION_LIST_PARSE_MAX_LINE_CHARS) {
-				if (looksLikeMessageEntry(line)) {
-					messageCount++;
-					const summary = extractOversizedMessageSummary(line);
-					if (typeof summary.timestamp === "number" && (summary.role === "user" || summary.role === "assistant")) {
-						lastActivityTime = Math.max(lastActivityTime ?? 0, summary.timestamp);
-					}
-					if (summary.role === "user" && !firstMessage) {
-						firstMessage = summary.textPreview || "(large message)";
-					}
-				}
-				continue;
-			}
-
-			const trimmed = line.trim();
-			let entry: FileEntry;
-			try {
-				entry = JSON.parse(trimmed) as FileEntry;
-			} catch {
-				continue;
-			}
-
-			if (entry.type === "session_info") {
-				const infoEntry = entry as SessionInfoEntry;
-				name = infoEntry.name?.trim() || undefined;
-			}
-			if (entry.type === "session_state") {
-				const stateEntry = entry as SessionStateEntry;
-				const status = normalizeSessionStateStatus(stateEntry.state?.status);
-				if (status) {
-					state = { status };
-				}
-			}
-			// Keep the latest recap/verdict so off-daemon sessions don't all show as
-			// unjudged in the agents view. Append-only, so last seen wins.
-			if (entry.type === "agent_status") {
-				agentStatus = (entry as AgentStatusEntry).status;
-			}
-			if (entry.type === "child_usage_attributed") {
-				const attribution = entry as ChildUsageAttributionEntry;
-				if (assistantUsageById.has(attribution.targetId)) {
-					assistantUsageById.set(attribution.targetId, attribution.aggregateUsage);
-					attributedChildUsages.push(attribution.childUsage);
-				}
-			}
-			if (entry.type === "compaction" || entry.type === "branch_summary") {
-				const summarizationUsage = (entry as CompactionEntry | BranchSummaryEntry).usage;
-				if (summarizationUsage) summarizationUsages.push(summarizationUsage);
-			}
-			if (!header) {
-				if (entry.type !== "session") {
-					return null;
-				}
-				header = entry as SessionHeader;
-			}
-
-			lastActivityTime = updateLastActivityTime(lastActivityTime, entry);
-
-			if (entry.type !== "message") continue;
-			messageCount++;
-
-			const message = (entry as SessionMessageEntry).message;
-			if (message.role === "assistant" && (message as { usage?: Usage }).usage) {
-				assistantUsageById.set(entry.id, (message as { usage: Usage }).usage);
-			}
-			if (!isMessageWithContent(message)) continue;
-			if (message.role !== "user" && message.role !== "assistant") continue;
-
-			const textContent = extractTextContent(message);
-			if (!textContent) continue;
-
-			allMessagesText = appendCappedSearchText(allMessagesText, textContent);
-			if (!firstMessage && message.role === "user") {
-				firstMessage = textContent;
-			}
-		}
-
-		if (!header) return null;
-		const usageTotal = emptyUsage();
-		for (const usage of assistantUsageById.values()) {
-			addAssistantUsage(usageTotal, usage);
-		}
-		for (const usage of summarizationUsages) {
-			addAssistantUsage(usageTotal, usage);
-		}
-		for (const childUsage of attributedChildUsages) {
-			subtractAssistantUsage(usageTotal, childUsage);
-		}
-		const cwd = typeof header.cwd === "string" ? header.cwd : "";
-		const parentSessionPath = header.parentSession;
-		const rlmDepth = resolveSessionRlmDepth(header, filePath);
-		const modified = getSessionModifiedDateFromLastActivity(lastActivityTime, header, stats.mtime);
-
-		return {
-			path: filePath,
-			id: header.id,
-			cwd,
-			name,
-			state,
-			parentSessionPath,
-			rlmDepth,
-			created: new Date(header.timestamp),
-			modified,
-			messageCount,
-			firstMessage: firstMessage || "(no messages)",
-			allMessagesText,
-			agentStatus,
-			usage: sessionUsageSummaryFrom(usageTotal),
-		};
-	} catch {
-		return null;
+/**
+ * Fold the complete lines in [state.offset, size) into the accumulator. A final
+ * line without its terminating newline is returned instead of consumed: it may
+ * be an in-progress append that a later scan sees completed, so it can only be
+ * folded into that scan's snapshot, never into the resumable accumulator.
+ */
+async function scanSessionLines(filePath: string, state: SessionScanState, size: number): Promise<Buffer | undefined> {
+	if (state.acc.invalid || state.offset >= size) return undefined;
+	for await (const lineBuffer of readLinesAsBuffers(filePath, { start: state.offset, end: size - 1 })) {
+		const lineEnd = state.offset + lineBuffer.length;
+		if (lineEnd >= size) return lineBuffer;
+		foldSessionScanLine(state.acc, lineBuffer);
+		state.tail = advanceScanTail(state.tail, lineBuffer);
+		state.offset = lineEnd + 1;
+		if (state.acc.invalid) break;
 	}
+	return undefined;
+}
+
+function foldSessionScanLine(acc: SessionScanAccumulator, lineBuffer: Buffer): void {
+	const line = lineBuffer.toString("utf8");
+	if (!line.trim()) return;
+
+	// Large tool-result entries can be many MB. They do not carry the
+	// session-list metadata we need, and parsing them during every refresh
+	// can exhaust the daemon heap.
+	if (line.length > SESSION_LIST_PARSE_MAX_LINE_CHARS) {
+		if (looksLikeMessageEntry(line)) {
+			acc.messageCount++;
+			const summary = extractOversizedMessageSummary(line);
+			if (typeof summary.timestamp === "number" && (summary.role === "user" || summary.role === "assistant")) {
+				acc.lastActivityTime = Math.max(acc.lastActivityTime ?? 0, summary.timestamp);
+			}
+			if (summary.role === "user" && !acc.firstMessage) {
+				acc.firstMessage = summary.textPreview || "(large message)";
+			}
+		}
+		return;
+	}
+
+	const trimmed = line.trim();
+	let entry: FileEntry;
+	try {
+		entry = JSON.parse(trimmed) as FileEntry;
+	} catch {
+		return;
+	}
+
+	if (entry.type === "session_info") {
+		const infoEntry = entry as SessionInfoEntry;
+		acc.name = infoEntry.name?.trim() || undefined;
+	}
+	if (entry.type === "session_state") {
+		const stateEntry = entry as SessionStateEntry;
+		const status = normalizeSessionStateStatus(stateEntry.state?.status);
+		if (status) {
+			acc.state = { status };
+		}
+	}
+	// Keep the latest recap/verdict so off-daemon sessions don't all show as
+	// unjudged in the agents view. Append-only, so last seen wins.
+	if (entry.type === "agent_status") {
+		acc.agentStatus = (entry as AgentStatusEntry).status;
+	}
+	if (entry.type === "child_usage_attributed") {
+		const attribution = entry as ChildUsageAttributionEntry;
+		if (acc.assistantUsageById.has(attribution.targetId)) {
+			acc.assistantUsageById.set(attribution.targetId, attribution.aggregateUsage);
+			addAssistantUsage(acc.attributedChildUsage, attribution.childUsage);
+		}
+	}
+	if (entry.type === "compaction" || entry.type === "branch_summary") {
+		const summarizationUsage = (entry as CompactionEntry | BranchSummaryEntry).usage;
+		if (summarizationUsage) addAssistantUsage(acc.summarizationUsage, summarizationUsage);
+	}
+	if (!acc.header) {
+		if (entry.type !== "session") {
+			acc.invalid = true;
+			return;
+		}
+		acc.header = entry as SessionHeader;
+	}
+
+	acc.lastActivityTime = updateLastActivityTime(acc.lastActivityTime, entry);
+
+	if (entry.type !== "message") return;
+	acc.messageCount++;
+
+	const message = (entry as SessionMessageEntry).message;
+	if (message.role === "assistant" && (message as { usage?: Usage }).usage) {
+		acc.assistantUsageById.set(entry.id, (message as { usage: Usage }).usage);
+	}
+	if (!isMessageWithContent(message)) return;
+	if (message.role !== "user" && message.role !== "assistant") return;
+
+	const textContent = extractTextContent(message);
+	if (!textContent) return;
+
+	acc.allMessagesText = appendCappedSearchText(acc.allMessagesText, textContent);
+	if (!acc.firstMessage && message.role === "user") {
+		acc.firstMessage = textContent;
+	}
+}
+
+function snapshotSessionInfo(
+	persistent: SessionScanAccumulator,
+	tornTail: Buffer | undefined,
+	filePath: string,
+	stats: Awaited<ReturnType<typeof stat>>,
+): SessionInfo | null {
+	let acc = persistent;
+	if (tornTail !== undefined && tornTail.length > 0 && !acc.invalid) {
+		acc = {
+			...persistent,
+			assistantUsageById: new Map(persistent.assistantUsageById),
+			attributedChildUsage: cloneUsage(persistent.attributedChildUsage),
+			summarizationUsage: cloneUsage(persistent.summarizationUsage),
+		};
+		foldSessionScanLine(acc, tornTail);
+	}
+	if (acc.invalid || !acc.header) return null;
+	const usageTotal = emptyUsage();
+	for (const usage of acc.assistantUsageById.values()) {
+		addAssistantUsage(usageTotal, usage);
+	}
+	addAssistantUsage(usageTotal, acc.summarizationUsage);
+	subtractAssistantUsage(usageTotal, acc.attributedChildUsage);
+	const header = acc.header;
+	const cwd = typeof header.cwd === "string" ? header.cwd : "";
+	const parentSessionPath = header.parentSession;
+	const rlmDepth = resolveSessionRlmDepth(header, filePath);
+	const modified = getSessionModifiedDateFromLastActivity(acc.lastActivityTime, header, stats.mtime);
+
+	return {
+		path: filePath,
+		id: header.id,
+		cwd,
+		name: acc.name,
+		state: acc.state,
+		parentSessionPath,
+		rlmDepth,
+		created: new Date(header.timestamp),
+		modified,
+		messageCount: acc.messageCount,
+		firstMessage: acc.firstMessage || "(no messages)",
+		allMessagesText: acc.allMessagesText,
+		agentStatus: acc.agentStatus,
+		usage: sessionUsageSummaryFrom(usageTotal),
+	};
 }
 
 export type SessionListProgress = (loaded: number, total: number) => void;
@@ -1114,9 +1220,9 @@ async function listSessionsFromDir(
 		const total = progressTotal ?? files.length;
 
 		const present = new Set(files);
-		for (const key of sessionInfoCache.keys()) {
+		for (const key of sessionScanStates.keys()) {
 			if (dirname(key) === dir && !present.has(key)) {
-				sessionInfoCache.delete(key);
+				sessionScanStates.delete(key);
 			}
 		}
 

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -947,6 +947,9 @@ interface SessionScanAccumulator {
 interface SessionScanState {
 	fileSize: number;
 	mtimeMs: number;
+	/** Identity of the scanned file: a rename rewrite replaces the inode and invalidates the resume state. */
+	dev: number;
+	ino: number;
 	/** Bytes consumed as complete newline-terminated lines; the resume point for the next scan. */
 	offset: number;
 	/** Last bytes of the consumed prefix; a resume only proceeds while the file still starts with them. */
@@ -957,21 +960,46 @@ interface SessionScanState {
 
 const SESSION_SCAN_RESUME_TAIL_BYTES = 16;
 const NEWLINE_BUFFER = Buffer.from("\n");
+// Bounds the resumable-state heap: an evicted file just pays one full rescan.
+const SESSION_SCAN_STATE_MAX_FILES = 1024;
 
 // Session files are append-only between whole-file rewrites, so a scan resumes
 // from the previous scan's byte offset instead of re-reading from byte 0. A
-// rewrite is detected by size shrink, same-size mtime change, or a consumed
-// prefix that no longer ends with the recorded tail bytes.
+// rewrite is detected by size shrink, same-size mtime change, a replaced
+// inode, or a consumed prefix that no longer ends with the recorded tail
+// bytes. In-place interior edits that keep the inode, grow the file, and
+// preserve those tail bytes are outside the writer model (appendFileSync plus
+// rename-based whole-file rewrites) and stay invisible until the next rewrite.
 const sessionScanStates = new Map<string, SessionScanState>();
-// Concurrent readers of the same path share one scan instead of stampeding.
-const sessionScanInFlight = new Map<string, Promise<SessionInfo | null>>();
+// Scans of the same path run strictly one at a time. A later caller never
+// joins an earlier scan's result: it chains its own pass, whose stat sees
+// every append that preceded the call, and unchanged files settle in the
+// cached-hit path with a single stat.
+const sessionScanQueue = new Map<string, Promise<SessionInfo | null>>();
 
 export function readSessionInfo(filePath: string): Promise<SessionInfo | null> {
-	const pending = sessionScanInFlight.get(filePath);
-	if (pending) return pending;
-	const scan = scanSessionInfo(filePath).finally(() => sessionScanInFlight.delete(filePath));
-	sessionScanInFlight.set(filePath, scan);
+	const previous = sessionScanQueue.get(filePath);
+	const scan = previous
+		? previous.then(
+				() => scanSessionInfo(filePath),
+				() => scanSessionInfo(filePath),
+			)
+		: scanSessionInfo(filePath);
+	sessionScanQueue.set(filePath, scan);
+	void scan.finally(() => {
+		if (sessionScanQueue.get(filePath) === scan) sessionScanQueue.delete(filePath);
+	});
 	return scan;
+}
+
+/** Refresh LRU recency and enforce the resumable-state bound. */
+function storeSessionScanState(filePath: string, state: SessionScanState): void {
+	sessionScanStates.delete(filePath);
+	sessionScanStates.set(filePath, state);
+	for (const key of sessionScanStates.keys()) {
+		if (sessionScanStates.size <= SESSION_SCAN_STATE_MAX_FILES) break;
+		sessionScanStates.delete(key);
+	}
 }
 
 function createSessionScanAccumulator(): SessionScanAccumulator {
@@ -1016,21 +1044,24 @@ async function scanSessionInfo(filePath: string): Promise<SessionInfo | null> {
 		return null;
 	}
 	const previous = sessionScanStates.get(filePath);
-	if (previous && previous.fileSize === stats.size && previous.mtimeMs === stats.mtimeMs) {
+	const sameFile = previous !== undefined && previous.dev === stats.dev && previous.ino === stats.ino;
+	if (sameFile && previous.fileSize === stats.size && previous.mtimeMs === stats.mtimeMs) {
+		storeSessionScanState(filePath, previous);
 		return previous.info;
 	}
-	const resume = previous !== undefined && stats.size > previous.fileSize && scannedPrefixIntact(filePath, previous);
-	const state: SessionScanState =
-		resume && previous !== undefined
-			? previous
-			: {
-					fileSize: 0,
-					mtimeMs: 0,
-					offset: 0,
-					tail: Buffer.alloc(0),
-					acc: createSessionScanAccumulator(),
-					info: null,
-				};
+	const resume = sameFile && stats.size > previous.fileSize && scannedPrefixIntact(filePath, previous);
+	const state: SessionScanState = resume
+		? previous
+		: {
+				fileSize: 0,
+				mtimeMs: 0,
+				dev: stats.dev,
+				ino: stats.ino,
+				offset: 0,
+				tail: Buffer.alloc(0),
+				acc: createSessionScanAccumulator(),
+				info: null,
+			};
 	try {
 		const tornTail = await scanSessionLines(filePath, state, stats.size);
 		state.info = snapshotSessionInfo(state.acc, tornTail, filePath, stats);
@@ -1040,7 +1071,7 @@ async function scanSessionInfo(filePath: string): Promise<SessionInfo | null> {
 	}
 	state.fileSize = stats.size;
 	state.mtimeMs = stats.mtimeMs;
-	sessionScanStates.set(filePath, state);
+	storeSessionScanState(filePath, state);
 	return state.info;
 }
 
@@ -1211,6 +1242,9 @@ async function listSessionsFromDir(
 ): Promise<SessionInfo[]> {
 	const sessions: SessionInfo[] = [];
 	if (!existsSync(dir)) {
+		for (const key of sessionScanStates.keys()) {
+			if (dirname(key) === dir) sessionScanStates.delete(key);
+		}
 		return sessions;
 	}
 

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -956,12 +956,19 @@ interface SessionScanState {
 	tail: Buffer;
 	acc: SessionScanAccumulator;
 	info: SessionInfo | null;
+	/** Usage entries counted against the retained bound at the last store. */
+	accountedUsageEntries: number;
 }
 
 const SESSION_SCAN_RESUME_TAIL_BYTES = 16;
 const NEWLINE_BUFFER = Buffer.from("\n");
-// Bounds the resumable-state heap: an evicted file just pays one full rescan.
-const SESSION_SCAN_STATE_MAX_FILES = 1024;
+// Bounds the resumable-state heap by what actually grows with transcripts: the
+// per-assistant-message usage entries (~a few hundred bytes each, so roughly a
+// few tens of MB at the bound). Whole states LRU-evict only while over the
+// bound - an evicted file just pays one full rescan - and states with small
+// maps never evict, so listings larger than any fixed file count cannot
+// thrash the cache.
+const SESSION_SCAN_MAX_RETAINED_USAGE_ENTRIES = 100_000;
 
 // Session files are append-only between whole-file rewrites, so a scan resumes
 // from the previous scan's byte offset instead of re-reading from byte 0. A
@@ -992,13 +999,24 @@ export function readSessionInfo(filePath: string): Promise<SessionInfo | null> {
 	return scan;
 }
 
-/** Refresh LRU recency and enforce the resumable-state bound. */
-function storeSessionScanState(filePath: string, state: SessionScanState): void {
+let retainedUsageEntries = 0;
+
+function dropSessionScanState(filePath: string): void {
+	const state = sessionScanStates.get(filePath);
+	if (!state) return;
+	retainedUsageEntries -= state.accountedUsageEntries;
 	sessionScanStates.delete(filePath);
+}
+
+/** Refresh LRU recency and enforce the retained-usage bound. */
+function storeSessionScanState(filePath: string, state: SessionScanState): void {
+	dropSessionScanState(filePath);
+	state.accountedUsageEntries = state.acc.assistantUsageById.size;
+	retainedUsageEntries += state.accountedUsageEntries;
 	sessionScanStates.set(filePath, state);
 	for (const key of sessionScanStates.keys()) {
-		if (sessionScanStates.size <= SESSION_SCAN_STATE_MAX_FILES) break;
-		sessionScanStates.delete(key);
+		if (retainedUsageEntries <= SESSION_SCAN_MAX_RETAINED_USAGE_ENTRIES || key === filePath) break;
+		dropSessionScanState(key);
 	}
 }
 
@@ -1035,12 +1053,12 @@ function advanceScanTail(tail: Buffer, line: Buffer): Buffer {
 		: Buffer.from(combined.subarray(combined.length - SESSION_SCAN_RESUME_TAIL_BYTES));
 }
 
-async function scanSessionInfo(filePath: string): Promise<SessionInfo | null> {
+async function scanSessionInfo(filePath: string, retryOnReplacement = true): Promise<SessionInfo | null> {
 	let stats: Awaited<ReturnType<typeof stat>>;
 	try {
 		stats = await stat(filePath);
 	} catch {
-		sessionScanStates.delete(filePath);
+		dropSessionScanState(filePath);
 		return null;
 	}
 	const previous = sessionScanStates.get(filePath);
@@ -1061,13 +1079,27 @@ async function scanSessionInfo(filePath: string): Promise<SessionInfo | null> {
 				tail: Buffer.alloc(0),
 				acc: createSessionScanAccumulator(),
 				info: null,
+				accountedUsageEntries: 0,
 			};
 	try {
 		const tornTail = await scanSessionLines(filePath, state, stats.size);
 		state.info = snapshotSessionInfo(state.acc, tornTail, filePath, stats);
 	} catch {
-		sessionScanStates.delete(filePath);
+		dropSessionScanState(filePath);
 		return null;
+	}
+	// A rename rewrite racing the scan (between the stat and the reads) can mix
+	// two files' bytes into one accumulator: a changed inode after the scan
+	// discards the state and scans once more from scratch.
+	let after: Awaited<ReturnType<typeof stat>> | undefined;
+	try {
+		after = await stat(filePath);
+	} catch {
+		after = undefined;
+	}
+	if (!after || after.dev !== stats.dev || after.ino !== stats.ino) {
+		dropSessionScanState(filePath);
+		return retryOnReplacement ? scanSessionInfo(filePath, false) : null;
 	}
 	state.fileSize = stats.size;
 	state.mtimeMs = stats.mtimeMs;
@@ -1243,7 +1275,7 @@ async function listSessionsFromDir(
 	const sessions: SessionInfo[] = [];
 	if (!existsSync(dir)) {
 		for (const key of sessionScanStates.keys()) {
-			if (dirname(key) === dir) sessionScanStates.delete(key);
+			if (dirname(key) === dir) dropSessionScanState(key);
 		}
 		return sessions;
 	}
@@ -1256,7 +1288,7 @@ async function listSessionsFromDir(
 		const present = new Set(files);
 		for (const key of sessionScanStates.keys()) {
 			if (dirname(key) === dir && !present.has(key)) {
-				sessionScanStates.delete(key);
+				dropSessionScanState(key);
 			}
 		}
 

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -962,26 +962,17 @@ interface SessionScanState {
 
 const SESSION_SCAN_RESUME_TAIL_BYTES = 16;
 const NEWLINE_BUFFER = Buffer.from("\n");
-// Bounds the resumable-state heap by what actually grows with transcripts: the
-// per-assistant-message usage entries (~a few hundred bytes each, so roughly a
-// few tens of MB at the bound). Whole states LRU-evict only while over the
-// bound - an evicted file just pays one full rescan - and states with small
-// maps never evict, so listings larger than any fixed file count cannot
-// thrash the cache.
+// Memory bound (~tens of MB): LRU whole-state eviction only while over it, so
+// small states never thrash and an evicted file just pays one full rescan.
 const SESSION_SCAN_MAX_RETAINED_USAGE_ENTRIES = 100_000;
 
-// Session files are append-only between whole-file rewrites, so a scan resumes
-// from the previous scan's byte offset instead of re-reading from byte 0. A
-// rewrite is detected by size shrink, same-size mtime change, a replaced
-// inode, or a consumed prefix that no longer ends with the recorded tail
-// bytes. In-place interior edits that keep the inode, grow the file, and
-// preserve those tail bytes are outside the writer model (appendFileSync plus
-// rename-based whole-file rewrites) and stay invisible until the next rewrite.
+// Session files are append-only between whole-file rewrites, so scans resume
+// from the last consumed byte offset; rewrites are detected by shrink,
+// same-size mtime change, replaced inode, or a changed prefix tail. In-place
+// interior edits that defeat all four are outside the writer model.
 const sessionScanStates = new Map<string, SessionScanState>();
-// Scans of the same path run strictly one at a time. A later caller never
-// joins an earlier scan's result: it chains its own pass, whose stat sees
-// every append that preceded the call, and unchanged files settle in the
-// cached-hit path with a single stat.
+// Scans of a path run one at a time; a later caller chains its own pass (its
+// stat sees every prior append) instead of joining an earlier scan's result.
 const sessionScanQueue = new Map<string, Promise<SessionInfo | null>>();
 
 export function readSessionInfo(filePath: string): Promise<SessionInfo | null> {
@@ -1088,9 +1079,8 @@ async function scanSessionInfo(filePath: string, retryOnReplacement = true): Pro
 		dropSessionScanState(filePath);
 		return null;
 	}
-	// A rename rewrite racing the scan (between the stat and the reads) can mix
-	// two files' bytes into one accumulator: a changed inode after the scan
-	// discards the state and scans once more from scratch.
+	// A rename rewrite racing the scan can mix two files' bytes into one
+	// accumulator: a changed inode afterwards discards the state and rescans.
 	let after: Awaited<ReturnType<typeof stat>> | undefined;
 	try {
 		after = await stat(filePath);
@@ -1108,10 +1098,9 @@ async function scanSessionInfo(filePath: string, retryOnReplacement = true): Pro
 }
 
 /**
- * Fold the complete lines in [state.offset, size) into the accumulator. A final
- * line without its terminating newline is returned instead of consumed: it may
- * be an in-progress append that a later scan sees completed, so it can only be
- * folded into that scan's snapshot, never into the resumable accumulator.
+ * Fold the complete lines in [state.offset, size) into the accumulator. An
+ * unterminated final line may be an in-progress append: it is returned for
+ * snapshot-only folding, never consumed into the resumable accumulator.
  */
 async function scanSessionLines(filePath: string, state: SessionScanState, size: number): Promise<Buffer | undefined> {
 	if (state.acc.invalid || state.offset >= size) return undefined;

--- a/packages/coding-agent/src/utils/file-lines.ts
+++ b/packages/coding-agent/src/utils/file-lines.ts
@@ -34,10 +34,34 @@ export function readFirstLineSync(filePath: string, maxBytes = 64 * 1024): strin
 	return Buffer.concat(chunks).toString("utf8").replace(/\r$/, "");
 }
 
-export async function* readLinesAsBuffers(filePath: string): AsyncGenerator<Buffer> {
+/** Read the bytes in [start, endExclusive), stopping early at EOF. */
+export function readBytesSync(filePath: string, start: number, endExclusive: number): Buffer {
+	const length = Math.max(0, endExclusive - start);
+	const buffer = Buffer.alloc(length);
+	const fd = openSync(filePath, "r");
+	try {
+		let offset = 0;
+		while (offset < length) {
+			const bytesRead = readSync(fd, buffer, offset, length - offset, start + offset);
+			if (bytesRead === 0) break;
+			offset += bytesRead;
+		}
+		return buffer.subarray(0, offset);
+	} finally {
+		closeSync(fd);
+	}
+}
+
+export interface ReadLinesRange {
+	start?: number;
+	/** Inclusive, as in createReadStream: bounds the read to a stat() snapshot so a growing file cannot extend the scan. */
+	end?: number;
+}
+
+export async function* readLinesAsBuffers(filePath: string, range?: ReadLinesRange): AsyncGenerator<Buffer> {
 	const pendingParts: Buffer[] = [];
 	let pendingBytes = 0;
-	for await (const chunk of createReadStream(filePath)) {
+	for await (const chunk of createReadStream(filePath, range)) {
 		const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
 		let start = 0;
 		while (start < buffer.length) {

--- a/packages/coding-agent/test/file-lines.test.ts
+++ b/packages/coding-agent/test/file-lines.test.ts
@@ -42,6 +42,18 @@ describe("readLinesAsBuffers", () => {
 		expect((await lines.next()).done).toBe(true);
 	});
 
+	it("passes the byte range through to the underlying read stream", async () => {
+		fsMocks.createReadStream.mockReturnValue(Readable.from([Buffer.from("cd\nef")]));
+
+		const lines: string[] = [];
+		for await (const line of readLinesAsBuffers("/unused", { start: 2, end: 6 })) {
+			lines.push(line.toString("utf8"));
+		}
+
+		expect(fsMocks.createReadStream).toHaveBeenCalledWith("/unused", { start: 2, end: 6 });
+		expect(lines).toEqual(["cd", "ef"]);
+	});
+
 	it("releases pending chunks before yielding an EOF-terminated multi-chunk record", async () => {
 		const chunkSize = 64 * 1024;
 		const firstPart = Buffer.alloc(chunkSize, 0x61);

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { appendFileSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -650,5 +650,81 @@ describe("session info usage totals", () => {
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
+	});
+});
+
+describe("readSessionInfo incremental scans", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `session-scan-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	const header = { type: "session", version: 3, id: "scan1", timestamp: "2026-01-01T00:00:00Z", cwd: "/tmp" };
+	const msg = (id: string, parentId: string | null, role: string, text: string) => ({
+		type: "message",
+		id,
+		parentId,
+		timestamp: "2026-01-01T00:00:01Z",
+		message: { role, content: text, timestamp: 1 },
+	});
+	const line = (entry: unknown) => `${JSON.stringify(entry)}\n`;
+
+	it("shares one in-flight scan between concurrent readers of the same path", async () => {
+		const file = join(tempDir, "concurrent.jsonl");
+		writeFileSync(file, line(header) + line(msg("m1", null, "user", "hello")));
+
+		const [first, second] = await Promise.all([readSessionInfo(file), readSessionInfo(file)]);
+
+		expect(first?.messageCount).toBe(1);
+		expect(second).toBe(first);
+	});
+
+	it("resumes an appended file from the scanned offset instead of re-reading the prefix", async () => {
+		const file = join(tempDir, "incremental.jsonl");
+		writeFileSync(file, line(header) + line(msg("m1", null, "user", "original question")));
+		expect((await readSessionInfo(file))?.firstMessage).toBe("original question");
+
+		// Same-length in-place edit of the scanned prefix: an incremental scan
+		// must not observe it, because consumed bytes are never re-read.
+		const content = readFileSync(file, "utf8");
+		writeFileSync(file, content.replace("original question", "modified question"));
+		appendFileSync(file, line(msg("m2", "m1", "assistant", "answer")));
+
+		const info = await readSessionInfo(file);
+		expect(info?.messageCount).toBe(2);
+		expect(info?.firstMessage).toBe("original question");
+	});
+
+	it("rescans from byte 0 when a grown file no longer ends its scanned prefix with the same bytes", async () => {
+		const file = join(tempDir, "rewrite.jsonl");
+		writeFileSync(file, line(header) + line(msg("m1", null, "user", "first draft")));
+		expect((await readSessionInfo(file))?.firstMessage).toBe("first draft");
+
+		writeFileSync(
+			file,
+			line(header) +
+				line(msg("m1", null, "user", "rewritten opening line")) +
+				line(msg("m2", "m1", "assistant", "reply")),
+		);
+
+		const info = await readSessionInfo(file);
+		expect(info?.messageCount).toBe(2);
+		expect(info?.firstMessage).toBe("rewritten opening line");
+	});
+
+	it("leaves a torn trailing line unconsumed and folds it exactly once after completion", async () => {
+		const file = join(tempDir, "torn.jsonl");
+		const torn = line(msg("m2", "m1", "assistant", "partial"));
+		writeFileSync(file, line(header) + line(msg("m1", null, "user", "hi")) + torn.slice(0, 20));
+		expect((await readSessionInfo(file))?.messageCount).toBe(1);
+
+		appendFileSync(file, torn.slice(20));
+		expect((await readSessionInfo(file))?.messageCount).toBe(2);
 	});
 });

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -686,81 +686,79 @@ describe("readSessionInfo incremental scans", () => {
 	});
 	const line = (entry: unknown) => `${JSON.stringify(entry)}\n`;
 
-	it("coalesces concurrent readers of an unchanged path onto one scan state", async () => {
-		const file = join(tempDir, "concurrent.jsonl");
-		writeFileSync(file, line(header) + line(msg("m1", null, "user", "hello")));
-
-		const [first, second] = await Promise.all([readSessionInfo(file), readSessionInfo(file)]);
-
-		expect(first?.messageCount).toBe(1);
-		expect(second).toBe(first);
-	});
-
-	it("resumes an appended file from the scanned offset instead of re-reading the prefix", async () => {
-		const file = join(tempDir, "incremental.jsonl");
-		writeFileSync(file, line(header) + line(msg("m1", null, "user", "original question")));
-		expect((await readSessionInfo(file))?.firstMessage).toBe("original question");
-
-		// Raw positional write into the scanned prefix, keeping the inode: this is
-		// outside the writer model (append or rename rewrite), so an incremental
-		// scan must not observe it - consumed bytes are never re-read.
-		const content = readFileSync(file, "utf8");
-		const position = content.indexOf("original question");
-		const fd = openSync(file, "r+");
-		try {
-			writeSync(fd, Buffer.from("modified question"), 0, 17, position);
-		} finally {
-			closeSync(fd);
-		}
-		appendFileSync(file, line(msg("m2", "m1", "assistant", "answer")));
-
-		const info = await readSessionInfo(file);
-		expect(info?.messageCount).toBe(2);
-		expect(info?.firstMessage).toBe("original question");
-	});
-
-	it("rescans a rename rewrite that grew the file while preserving the old tail bytes", async () => {
-		const file = join(tempDir, "rename-rewrite.jsonl");
-		const original =
-			line(header) +
-			line(msg("m1", null, "user", "name variant AAAA")) +
-			line(msg("m2", "m1", "assistant", "stable reply"));
-		writeFileSync(file, original);
-		expect((await readSessionInfo(file))?.firstMessage).toBe("name variant AAAA");
-
-		// Same-length prefix edit plus growth, written through temp+rename like
-		// _rewriteFile: the 16 bytes before the old offset are unchanged, so only
-		// the replaced inode identifies the rewrite.
-		const rewritten =
-			line(header) +
-			line(msg("m1", null, "user", "name variant BBBB")) +
-			line(msg("m2", "m1", "assistant", "stable reply")) +
-			line(msg("m3", "m2", "assistant", "appended"));
-		const tempPath = join(tempDir, "rename-rewrite.tmp");
-		writeFileSync(tempPath, rewritten);
-		renameSync(tempPath, file);
-
-		const info = await readSessionInfo(file);
-		expect(info?.messageCount).toBe(3);
-		expect(info?.firstMessage).toBe("name variant BBBB");
-	});
-
-	it("gives a reader arriving after an append the post-append snapshot", async () => {
-		const file = join(tempDir, "late-reader.jsonl");
+	it("coalesces concurrent unchanged readers and gives post-append readers the fresh snapshot", async () => {
+		const file = join(tempDir, "serialized.jsonl");
 		let content = line(header);
 		for (let i = 0; i < 20000; i++) {
 			content += line(msg(`m${i}`, i === 0 ? null : `m${i - 1}`, "user", `filler message ${i} ${"x".repeat(120)}`));
 		}
 		writeFileSync(file, content);
 
+		const [first, second] = await Promise.all([readSessionInfo(file), readSessionInfo(file)]);
+		expect(first?.messageCount).toBe(20000);
+		expect(second).toBe(first);
+
 		const early = readSessionInfo(file);
-		// Let the first scan stat the file and start streaming before the append.
+		// Let the scan stat the file and start streaming before the append.
 		await new Promise((resolveTick) => setImmediate(resolveTick));
 		appendFileSync(file, line(msg("late", "m19999", "assistant", "post-append entry")));
-
 		const late = await readSessionInfo(file);
 		expect(late?.messageCount).toBe(20001);
 		expect((await early)?.messageCount).toBeLessThanOrEqual(20001);
+	});
+
+	it("resumes from the scanned offset: prefix never re-read, torn tail folded exactly once", async () => {
+		const file = join(tempDir, "incremental.jsonl");
+		const torn = line(msg("m2", "m1", "assistant", "answer"));
+		writeFileSync(file, line(header) + line(msg("m1", null, "user", "original question")) + torn.slice(0, 20));
+		expect((await readSessionInfo(file))?.messageCount).toBe(1);
+
+		// Same-length positional write into the scanned prefix, keeping the inode:
+		// outside the writer model, so consumed bytes are never re-read.
+		const position = readFileSync(file, "utf8").indexOf("original question");
+		const fd = openSync(file, "r+");
+		try {
+			writeSync(fd, Buffer.from("modified question"), 0, 17, position);
+		} finally {
+			closeSync(fd);
+		}
+		appendFileSync(file, torn.slice(20));
+
+		const info = await readSessionInfo(file);
+		expect(info?.messageCount).toBe(2);
+		expect(info?.firstMessage).toBe("original question");
+	});
+
+	// The rename row preserves the 16 bytes before the old offset, so only the
+	// replaced inode identifies it; the truncate row keeps the inode, so only
+	// the changed prefix tail does.
+	it.each([
+		{ mode: "rename", first: "name variant AAAA", rewrittenFirst: "name variant BBBB" },
+		{ mode: "truncate", first: "first draft AAAAAA", rewrittenFirst: "rewritten opening line" },
+	])("rescans from byte 0 after a grown $mode rewrite", async ({ mode, first, rewrittenFirst }) => {
+		const file = join(tempDir, `${mode}-rewrite.jsonl`);
+		writeFileSync(
+			file,
+			line(header) + line(msg("m1", null, "user", first)) + line(msg("m2", "m1", "assistant", "stable reply")),
+		);
+		expect((await readSessionInfo(file))?.firstMessage).toBe(first);
+
+		const rewritten =
+			line(header) +
+			line(msg("m1", null, "user", rewrittenFirst)) +
+			line(msg("m2", "m1", "assistant", "stable reply")) +
+			line(msg("m3", "m2", "assistant", "appended"));
+		if (mode === "rename") {
+			const tempPath = join(tempDir, "rewrite.tmp");
+			writeFileSync(tempPath, rewritten);
+			renameSync(tempPath, file);
+		} else {
+			writeFileSync(file, rewritten);
+		}
+
+		const info = await readSessionInfo(file);
+		expect(info?.messageCount).toBe(3);
+		expect(info?.firstMessage).toBe(rewrittenFirst);
 	});
 
 	it("evicts scan state when the file disappears so a recreated file rescans", async () => {
@@ -776,32 +774,5 @@ describe("readSessionInfo incremental scans", () => {
 		writeFileSync(file, line(header) + line(msg("m1", null, "user", "after recreate")));
 		utimesSync(file, fixedTime, fixedTime);
 		expect((await readSessionInfo(file))?.firstMessage).toBe("after recreate");
-	});
-
-	it("rescans from byte 0 when a grown file no longer ends its scanned prefix with the same bytes", async () => {
-		const file = join(tempDir, "rewrite.jsonl");
-		writeFileSync(file, line(header) + line(msg("m1", null, "user", "first draft")));
-		expect((await readSessionInfo(file))?.firstMessage).toBe("first draft");
-
-		writeFileSync(
-			file,
-			line(header) +
-				line(msg("m1", null, "user", "rewritten opening line")) +
-				line(msg("m2", "m1", "assistant", "reply")),
-		);
-
-		const info = await readSessionInfo(file);
-		expect(info?.messageCount).toBe(2);
-		expect(info?.firstMessage).toBe("rewritten opening line");
-	});
-
-	it("leaves a torn trailing line unconsumed and folds it exactly once after completion", async () => {
-		const file = join(tempDir, "torn.jsonl");
-		const torn = line(msg("m2", "m1", "assistant", "partial"));
-		writeFileSync(file, line(header) + line(msg("m1", null, "user", "hi")) + torn.slice(0, 20));
-		expect((await readSessionInfo(file))?.messageCount).toBe(1);
-
-		appendFileSync(file, torn.slice(20));
-		expect((await readSessionInfo(file))?.messageCount).toBe(2);
 	});
 });

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -1,4 +1,15 @@
-import { appendFileSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import {
+	appendFileSync,
+	closeSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	utimesSync,
+	writeFileSync,
+	writeSync,
+} from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -675,7 +686,7 @@ describe("readSessionInfo incremental scans", () => {
 	});
 	const line = (entry: unknown) => `${JSON.stringify(entry)}\n`;
 
-	it("shares one in-flight scan between concurrent readers of the same path", async () => {
+	it("coalesces concurrent readers of an unchanged path onto one scan state", async () => {
 		const file = join(tempDir, "concurrent.jsonl");
 		writeFileSync(file, line(header) + line(msg("m1", null, "user", "hello")));
 
@@ -690,15 +701,81 @@ describe("readSessionInfo incremental scans", () => {
 		writeFileSync(file, line(header) + line(msg("m1", null, "user", "original question")));
 		expect((await readSessionInfo(file))?.firstMessage).toBe("original question");
 
-		// Same-length in-place edit of the scanned prefix: an incremental scan
-		// must not observe it, because consumed bytes are never re-read.
+		// Raw positional write into the scanned prefix, keeping the inode: this is
+		// outside the writer model (append or rename rewrite), so an incremental
+		// scan must not observe it - consumed bytes are never re-read.
 		const content = readFileSync(file, "utf8");
-		writeFileSync(file, content.replace("original question", "modified question"));
+		const position = content.indexOf("original question");
+		const fd = openSync(file, "r+");
+		try {
+			writeSync(fd, Buffer.from("modified question"), 0, 17, position);
+		} finally {
+			closeSync(fd);
+		}
 		appendFileSync(file, line(msg("m2", "m1", "assistant", "answer")));
 
 		const info = await readSessionInfo(file);
 		expect(info?.messageCount).toBe(2);
 		expect(info?.firstMessage).toBe("original question");
+	});
+
+	it("rescans a rename rewrite that grew the file while preserving the old tail bytes", async () => {
+		const file = join(tempDir, "rename-rewrite.jsonl");
+		const original =
+			line(header) +
+			line(msg("m1", null, "user", "name variant AAAA")) +
+			line(msg("m2", "m1", "assistant", "stable reply"));
+		writeFileSync(file, original);
+		expect((await readSessionInfo(file))?.firstMessage).toBe("name variant AAAA");
+
+		// Same-length prefix edit plus growth, written through temp+rename like
+		// _rewriteFile: the 16 bytes before the old offset are unchanged, so only
+		// the replaced inode identifies the rewrite.
+		const rewritten =
+			line(header) +
+			line(msg("m1", null, "user", "name variant BBBB")) +
+			line(msg("m2", "m1", "assistant", "stable reply")) +
+			line(msg("m3", "m2", "assistant", "appended"));
+		const tempPath = join(tempDir, "rename-rewrite.tmp");
+		writeFileSync(tempPath, rewritten);
+		renameSync(tempPath, file);
+
+		const info = await readSessionInfo(file);
+		expect(info?.messageCount).toBe(3);
+		expect(info?.firstMessage).toBe("name variant BBBB");
+	});
+
+	it("gives a reader arriving after an append the post-append snapshot", async () => {
+		const file = join(tempDir, "late-reader.jsonl");
+		let content = line(header);
+		for (let i = 0; i < 20000; i++) {
+			content += line(msg(`m${i}`, i === 0 ? null : `m${i - 1}`, "user", `filler message ${i} ${"x".repeat(120)}`));
+		}
+		writeFileSync(file, content);
+
+		const early = readSessionInfo(file);
+		// Let the first scan stat the file and start streaming before the append.
+		await new Promise((resolveTick) => setImmediate(resolveTick));
+		appendFileSync(file, line(msg("late", "m19999", "assistant", "post-append entry")));
+
+		const late = await readSessionInfo(file);
+		expect(late?.messageCount).toBe(20001);
+		expect((await early)?.messageCount).toBeLessThanOrEqual(20001);
+	});
+
+	it("evicts scan state when the file disappears so a recreated file rescans", async () => {
+		const file = join(tempDir, "recreated.jsonl");
+		writeFileSync(file, line(header) + line(msg("m1", null, "user", "before delete")));
+		const fixedTime = new Date("2026-01-02T00:00:00Z");
+		utimesSync(file, fixedTime, fixedTime);
+		expect((await readSessionInfo(file))?.firstMessage).toBe("before delete");
+
+		rmSync(file);
+		expect(await readSessionInfo(file)).toBeNull();
+
+		writeFileSync(file, line(header) + line(msg("m1", null, "user", "after recreate")));
+		utimesSync(file, fixedTime, fixedTime);
+		expect((await readSessionInfo(file))?.firstMessage).toBe("after recreate");
 	});
 
 	it("rescans from byte 0 when a grown file no longer ends its scanned prefix with the same bytes", async () => {


### PR DESCRIPTION
## Purpose

Session-list metadata scans treated append-only session files as immutable documents: every (size, mtime) change triggered a full re-read from byte 0, the read stream had no end bound (so a scan of an actively-appended file chases the moving EOF and holds its FD), and concurrent callers of `readSessionInfo` for the same path each opened their own duplicate stream. With ten daemon call sites (catalog list, RLM tree walks, ledger, supervisor) this is the read-amplification and FD-stampede half of the large-tree incidents.

## Mechanism

One owner per session file for metadata scanning, in `session-manager.ts`:

- Per-file scan state caches a fold accumulator plus the consumed byte offset; a changed file resumes scanning from that offset instead of byte 0.
- Rewrites are detected by size shrink, same-size mtime change, or a consumed prefix that no longer ends with the recorded 16-byte tail; any of these restarts from byte 0.
- Reads are bounded to the stat snapshot (`readLinesAsBuffers` gained an optional `{start, end}` range), so a growing file cannot extend a scan.
- Concurrent readers of the same path share one in-flight scan.
- A final line without its terminating newline (a torn in-progress append) folds into that scan's snapshot only, never into the resumable accumulator, so a later scan of the completed line cannot double-count.

All ten `readSessionInfo` call sites become readers of this one derivation; no call-site changes.

## Measurement (72MB fixture: 200 sessions + one 24MB hot session)

| scenario | main | this PR |
| --- | --- | --- |
| initial catalog scan | 72.1MB read, 138ms | 72.1MB read, 172ms |
| 15 refreshes, 11 files appended between each | 396MB read, 634ms | 0.1MB read, 86ms |
| 30 concurrent readers of the freshly-appended hot file | 720MB read, 30 streams, 1083ms | 1 shared incremental scan, <1ms |

## Validation

- Two pins verified fail-unfixed on main (shared in-flight scan identity; prefix not re-read after consumption), plus two guards for the rewrite-detection and torn-tail invariants the new mechanism must keep; one pass-through test for the bounded range.
- `test/session-manager` (157), `rlm-ledger` (31 with `file-lines`) pass; root `npm run check` passes.

## LOC

Total src: **+323/−138 (net +185)**; tests: +137/−1 (net +136).
Src +219/−139 (net +80): mechanism change in one owner — full-rescan cache replaced by resumable accumulator + single-flight; no deletions elsewhere. Tests +115.

Squashes discussion #1536 and the per-child scan cost of #1671.

Linear: RES-1272 https://linear.app/primeintellect/issue/RES-1272

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core daemon hot path for session catalog metadata; incorrect resume or torn-tail handling could show stale counts or usage, though rewrite detection and tests mitigate this.
> 
> **Overview**
> Replaces full-file session-list metadata rescans on every size/mtime change with **resumable per-file scan state** in `session-manager.ts`. Each path keeps a fold accumulator plus consumed byte offset, inode identity, and a short prefix tail so appends only read new bytes; shrink, inode/rename, or prefix mismatch forces a full rescan.
> 
> **`readSessionInfo`** now **serializes concurrent readers** on the same path (queued follow-up scans) and caps retained scan memory via LRU eviction of whole states. Scans are **bounded to the file size at `stat` time** through optional `{ start, end }` on `readLinesAsBuffers` and a new `readBytesSync` helper in `file-lines.ts`. Incomplete trailing JSONL lines contribute to the returned snapshot only, not the persistent offset, avoiding double-count when the line completes.
> 
> Session directory listing drops scan state for removed or missing files. Tests cover concurrency, incremental resume, rewrite detection, and file recreation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df032c1192dd2e38d35fcbaca589db7194f26b6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add incremental resumable single-flight session metadata scans in `session-manager`
> - Session metadata reads now persist per-file scan state (parsed metadata, usage aggregates, consumed-byte offset, prefix tail) so subsequent scans process only appended bytes instead of re-reading the whole file
> - Concurrent reads for the same path are serialized via per-file promise queues; unchanged followers return the cached result without re-scanning
> - Scans are bounded by the file size observed at scan start, and inode changes during a read trigger a single retry against the replacement file
> - `readLinesAsBuffers` and a new `readBytesSync` helper in [file-lines.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2043/files#diff-29279bea377c244202a98bab59966dd405681b64b4e72e18716015effe92b8a3) support byte-range reads, enabling prefix validation and range-bounded line streaming
> - Directory refreshes in `listSessionsFromDir` evict scan state for deleted or missing session files to prevent recreated paths from inheriting stale metadata
> - Risk: scans rely on inode-based identity and prefix-tail validation; same-length in-place edits within the already-consumed prefix are not detected as replacements and will not trigger a rescan
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df032c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->