### PR TITLE
fix(coding-agent): snapshot transfer ids from the materialized cursor; mismatches settle the transfer, not the worker channel

### DIFF
--- a/packages/coding-agent/.changes/worker-snapshot-cursor.md
+++ b/packages/coding-agent/.changes/worker-snapshot-cursor.md
@@ -1,0 +1,1 @@
+- Fixed chunked session-snapshot transfers so the transfer id names the exact materialized snapshot cut, and a mismatched or restarted transfer now fails only that transfer (clients resync) instead of bouncing the whole worker channel.

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -3956,7 +3956,7 @@ export class AgentDaemon {
 					});
 				}
 				if (streamsSnapshot) {
-					const snapshotId = `${state.activeSessionId}-${state.eventGeneration}-${state.lastEventSequence}`;
+					const snapshotId = snapshotTransferId(result.snapshot);
 					let transcript: SnapshotTranscriptChunkSource;
 					try {
 						transcript = createSnapshotTranscriptChunks({
@@ -6674,10 +6674,9 @@ export class AgentDaemon {
 		state: ActiveSessionState,
 		message: Extract<DaemonOutbound, { type: "session_replaced" }>,
 	): void {
-		const snapshotId = `${state.activeSessionId}-${state.eventGeneration}-${state.lastEventSequence}`;
 		// Mark before the registry read so later events queue behind this snapshot.
 		const snapshotSignal = markClientSnapshotStreaming(client, state.activeSessionId);
-		void this.prepareReplacementSnapshot(client, state, message, snapshotId, snapshotSignal).catch((error) => {
+		void this.prepareReplacementSnapshot(client, state, message, snapshotSignal).catch((error) => {
 			finishClientSnapshotStreaming(client, state.activeSessionId);
 			this.log(`could not prepare replacement snapshot: ${String(error)}`);
 			if (!client.socket.destroyed && this.sessions.get(state.activeSessionId) === state) {
@@ -6695,13 +6694,13 @@ export class AgentDaemon {
 		client: DaemonSocketClient,
 		state: ActiveSessionState,
 		message: Extract<DaemonOutbound, { type: "session_replaced" }>,
-		snapshotId: string,
 		snapshotSignal: AbortSignal,
 	): Promise<void> {
 		const result = await this.createAttachResult(client, state, {
 			type: "attach",
 			activeSessionId: state.activeSessionId,
 		});
+		const snapshotId = snapshotTransferId(result.snapshot);
 		if (this.sessions.get(state.activeSessionId) !== state) {
 			finishClientSnapshotStreaming(client, state.activeSessionId);
 			if (!client.snapshotStreaming && client.catchupActiveSessionIds?.size) {
@@ -7103,7 +7102,7 @@ export class AgentDaemon {
 							),
 						});
 					}
-					const snapshotId = `${activeSessionId}-${state.eventGeneration}-${state.lastEventSequence}`;
+					const snapshotId = snapshotTransferId(result.snapshot);
 					const snapshotSignal = markClientSnapshotStreaming(client, activeSessionId);
 					let transcript: SnapshotTranscriptChunkSource;
 					try {
@@ -7384,6 +7383,18 @@ const ROSTER_SESSION_EVENT_TRIGGERS = new Set([
 	"session_info_changed",
 	"thinking_level_changed",
 ]);
+
+/**
+ * A chunked-snapshot transfer id must name the cursor observed when the message
+ * array was materialized, not the live session cursor: events appended between
+ * materialization and id computation would let two different byte streams share
+ * one snapshot id, which the supervisor rejects as a mismatched transfer.
+ */
+function snapshotTransferId(snapshot: DaemonSessionSnapshot): string {
+	// createSessionSnapshot always sets lastEventCursor; it is optional only on the wire.
+	const cursor = snapshot.lastEventCursor!;
+	return `${snapshot.activeSessionId}-${cursor.generation}-${cursor.sequence}`;
+}
 
 function hasDaemonOutboundActiveSessionId(
 	message: DaemonOutbound,

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -7385,10 +7385,8 @@ const ROSTER_SESSION_EVENT_TRIGGERS = new Set([
 ]);
 
 /**
- * A chunked-snapshot transfer id must name the cursor observed when the message
- * array was materialized, not the live session cursor: events appended between
- * materialization and id computation would let two different byte streams share
- * one snapshot id, which the supervisor rejects as a mismatched transfer.
+ * The transfer id must name the cursor observed at materialization, not the live session cursor:
+ * events appended in between would let two different byte streams share one snapshot id.
  */
 function snapshotTransferId(snapshot: DaemonSessionSnapshot): string {
 	// createSessionSnapshot always sets lastEventCursor; it is optional only on the wire.

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -3705,6 +3705,36 @@ export class DaemonSupervisor {
 		}
 	}
 
+	/**
+	 * Settle a snapshot transfer anomaly with the transfer itself as the blast
+	 * radius: the worker channel (and every other session on it) stays up, and
+	 * attached clients resync from a fresh snapshot instead of riding a worker
+	 * reconnect.
+	 */
+	private failSnapshotTransfer(
+		worker: ResidentWorker,
+		activeSessionId: string,
+		snapshotId: string,
+		error: Error,
+		snapshotPurpose: Extract<DaemonWorkerFrameHeader, { kind: "outbound" }>["snapshotPurpose"],
+	): void {
+		const published = worker.transcriptCaches.get(activeSessionId)?.snapshotId === snapshotId;
+		this.failWorkerSnapshotCache(worker, activeSessionId, error, false, snapshotId);
+		if (published && (snapshotPurpose === "replacement" || snapshotPurpose === "catchup")) {
+			this.queueSnapshotResync(activeSessionId, snapshotPurpose);
+		}
+	}
+
+	private queueSnapshotResync(activeSessionId: string, snapshotPurpose: "replacement" | "catchup"): void {
+		for (const client of this.clients) {
+			if (!client.attachedActiveSessionIds.has(activeSessionId)) continue;
+			this.queueCatchup(client, activeSessionId, snapshotPurpose === "replacement" ? "replacement" : "resync");
+			void this.catchUpClient(client).catch((error) =>
+				this.log(`Failed to catch up client ${client.id}: ${String(error)}`),
+			);
+		}
+	}
+
 	private retireWorkerSnapshotCache(
 		worker: ResidentWorker,
 		activeSessionId: string,
@@ -5511,12 +5541,12 @@ export class DaemonSupervisor {
 				const generations = this.snapshotGenerationsFor(worker, activeSessionId);
 				let generation = generations.get(begin.snapshotId);
 				if (generation?.incoming) {
-					this.failWorkerSnapshotCache(
+					this.failSnapshotTransfer(
 						worker,
 						activeSessionId,
-						new Error(`Snapshot ${begin.snapshotId} restarted before completion`),
-						true,
 						begin.snapshotId,
+						new Error(`Snapshot ${begin.snapshotId} restarted before completion`),
+						snapshotPurpose,
 					);
 					return;
 				}
@@ -5533,12 +5563,12 @@ export class DaemonSupervisor {
 					generation.result.snapshot.lastEventCursor?.generation === result.snapshot.lastEventCursor?.generation &&
 					generation.result.snapshot.lastEventCursor?.sequence === result.snapshot.lastEventCursor?.sequence;
 				if (generation?.transcript.complete && !duplicate) {
-					this.failWorkerSnapshotCache(
+					this.failSnapshotTransfer(
 						worker,
 						activeSessionId,
-						new Error(`Snapshot ${begin.snapshotId} did not match the cached transfer`),
-						true,
 						begin.snapshotId,
+						new Error(`Snapshot ${begin.snapshotId} did not match the cached transfer`),
+						snapshotPurpose,
 					);
 					return;
 				}
@@ -5647,12 +5677,12 @@ export class DaemonSupervisor {
 						generation.duplicateChunkIndex = duplicateIndex + 1;
 					}
 				} catch (error) {
-					this.failWorkerSnapshotCache(
+					this.failSnapshotTransfer(
 						worker,
 						activeSessionId,
-						error instanceof Error ? error : new Error(String(error)),
-						true,
 						generation.transcript.snapshotId,
+						error instanceof Error ? error : new Error(String(error)),
+						snapshotPurpose,
 					);
 				}
 			}
@@ -5704,12 +5734,12 @@ export class DaemonSupervisor {
 				generation.duplicateChunkIndex = undefined;
 				generation.duplicateResult = undefined;
 			} catch (error) {
-				this.failWorkerSnapshotCache(
+				this.failSnapshotTransfer(
 					worker,
 					activeSessionId,
-					error instanceof Error ? error : new Error(String(error)),
-					true,
 					transcript.snapshotId,
+					error instanceof Error ? error : new Error(String(error)),
+					snapshotPurpose,
 				);
 				return;
 			}
@@ -5719,13 +5749,7 @@ export class DaemonSupervisor {
 				transcript.dispose();
 			}
 			if (published && (snapshotPurpose === "replacement" || snapshotPurpose === "catchup")) {
-				for (const client of this.clients) {
-					if (!client.attachedActiveSessionIds.has(activeSessionId)) continue;
-					this.queueCatchup(client, activeSessionId, snapshotPurpose === "replacement" ? "replacement" : "resync");
-					void this.catchUpClient(client).catch((error) =>
-						this.log(`Failed to catch up client ${client.id}: ${String(error)}`),
-					);
-				}
+				this.queueSnapshotResync(activeSessionId, snapshotPurpose);
 			}
 			return;
 		}
@@ -5751,21 +5775,13 @@ export class DaemonSupervisor {
 				if (!generation) {
 					return;
 				}
-				const published = worker.transcriptCaches.get(activeSessionId) === generation.transcript;
-				this.failWorkerSnapshotCache(worker, activeSessionId, new Error(failed.error), false, failed.snapshotId);
-				if (published && (snapshotPurpose === "replacement" || snapshotPurpose === "catchup")) {
-					for (const client of this.clients) {
-						if (!client.attachedActiveSessionIds.has(activeSessionId)) continue;
-						this.queueCatchup(
-							client,
-							activeSessionId,
-							snapshotPurpose === "replacement" ? "replacement" : "resync",
-						);
-						void this.catchUpClient(client).catch((error) =>
-							this.log(`Failed to catch up client ${client.id}: ${String(error)}`),
-						);
-					}
-				}
+				this.failSnapshotTransfer(
+					worker,
+					activeSessionId,
+					failed.snapshotId,
+					new Error(failed.error),
+					snapshotPurpose,
+				);
 			} catch (error) {
 				this.failWorkerSnapshotCache(
 					worker,

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -3720,8 +3720,11 @@ export class DaemonSupervisor {
 	): void {
 		const published = worker.transcriptCaches.get(activeSessionId)?.snapshotId === snapshotId;
 		this.failWorkerSnapshotCache(worker, activeSessionId, error, false, snapshotId);
-		if (published && (snapshotPurpose === "replacement" || snapshotPurpose === "catchup")) {
-			this.queueSnapshotResync(activeSessionId, snapshotPurpose);
+		// The resync is driven by the published-cache drop, not the failing frame's
+		// purpose: a published transfer can be serving any attached client's
+		// catch-up wait, whose queue entry drainClientCatchups already cleared.
+		if (published) {
+			this.queueSnapshotResync(activeSessionId, snapshotPurpose === "replacement" ? "replacement" : "catchup");
 		}
 	}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -3705,12 +3705,7 @@ export class DaemonSupervisor {
 		}
 	}
 
-	/**
-	 * Settle a snapshot transfer anomaly with the transfer itself as the blast
-	 * radius: the worker channel (and every other session on it) stays up, and
-	 * attached clients resync from a fresh snapshot instead of riding a worker
-	 * reconnect.
-	 */
+	/** Settle a transfer anomaly with the transfer as the blast radius: the worker channel stays up and clients resync fresh. */
 	private failSnapshotTransfer(
 		worker: ResidentWorker,
 		activeSessionId: string,
@@ -3720,9 +3715,8 @@ export class DaemonSupervisor {
 	): void {
 		const published = worker.transcriptCaches.get(activeSessionId)?.snapshotId === snapshotId;
 		this.failWorkerSnapshotCache(worker, activeSessionId, error, false, snapshotId);
-		// The resync is driven by the published-cache drop, not the failing frame's
-		// purpose: a published transfer can be serving any attached client's
-		// catch-up wait, whose queue entry drainClientCatchups already cleared.
+		// The published-cache drop drives the resync, not the frame's purpose: a published transfer
+		// can be serving any client's catch-up wait, whose queue entry drainClientCatchups already cleared.
 		if (published) {
 			this.queueSnapshotResync(activeSessionId, snapshotPurpose === "replacement" ? "replacement" : "catchup");
 		}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -3650,7 +3650,14 @@ describe("daemon mode helpers", () => {
 			client.transport = "private-framed";
 			const result = {
 				activeSessionId: state.activeSessionId,
-				snapshot: { summary: {}, state: {}, messages: [] },
+				snapshot: {
+					activeSessionId: state.activeSessionId,
+					summary: {},
+					state: {},
+					messages: [],
+					lastEventSequence: 0,
+					lastEventCursor: { generation: state.eventGeneration, sequence: 0 },
+				},
 				lastEventSequence: 0,
 			} as unknown as DaemonAttachResult;
 			const streamWorkerSnapshot = vi.fn(async () => undefined);
@@ -3717,9 +3724,12 @@ describe("daemon mode helpers", () => {
 			const result = {
 				activeSessionId: state.activeSessionId,
 				snapshot: {
+					activeSessionId: state.activeSessionId,
 					summary: {},
 					state: {},
 					messages: [{ role: "user", content: "x".repeat(4 * 1024 * 1024 + 1), timestamp: 0 }],
+					lastEventSequence: 0,
+					lastEventCursor: { generation: state.eventGeneration, sequence: 0 },
 				},
 				lastEventSequence: 0,
 			} as unknown as DaemonAttachResult;

--- a/packages/coding-agent/test/suite/regressions/4602-snapshot-transfer-idempotency.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4602-snapshot-transfer-idempotency.test.ts
@@ -232,6 +232,53 @@ describe("ENG-4602 snapshot transfer containment", () => {
 		expect(unhandled).not.toHaveBeenCalled();
 	});
 
+	it("derives the chunked transfer id from the materialized snapshot cursor", async () => {
+		const daemon = new AgentDaemon("/tmp/eng-4602-worker-cursor.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		// The session cursor has advanced past the materialized snapshot cut.
+		const state = {
+			activeSessionId,
+			clients: new Set<DaemonSocketClient>(),
+			eventGeneration: "generation-4602",
+			lastEventSequence: 5,
+			runtime: { metadata: { kind: "top-level", createdAt: 1 } },
+		} as unknown as ActiveSessionState;
+		const socket = new PassThrough();
+		const client = {
+			id: "supervisor",
+			socket: socket as unknown as Socket,
+			transport: "private-framed",
+			attachedActiveSessionIds: new Set<string>(),
+			detachInput: () => {},
+			supportsExtensionUi: false,
+			capabilities: new Set<string>(),
+		} as DaemonSocketClient;
+		const streamWorkerSnapshot = vi.fn(async () => {});
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			createAttachResult(): DaemonAttachResult;
+			streamWorkerSnapshot: typeof streamWorkerSnapshot;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+		};
+		internals.sessions.set(activeSessionId, state);
+		internals.createAttachResult = () => streamedResult([]);
+		internals.streamWorkerSnapshot = streamWorkerSnapshot;
+		try {
+			const response = (await internals.handleCommand(client, {
+				type: "attach",
+				activeSessionId,
+				capabilities: ["attach_snapshot", "event_sequence", "slim_attach", "chunked_snapshot"],
+			})) as { data?: DaemonAttachResult };
+			expect(response.data?.snapshotStream?.id).toBe(`${activeSessionId}-generation-4602-1`);
+		} finally {
+			socket.destroy();
+		}
+	});
+
 	it("fails one worker snapshot without dropping another session on the supervisor channel", async () => {
 		const daemon = new AgentDaemon("/tmp/eng-4602-stream.sock", {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
@@ -339,7 +386,7 @@ describe("ENG-4602 snapshot transfer containment", () => {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
 			descriptorDir: "/tmp/eng-4602-supervisor-state",
 		});
-		const { close, worker } = workerHarness();
+		const { close, request, worker } = workerHarness();
 		const client = socketClient("public", new PassThrough());
 		const streamSnapshot = vi.fn(async () => {});
 		const internals = supervisor as unknown as {
@@ -416,7 +463,11 @@ describe("ENG-4602 snapshot transfer containment", () => {
 		expect(worker.transcriptCaches.has(activeSessionId)).toBe(false);
 		expect(worker.snapshotCache.has(activeSessionId)).toBe(false);
 		expect(streamSnapshot).not.toHaveBeenCalled();
-		expect(close).toHaveBeenCalledOnce();
+		expect(close).not.toHaveBeenCalled();
+		expect(worker.descriptor.lifecycle).toBe("ready");
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(request).toHaveBeenCalledWith(expect.objectContaining({ type: "attach" }));
 	});
 
 	it("holds catch-up behind duplicate validation and rejects it on mismatch", async () => {
@@ -480,7 +531,8 @@ describe("ENG-4602 snapshot transfer containment", () => {
 		expect(streamSnapshot).not.toHaveBeenCalled();
 		expect(worker.snapshotCache.has(activeSessionId)).toBe(false);
 		expect(worker.transcriptCaches.has(activeSessionId)).toBe(false);
-		expect(close).toHaveBeenCalledOnce();
+		expect(close).not.toHaveBeenCalled();
+		expect(worker.descriptor.lifecycle).toBe("ready");
 	});
 
 	it("rejects a quarantined catch-up before intentional worker stop", async () => {
@@ -603,18 +655,18 @@ describe("ENG-4602 snapshot transfer containment", () => {
 		internals.handleWorkerFrame(reentrant.worker, frame(frames.begin));
 		internals.handleWorkerFrame(reentrant.worker, frame(frames.begin));
 		await new Promise<void>((resolve) => setImmediate(resolve));
-		expect(reentrant.close).toHaveBeenCalledOnce();
+		expect(reentrant.close).not.toHaveBeenCalled();
 		expect(reentrant.worker.transcriptCaches.has(activeSessionId)).toBe(false);
-		expect(reentrant.worker.client).toBeUndefined();
-		expect(reentrant.worker.descriptor.lifecycle).toBe("recovering");
-		expect(recoverWorker).toHaveBeenCalledWith(reentrant.worker);
+		expect(reentrant.worker.client).toBeDefined();
+		expect(reentrant.worker.descriptor.lifecycle).toBe("ready");
+		expect(recoverWorker).not.toHaveBeenCalled();
 
 		const completed = workerHarness();
 		for (const message of [frames.begin, frames.chunk, frames.end]) {
 			internals.handleWorkerFrame(completed.worker, frame(message));
 		}
 		internals.handleWorkerFrame(completed.worker, frame({ ...frames.begin, messageCount: 2 }));
-		expect(completed.close).toHaveBeenCalledOnce();
+		expect(completed.close).not.toHaveBeenCalled();
 		expect(completed.worker.transcriptCaches.has(activeSessionId)).toBe(false);
 
 		const mismatchedEnd = workerHarness();
@@ -622,7 +674,7 @@ describe("ENG-4602 snapshot transfer containment", () => {
 			internals.handleWorkerFrame(mismatchedEnd.worker, frame(message));
 		}
 		internals.handleWorkerFrame(mismatchedEnd.worker, frame({ ...frames.end, lastEventSequence: 2 }));
-		expect(mismatchedEnd.close).toHaveBeenCalledOnce();
+		expect(mismatchedEnd.close).not.toHaveBeenCalled();
 		expect(mismatchedEnd.worker.transcriptCaches.has(activeSessionId)).toBe(false);
 
 		const replaced = workerHarness();

--- a/packages/coding-agent/test/suite/regressions/4602-snapshot-transfer-idempotency.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4602-snapshot-transfer-idempotency.test.ts
@@ -527,7 +527,9 @@ describe("ENG-4602 snapshot transfer containment", () => {
 		);
 		await failedCatchup;
 
-		expect(request).not.toHaveBeenCalled();
+		// The rejected catch-up waiter is requeued by the published-cache drop and
+		// retries with a fresh worker snapshot request instead of staying stale.
+		expect(request).toHaveBeenCalledWith(expect.objectContaining({ type: "attach", activeSessionId }));
 		expect(streamSnapshot).not.toHaveBeenCalled();
 		expect(worker.snapshotCache.has(activeSessionId)).toBe(false);
 		expect(worker.transcriptCaches.has(activeSessionId)).toBe(false);

--- a/packages/coding-agent/test/suite/regressions/4602-snapshot-transfer-idempotency.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4602-snapshot-transfer-idempotency.test.ts
@@ -172,8 +172,8 @@ function snapshotFrames(messages: AgentMessage[]) {
 }
 
 describe("ENG-4602 snapshot transfer containment", () => {
-	it("observes the deferred attach snapshot promise", async () => {
-		const daemon = new AgentDaemon("/tmp/eng-4602-worker.sock", {
+	function workerAttachHarness(socketPath: string, lastEventSequence: number) {
+		const daemon = new AgentDaemon(socketPath, {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
 			createRuntime: async () => {
 				throw new Error("unexpected runtime creation");
@@ -183,7 +183,7 @@ describe("ENG-4602 snapshot transfer containment", () => {
 			activeSessionId,
 			clients: new Set<DaemonSocketClient>(),
 			eventGeneration: "generation-4602",
-			lastEventSequence: 1,
+			lastEventSequence,
 			runtime: { metadata: { kind: "top-level", createdAt: 1 } },
 		} as unknown as ActiveSessionState;
 		const socket = new PassThrough();
@@ -196,30 +196,37 @@ describe("ENG-4602 snapshot transfer containment", () => {
 			supportsExtensionUi: false,
 			capabilities: new Set<string>(),
 		} as DaemonSocketClient;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			createAttachResult(): DaemonAttachResult;
+			streamWorkerSnapshot(): Promise<void>;
+			log(message: string): void;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+		};
+		internals.sessions.set(activeSessionId, state);
+		internals.createAttachResult = () => streamedResult([]);
+		const attach = () =>
+			internals.handleCommand(client, {
+				type: "attach",
+				activeSessionId,
+				capabilities: ["attach_snapshot", "event_sequence", "slim_attach", "chunked_snapshot"],
+			});
+		return { internals, client, socket, attach };
+	}
+
+	it("observes the deferred attach snapshot promise", async () => {
+		const { internals, socket, attach } = workerAttachHarness("/tmp/eng-4602-worker.sock", 1);
 		const streamError = new Error("encoder failed after begin");
 		const log = vi.fn();
 		const streamWorkerSnapshot = vi.fn(async () => {
 			throw streamError;
 		});
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			createAttachResult(): DaemonAttachResult;
-			streamWorkerSnapshot: typeof streamWorkerSnapshot;
-			log: typeof log;
-			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
-		};
-		internals.sessions.set(activeSessionId, state);
-		internals.createAttachResult = () => streamedResult([]);
 		internals.streamWorkerSnapshot = streamWorkerSnapshot;
 		internals.log = log;
 		const unhandled = vi.fn();
 		process.on("unhandledRejection", unhandled);
 		try {
-			await internals.handleCommand(client, {
-				type: "attach",
-				activeSessionId,
-				capabilities: ["attach_snapshot", "event_sequence", "slim_attach", "chunked_snapshot"],
-			});
+			await attach();
 			await new Promise<void>((resolve) => setImmediate(resolve));
 			await new Promise<void>((resolve) => setImmediate(resolve));
 		} finally {
@@ -233,46 +240,11 @@ describe("ENG-4602 snapshot transfer containment", () => {
 	});
 
 	it("derives the chunked transfer id from the materialized snapshot cursor", async () => {
-		const daemon = new AgentDaemon("/tmp/eng-4602-worker-cursor.sock", {
-			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		// The session cursor has advanced past the materialized snapshot cut.
-		const state = {
-			activeSessionId,
-			clients: new Set<DaemonSocketClient>(),
-			eventGeneration: "generation-4602",
-			lastEventSequence: 5,
-			runtime: { metadata: { kind: "top-level", createdAt: 1 } },
-		} as unknown as ActiveSessionState;
-		const socket = new PassThrough();
-		const client = {
-			id: "supervisor",
-			socket: socket as unknown as Socket,
-			transport: "private-framed",
-			attachedActiveSessionIds: new Set<string>(),
-			detachInput: () => {},
-			supportsExtensionUi: false,
-			capabilities: new Set<string>(),
-		} as DaemonSocketClient;
-		const streamWorkerSnapshot = vi.fn(async () => {});
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			createAttachResult(): DaemonAttachResult;
-			streamWorkerSnapshot: typeof streamWorkerSnapshot;
-			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
-		};
-		internals.sessions.set(activeSessionId, state);
-		internals.createAttachResult = () => streamedResult([]);
-		internals.streamWorkerSnapshot = streamWorkerSnapshot;
+		// The live session cursor (sequence 5) has advanced past the materialized snapshot cut (sequence 1).
+		const { internals, socket, attach } = workerAttachHarness("/tmp/eng-4602-worker-cursor.sock", 5);
+		internals.streamWorkerSnapshot = vi.fn(async () => {});
 		try {
-			const response = (await internals.handleCommand(client, {
-				type: "attach",
-				activeSessionId,
-				capabilities: ["attach_snapshot", "event_sequence", "slim_attach", "chunked_snapshot"],
-			})) as { data?: DaemonAttachResult };
+			const response = (await attach()) as { data?: DaemonAttachResult };
 			expect(response.data?.snapshotStream?.id).toBe(`${activeSessionId}-generation-4602-1`);
 		} finally {
 			socket.destroy();
@@ -527,8 +499,7 @@ describe("ENG-4602 snapshot transfer containment", () => {
 		);
 		await failedCatchup;
 
-		// The rejected catch-up waiter is requeued by the published-cache drop and
-		// retries with a fresh worker snapshot request instead of staying stale.
+		// The published-cache drop requeued the rejected waiter: it retries with a fresh snapshot request.
 		expect(request).toHaveBeenCalledWith(expect.objectContaining({ type: "attach", activeSessionId }));
 		expect(streamSnapshot).not.toHaveBeenCalled();
 		expect(worker.snapshotCache.has(activeSessionId)).toBe(false);


### PR DESCRIPTION
Part of the worker-state single-truth program (Linear RES-1270); squashes discussion #1662 (both halves).

## Purpose

Two halves of one duplicate-truth defect in chunked snapshot transfers:

1. Worker side, the transfer id `${activeSessionId}-${eventGeneration}-${lastEventSequence}` was computed from the live session cursor at a different time than the message-array capture it labels (after `createAttachResult`'s awaits on attach/catchup, before them on replacement). Events arriving during materialization let two different byte streams legitimately share one snapshot id.
2. Supervisor side, the resulting duplicate-transfer disagreement (reentrant begin, mismatched duplicate envelope / chunk bytes / end metadata) was treated as protocol corruption and handled with `closeWorkerChannel=true`: `handleWorkerClose` + `client.close()` on a healthy worker, failing every in-flight request for every session on that worker. Since #1929 this is a control-plane bounce rather than a terminal brick, but it can recur every time the race re-fires on a big busy transcript.

## Change

- `daemon-mode.ts`: new `snapshotTransferId(snapshot)` derives the id from `snapshot.lastEventCursor` — the cursor captured synchronously with the message array in `createSessionSnapshot` — and all three call sites use it. For the replacement path the id computation moves after materialization (parameter deleted).
- `daemon-supervisor.ts`: new `failSnapshotTransfer` settles a transfer anomaly with the transfer as the blast radius: fail that one generation (existing `failWorkerSnapshotCache` with `closeWorkerChannel=false`) and queue attached clients for a resync from a fresh snapshot. The four mismatch sites use it, and the existing `session_snapshot_failed` handler plus the end-frame catchup loop are consolidated through the same helpers (they previously duplicated the loop inline). Malformed-frame handling (undecodable payloads) still closes the channel.

Net src LOC: +33/-27 in daemon-supervisor (mostly the extracted helpers replacing two inline copies), +14/-5 in daemon-mode. No wire-shape change: snapshot ids are opaque strings and the mismatch handling is supervisor-internal, so this is backward-compatible with old workers and clients.

## Tests

In `4602-snapshot-transfer-idempotency.test.ts` (the existing file for exactly this machinery):

- New pin: the attach response's `snapshotStream.id` names the materialized snapshot cursor even when the live session cursor has advanced (fail-unfixed verified: reverting the worker-side hunk yields the live-cursor id).
- Updated the three pins that asserted the old channel-close behavior: reentrant begin, mismatched duplicate envelope, mismatched chunk bytes, and mismatched end metadata now assert the worker client stays connected, lifecycle stays `ready`, no recovery run, caches dropped — and for a published replacement-purpose mismatch, that a fresh `attach` reload is requested from the worker (the queued resync).

Ran locally: 4602, 4601, 4677, snapshot-transcript-cache, agent-connection-daemon, daemon-supervisor-monitor — 224/224 pass; `npm run check` green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon worker/supervisor snapshot protocol behavior; incorrect resync paths could leave clients stale, but blast radius is intentionally narrowed from whole-worker bounce to per-transfer recovery.
> 
> **Overview**
> Chunked session snapshot transfers now use a **transfer id tied to the materialized snapshot cursor** (`snapshot.lastEventCursor`) instead of the live session generation/sequence, so late-arriving events cannot label two different byte streams with the same id. Replacement snapshots compute that id only after `createAttachResult` materializes the snapshot.
> 
> On the supervisor, **duplicate or invalid snapshot transfers** (restarted begin, envelope mismatch, bad chunks/end, worker-reported failure) are handled via `failSnapshotTransfer` / `queueSnapshotResync`: drop the affected cache generation, keep the worker channel open, and queue attached clients for a fresh attach/catch-up when the failed transfer was published. Malformed frame handling that still closes the channel is unchanged.
> 
> Tests in ENG-4602 pin the materialized-cursor id and expect resync instead of worker channel close for those anomaly paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5af3bbe8090240507d6b0297d0da007159e15305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## LOC

Total src: **+61/−39 (net +22)**; tests: +61/−26 (net +35).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix snapshot transfer IDs to use materialized cursor and scope transfer failures away from worker channel
> - Snapshot transfer IDs for attach, replacement, and catch-up now derive from the snapshot's materialized event cursor via the new `snapshotTransferId` helper in [daemon-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2044/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450), instead of the live session's current generation and sequence.
> - The `DaemonSupervisor.failSnapshotTransfer` helper in [daemon-supervisor.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2044/files#diff-18f2d5ec391785bebc6ddf3c1bd3b795e4ed6e02d0aa3852f5bf247d61d012f8) contains anomalies to the affected transfer: it discards the matching snapshot cache and queues a fresh catch-up or replacement for attached clients.
> - Restart, mismatch, and validation failures during chunked snapshot transfers no longer close or recover the worker channel; the worker stays ready while clients retry.
> - Risk: `handleWorkerFrame` now routes restart, completed-transfer mismatch, chunk-byte validation, end-frame validation, and worker-reported snapshot failures through `failSnapshotTransfer` instead of worker-level recovery; any snapshot protocol path not covered by this routing will still trigger the old worker-close path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5af3bbe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->