### PR TITLE
fix(coding-agent): failed workers recover on touch; roster gaps answer a structured recovering error

### DIFF
--- a/packages/coding-agent/.changes/worker-state-recovery.md
+++ b/packages/coding-agent/.changes/worker-state-recovery.md
@@ -1,0 +1,1 @@
+- Fixed daemon sessions bricking behind a terminal failed worker state: attach, create, and retry now re-run recovery for a failed worker whose process is verified alive, and a known-but-still-recovering session answers with a structured retryable error instead of "Unknown active session".

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -958,7 +958,9 @@ async function findActiveDaemonSessionSummary(
 	try {
 		const response = await client.request({ type: "get_state", activeSessionId: selector }, 3000);
 		if (!response.success) {
-			if (isUnknownActiveSessionError(response.error)) {
+			// A recovering session falls back to the saved-session path too: the
+			// create/open route waits for or retries the worker's recovery.
+			if (isUnknownActiveSessionError(response.error) || response.errorInfo?.code === "session_recovering") {
 				return undefined;
 			}
 			throw new Error(response.error);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -953,11 +953,8 @@ function isUnknownActiveSessionError(message: string): boolean {
 }
 
 /**
- * Unknown means the lookup falls back to the saved-session path (whose
- * create/open route waits for or retries worker recovery); a recovering
- * session throws typed instead, so an explicit --attach-agent surfaces the
- * retryable state rather than "No active agent found". Interactive lookups
- * swallow the throw into the same saved-session fallback.
+ * Unknown falls back to the saved-session path (whose create/open route retries recovery); recovering
+ * throws typed so an explicit --attach-agent surfaces the retryable state, not "No active agent found".
  */
 export function resolveActiveSessionLookupFailure(
 	response: Extract<DaemonResponse, { success: false }>,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -74,8 +74,12 @@ import { isTelemetryEnabled } from "./core/telemetry.js";
 import { printTimings, resetTimings, time } from "./core/timings.js";
 import { runMigrations, showDeprecationWarnings } from "./migrations.js";
 import { isDaemonCatalogProcess, runDaemonCatalogProcess } from "./modes/daemon/daemon-catalog-process.js";
-import { DaemonSessionCreateError, deserializeDaemonCreateError } from "./modes/daemon/daemon-errors.js";
-import { collectDaemonClientEnv, collectDaemonLaunchEnv } from "./modes/daemon/daemon-protocol.js";
+import {
+	DaemonSessionCreateError,
+	deserializeDaemonCreateError,
+	deserializeDaemonError,
+} from "./modes/daemon/daemon-errors.js";
+import { collectDaemonClientEnv, collectDaemonLaunchEnv, type DaemonResponse } from "./modes/daemon/daemon-protocol.js";
 import {
 	DAEMON_WORKER_ACTIVE_SESSION_ID_ENV,
 	daemonWorkerInstanceId,
@@ -948,6 +952,25 @@ function isUnknownActiveSessionError(message: string): boolean {
 	return message.startsWith("Unknown active session:");
 }
 
+/**
+ * Unknown means the lookup falls back to the saved-session path (whose
+ * create/open route waits for or retries worker recovery); a recovering
+ * session throws typed instead, so an explicit --attach-agent surfaces the
+ * retryable state rather than "No active agent found". Interactive lookups
+ * swallow the throw into the same saved-session fallback.
+ */
+export function resolveActiveSessionLookupFailure(
+	response: Extract<DaemonResponse, { success: false }>,
+): Error | undefined {
+	if (response.errorInfo?.code === "session_recovering") {
+		return deserializeDaemonError(response);
+	}
+	if (isUnknownActiveSessionError(response.error)) {
+		return undefined;
+	}
+	return new Error(response.error);
+}
+
 async function findActiveDaemonSessionSummary(
 	socketPath: string,
 	selector: string,
@@ -958,12 +981,11 @@ async function findActiveDaemonSessionSummary(
 	try {
 		const response = await client.request({ type: "get_state", activeSessionId: selector }, 3000);
 		if (!response.success) {
-			// A recovering session falls back to the saved-session path too: the
-			// create/open route waits for or retries the worker's recovery.
-			if (isUnknownActiveSessionError(response.error) || response.errorInfo?.code === "session_recovering") {
-				return undefined;
+			const failure = resolveActiveSessionLookupFailure(response);
+			if (failure) {
+				throw failure;
 			}
-			throw new Error(response.error);
+			return undefined;
 		}
 		if (!isDaemonSessionSummary(response.data)) {
 			throw new Error("Daemon returned an invalid active session summary");

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -29,6 +29,7 @@ import { ensureTool } from "../../utils/tools-manager.js";
 import { DaemonAgentConnection } from "../agent-connection/daemon-agent-connection.js";
 import type { AgentConnectionHeartbeat, AgentConnectionSavedSessionInfo } from "../agent-connection/types.js";
 import { DaemonClient, getDaemonSocketCloseReason } from "../daemon/daemon-client.js";
+import { DaemonSessionRecoveringError } from "../daemon/daemon-errors.js";
 import {
 	collectDaemonClientEnv,
 	type DaemonClosingReason,
@@ -344,7 +345,12 @@ async function openAgentsViewSession(
 			return { connection, summary };
 		} catch (error) {
 			client.close();
-			if (!summary.sessionFile || !isUnknownActiveSessionError(error)) {
+			// A recovering session takes the saved-session path too: the create/open
+			// route waits for or retries the worker's recovery.
+			if (
+				!summary.sessionFile ||
+				!(isUnknownActiveSessionError(error) || error instanceof DaemonSessionRecoveringError)
+			) {
 				throw error;
 			}
 			client = await connectAgentsViewDaemonClient(socketPath);

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -345,8 +345,7 @@ async function openAgentsViewSession(
 			return { connection, summary };
 		} catch (error) {
 			client.close();
-			// A recovering session takes the saved-session path too: the create/open
-			// route waits for or retries the worker's recovery.
+			// Recovering takes the saved-session path too; its create/open route retries the recovery.
 			if (
 				!summary.sessionFile ||
 				!(isUnknownActiveSessionError(error) || error instanceof DaemonSessionRecoveringError)

--- a/packages/coding-agent/src/modes/daemon/daemon-errors.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-errors.ts
@@ -3,11 +3,7 @@ import { SessionImportFileNotFoundError } from "../../core/session-import-errors
 import { SessionAlreadyActiveError } from "../../core/session-lease.js";
 import type { DaemonErrorInfo, DaemonResponse } from "./daemon-protocol.js";
 
-/**
- * The supervisor knows the session (a persisted worker descriptor names it) but
- * cannot route to it yet because the worker is still being adopted or recovered.
- * Retryable, unlike "Unknown active session".
- */
+/** A known session (a persisted descriptor names it) that cannot be routed to yet; retryable, unlike "Unknown active session". */
 export class DaemonSessionRecoveringError extends Error {
 	readonly code = "session_recovering" as const;
 

--- a/packages/coding-agent/src/modes/daemon/daemon-errors.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-errors.ts
@@ -3,6 +3,20 @@ import { SessionImportFileNotFoundError } from "../../core/session-import-errors
 import { SessionAlreadyActiveError } from "../../core/session-lease.js";
 import type { DaemonErrorInfo, DaemonResponse } from "./daemon-protocol.js";
 
+/**
+ * The supervisor knows the session (a persisted worker descriptor names it) but
+ * cannot route to it yet because the worker is still being adopted or recovered.
+ * Retryable, unlike "Unknown active session".
+ */
+export class DaemonSessionRecoveringError extends Error {
+	readonly code = "session_recovering" as const;
+
+	constructor(readonly activeSessionId: string) {
+		super(`Active session ${activeSessionId} is recovering; retry shortly`);
+		this.name = "DaemonSessionRecoveringError";
+	}
+}
+
 export function serializeDaemonError(error: unknown): DaemonErrorInfo | undefined {
 	if (error instanceof MissingSessionCwdError) {
 		return { code: "missing_session_cwd", issue: error.issue };
@@ -16,6 +30,9 @@ export function serializeDaemonError(error: unknown): DaemonErrorInfo | undefine
 			sessionPath: error.sessionPath,
 			activeSessionId: error.activeSessionId,
 		};
+	}
+	if (error instanceof DaemonSessionRecoveringError) {
+		return { code: "session_recovering", activeSessionId: error.activeSessionId };
 	}
 	return undefined;
 }
@@ -44,6 +61,9 @@ export function deserializeDaemonError(response: Extract<DaemonResponse, { succe
 	}
 	if (errorInfo?.code === "session_already_active") {
 		return new SessionAlreadyActiveError(errorInfo.sessionPath, errorInfo.activeSessionId);
+	}
+	if (errorInfo?.code === "session_recovering") {
+		return new DaemonSessionRecoveringError(errorInfo.activeSessionId);
 	}
 	return new Error(response.error);
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -72,8 +72,9 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 24 adds the capability-gated agent-roster subscription and push.
 // Revision 25 adds capability-gated direct worker peer transport discovery.
 // Revision 26 publishes own-session usage totals on session summary and saved-session rows.
-export const DAEMON_SCHEMA_REVISION = 26;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-26-962b8b4c5e35";
+// Revision 27 adds structured session_recovering failure info for known-but-unaddressable sessions.
+export const DAEMON_SCHEMA_REVISION = 27;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-27-12faa7959cd3";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -1026,6 +1027,7 @@ export type DaemonErrorInfo =
 	| { code: "missing_session_cwd"; issue: SessionCwdIssue }
 	| { code: "session_import_file_not_found"; filePath: string }
 	| { code: "session_already_active"; sessionPath: string; activeSessionId?: string }
+	| { code: "session_recovering"; activeSessionId: string }
 	| { code: "command_result_uncertain"; clientId: DaemonClientId; commandId: DaemonCommandId };
 
 export type DaemonSessionClosedReason = "killed" | "shutdown" | "completed" | "replaced" | "update";

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -74,7 +74,7 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 26 publishes own-session usage totals on session summary and saved-session rows.
 // Revision 27 adds structured session_recovering failure info for known-but-unaddressable sessions.
 export const DAEMON_SCHEMA_REVISION = 27;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-27-12faa7959cd3";
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-27-962b8b4c5e35";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -4866,7 +4866,7 @@ export class DaemonSupervisor {
 				this.isWorkerRecoveryCandidate(worker),
 		);
 		if (recoveringWorker) {
-			throw new DaemonSessionRecoveringError(selector);
+			throw new DaemonSessionRecoveringError(recoveringWorker.descriptor.rootActiveSessionId);
 		}
 		throw new Error(`Unknown active session: ${selector}`);
 	}
@@ -4968,6 +4968,12 @@ export class DaemonSupervisor {
 		command: DaemonCommand,
 		timeoutMs = WORKER_REQUEST_TIMEOUT_MS,
 	): Promise<DaemonResponse> {
+		// Every forwarded command is a touch: a cached failed roster row must not
+		// outrank the descriptor truth that the worker is recoverable (the
+		// --attach-agent preflight's get_state lands here before any attach).
+		if (this.canRetryFailedWorker(worker)) {
+			await this.retryWorkerRecovery(worker);
+		}
 		const client = this.requireAvailableWorkerClient(worker, command.type === "kill");
 		const response = await client.request(withoutCommandId(command), timeoutMs);
 		if (command.type === "get_state" && response.success && isSessionSummary(response.data)) {
@@ -5022,9 +5028,10 @@ export class DaemonSupervisor {
 		}
 		const match = await this.findWorkerForClient(client, command.activeSessionId);
 		this.assertTelemetryAttachAllowed(match.worker, command.telemetryDisabled);
-		if (this.canRetryFailedWorker(match.worker)) {
+		if (match.worker !== descriptorWorker && this.canRetryFailedWorker(match.worker)) {
 			// A child-session attach lands here without a descriptor match; failed
-			// is retryable for an identity-verified live worker on any touch.
+			// is retryable for an identity-verified live worker, but one touch runs
+			// at most one recovery ladder, so the pre-pass worker is not retried twice.
 			await this.retryWorkerRecovery(match.worker);
 		}
 		this.requireAvailableWorkerClient(match.worker);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -79,7 +79,7 @@ import {
 import { CommandRecoveryJournal, createCommandIdempotencyKey } from "./command-recovery-journal.js";
 import { CompactAssistantStreamReconstructor, isCompactAssistantDelta } from "./compact-session-stream.js";
 import { DAEMON_CATALOG_ROLE_ENV, DaemonCatalogClient } from "./daemon-catalog-process.js";
-import { deserializeDaemonError, serializeDaemonError } from "./daemon-errors.js";
+import { DaemonSessionRecoveringError, deserializeDaemonError, serializeDaemonError } from "./daemon-errors.js";
 import {
 	collectDaemonClientEnv,
 	createDaemonEventMeta,
@@ -2208,14 +2208,7 @@ export class DaemonSupervisor {
 				if ((this.workerStopCounts?.get(worker) ?? 0) > 0) {
 					throw new Error("Session worker is stopping; retry after it finishes");
 				}
-				worker.intentionalStop = false;
-				worker.descriptor.stopRequestedAt = undefined;
-				worker.descriptor.archiveOnStop = undefined;
-				worker.descriptor.lifecycle = "recovering";
-				worker.descriptor.consecutiveFailures = 0;
-				worker.deferredRecoveryRounds = 0;
-				this.persistWorker(worker);
-				await this.recoverWorker(worker);
+				await this.retryWorkerRecovery(worker);
 				if (this.workers.get(worker.descriptor.workerId)?.descriptor.lifecycle !== "ready") {
 					throw new Error(worker.descriptor.lastError ?? "Session worker recovery failed");
 				}
@@ -2923,13 +2916,15 @@ export class DaemonSupervisor {
 		ownerClientId: string | undefined,
 		sessionPath: string,
 	): Promise<ResidentWorker> {
-		if (worker.descriptor.lifecycle === "failed") {
+		if (worker.descriptor.lifecycle === "failed" && !this.canRetryFailedWorker(worker)) {
 			throw new Error(
 				`Session "${sessionPath}" is registered to a failed worker that could not be safely reclaimed`,
 			);
 		}
 		this.assertWorkerCreateOwner(worker, ownerClientId, sessionPath);
-		if (!this.isWorkerReadyForCreate(worker)) {
+		if (this.canRetryFailedWorker(worker)) {
+			await this.retryWorkerRecovery(worker);
+		} else if (!this.isWorkerReadyForCreate(worker)) {
 			if (worker.recovery) {
 				await worker.recovery;
 			} else if (this.isWorkerRecoveryEligible(worker)) {
@@ -3595,6 +3590,30 @@ export class DaemonSupervisor {
 		return this.isWorkerRecoveryCandidate(worker) && worker.recovery === undefined;
 	}
 
+	/**
+	 * A failed lifecycle is not terminal for a worker whose process identity is
+	 * verified current: any attach or create touching it retries recovery, the
+	 * same way the manual retry_worker command does.
+	 */
+	private canRetryFailedWorker(worker: ResidentWorker): boolean {
+		return (
+			worker.descriptor.lifecycle === "failed" &&
+			(this.workerStopCounts?.get(worker) ?? 0) === 0 &&
+			this.processIdentity(worker.descriptor.pid, worker.descriptor.processStartId) === "current"
+		);
+	}
+
+	private async retryWorkerRecovery(worker: ResidentWorker): Promise<void> {
+		worker.intentionalStop = false;
+		worker.descriptor.stopRequestedAt = undefined;
+		worker.descriptor.archiveOnStop = undefined;
+		worker.descriptor.lifecycle = "recovering";
+		worker.descriptor.consecutiveFailures = 0;
+		worker.deferredRecoveryRounds = 0;
+		this.persistWorker(worker);
+		await this.recoverWorker(worker);
+	}
+
 	private isWorkerRecoveryCandidate(worker: ResidentWorker): boolean {
 		return (
 			!this.shuttingDown &&
@@ -3610,7 +3629,8 @@ export class DaemonSupervisor {
 			return;
 		}
 		// A live-but-silent worker must not probe forever: park it failed (user-visible through the
-		// roster's failed status) and keep its process alive for a manual retry_worker.
+		// roster's failed status) and keep its process alive. The park is not terminal: retry_worker,
+		// attach, and create all retry recovery while the process identity stays current.
 		worker.deferredRecoveryRounds = (worker.deferredRecoveryRounds ?? 0) + 1;
 		if (worker.deferredRecoveryRounds > MAX_DEFERRED_RECOVERY_ROUNDS) {
 			worker.descriptor.lifecycle = "failed";
@@ -4831,6 +4851,20 @@ export class DaemonSupervisor {
 		if (matches.length > 1) {
 			throw new Error(`Ambiguous active session "${selector}"`);
 		}
+		// Persisted descriptors are the durable half of session addressability: a
+		// root session on a worker whose roster snapshot has not arrived yet is
+		// recovering, not unknown. Failed workers keep the unknown answer so
+		// clients fall back to the create path, which can reclaim or retry them.
+		const recoveringWorker = [...this.workers.values()].find(
+			(worker) =>
+				(worker.descriptor.rootActiveSessionId === selector || worker.descriptor.rootSessionId === selector) &&
+				(!includeWorker || includeWorker(worker)) &&
+				worker.descriptor.lifecycle !== "failed" &&
+				this.isWorkerRecoveryCandidate(worker),
+		);
+		if (recoveringWorker) {
+			throw new DaemonSessionRecoveringError(selector);
+		}
 		throw new Error(`Unknown active session: ${selector}`);
 	}
 
@@ -4947,46 +4981,48 @@ export class DaemonSupervisor {
 		client: DaemonSocketClient,
 		command: Extract<DaemonCommand, { type: "attach" }>,
 	): Promise<WorkerAttachData> {
-		const ownedWorker = [...this.workers.values()].find(
+		const descriptorWorker = [...this.workers.values()].find(
 			(worker) =>
-				worker.descriptor.ownerClientId !== undefined &&
-				(worker.descriptor.rootActiveSessionId === command.activeSessionId ||
-					worker.descriptor.rootSessionId === command.activeSessionId),
+				worker.descriptor.rootActiveSessionId === command.activeSessionId ||
+				worker.descriptor.rootSessionId === command.activeSessionId,
 		);
-		if (ownedWorker) {
-			if (ownedWorker.descriptor.ownerClientId !== this.protocolClientId(client)) {
+		if (descriptorWorker) {
+			const owned = descriptorWorker.descriptor.ownerClientId !== undefined;
+			if (owned && descriptorWorker.descriptor.ownerClientId !== this.protocolClientId(client)) {
 				throw new Error(`Unknown active session: ${command.activeSessionId}`);
 			}
-			this.assertTelemetryAttachAllowed(ownedWorker, command.telemetryDisabled);
-			ownedWorker.launchEnv = command.launchEnv ?? ownedWorker.launchEnv;
-			if (!ownedWorker.client || ownedWorker.descriptor.lifecycle !== "ready") {
-				if (command.recoveryConfig) {
-					ownedWorker.transientCreateCommand = {
-						...ownedWorker.descriptor.createCommand,
-						config: {
-							...command.recoveryConfig,
-							...(ownedWorker.descriptor.telemetryDisabled === true ? { telemetryDisabled: true } : {}),
-						},
-						env: command.env,
-						launchEnv: command.launchEnv,
-						lifecycle: "client_owned",
-					};
+			this.assertTelemetryAttachAllowed(descriptorWorker, command.telemetryDisabled);
+			descriptorWorker.launchEnv = command.launchEnv ?? descriptorWorker.launchEnv;
+			if (!descriptorWorker.client || descriptorWorker.descriptor.lifecycle !== "ready") {
+				if (owned) {
+					if (command.recoveryConfig) {
+						descriptorWorker.transientCreateCommand = {
+							...descriptorWorker.descriptor.createCommand,
+							config: {
+								...command.recoveryConfig,
+								...(descriptorWorker.descriptor.telemetryDisabled === true ? { telemetryDisabled: true } : {}),
+							},
+							env: command.env,
+							launchEnv: command.launchEnv,
+							lifecycle: "client_owned",
+						};
+					}
+					if (!descriptorWorker.launchEnv) {
+						throw new Error("Client-owned session recovery requires the owning client environment");
+					}
+					await this.retryWorkerRecovery(descriptorWorker);
+				} else if (this.canRetryFailedWorker(descriptorWorker)) {
+					await this.retryWorkerRecovery(descriptorWorker);
 				}
-				if (!ownedWorker.launchEnv) {
-					throw new Error("Client-owned session recovery requires the owning client environment");
-				}
-				ownedWorker.intentionalStop = false;
-				ownedWorker.descriptor.stopRequestedAt = undefined;
-				ownedWorker.descriptor.archiveOnStop = undefined;
-				ownedWorker.descriptor.lifecycle = "recovering";
-				ownedWorker.descriptor.consecutiveFailures = 0;
-				ownedWorker.deferredRecoveryRounds = 0;
-				this.persistWorker(ownedWorker);
-				await this.recoverWorker(ownedWorker);
 			}
 		}
 		const match = await this.findWorkerForClient(client, command.activeSessionId);
 		this.assertTelemetryAttachAllowed(match.worker, command.telemetryDisabled);
+		if (this.canRetryFailedWorker(match.worker)) {
+			// A child-session attach lands here without a descriptor match; failed
+			// is retryable for an identity-verified live worker on any touch.
+			await this.retryWorkerRecovery(match.worker);
+		}
 		this.requireAvailableWorkerClient(match.worker);
 		const activeSessionId = match.summary.activeSessionId ?? match.summary.id;
 		const duplicateValidation = this.currentSnapshotGeneration(match.worker, activeSessionId)?.validation;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -4858,15 +4858,29 @@ export class DaemonSupervisor {
 		// root session on a worker whose roster snapshot has not arrived yet is
 		// recovering, not unknown. Failed workers keep the unknown answer so
 		// clients fall back to the create path, which can reclaim or retry them.
-		const recoveringWorker = [...this.workers.values()].find(
-			(worker) =>
-				(worker.descriptor.rootActiveSessionId === selector || worker.descriptor.rootSessionId === selector) &&
-				(!includeWorker || includeWorker(worker)) &&
-				worker.descriptor.lifecycle !== "failed" &&
-				this.isWorkerRecoveryCandidate(worker),
+		const recoveringRoots = (matchesSelector: (worker: ResidentWorker) => boolean) =>
+			[...this.workers.values()].filter(
+				(worker) =>
+					matchesSelector(worker) &&
+					(!includeWorker || includeWorker(worker)) &&
+					worker.descriptor.lifecycle !== "failed" &&
+					this.isWorkerRecoveryCandidate(worker),
+			);
+		// Same addressing rule as matchWorkers: exact ids first, then unambiguous
+		// hex suffixes; ambiguous suffixes stay unknown.
+		const exactRecovering = recoveringRoots(
+			(worker) => worker.descriptor.rootActiveSessionId === selector || worker.descriptor.rootSessionId === selector,
 		);
-		if (recoveringWorker) {
-			throw new DaemonSessionRecoveringError(recoveringWorker.descriptor.rootActiveSessionId);
+		const recoveringMatches =
+			exactRecovering.length > 0
+				? exactRecovering
+				: recoveringRoots(
+						(worker) =>
+							matchesSessionIdSuffix(worker.descriptor.rootActiveSessionId, selector) ||
+							matchesSessionIdSuffix(worker.descriptor.rootSessionId ?? "", selector),
+					);
+		if (recoveringMatches.length === 1) {
+			throw new DaemonSessionRecoveringError(recoveringMatches[0]!.descriptor.rootActiveSessionId);
 		}
 		throw new Error(`Unknown active session: ${selector}`);
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -3599,6 +3599,9 @@ export class DaemonSupervisor {
 		return (
 			worker.descriptor.lifecycle === "failed" &&
 			(this.workerStopCounts?.get(worker) ?? 0) === 0 &&
+			// A user-stopped worker stays stopped: the persisted stop markers gate
+			// on-touch retries, which only the explicit retry_worker command clears.
+			!this.isWorkerStopping(worker) &&
 			this.processIdentity(worker.descriptor.pid, worker.descriptor.processStartId) === "current"
 		);
 	}
@@ -4987,14 +4990,15 @@ export class DaemonSupervisor {
 				worker.descriptor.rootSessionId === command.activeSessionId,
 		);
 		if (descriptorWorker) {
-			const owned = descriptorWorker.descriptor.ownerClientId !== undefined;
-			if (owned && descriptorWorker.descriptor.ownerClientId !== this.protocolClientId(client)) {
-				throw new Error(`Unknown active session: ${command.activeSessionId}`);
-			}
-			this.assertTelemetryAttachAllowed(descriptorWorker, command.telemetryDisabled);
-			descriptorWorker.launchEnv = command.launchEnv ?? descriptorWorker.launchEnv;
-			if (!descriptorWorker.client || descriptorWorker.descriptor.lifecycle !== "ready") {
-				if (owned) {
+			// The descriptor lookup is universal; the owned branch alone carries the
+			// owner-only attach payload (telemetry gate, launchEnv, recovery context).
+			if (descriptorWorker.descriptor.ownerClientId !== undefined) {
+				if (descriptorWorker.descriptor.ownerClientId !== this.protocolClientId(client)) {
+					throw new Error(`Unknown active session: ${command.activeSessionId}`);
+				}
+				this.assertTelemetryAttachAllowed(descriptorWorker, command.telemetryDisabled);
+				descriptorWorker.launchEnv = command.launchEnv ?? descriptorWorker.launchEnv;
+				if (!descriptorWorker.client || descriptorWorker.descriptor.lifecycle !== "ready") {
 					if (command.recoveryConfig) {
 						descriptorWorker.transientCreateCommand = {
 							...descriptorWorker.descriptor.createCommand,
@@ -5011,9 +5015,9 @@ export class DaemonSupervisor {
 						throw new Error("Client-owned session recovery requires the owning client environment");
 					}
 					await this.retryWorkerRecovery(descriptorWorker);
-				} else if (this.canRetryFailedWorker(descriptorWorker)) {
-					await this.retryWorkerRecovery(descriptorWorker);
 				}
+			} else if (this.canRetryFailedWorker(descriptorWorker)) {
+				await this.retryWorkerRecovery(descriptorWorker);
 			}
 		}
 		const match = await this.findWorkerForClient(client, command.activeSessionId);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -4987,6 +4987,10 @@ export class DaemonSupervisor {
 		// --attach-agent preflight's get_state lands here before any attach).
 		if (this.canRetryFailedWorker(worker)) {
 			await this.retryWorkerRecovery(worker);
+		} else if (worker.recovery) {
+			// A concurrent touch already started this recovery: join it instead of
+			// throwing mid-ladder (and instead of starting a second ladder).
+			await worker.recovery;
 		}
 		const client = this.requireAvailableWorkerClient(worker, command.type === "kill");
 		const response = await client.request(withoutCommandId(command), timeoutMs);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -3590,17 +3590,12 @@ export class DaemonSupervisor {
 		return this.isWorkerRecoveryCandidate(worker) && worker.recovery === undefined;
 	}
 
-	/**
-	 * A failed lifecycle is not terminal for a worker whose process identity is
-	 * verified current: any attach or create touching it retries recovery, the
-	 * same way the manual retry_worker command does.
-	 */
+	/** Failed is not terminal for an identity-verified live worker: any touch retries recovery, like manual retry_worker. */
 	private canRetryFailedWorker(worker: ResidentWorker): boolean {
 		return (
 			worker.descriptor.lifecycle === "failed" &&
 			(this.workerStopCounts?.get(worker) ?? 0) === 0 &&
-			// A user-stopped worker stays stopped: the persisted stop markers gate
-			// on-touch retries, which only the explicit retry_worker command clears.
+			// A user-stopped worker stays stopped; only an explicit retry_worker clears the persisted stop markers.
 			!this.isWorkerStopping(worker) &&
 			this.processIdentity(worker.descriptor.pid, worker.descriptor.processStartId) === "current"
 		);
@@ -4854,10 +4849,8 @@ export class DaemonSupervisor {
 		if (matches.length > 1) {
 			throw new Error(`Ambiguous active session "${selector}"`);
 		}
-		// Persisted descriptors are the durable half of session addressability: a
-		// root session on a worker whose roster snapshot has not arrived yet is
-		// recovering, not unknown. Failed workers keep the unknown answer so
-		// clients fall back to the create path, which can reclaim or retry them.
+		// Descriptors are the durable half of addressability: an unhydrated root is recovering, not unknown;
+		// failed workers stay unknown so clients take the create fallback, which reclaims or retries them.
 		const recoveringRoots = (matchesSelector: (worker: ResidentWorker) => boolean) =>
 			[...this.workers.values()].filter(
 				(worker) =>
@@ -4866,8 +4859,7 @@ export class DaemonSupervisor {
 					worker.descriptor.lifecycle !== "failed" &&
 					this.isWorkerRecoveryCandidate(worker),
 			);
-		// Same addressing rule as matchWorkers: exact ids first, then unambiguous
-		// hex suffixes; ambiguous suffixes stay unknown.
+		// matchWorkers' addressing rule: exact ids first, unambiguous hex suffixes second.
 		const exactRecovering = recoveringRoots(
 			(worker) => worker.descriptor.rootActiveSessionId === selector || worker.descriptor.rootSessionId === selector,
 		);
@@ -4982,14 +4974,12 @@ export class DaemonSupervisor {
 		command: DaemonCommand,
 		timeoutMs = WORKER_REQUEST_TIMEOUT_MS,
 	): Promise<DaemonResponse> {
-		// Every forwarded command is a touch: a cached failed roster row must not
-		// outrank the descriptor truth that the worker is recoverable (the
-		// --attach-agent preflight's get_state lands here before any attach).
+		// Every forwarded command is a touch: a cached failed roster row must not outrank
+		// the descriptor truth that the worker is recoverable (--attach-agent's get_state preflight lands here).
 		if (this.canRetryFailedWorker(worker)) {
 			await this.retryWorkerRecovery(worker);
 		} else if (worker.recovery) {
-			// A concurrent touch already started this recovery: join it instead of
-			// throwing mid-ladder (and instead of starting a second ladder).
+			// Join a concurrent touch's in-flight recovery instead of throwing mid-ladder.
 			await worker.recovery;
 		}
 		const client = this.requireAvailableWorkerClient(worker, command.type === "kill");
@@ -5014,8 +5004,7 @@ export class DaemonSupervisor {
 				worker.descriptor.rootSessionId === command.activeSessionId,
 		);
 		if (descriptorWorker) {
-			// The descriptor lookup is universal; the owned branch alone carries the
-			// owner-only attach payload (telemetry gate, launchEnv, recovery context).
+			// The descriptor lookup is universal; owner-only attach payload stays in the owned branch.
 			if (descriptorWorker.descriptor.ownerClientId !== undefined) {
 				if (descriptorWorker.descriptor.ownerClientId !== this.protocolClientId(client)) {
 					throw new Error(`Unknown active session: ${command.activeSessionId}`);
@@ -5047,9 +5036,7 @@ export class DaemonSupervisor {
 		const match = await this.findWorkerForClient(client, command.activeSessionId);
 		this.assertTelemetryAttachAllowed(match.worker, command.telemetryDisabled);
 		if (match.worker !== descriptorWorker && this.canRetryFailedWorker(match.worker)) {
-			// A child-session attach lands here without a descriptor match; failed
-			// is retryable for an identity-verified live worker, but one touch runs
-			// at most one recovery ladder, so the pre-pass worker is not retried twice.
+			// Child-session attaches land here without a descriptor match; one touch runs at most one ladder.
 			await this.retryWorkerRecovery(match.worker);
 		}
 		this.requireAvailableWorkerClient(match.worker);

--- a/packages/coding-agent/test/daemon-errors.test.ts
+++ b/packages/coding-agent/test/daemon-errors.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { SessionAlreadyActiveError } from "../src/core/session-lease.js";
-import { DaemonSessionCreateError, deserializeDaemonCreateError } from "../src/modes/daemon/daemon-errors.js";
+import {
+	DaemonSessionCreateError,
+	DaemonSessionRecoveringError,
+	deserializeDaemonCreateError,
+	deserializeDaemonError,
+	serializeDaemonError,
+} from "../src/modes/daemon/daemon-errors.js";
 
 describe("deserializeDaemonCreateError", () => {
 	it("wraps generic create failures so the CLI boundary prints one line instead of rethrowing", () => {
@@ -23,5 +29,32 @@ describe("deserializeDaemonCreateError", () => {
 			errorInfo: { code: "session_already_active", sessionPath: "/tmp/session.jsonl" },
 		});
 		expect(error).toBeInstanceOf(SessionAlreadyActiveError);
+	});
+});
+
+describe("session_recovering wire round-trip", () => {
+	it("serializes for old clients (readable message) and deserializes for new clients (typed, retryable)", () => {
+		const error = new DaemonSessionRecoveringError("active-gap");
+		const errorInfo = serializeDaemonError(error);
+		expect(errorInfo).toEqual({ code: "session_recovering", activeSessionId: "active-gap" });
+		// Old client / new daemon: errorInfo is ignored, the message alone must carry the state.
+		expect(error.message).toBe("Active session active-gap is recovering; retry shortly");
+		const roundTripped = deserializeDaemonError({
+			type: "response",
+			command: "attach",
+			success: false,
+			error: error.message,
+			errorInfo,
+		});
+		expect(roundTripped).toBeInstanceOf(DaemonSessionRecoveringError);
+		expect((roundTripped as DaemonSessionRecoveringError).activeSessionId).toBe("active-gap");
+		// New client / old daemon: a plain unknown-session failure stays a plain error.
+		const legacy = deserializeDaemonError({
+			type: "response",
+			command: "attach",
+			success: false,
+			error: "Unknown active session: active-gap",
+		});
+		expect(legacy).not.toBeInstanceOf(DaemonSessionRecoveringError);
 	});
 });

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1833,6 +1833,100 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(worker.deferredRecoveryRounds).toBe(0);
 	});
 
+	it("recovers a failed identity-current worker when a command is forwarded to it", async () => {
+		const root = {
+			id: "active-failed-root",
+			activeSessionId: "active-failed-root",
+			sessionId: "session-failed-root",
+			cwd: "/tmp",
+		} as SessionSummary;
+		const worker = {
+			descriptor: {
+				workerId: "worker-failed-root",
+				rootActiveSessionId: root.activeSessionId,
+				rootSessionId: root.sessionId,
+				lifecycle: "failed" as string,
+				pid: process.pid,
+				processStartId: getProcessStartId(process.pid),
+			},
+			client: undefined as { request: ReturnType<typeof vi.fn> } | undefined,
+			summaries: new Map<string, SessionSummary>(),
+			intentionalStop: false,
+		};
+		const request = vi.fn(async () => ({
+			type: "response",
+			command: "get_state",
+			success: true,
+			data: root,
+		}));
+		const recoverWorker = vi.fn(async () => {
+			worker.descriptor.lifecycle = "ready";
+			worker.client = { request };
+		});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			clients: new Set(),
+			persistWorker: vi.fn(),
+			recoverWorker,
+		}) as unknown as {
+			forwardToWorker(
+				target: typeof worker,
+				command: { type: "get_state"; activeSessionId: string },
+			): Promise<{ success: boolean; data?: SessionSummary }>;
+		};
+
+		const response = await supervisor.forwardToWorker(worker, {
+			type: "get_state",
+			activeSessionId: "active-failed-root",
+		});
+		expect(recoverWorker).toHaveBeenCalledOnce();
+		expect(response.success).toBe(true);
+		expect(response.data?.workerState).toBe("ready");
+	});
+
+	it("runs at most one recovery ladder for a single attach touch", async () => {
+		const root = {
+			id: "active-double",
+			activeSessionId: "active-double",
+			sessionId: "session-double",
+			cwd: "/tmp",
+		} as SessionSummary;
+		const worker = {
+			descriptor: {
+				workerId: "worker-double",
+				rootActiveSessionId: root.activeSessionId,
+				rootSessionId: root.sessionId,
+				lifecycle: "failed" as string,
+				pid: process.pid,
+				processStartId: getProcessStartId(process.pid),
+			},
+			client: undefined,
+			summaries: new Map<string, SessionSummary>([["active-double", root]]),
+			intentionalStop: false,
+		};
+		// Recovery exhausts and parks the same live worker failed again.
+		const recoverWorker = vi.fn(async () => {
+			worker.descriptor.lifecycle = "failed";
+		});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			shuttingDown: false,
+			persistWorker: vi.fn(),
+			recoverWorker,
+		}) as unknown as {
+			attachClient(
+				client: DaemonSocketClient,
+				command: { type: "attach"; activeSessionId: string },
+			): Promise<unknown>;
+		};
+		seedSupervisorRoster(supervisor as object as Parameters<typeof seedSupervisorRoster>[0], worker);
+
+		await expect(
+			supervisor.attachClient({} as DaemonSocketClient, { type: "attach", activeSessionId: "active-double" }),
+		).rejects.toThrow("Session worker is failed");
+		expect(recoverWorker).toHaveBeenCalledOnce();
+	});
+
 	it("does not revive a stop-marked failed worker on attach", async () => {
 		const worker = {
 			descriptor: {
@@ -1893,6 +1987,11 @@ describe("daemon worker supervisor monitoring", () => {
 
 		await expect(supervisor.findWorker("active-gap")).rejects.toMatchObject({
 			name: "DaemonSessionRecoveringError",
+			code: "session_recovering",
+			activeSessionId: "active-gap",
+		});
+		// A stable-session-id selector still reports the ACTIVE id on the wire.
+		await expect(supervisor.findWorker("session-gap")).rejects.toMatchObject({
 			code: "session_recovering",
 			activeSessionId: "active-gap",
 		});

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1799,25 +1799,50 @@ describe("daemon worker supervisor monitoring", () => {
 		);
 	});
 
-	it("retries recovery on create reuse for a failed worker with a current process identity", async () => {
+	/** A failed worker whose process identity is verifiably current (this test process). */
+	function retryableWorkerFixture(prefix: string) {
+		const root = {
+			id: `active-${prefix}`,
+			activeSessionId: `active-${prefix}`,
+			sessionId: `session-${prefix}`,
+			cwd: "/tmp",
+		} as SessionSummary;
 		const worker = {
 			descriptor: {
-				workerId: "failed-live",
-				rootActiveSessionId: "active-failed-live",
+				workerId: `worker-${prefix}`,
+				rootActiveSessionId: `active-${prefix}`,
+				rootSessionId: `session-${prefix}`,
 				lifecycle: "failed" as string,
-				consecutiveFailures: 3,
 				pid: process.pid,
 				processStartId: getProcessStartId(process.pid),
+				stopRequestedAt: undefined as string | undefined,
 			},
+			client: undefined as { request: ReturnType<typeof vi.fn> } | undefined,
+			recovery: undefined as Promise<void> | undefined,
+			summaries: new Map<string, SessionSummary>(),
 			intentionalStop: false,
-			deferredRecoveryRounds: 11,
+			deferredRecoveryRounds: 0,
 		};
+		return { root, worker };
+	}
+
+	function retrySupervisor(worker: { descriptor: { workerId: string } }, overrides: Record<string, unknown>) {
+		return Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			clients: new Set(),
+			shuttingDown: false,
+			persistWorker: vi.fn(),
+			...overrides,
+		}) as object;
+	}
+
+	it("retries recovery on create reuse for a failed worker with a current process identity", async () => {
+		const { worker } = retryableWorkerFixture("failed-live");
+		worker.deferredRecoveryRounds = 11;
 		const recoverWorker = vi.fn(async () => {
 			worker.descriptor.lifecycle = "ready";
 		});
-		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
-			workers: new Map([[worker.descriptor.workerId, worker]]),
-			persistWorker: vi.fn(),
+		const supervisor = retrySupervisor(worker, {
 			recoverWorker,
 			isWorkerReadyForCreate: (target: typeof worker) => target.descriptor.lifecycle === "ready",
 		}) as unknown as {
@@ -1834,41 +1859,13 @@ describe("daemon worker supervisor monitoring", () => {
 	});
 
 	it("recovers a failed identity-current worker when a command is forwarded to it", async () => {
-		const root = {
-			id: "active-failed-root",
-			activeSessionId: "active-failed-root",
-			sessionId: "session-failed-root",
-			cwd: "/tmp",
-		} as SessionSummary;
-		const worker = {
-			descriptor: {
-				workerId: "worker-failed-root",
-				rootActiveSessionId: root.activeSessionId,
-				rootSessionId: root.sessionId,
-				lifecycle: "failed" as string,
-				pid: process.pid,
-				processStartId: getProcessStartId(process.pid),
-			},
-			client: undefined as { request: ReturnType<typeof vi.fn> } | undefined,
-			summaries: new Map<string, SessionSummary>(),
-			intentionalStop: false,
-		};
-		const request = vi.fn(async () => ({
-			type: "response",
-			command: "get_state",
-			success: true,
-			data: root,
-		}));
+		const { root, worker } = retryableWorkerFixture("failed-root");
+		const request = vi.fn(async () => ({ type: "response", command: "get_state", success: true, data: root }));
 		const recoverWorker = vi.fn(async () => {
 			worker.descriptor.lifecycle = "ready";
 			worker.client = { request };
 		});
-		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
-			workers: new Map([[worker.descriptor.workerId, worker]]),
-			clients: new Set(),
-			persistWorker: vi.fn(),
-			recoverWorker,
-		}) as unknown as {
+		const supervisor = retrySupervisor(worker, { recoverWorker }) as unknown as {
 			forwardToWorker(
 				target: typeof worker,
 				command: { type: "get_state"; activeSessionId: string },
@@ -1885,32 +1882,8 @@ describe("daemon worker supervisor monitoring", () => {
 	});
 
 	it("joins an in-flight recovery instead of failing a concurrent forwarded command", async () => {
-		const root = {
-			id: "active-race",
-			activeSessionId: "active-race",
-			sessionId: "session-race",
-			cwd: "/tmp",
-		} as SessionSummary;
-		const request = vi.fn(async () => ({
-			type: "response",
-			command: "get_state",
-			success: true,
-			data: root,
-		}));
-		const worker = {
-			descriptor: {
-				workerId: "worker-race",
-				rootActiveSessionId: "active-race",
-				rootSessionId: "session-race",
-				lifecycle: "failed" as string,
-				pid: process.pid,
-				processStartId: getProcessStartId(process.pid),
-			},
-			client: undefined as { request: ReturnType<typeof vi.fn> } | undefined,
-			recovery: undefined as Promise<void> | undefined,
-			summaries: new Map<string, SessionSummary>(),
-			intentionalStop: false,
-		};
+		const { root, worker } = retryableWorkerFixture("race");
+		const request = vi.fn(async () => ({ type: "response", command: "get_state", success: true, data: root }));
 		const release = createDeferred<void>();
 		const recoverWorker = vi.fn(() => {
 			worker.recovery = release.promise.then(() => {
@@ -1920,12 +1893,7 @@ describe("daemon worker supervisor monitoring", () => {
 			});
 			return worker.recovery;
 		});
-		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
-			workers: new Map([[worker.descriptor.workerId, worker]]),
-			clients: new Set(),
-			persistWorker: vi.fn(),
-			recoverWorker,
-		}) as unknown as {
+		const supervisor = retrySupervisor(worker, { recoverWorker }) as unknown as {
 			forwardToWorker(
 				target: typeof worker,
 				command: { type: "get_state"; activeSessionId: string },
@@ -1944,35 +1912,13 @@ describe("daemon worker supervisor monitoring", () => {
 	});
 
 	it("runs at most one recovery ladder for a single attach touch", async () => {
-		const root = {
-			id: "active-double",
-			activeSessionId: "active-double",
-			sessionId: "session-double",
-			cwd: "/tmp",
-		} as SessionSummary;
-		const worker = {
-			descriptor: {
-				workerId: "worker-double",
-				rootActiveSessionId: root.activeSessionId,
-				rootSessionId: root.sessionId,
-				lifecycle: "failed" as string,
-				pid: process.pid,
-				processStartId: getProcessStartId(process.pid),
-			},
-			client: undefined,
-			summaries: new Map<string, SessionSummary>([["active-double", root]]),
-			intentionalStop: false,
-		};
+		const { root, worker } = retryableWorkerFixture("double");
+		worker.summaries.set("active-double", root);
 		// Recovery exhausts and parks the same live worker failed again.
 		const recoverWorker = vi.fn(async () => {
 			worker.descriptor.lifecycle = "failed";
 		});
-		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
-			workers: new Map([[worker.descriptor.workerId, worker]]),
-			shuttingDown: false,
-			persistWorker: vi.fn(),
-			recoverWorker,
-		}) as unknown as {
+		const supervisor = retrySupervisor(worker, { recoverWorker }) as unknown as {
 			attachClient(
 				client: DaemonSocketClient,
 				command: { type: "attach"; activeSessionId: string },
@@ -1987,25 +1933,14 @@ describe("daemon worker supervisor monitoring", () => {
 	});
 
 	it("does not revive a stop-marked failed worker on attach", async () => {
-		const worker = {
-			descriptor: {
-				workerId: "worker-stopped",
-				rootActiveSessionId: "active-stopped",
-				rootSessionId: "session-stopped",
-				lifecycle: "failed" as string,
-				stopRequestedAt: new Date().toISOString(),
-				pid: process.pid,
-				processStartId: getProcessStartId(process.pid),
-			},
-			intentionalStop: true,
-			summaries: new Map(),
-		};
+		const { worker } = retryableWorkerFixture("stopped");
+		worker.descriptor.stopRequestedAt = new Date().toISOString();
+		worker.intentionalStop = true;
 		const recoverWorker = vi.fn(async () => {});
 		const persistWorker = vi.fn();
-		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
-			workers: new Map([[worker.descriptor.workerId, worker]]),
-			persistWorker,
+		const supervisor = retrySupervisor(worker, {
 			recoverWorker,
+			persistWorker,
 			findWorkerForClient: vi.fn(async () => {
 				throw new Error("Unknown active session: active-stopped");
 			}),
@@ -2027,35 +1962,17 @@ describe("daemon worker supervisor monitoring", () => {
 	});
 
 	it("answers a descriptor-known unaddressable root session with a structured recovering error", async () => {
-		const worker = {
-			descriptor: {
-				workerId: "worker-gap",
-				rootActiveSessionId: "active-gap",
-				rootSessionId: "session-gap",
-				lifecycle: "recovering" as string,
-			},
-			intentionalStop: false,
-			summaries: new Map(),
-		};
-		const hexWorker = {
-			descriptor: {
-				workerId: "worker-hex-gap",
-				rootActiveSessionId: "00ff77aa11bb22cc",
-				rootSessionId: "0123456789abcdef",
-				lifecycle: "recovering" as string,
-			},
-			intentionalStop: false,
-			summaries: new Map(),
-		};
-		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
-			workers: new Map([
-				[worker.descriptor.workerId, worker],
-				[hexWorker.descriptor.workerId, hexWorker],
-			]),
-			shuttingDown: false,
+		const { worker } = retryableWorkerFixture("gap");
+		worker.descriptor.lifecycle = "recovering";
+		const { worker: hexWorker } = retryableWorkerFixture("hex");
+		hexWorker.descriptor.rootActiveSessionId = "00ff77aa11bb22cc";
+		hexWorker.descriptor.rootSessionId = "0123456789abcdef";
+		hexWorker.descriptor.lifecycle = "recovering";
+		const supervisor = retrySupervisor(worker, {
 			matchWorkers: () => [],
 			refreshWorkerSummaries: vi.fn(async () => {}),
 		}) as unknown as { findWorker(selector: string): Promise<unknown> };
+		(supervisor as unknown as { workers: Map<string, unknown> }).workers.set("worker-hex", hexWorker);
 
 		await expect(supervisor.findWorker("active-gap")).rejects.toMatchObject({
 			name: "DaemonSessionRecoveringError",
@@ -2067,14 +1984,12 @@ describe("daemon worker supervisor monitoring", () => {
 			code: "session_recovering",
 			activeSessionId: "active-gap",
 		});
-		// Suffix addressing follows the roster rule: an unambiguous hex suffix of
-		// a recovering root is recovering, not unknown.
+		// Suffix addressing follows the roster rule: an unambiguous hex suffix of a recovering root is recovering.
 		await expect(supervisor.findWorker("77aa11bb22cc")).rejects.toMatchObject({
 			code: "session_recovering",
 			activeSessionId: "00ff77aa11bb22cc",
 		});
-		// A failed worker keeps the unknown answer so clients fall back to the
-		// create path, which reclaims or retries it.
+		// Failed workers keep the unknown answer so clients take the create fallback that reclaims them.
 		worker.descriptor.lifecycle = "failed";
 		await expect(supervisor.findWorker("active-gap")).rejects.toThrow("Unknown active session: active-gap");
 		await expect(supervisor.findWorker("missing")).rejects.toThrow("Unknown active session: missing");

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1884,6 +1884,65 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(response.data?.workerState).toBe("ready");
 	});
 
+	it("joins an in-flight recovery instead of failing a concurrent forwarded command", async () => {
+		const root = {
+			id: "active-race",
+			activeSessionId: "active-race",
+			sessionId: "session-race",
+			cwd: "/tmp",
+		} as SessionSummary;
+		const request = vi.fn(async () => ({
+			type: "response",
+			command: "get_state",
+			success: true,
+			data: root,
+		}));
+		const worker = {
+			descriptor: {
+				workerId: "worker-race",
+				rootActiveSessionId: "active-race",
+				rootSessionId: "session-race",
+				lifecycle: "failed" as string,
+				pid: process.pid,
+				processStartId: getProcessStartId(process.pid),
+			},
+			client: undefined as { request: ReturnType<typeof vi.fn> } | undefined,
+			recovery: undefined as Promise<void> | undefined,
+			summaries: new Map<string, SessionSummary>(),
+			intentionalStop: false,
+		};
+		const release = createDeferred<void>();
+		const recoverWorker = vi.fn(() => {
+			worker.recovery = release.promise.then(() => {
+				worker.descriptor.lifecycle = "ready";
+				worker.client = { request };
+				worker.recovery = undefined;
+			});
+			return worker.recovery;
+		});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			clients: new Set(),
+			persistWorker: vi.fn(),
+			recoverWorker,
+		}) as unknown as {
+			forwardToWorker(
+				target: typeof worker,
+				command: { type: "get_state"; activeSessionId: string },
+			): Promise<{ success: boolean }>;
+		};
+
+		const first = supervisor.forwardToWorker(worker, { type: "get_state", activeSessionId: "active-race" });
+		await Promise.resolve();
+		const second = supervisor.forwardToWorker(worker, { type: "get_state", activeSessionId: "active-race" });
+		await Promise.resolve();
+		release.resolve();
+		const [firstResponse, secondResponse] = await Promise.all([first, second]);
+		expect(firstResponse.success).toBe(true);
+		expect(secondResponse.success).toBe(true);
+		expect(recoverWorker).toHaveBeenCalledOnce();
+	});
+
 	it("runs at most one recovery ladder for a single attach touch", async () => {
 		const root = {
 			id: "active-double",

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1809,7 +1809,7 @@ describe("daemon worker supervisor monitoring", () => {
 				pid: process.pid,
 				processStartId: getProcessStartId(process.pid),
 			},
-			intentionalStop: true,
+			intentionalStop: false,
 			deferredRecoveryRounds: 11,
 		};
 		const recoverWorker = vi.fn(async () => {
@@ -1830,8 +1830,47 @@ describe("daemon worker supervisor monitoring", () => {
 
 		await expect(supervisor.reuseWorkerForCreate(worker, undefined, "/tmp/failed-live.jsonl")).resolves.toBe(worker);
 		expect(recoverWorker).toHaveBeenCalledWith(worker);
-		expect(worker.intentionalStop).toBe(false);
 		expect(worker.deferredRecoveryRounds).toBe(0);
+	});
+
+	it("does not revive a stop-marked failed worker on attach", async () => {
+		const worker = {
+			descriptor: {
+				workerId: "worker-stopped",
+				rootActiveSessionId: "active-stopped",
+				rootSessionId: "session-stopped",
+				lifecycle: "failed" as string,
+				stopRequestedAt: new Date().toISOString(),
+				pid: process.pid,
+				processStartId: getProcessStartId(process.pid),
+			},
+			intentionalStop: true,
+			summaries: new Map(),
+		};
+		const recoverWorker = vi.fn(async () => {});
+		const persistWorker = vi.fn();
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			persistWorker,
+			recoverWorker,
+			findWorkerForClient: vi.fn(async () => {
+				throw new Error("Unknown active session: active-stopped");
+			}),
+		}) as unknown as {
+			attachClient(
+				client: DaemonSocketClient,
+				command: { type: "attach"; activeSessionId: string },
+			): Promise<unknown>;
+		};
+
+		await expect(
+			supervisor.attachClient({} as DaemonSocketClient, { type: "attach", activeSessionId: "active-stopped" }),
+		).rejects.toThrow("Unknown active session: active-stopped");
+		expect(recoverWorker).not.toHaveBeenCalled();
+		expect(persistWorker).not.toHaveBeenCalled();
+		expect(worker.intentionalStop).toBe(true);
+		expect(worker.descriptor.stopRequestedAt).toBeDefined();
+		expect(worker.descriptor.lifecycle).toBe("failed");
 	});
 
 	it("answers a descriptor-known unaddressable root session with a structured recovering error", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1978,8 +1978,21 @@ describe("daemon worker supervisor monitoring", () => {
 			intentionalStop: false,
 			summaries: new Map(),
 		};
+		const hexWorker = {
+			descriptor: {
+				workerId: "worker-hex-gap",
+				rootActiveSessionId: "00ff77aa11bb22cc",
+				rootSessionId: "0123456789abcdef",
+				lifecycle: "recovering" as string,
+			},
+			intentionalStop: false,
+			summaries: new Map(),
+		};
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
-			workers: new Map([[worker.descriptor.workerId, worker]]),
+			workers: new Map([
+				[worker.descriptor.workerId, worker],
+				[hexWorker.descriptor.workerId, hexWorker],
+			]),
 			shuttingDown: false,
 			matchWorkers: () => [],
 			refreshWorkerSummaries: vi.fn(async () => {}),
@@ -1994,6 +2007,12 @@ describe("daemon worker supervisor monitoring", () => {
 		await expect(supervisor.findWorker("session-gap")).rejects.toMatchObject({
 			code: "session_recovering",
 			activeSessionId: "active-gap",
+		});
+		// Suffix addressing follows the roster rule: an unambiguous hex suffix of
+		// a recovering root is recovering, not unknown.
+		await expect(supervisor.findWorker("77aa11bb22cc")).rejects.toMatchObject({
+			code: "session_recovering",
+			activeSessionId: "00ff77aa11bb22cc",
 		});
 		// A failed worker keeps the unknown answer so clients fall back to the
 		// create path, which reclaims or retries it.

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1799,6 +1799,71 @@ describe("daemon worker supervisor monitoring", () => {
 		);
 	});
 
+	it("retries recovery on create reuse for a failed worker with a current process identity", async () => {
+		const worker = {
+			descriptor: {
+				workerId: "failed-live",
+				rootActiveSessionId: "active-failed-live",
+				lifecycle: "failed" as string,
+				consecutiveFailures: 3,
+				pid: process.pid,
+				processStartId: getProcessStartId(process.pid),
+			},
+			intentionalStop: true,
+			deferredRecoveryRounds: 11,
+		};
+		const recoverWorker = vi.fn(async () => {
+			worker.descriptor.lifecycle = "ready";
+		});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			persistWorker: vi.fn(),
+			recoverWorker,
+			isWorkerReadyForCreate: (target: typeof worker) => target.descriptor.lifecycle === "ready",
+		}) as unknown as {
+			reuseWorkerForCreate(
+				target: typeof worker,
+				ownerClientId: undefined,
+				sessionPath: string,
+			): Promise<typeof worker>;
+		};
+
+		await expect(supervisor.reuseWorkerForCreate(worker, undefined, "/tmp/failed-live.jsonl")).resolves.toBe(worker);
+		expect(recoverWorker).toHaveBeenCalledWith(worker);
+		expect(worker.intentionalStop).toBe(false);
+		expect(worker.deferredRecoveryRounds).toBe(0);
+	});
+
+	it("answers a descriptor-known unaddressable root session with a structured recovering error", async () => {
+		const worker = {
+			descriptor: {
+				workerId: "worker-gap",
+				rootActiveSessionId: "active-gap",
+				rootSessionId: "session-gap",
+				lifecycle: "recovering" as string,
+			},
+			intentionalStop: false,
+			summaries: new Map(),
+		};
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			shuttingDown: false,
+			matchWorkers: () => [],
+			refreshWorkerSummaries: vi.fn(async () => {}),
+		}) as unknown as { findWorker(selector: string): Promise<unknown> };
+
+		await expect(supervisor.findWorker("active-gap")).rejects.toMatchObject({
+			name: "DaemonSessionRecoveringError",
+			code: "session_recovering",
+			activeSessionId: "active-gap",
+		});
+		// A failed worker keeps the unknown answer so clients fall back to the
+		// create path, which reclaims or retries it.
+		worker.descriptor.lifecycle = "failed";
+		await expect(supervisor.findWorker("active-gap")).rejects.toThrow("Unknown active session: active-gap");
+		await expect(supervisor.findWorker("missing")).rejects.toThrow("Unknown active session: missing");
+	});
+
 	it("waits for worker recovery before reusing a saved session", async () => {
 		const root = { id: "active-root", activeSessionId: "active-root", sessionId: "session-root", cwd: "/tmp" };
 		const recovery = createDeferred<void>();

--- a/packages/coding-agent/test/main-interactive-routing.test.ts
+++ b/packages/coding-agent/test/main-interactive-routing.test.ts
@@ -12,6 +12,7 @@ import {
 	type InteractiveDaemonStartupDecision,
 	isClientOwnedDaemonSession,
 	parseAgentsViewCommand,
+	resolveActiveSessionLookupFailure,
 	resolveRuntimeSessionOptions,
 	shouldEnsureDaemonBeforeActiveSessionLookup,
 	shouldEnsureInteractiveDaemonForStartup,
@@ -23,6 +24,7 @@ import {
 	shouldUseDaemonInteractive,
 	shouldUseEphemeralSessionManagerForDaemonInteractive,
 } from "../src/main.js";
+import { DaemonSessionRecoveringError } from "../src/modes/daemon/daemon-errors.js";
 import type { SessionSummary } from "../src/modes/index.js";
 
 describe("interactive startup routing", () => {
@@ -447,6 +449,34 @@ describe("runtime session option resolution", () => {
 			maxContinuations: 5,
 			gates: { commands: ["npm test"], maxRetries: 3, timeoutMs: 1000 },
 		});
+	});
+
+	test("classifies active-session lookup failures: recovering is typed, unknown falls back", () => {
+		const recovering = resolveActiveSessionLookupFailure({
+			type: "response",
+			command: "get_state",
+			success: false,
+			error: "Active session active-gap is recovering; retry shortly",
+			errorInfo: { code: "session_recovering", activeSessionId: "active-gap" },
+		});
+		expect(recovering).toBeInstanceOf(DaemonSessionRecoveringError);
+		expect((recovering as DaemonSessionRecoveringError).activeSessionId).toBe("active-gap");
+		expect(
+			resolveActiveSessionLookupFailure({
+				type: "response",
+				command: "get_state",
+				success: false,
+				error: "Unknown active session: active-gap",
+			}),
+		).toBeUndefined();
+		expect(
+			resolveActiveSessionLookupFailure({
+				type: "response",
+				command: "get_state",
+				success: false,
+				error: "socket closed",
+			}),
+		).toBeInstanceOf(Error);
 	});
 });
 


### PR DESCRIPTION
Part of the worker-state single-truth program (Linear RES-1270); squashes the confirmed residuals of discussions #1742 and #1650 and the mechanism behind #1870/#1641 (and the #1904d reconnect gap).

## Purpose

Two owners for two worker-state facts:

1. **Liveness/failure.** After `MAX_DEFERRED_RECOVERY_ROUNDS` the recovery ladder parks a live-but-silent worker `lifecycle='failed'` terminally: no timer re-probes it, `reuseWorkerForCreate` hard-rejects it, and only client-owned workers auto-recover on attach. A worker frozen longer than the ~2-3 min probe budget (dark wake, paused VM, swap-in) stays written off even though `isProcessAlive` + `processStartId` prove it is ours and alive (#1742 residual). The create path threw exactly in the gap where neither `retry_worker` nor a launchEnv-bearing fresh create applied (#1650 residual).
2. **Addressability.** `findWorker` resolves selectors only through the in-memory roster, hydrated lazily from live workers after adoption; the persisted worker descriptors that carry `rootActiveSessionId`/`rootSessionId` were consulted only in the client-owned attach special case. Every supervisor replacement re-opens a window where attach/prompt/kill on a provably-known session answer `Unknown active session`, and clients cannot distinguish gone from recovering (#1870, #1641).

## Change

- `canRetryFailedWorker` (failed + no stop in flight + process identity verified current) and `retryWorkerRecovery` (the state reset `retry_worker` already performed) become the single retry semantics. `retry_worker`, attach, and create reuse all share them; the parked state is now exit-able on any touch. Identity gone/replaced/unverifiable keeps the old hard answers.
- The client-owned attach pre-pass generalizes to any descriptor-matched worker (owned keeps its launchEnv/recoveryConfig relaunch semantics; non-owned recovers only when identity-current-failed, and never blocks on an in-flight recovery). A child-session attach onto a failed worker retries after roster resolution.
- `findWorker` on a roster miss consults descriptors: a root session on a recovery-candidate worker answers with a structured, retryable `session_recovering` error (`DaemonSessionRecoveringError`, new `DaemonErrorInfo` variant, `DAEMON_SCHEMA_REVISION` 27). Failed workers deliberately keep `Unknown active session` so first-party clients take the saved-session/create fallback, which reclaims or retries them (that fallback is what self-heals identity-gone workers via `launchEnv`).
- `main.ts` (get_state lookup) and the agents view treat `session_recovering` like the unknown fallback, converging on the create path.

Wire classification: backward-compatible. The new variant rides the existing optional `errorInfo`; old clients see a readable message, old daemons never send it, nothing is capability-gated because it degrades to a plain error.

Net src LOC: +102/-38, of which the supervisor is +84/-38 (about half is the owned-attach special case becoming the general pre-pass, plus the two shared helpers replacing three inline copies of the reset).

## Tests

- New pin: create reuse on a failed worker with a current process identity retries recovery instead of throwing (fail-unfixed verified: forcing the old terminal semantics rejects with "could not be safely reclaimed").
- New pin: a descriptor-known unaddressable root session answers `session_recovering` (typed, with `activeSessionId`); a failed worker and a truly unknown selector keep `Unknown active session` (fail-unfixed verified: removing the fallback yields Unknown).
- Both-direction wire pins in `daemon-errors.test.ts`: serialize/deserialize round-trip for new clients, readable message for old clients, and plain old-daemon failures do not misclassify.
- Existing pins kept green: retry-while-stopping rejection, intentional-stop tombstone reset, failed-unreclaimable create rejection (identity gone), owned-session recovery paths.

Ran locally: daemon-supervisor-{monitor,process,eviction,admission,input-pause}, daemon-agent-roster, daemon-supervisor-lazy-subagents, daemon-errors, regressions 4656 + 4603, agent-connection-daemon, daemon-ps, agents-view suite, main-interactive-routing — 540 tests pass; `npm run check` green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core daemon supervisor routing, attach/create, and worker lifecycle; behavior changes for failed-but-live workers and session lookup errors, though guarded by process identity and extensive new tests.
> 
> **Overview**
> Fixes daemon sessions getting stuck when a worker is parked **`failed`** but its process is still alive, and when the supervisor knows a session id but cannot route to it yet.
> 
> **Failed worker recovery:** Shared **`canRetryFailedWorker`** / **`retryWorkerRecovery`** replace duplicated reset logic. **`retry_worker`**, session **create** reuse, **attach**, and any command **forwarded** to the worker now automatically retry recovery when failure is not terminal (current process identity, no stop in flight). User-stopped workers stay stopped until an explicit **`retry_worker`**.
> 
> **Addressability:** When roster lookup misses but a persisted descriptor matches a recovering (non-failed) worker, **`findWorker`** returns **`DaemonSessionRecoveringError`** with wire **`errorInfo.code: session_recovering`** (daemon schema **27**). Failed workers still answer **`Unknown active session`** so clients can fall through to create/reclaim. **`resolveActiveSessionLookupFailure`** and the agents view treat recovering like unknown for the saved-session reopen path, while explicit attach can surface the typed retryable error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77b747afab402a9e2f5eada227ffe6fed626a634. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## LOC

Total src: **+148/−52 (net +96)**; tests: +260/−1 (net +259).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry failed daemon workers on touch and add `DaemonSessionRecoveringError` to protocol revision 27
> - Failed workers whose recorded process identity is still current are now retried on attach, create, retry, and command forwarding via a shared `retryWorkerRecovery` helper that clears stop/archive markers and waits for recovery
> - Adds a typed `DaemonSessionRecoveringError` with an active session identifier, serialized over the wire as a structured error variant; clients deserialize it distinctly from unknown-session failures so they no longer treat a known recovering session as absent
> - `findWorker` resolves descriptor-known recovering root sessions to the typed error instead of unknown-session, preserving the failed-session create fallback
> - `resolveActiveSessionLookupFailure` in [main.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2047/files#diff-4baeaa77e0a68df3cb411f5b9f216f6a26a7a23495a61b955b1d46482f76d586) classifies structured recovering failures as thrown errors while keeping the saved-session fallback for unknown sessions; `agents-view.openAgentsViewSession` falls back to the saved session on recovering attach failures
> - Risk: daemon protocol schema advances to revision 27; older clients without `deserializeDaemonError` support see only the plain message and cannot distinguish recovering sessions. Stop-marked or identity-invalid failed workers are excluded from retry by `canRetryFailedWorker` — reviewers should confirm no lifecycle path clears stop markers unintentionally
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 77b747a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->