### PR TITLE
fix(coding-agent): coalesce child-usage attribution and gate agent-status persistence on real changes

### DIFF
--- a/packages/coding-agent/.changes/res-1272-coalesced-bookkeeping-appends.md
+++ b/packages/coding-agent/.changes/res-1272-coalesced-bookkeeping-appends.md
@@ -1,0 +1,1 @@
+- Fixed unbounded session-journal growth from derived bookkeeping: child usage attribution now flushes one entry per child turn instead of one per model request, and idle status sweeps no longer persist fabricated fallback verdicts, duplicate statuses, or retry failed summary generations (including paid model calls) every 25 seconds on unchanged content.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10630,11 +10630,17 @@ export class AgentSession {
 		// entry per settle boundary (child agent_end, run settlement) instead of
 		// one journal append per child assistant message. Crash durability is
 		// bounded, not per-message: a batch older than the staleness bound flushes
-		// before it grows or a tool starts, so process death loses at most that
-		// window of accumulated child usage.
+		// at the next checkpoint (accumulation, tool start) or on the wall-clock
+		// timer backstop, so process death loses at most that window of
+		// accumulated child usage.
 		const pendingChildUsage = new Map<ChildUsageAttributionEntry["origin"], Usage>();
 		let pendingChildUsageSince = 0;
+		let pendingChildUsageTimer: ReturnType<typeof setTimeout> | undefined;
 		const flushPendingChildUsageAttribution = () => {
+			if (pendingChildUsageTimer !== undefined) {
+				clearTimeout(pendingChildUsageTimer);
+				pendingChildUsageTimer = undefined;
+			}
 			if (pendingChildUsage.size === 0 || !parentAssistantForUsage) return;
 			const batches = [...pendingChildUsage.entries()];
 			pendingChildUsage.clear();
@@ -10780,11 +10786,24 @@ export class AgentSession {
 					} else if (event.type === "message_end" && event.message.role === "assistant") {
 						const assistant = event.message as AssistantMessage;
 						if (assistant.stopReason !== "error" && assistant.stopReason !== "aborted") {
+							// A stale batch must flush before this completion folds into the
+							// parent aggregate: the persisted aggregateUsage of an entry may
+							// only include completions whose childUsage is durable with or
+							// before it, or replay would inflate the parent's own spend.
+							flushPendingChildUsageIfStale();
 							attributeChildUsage(parentAssistantForUsage?.usage ?? emptyUsage(), assistant.usage);
 							if (parentAssistantForUsage) {
-								flushPendingChildUsageIfStale();
 								const origin = rlmChildUsageOrigin(child.messages, assistant);
-								if (pendingChildUsage.size === 0) pendingChildUsageSince = Date.now();
+								if (pendingChildUsage.size === 0) {
+									pendingChildUsageSince = Date.now();
+									// Wall-clock backstop: a long tool execution has no event
+									// checkpoints, so the batch flushes on time regardless.
+									pendingChildUsageTimer = setTimeout(
+										flushPendingChildUsageAttribution,
+										RLM_CHILD_USAGE_FLUSH_MAX_PENDING_MS,
+									);
+									pendingChildUsageTimer.unref?.();
+								}
 								const bucket = pendingChildUsage.get(origin) ?? emptyUsage();
 								addAssistantUsage(bucket, assistant.usage);
 								pendingChildUsage.set(origin, bucket);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1043,6 +1043,27 @@ function waitForPromiseOrAbort<T>(
 	});
 }
 
+// Bounds how much accumulated child usage a parent process crash can lose
+// before the batch is flushed durable.
+const RLM_CHILD_USAGE_FLUSH_MAX_PENDING_MS = 60_000;
+
+/** Label a child completion's usage by the nearest preceding prompt that triggered it. */
+function rlmChildUsageOrigin(
+	messages: readonly AgentMessage[],
+	assistant: AssistantMessage,
+): ChildUsageAttributionEntry["origin"] {
+	for (let index = messages.lastIndexOf(assistant) - 1; index >= 0; index--) {
+		const message = messages[index];
+		if (message.role !== "user" && message.role !== "custom") continue;
+		return message.role === "custom" && isAgentSessionMessage(message)
+			? message.details.id.startsWith("spawn:")
+				? "spawn_task"
+				: "agent_message"
+			: "direct_user";
+	}
+	return "direct_user";
+}
+
 function attributeChildUsage(parentUsage: Usage, childUsage: Usage): void {
 	const parentContextTokens =
 		parentUsage.totalTokens ||
@@ -10605,28 +10626,39 @@ export class AgentSession {
 		if (!requestedSessionName) await this._assertRlmSubagentSessionNameAvailable(sessionName);
 		const startedAt = Date.now();
 		const parentAssistantForUsage = this._findLastAssistantMessage();
-		// Child completions accumulate in memory and flush one durable attribution
+		// Child completions accumulate per origin and flush one durable attribution
 		// entry per settle boundary (child agent_end, run settlement) instead of
-		// one journal append per child assistant message.
-		let pendingChildUsage: Usage | undefined;
-		let pendingChildUsageOrigin: ChildUsageAttributionEntry["origin"];
+		// one journal append per child assistant message. Crash durability is
+		// bounded, not per-message: a batch older than the staleness bound flushes
+		// before it grows or a tool starts, so process death loses at most that
+		// window of accumulated child usage.
+		const pendingChildUsage = new Map<ChildUsageAttributionEntry["origin"], Usage>();
+		let pendingChildUsageSince = 0;
 		const flushPendingChildUsageAttribution = () => {
-			if (!pendingChildUsage || !parentAssistantForUsage) return;
-			const childUsage = pendingChildUsage;
-			const origin = pendingChildUsageOrigin;
-			pendingChildUsage = undefined;
-			pendingChildUsageOrigin = undefined;
+			if (pendingChildUsage.size === 0 || !parentAssistantForUsage) return;
+			const batches = [...pendingChildUsage.entries()];
+			pendingChildUsage.clear();
 			const parentEntry = this._findAssistantEntryForMessage(parentAssistantForUsage);
 			if (!parentEntry) return;
-			try {
-				this.sessionManager.appendChildUsageAttribution(
-					parentEntry.id,
-					childUsage,
-					parentAssistantForUsage.usage,
-					origin,
-				);
-			} catch {
-				// Attribution is recoverable bookkeeping; a failed append must not break run settlement.
+			for (const [origin, childUsage] of batches) {
+				try {
+					this.sessionManager.appendChildUsageAttribution(
+						parentEntry.id,
+						childUsage,
+						parentAssistantForUsage.usage,
+						origin,
+					);
+				} catch {
+					// Attribution is recoverable bookkeeping; a failed append must not break run settlement.
+				}
+			}
+		};
+		const flushPendingChildUsageIfStale = () => {
+			if (
+				pendingChildUsage.size > 0 &&
+				Date.now() - pendingChildUsageSince >= RLM_CHILD_USAGE_FLUSH_MAX_PENDING_MS
+			) {
+				flushPendingChildUsageAttribution();
 			}
 		};
 		let runningToolCount = 0;
@@ -10750,22 +10782,12 @@ export class AgentSession {
 						if (assistant.stopReason !== "error" && assistant.stopReason !== "aborted") {
 							attributeChildUsage(parentAssistantForUsage?.usage ?? emptyUsage(), assistant.usage);
 							if (parentAssistantForUsage) {
-								if (!pendingChildUsage) {
-									pendingChildUsage = emptyUsage();
-									const messages = child.messages;
-									const assistantIndex = messages.lastIndexOf(assistant);
-									const precedingPrompt = messages
-										.slice(0, assistantIndex)
-										.reverse()
-										.find((message) => message.role === "user" || message.role === "custom");
-									pendingChildUsageOrigin =
-										precedingPrompt?.role === "custom" && isAgentSessionMessage(precedingPrompt)
-											? precedingPrompt.details.id.startsWith("spawn:")
-												? "spawn_task"
-												: "agent_message"
-											: "direct_user";
-								}
-								addAssistantUsage(pendingChildUsage, assistant.usage);
+								flushPendingChildUsageIfStale();
+								const origin = rlmChildUsageOrigin(child.messages, assistant);
+								if (pendingChildUsage.size === 0) pendingChildUsageSince = Date.now();
+								const bucket = pendingChildUsage.get(origin) ?? emptyUsage();
+								addAssistantUsage(bucket, assistant.usage);
+								pendingChildUsage.set(origin, bucket);
 							}
 						}
 						const text = compactRlmText(readAssistantText(assistant));
@@ -10779,6 +10801,7 @@ export class AgentSession {
 							emitChildUpdate();
 						}
 					} else if (event.type === "tool_execution_start") {
+						flushPendingChildUsageIfStale();
 						run.toolUseCount += 1;
 						runningToolCount += 1;
 						run.activity = { kind: "executing", toolName: event.toolName };

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1043,8 +1043,7 @@ function waitForPromiseOrAbort<T>(
 	});
 }
 
-// Bounds how much accumulated child usage a parent process crash can lose
-// before the batch is flushed durable.
+// Bounds how much accumulated child usage a parent process crash can lose.
 const RLM_CHILD_USAGE_FLUSH_MAX_PENDING_MS = 60_000;
 
 /** Label a child completion's usage by the nearest preceding prompt that triggered it. */
@@ -10626,13 +10625,9 @@ export class AgentSession {
 		if (!requestedSessionName) await this._assertRlmSubagentSessionNameAvailable(sessionName);
 		const startedAt = Date.now();
 		const parentAssistantForUsage = this._findLastAssistantMessage();
-		// Child completions accumulate per origin and flush one durable attribution
-		// entry per settle boundary (child agent_end, run settlement) instead of
-		// one journal append per child assistant message. Crash durability is
-		// bounded, not per-message: a batch older than the staleness bound flushes
-		// at the next checkpoint (accumulation, tool start) or on the wall-clock
-		// timer backstop, so process death loses at most that window of
-		// accumulated child usage.
+		// Child completions accumulate per origin and flush one durable entry per
+		// settle boundary (agent_end, settlement); the staleness checkpoints and
+		// timer bound crash loss to one window of accumulated usage.
 		const pendingChildUsage = new Map<ChildUsageAttributionEntry["origin"], Usage>();
 		let pendingChildUsageSince = 0;
 		let pendingChildUsageTimer: ReturnType<typeof setTimeout> | undefined;
@@ -10786,18 +10781,15 @@ export class AgentSession {
 					} else if (event.type === "message_end" && event.message.role === "assistant") {
 						const assistant = event.message as AssistantMessage;
 						if (assistant.stopReason !== "error" && assistant.stopReason !== "aborted") {
-							// A stale batch must flush before this completion folds into the
-							// parent aggregate: the persisted aggregateUsage of an entry may
-							// only include completions whose childUsage is durable with or
-							// before it, or replay would inflate the parent's own spend.
+							// Flush before the fold: a persisted aggregate may only include
+							// completions whose childUsage is durable with or before it.
 							flushPendingChildUsageIfStale();
 							attributeChildUsage(parentAssistantForUsage?.usage ?? emptyUsage(), assistant.usage);
 							if (parentAssistantForUsage) {
 								const origin = rlmChildUsageOrigin(child.messages, assistant);
 								if (pendingChildUsage.size === 0) {
 									pendingChildUsageSince = Date.now();
-									// Wall-clock backstop: a long tool execution has no event
-									// checkpoints, so the batch flushes on time regardless.
+									// Wall-clock backstop for long tool runs without checkpoints.
 									pendingChildUsageTimer = setTimeout(
 										flushPendingChildUsageAttribution,
 										RLM_CHILD_USAGE_FLUSH_MAX_PENDING_MS,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -255,7 +255,13 @@ import {
 	transitionSessionAction,
 	type WakePolicy,
 } from "./session-action-store.js";
-import type { BranchSummaryEntry, CompactionEntry, SessionContext, SessionMessageEntry } from "./session-manager.js";
+import type {
+	BranchSummaryEntry,
+	ChildUsageAttributionEntry,
+	CompactionEntry,
+	SessionContext,
+	SessionMessageEntry,
+} from "./session-manager.js";
 import {
 	CURRENT_SESSION_VERSION,
 	getLatestCompactionEntry,
@@ -10599,6 +10605,30 @@ export class AgentSession {
 		if (!requestedSessionName) await this._assertRlmSubagentSessionNameAvailable(sessionName);
 		const startedAt = Date.now();
 		const parentAssistantForUsage = this._findLastAssistantMessage();
+		// Child completions accumulate in memory and flush one durable attribution
+		// entry per settle boundary (child agent_end, run settlement) instead of
+		// one journal append per child assistant message.
+		let pendingChildUsage: Usage | undefined;
+		let pendingChildUsageOrigin: ChildUsageAttributionEntry["origin"];
+		const flushPendingChildUsageAttribution = () => {
+			if (!pendingChildUsage || !parentAssistantForUsage) return;
+			const childUsage = pendingChildUsage;
+			const origin = pendingChildUsageOrigin;
+			pendingChildUsage = undefined;
+			pendingChildUsageOrigin = undefined;
+			const parentEntry = this._findAssistantEntryForMessage(parentAssistantForUsage);
+			if (!parentEntry) return;
+			try {
+				this.sessionManager.appendChildUsageAttribution(
+					parentEntry.id,
+					childUsage,
+					parentAssistantForUsage.usage,
+					origin,
+				);
+			} catch {
+				// Attribution is recoverable bookkeeping; a failed append must not break run settlement.
+			}
+		};
 		let runningToolCount = 0;
 		let childSession: AgentSession | undefined;
 		const run: RlmChildRun = {
@@ -10712,6 +10742,7 @@ export class AgentSession {
 						run.activity = { kind: "waiting" };
 						emitChildUpdate();
 					} else if (event.type === "agent_end") {
+						flushPendingChildUsageAttribution();
 						run.activity = undefined;
 						emitChildUpdate();
 					} else if (event.type === "message_end" && event.message.role === "assistant") {
@@ -10719,27 +10750,22 @@ export class AgentSession {
 						if (assistant.stopReason !== "error" && assistant.stopReason !== "aborted") {
 							attributeChildUsage(parentAssistantForUsage?.usage ?? emptyUsage(), assistant.usage);
 							if (parentAssistantForUsage) {
-								const parentEntry = this._findAssistantEntryForMessage(parentAssistantForUsage);
-								if (parentEntry) {
+								if (!pendingChildUsage) {
+									pendingChildUsage = emptyUsage();
 									const messages = child.messages;
 									const assistantIndex = messages.lastIndexOf(assistant);
 									const precedingPrompt = messages
 										.slice(0, assistantIndex)
 										.reverse()
 										.find((message) => message.role === "user" || message.role === "custom");
-									const origin =
+									pendingChildUsageOrigin =
 										precedingPrompt?.role === "custom" && isAgentSessionMessage(precedingPrompt)
 											? precedingPrompt.details.id.startsWith("spawn:")
 												? "spawn_task"
 												: "agent_message"
 											: "direct_user";
-									this.sessionManager.appendChildUsageAttribution(
-										parentEntry.id,
-										assistant.usage,
-										parentAssistantForUsage.usage,
-										origin,
-									);
 								}
+								addAssistantUsage(pendingChildUsage, assistant.usage);
 							}
 						}
 						const text = compactRlmText(readAssistantText(assistant));
@@ -10901,6 +10927,7 @@ export class AgentSession {
 					}
 				}
 			} finally {
+				flushPendingChildUsageAttribution();
 				if (run.detachedDeletion) {
 					run.deletionRunFinished = true;
 					if (!run.settled) {

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -8,6 +8,9 @@ import type { ActiveSessionState } from "./active-session-state.js";
 const SWEEP_INTERVAL_MS = 25_000;
 // Collapse a tool-use loop's rapid turn_end bursts into one summarization.
 const SETTLE_DEBOUNCE_MS = 2_000;
+// An idle session whose generation keeps failing on the same settled content
+// stops retrying (and paying for model calls) until new activity arrives.
+const IDLE_GENERATION_ATTEMPT_LIMIT = 3;
 
 const SUMMARY_MODEL_PROVIDER = "prime-inference";
 const SUMMARY_MODEL_ID = "qwen/qwen3-30b-a3b-instruct-2507";
@@ -207,6 +210,8 @@ export class DaemonSessionSummarizer {
 	private readonly inFlight = new Map<string, AbortController>();
 	// Sessions requested while one was running; get one more pass on completion.
 	private readonly rerunRequested = new Set<string>();
+	// Failed idle generations per session, keyed to the message count they saw.
+	private readonly failedIdleGenerations = new Map<string, { messageCount: number; attempts: number }>();
 
 	constructor(
 		private readonly listSessions: () => readonly ActiveSessionState[],
@@ -242,6 +247,7 @@ export class DaemonSessionSummarizer {
 			controller.abort();
 		}
 		this.rerunRequested.clear();
+		this.failedIdleGenerations.clear();
 	}
 
 	/** Drop any pending work for a session that is closing. */
@@ -253,6 +259,7 @@ export class DaemonSessionSummarizer {
 		}
 		this.inFlight.get(activeSessionId)?.abort();
 		this.rerunRequested.delete(activeSessionId);
+		this.failedIdleGenerations.delete(activeSessionId);
 	}
 
 	/** Seed in-memory status from the persisted entry when a session is added. */
@@ -306,6 +313,12 @@ export class DaemonSessionSummarizer {
 		if (contentUnchanged && !isWorking && !owesIdleVerdict && !owesSummary) {
 			return;
 		}
+		// A generation that keeps failing on identical idle content will keep
+		// failing: stop re-attempting until the session produces new messages.
+		const failed = this.failedIdleGenerations.get(id);
+		if (!isWorking && failed?.messageCount === messageCount && failed.attempts >= IDLE_GENERATION_ATTEMPT_LIMIT) {
+			return;
+		}
 		// Include the in-progress message so a long streaming turn gets a live recap.
 		const streaming = isWorking ? session.state.streamingMessage : undefined;
 		const contextMessages = streaming ? [...messages, streaming] : messages;
@@ -319,6 +332,14 @@ export class DaemonSessionSummarizer {
 				isWorking,
 				signal: controller.signal,
 			});
+			if (generated) {
+				this.failedIdleGenerations.delete(id);
+			} else if (!isWorking) {
+				this.failedIdleGenerations.set(id, {
+					messageCount,
+					attempts: failed?.messageCount === messageCount ? failed.attempts + 1 : 1,
+				});
+			}
 			// A failed classification on an idle session would spin at "working"
 			// forever (the activity axis holds unjudged idle sessions there), so
 			// settle it to needs_input.
@@ -356,12 +377,21 @@ export class DaemonSessionSummarizer {
 				previous?.taskState !== status.taskState ||
 				(!isWorking && previous?.basedOnMessageCount !== status.basedOnMessageCount);
 			state.summaryState = status;
-			// Persist only settled idle verdicts, never mid-stream.
-			if (!isWorking) {
-				try {
-					session.sessionManager.appendAgentStatus(status);
-				} catch {
-					// best-effort; in-memory status still shows
+			// Persist only settled idle verdicts from real classifications, never
+			// mid-stream, never a fabricated fallback, and never a duplicate of the
+			// latest persisted entry: an idle sweep must not grow the journal.
+			if (!isWorking && generated) {
+				const persisted = session.sessionManager.getLatestAgentStatus();
+				if (
+					persisted?.summary !== status.summary ||
+					persisted.taskState !== status.taskState ||
+					persisted.basedOnMessageCount !== status.basedOnMessageCount
+				) {
+					try {
+						session.sessionManager.appendAgentStatus(status);
+					} catch {
+						// best-effort; in-memory status still shows
+					}
 				}
 			}
 			if (changed) {

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -8,9 +8,8 @@ import type { ActiveSessionState } from "./active-session-state.js";
 const SWEEP_INTERVAL_MS = 25_000;
 // Collapse a tool-use loop's rapid turn_end bursts into one summarization.
 const SETTLE_DEBOUNCE_MS = 2_000;
-// An idle session whose generation keeps failing on the same settled content
-// stops retrying (and paying for model calls) until new activity arrives or
-// the backoff elapses, so transient outages and late credentials recover.
+// Idle generations stop retrying (and paying) on unchanged content until the
+// backoff elapses, so transient outages and late credentials still recover.
 const IDLE_GENERATION_ATTEMPT_LIMIT = 3;
 const IDLE_GENERATION_RETRY_BACKOFF_MS = 30 * 60_000;
 
@@ -318,11 +317,8 @@ export class DaemonSessionSummarizer {
 		if (contentUnchanged && !isWorking && !owesIdleVerdict && !owesSummary) {
 			return;
 		}
-		// A generation that keeps failing on identical idle content will keep
-		// failing: stop re-attempting until the content changes or the backoff
-		// elapses for externally-caused failures. The leaf entry id is the branch
-		// tip identity: appends, edits, and branch navigation all move it, while
-		// message counts and timestamps can collide across sibling branches.
+		// The leaf entry id is the branch-tip identity (appends, edits, and branch
+		// navigation all move it; counts and timestamps collide across siblings).
 		const contentKey = `${session.sessionManager.getLeafId() ?? "root"}:${messageCount}`;
 		const failed = this.failedIdleGenerations.get(id);
 		if (
@@ -349,8 +345,7 @@ export class DaemonSessionSummarizer {
 			if (generated) {
 				this.failedIdleGenerations.delete(id);
 			} else if (!isWorking && !controller.signal.aborted) {
-				// The aborted check keeps a forget() during the call from
-				// repopulating the map for a closed session.
+				// The aborted check keeps a racing forget() from repopulating the map.
 				this.failedIdleGenerations.set(id, {
 					contentKey,
 					attempts: failed?.contentKey === contentKey ? failed.attempts + 1 : 1,
@@ -394,9 +389,8 @@ export class DaemonSessionSummarizer {
 				previous?.taskState !== status.taskState ||
 				(!isWorking && previous?.basedOnMessageCount !== status.basedOnMessageCount);
 			state.summaryState = status;
-			// Persist only settled idle verdicts from real classifications, never
-			// mid-stream, never a fabricated fallback, and never a duplicate of the
-			// latest persisted entry: an idle sweep must not grow the journal.
+			// Persist only settled idle verdicts from real classifications that
+			// differ from the latest persisted entry: idle sweeps must not grow the journal.
 			if (!isWorking && generated) {
 				const persisted = session.sessionManager.getLatestAgentStatus();
 				if (

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -9,8 +9,10 @@ const SWEEP_INTERVAL_MS = 25_000;
 // Collapse a tool-use loop's rapid turn_end bursts into one summarization.
 const SETTLE_DEBOUNCE_MS = 2_000;
 // An idle session whose generation keeps failing on the same settled content
-// stops retrying (and paying for model calls) until new activity arrives.
+// stops retrying (and paying for model calls) until new activity arrives or
+// the backoff elapses, so transient outages and late credentials recover.
 const IDLE_GENERATION_ATTEMPT_LIMIT = 3;
+const IDLE_GENERATION_RETRY_BACKOFF_MS = 30 * 60_000;
 
 const SUMMARY_MODEL_PROVIDER = "prime-inference";
 const SUMMARY_MODEL_ID = "qwen/qwen3-30b-a3b-instruct-2507";
@@ -210,8 +212,11 @@ export class DaemonSessionSummarizer {
 	private readonly inFlight = new Map<string, AbortController>();
 	// Sessions requested while one was running; get one more pass on completion.
 	private readonly rerunRequested = new Set<string>();
-	// Failed idle generations per session, keyed to the message count they saw.
-	private readonly failedIdleGenerations = new Map<string, { messageCount: number; attempts: number }>();
+	// Failed idle generations per session, keyed to the settled content they saw.
+	private readonly failedIdleGenerations = new Map<
+		string,
+		{ contentKey: string; attempts: number; lastFailureAt: number }
+	>();
 
 	constructor(
 		private readonly listSessions: () => readonly ActiveSessionState[],
@@ -314,9 +319,17 @@ export class DaemonSessionSummarizer {
 			return;
 		}
 		// A generation that keeps failing on identical idle content will keep
-		// failing: stop re-attempting until the session produces new messages.
+		// failing: stop re-attempting until the content changes (count plus last
+		// timestamp, so a branch/edit back to the same length re-arms) or the
+		// backoff elapses for externally-caused failures.
+		const contentKey = `${messageCount}:${messages[messageCount - 1]?.timestamp ?? 0}`;
 		const failed = this.failedIdleGenerations.get(id);
-		if (!isWorking && failed?.messageCount === messageCount && failed.attempts >= IDLE_GENERATION_ATTEMPT_LIMIT) {
+		if (
+			!isWorking &&
+			failed?.contentKey === contentKey &&
+			failed.attempts >= IDLE_GENERATION_ATTEMPT_LIMIT &&
+			Date.now() - failed.lastFailureAt < IDLE_GENERATION_RETRY_BACKOFF_MS
+		) {
 			return;
 		}
 		// Include the in-progress message so a long streaming turn gets a live recap.
@@ -334,10 +347,13 @@ export class DaemonSessionSummarizer {
 			});
 			if (generated) {
 				this.failedIdleGenerations.delete(id);
-			} else if (!isWorking) {
+			} else if (!isWorking && !controller.signal.aborted) {
+				// The aborted check keeps a forget() during the call from
+				// repopulating the map for a closed session.
 				this.failedIdleGenerations.set(id, {
-					messageCount,
-					attempts: failed?.messageCount === messageCount ? failed.attempts + 1 : 1,
+					contentKey,
+					attempts: failed?.contentKey === contentKey ? failed.attempts + 1 : 1,
+					lastFailureAt: Date.now(),
 				});
 			}
 			// A failed classification on an idle session would spin at "working"

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -319,10 +319,11 @@ export class DaemonSessionSummarizer {
 			return;
 		}
 		// A generation that keeps failing on identical idle content will keep
-		// failing: stop re-attempting until the content changes (count plus last
-		// timestamp, so a branch/edit back to the same length re-arms) or the
-		// backoff elapses for externally-caused failures.
-		const contentKey = `${messageCount}:${messages[messageCount - 1]?.timestamp ?? 0}`;
+		// failing: stop re-attempting until the content changes or the backoff
+		// elapses for externally-caused failures. The leaf entry id is the branch
+		// tip identity: appends, edits, and branch navigation all move it, while
+		// message counts and timestamps can collide across sibling branches.
+		const contentKey = `${session.sessionManager.getLeafId() ?? "root"}:${messageCount}`;
 		const failed = this.failedIdleGenerations.get(id);
 		if (
 			!isWorking &&

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2462,7 +2462,7 @@ describe("AgentSession rlm recursion", () => {
 		expect(attribution.aggregateUsage.cost.total).toBe(10);
 	});
 
-	it("attributes every tool-loop turn in the admitted task to spawn usage", async () => {
+	it("coalesces the admitted task's tool-loop turns into one flushed spawn-usage attribution", async () => {
 		const tool = {
 			name: "echo",
 			description: "Echo a value",
@@ -2507,8 +2507,10 @@ describe("AgentSession rlm recursion", () => {
 			const attributions = root.sessionManager
 				.getEntries()
 				.filter((entry) => entry.type === "child_usage_attributed");
-			expect(attributions).toHaveLength(2);
-			expect(attributions.map((entry) => entry.origin)).toEqual(["spawn_task", "spawn_task"]);
+			expect(attributions).toHaveLength(1);
+			expect(attributions[0]?.origin).toBe("spawn_task");
+			expect(attributions[0]?.childUsage.input).toBe(3);
+			expect(attributions[0]?.childUsage.output).toBe(3);
 		});
 	});
 

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -248,6 +248,51 @@ describe("AgentSession rlm recursion", () => {
 		return session;
 	}
 
+	/** Session with a zero-usage parent assistant whose child answers a tool loop: usages[i] per request, tool calls until the last, then stop. */
+	function createToolLoopSession(requests: number, usages: Usage[], onRequest?: (toolResultCount: number) => void) {
+		const tool = {
+			name: "echo",
+			description: "Echo a value",
+			label: "echo",
+			parameters: Type.Object({ value: Type.String() }),
+			execute: async (_toolCallId: string, params: { value: string }) => ({
+				content: [{ type: "text" as const, text: params.value }],
+				details: {},
+			}),
+		};
+		const root = createSession({
+			customTools: [tool],
+			streamFn: (_model, context) => {
+				const toolResultCount = context.messages.filter((message) => message.role === "toolResult").length;
+				onRequest?.(toolResultCount);
+				const last = toolResultCount >= requests - 1;
+				const stream = createAssistantMessageEventStream();
+				queueMicrotask(() => {
+					const message = last
+						? assistantMessage("done", usages[toolResultCount])
+						: {
+								...assistantMessage("", usages[toolResultCount]),
+								content: [
+									{
+										type: "toolCall" as const,
+										id: `echo-${toolResultCount}`,
+										name: "echo",
+										arguments: { value: "ok" },
+									},
+								],
+								stopReason: "toolUse" as const,
+							};
+					stream.push({ type: "done", reason: last ? "stop" : "toolUse", message });
+				});
+				return stream;
+			},
+		});
+		const parentAssistant = assistantMessage("running ipython", usage(0, 0));
+		root.agent.state.messages.push(parentAssistant);
+		root.sessionManager.appendMessage(parentAssistant);
+		return root;
+	}
+
 	function createAbortInsensitiveChild(): {
 		child: AgentSession;
 		completion: ReturnType<typeof deferred<void>>;
@@ -2463,44 +2508,7 @@ describe("AgentSession rlm recursion", () => {
 	});
 
 	it("coalesces the admitted task's tool-loop turns into one flushed spawn-usage attribution", async () => {
-		const tool = {
-			name: "echo",
-			description: "Echo a value",
-			label: "echo",
-			parameters: Type.Object({ value: Type.String() }),
-			execute: async (_toolCallId: string, params: { value: string }) => ({
-				content: [{ type: "text" as const, text: params.value }],
-				details: {},
-			}),
-		};
-		const root = createSession({
-			customTools: [tool],
-			streamFn: (_model, context) => {
-				const toolResultCount = context.messages.filter((message) => message.role === "toolResult").length;
-				const stream = createAssistantMessageEventStream();
-				queueMicrotask(() => {
-					const message =
-						toolResultCount === 0
-							? {
-									...assistantMessage("", usage(1, 1)),
-									content: [
-										{ type: "toolCall" as const, id: "echo-1", name: "echo", arguments: { value: "ok" } },
-									],
-									stopReason: "toolUse" as const,
-								}
-							: assistantMessage("done", usage(2, 2));
-					stream.push({
-						type: "done",
-						reason: toolResultCount === 0 ? "toolUse" : "stop",
-						message,
-					});
-				});
-				return stream;
-			},
-		});
-		const parentAssistant = assistantMessage("running ipython", usage(0, 0));
-		root.agent.state.messages.push(parentAssistant);
-		root.sessionManager.appendMessage(parentAssistant);
+		const root = createToolLoopSession(2, [usage(1, 1), usage(2, 2)]);
 
 		await root.runRlmChild("use a tool");
 		await vi.waitFor(() => {
@@ -2517,54 +2525,11 @@ describe("AgentSession rlm recursion", () => {
 	it("flushes a stale pending usage batch before extending it, bounding crash loss", async () => {
 		vi.useFakeTimers({ toFake: ["Date"] });
 		try {
-			const tool = {
-				name: "echo",
-				description: "Echo a value",
-				label: "echo",
-				parameters: Type.Object({ value: Type.String() }),
-				execute: async (_toolCallId: string, params: { value: string }) => ({
-					content: [{ type: "text" as const, text: params.value }],
-					details: {},
-				}),
-			};
-			const root = createSession({
-				customTools: [tool],
-				streamFn: (_model, context) => {
-					const toolResultCount = context.messages.filter((message) => message.role === "toolResult").length;
-					if (toolResultCount === 2) {
-						// The pending batch from the first two completions is now older
-						// than the staleness bound when the third completion lands.
-						vi.setSystemTime(Date.now() + 61_000);
-					}
-					const stream = createAssistantMessageEventStream();
-					queueMicrotask(() => {
-						const message =
-							toolResultCount < 2
-								? {
-										...assistantMessage("", usage(toolResultCount + 1, toolResultCount + 1)),
-										content: [
-											{
-												type: "toolCall" as const,
-												id: `echo-${toolResultCount}`,
-												name: "echo",
-												arguments: { value: "ok" },
-											},
-										],
-										stopReason: "toolUse" as const,
-									}
-								: assistantMessage("done", usage(4, 4));
-						stream.push({
-							type: "done",
-							reason: toolResultCount < 2 ? "toolUse" : "stop",
-							message,
-						});
-					});
-					return stream;
-				},
+			// The batch from the first two completions is older than the staleness
+			// bound when the third lands.
+			const root = createToolLoopSession(3, [usage(1, 1), usage(2, 2), usage(4, 4)], (toolResultCount) => {
+				if (toolResultCount === 2) vi.setSystemTime(Date.now() + 61_000);
 			});
-			const parentAssistant = assistantMessage("running ipython", usage(0, 0));
-			root.agent.state.messages.push(parentAssistant);
-			root.sessionManager.appendMessage(parentAssistant);
 
 			await root.runRlmChild("use a tool");
 			await vi.waitFor(() => {
@@ -2576,25 +2541,19 @@ describe("AgentSession rlm recursion", () => {
 					[4, 4],
 				]);
 				expect(attributions.map((entry) => entry.origin)).toEqual(["spawn_task", "spawn_task"]);
-				// Each persisted aggregate covers exactly the completions whose
-				// childUsage is durable with or before it, so a replay at any
-				// prefix reproduces the parent's own spend exactly.
+				// Each aggregate covers exactly the completions durable with or
+				// before it, so any prefix replays to the exact own spend.
 				expect(attributions.map((entry) => entry.aggregateUsage.input)).toEqual([3, 7]);
 			});
 
 			const sessionFile = root.sessionManager.getSessionFile();
 			if (!sessionFile) throw new Error("parent session file was not created");
-			const reloaded = SessionManager.open(sessionFile, join(tempDir, "sessions")).getEntries();
-			const reloadedParent = reloaded.find(
-				(entry) => entry.type === "message" && entry.message.role === "assistant",
-			);
-			if (!reloadedParent || reloadedParent.type !== "message" || reloadedParent.message.role !== "assistant") {
-				throw new Error("parent assistant entry was not reloaded");
-			}
-			const reloadedChildTotal = reloaded
-				.filter((entry) => entry.type === "child_usage_attributed")
-				.reduce((total, entry) => total + entry.childUsage.input, 0);
-			expect(reloadedParent.message.usage.input - reloadedChildTotal).toBe(0);
+			const reloadedAttributions = SessionManager.open(sessionFile, join(tempDir, "sessions"))
+				.getEntries()
+				.filter((entry) => entry.type === "child_usage_attributed");
+			const childTotal = reloadedAttributions.reduce((total, entry) => total + entry.childUsage.input, 0);
+			// Parent own spend is zero here, so the reloaded aggregate must equal the summed child usage.
+			expect(reloadedAttributions.at(-1)?.aggregateUsage.input).toBe(childTotal);
 		} finally {
 			vi.useRealTimers();
 		}

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2576,7 +2576,25 @@ describe("AgentSession rlm recursion", () => {
 					[4, 4],
 				]);
 				expect(attributions.map((entry) => entry.origin)).toEqual(["spawn_task", "spawn_task"]);
+				// Each persisted aggregate covers exactly the completions whose
+				// childUsage is durable with or before it, so a replay at any
+				// prefix reproduces the parent's own spend exactly.
+				expect(attributions.map((entry) => entry.aggregateUsage.input)).toEqual([3, 7]);
 			});
+
+			const sessionFile = root.sessionManager.getSessionFile();
+			if (!sessionFile) throw new Error("parent session file was not created");
+			const reloaded = SessionManager.open(sessionFile, join(tempDir, "sessions")).getEntries();
+			const reloadedParent = reloaded.find(
+				(entry) => entry.type === "message" && entry.message.role === "assistant",
+			);
+			if (!reloadedParent || reloadedParent.type !== "message" || reloadedParent.message.role !== "assistant") {
+				throw new Error("parent assistant entry was not reloaded");
+			}
+			const reloadedChildTotal = reloaded
+				.filter((entry) => entry.type === "child_usage_attributed")
+				.reduce((total, entry) => total + entry.childUsage.input, 0);
+			expect(reloadedParent.message.usage.input - reloadedChildTotal).toBe(0);
 		} finally {
 			vi.useRealTimers();
 		}

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2514,6 +2514,74 @@ describe("AgentSession rlm recursion", () => {
 		});
 	});
 
+	it("flushes a stale pending usage batch before extending it, bounding crash loss", async () => {
+		vi.useFakeTimers({ toFake: ["Date"] });
+		try {
+			const tool = {
+				name: "echo",
+				description: "Echo a value",
+				label: "echo",
+				parameters: Type.Object({ value: Type.String() }),
+				execute: async (_toolCallId: string, params: { value: string }) => ({
+					content: [{ type: "text" as const, text: params.value }],
+					details: {},
+				}),
+			};
+			const root = createSession({
+				customTools: [tool],
+				streamFn: (_model, context) => {
+					const toolResultCount = context.messages.filter((message) => message.role === "toolResult").length;
+					if (toolResultCount === 2) {
+						// The pending batch from the first two completions is now older
+						// than the staleness bound when the third completion lands.
+						vi.setSystemTime(Date.now() + 61_000);
+					}
+					const stream = createAssistantMessageEventStream();
+					queueMicrotask(() => {
+						const message =
+							toolResultCount < 2
+								? {
+										...assistantMessage("", usage(toolResultCount + 1, toolResultCount + 1)),
+										content: [
+											{
+												type: "toolCall" as const,
+												id: `echo-${toolResultCount}`,
+												name: "echo",
+												arguments: { value: "ok" },
+											},
+										],
+										stopReason: "toolUse" as const,
+									}
+								: assistantMessage("done", usage(4, 4));
+						stream.push({
+							type: "done",
+							reason: toolResultCount < 2 ? "toolUse" : "stop",
+							message,
+						});
+					});
+					return stream;
+				},
+			});
+			const parentAssistant = assistantMessage("running ipython", usage(0, 0));
+			root.agent.state.messages.push(parentAssistant);
+			root.sessionManager.appendMessage(parentAssistant);
+
+			await root.runRlmChild("use a tool");
+			await vi.waitFor(() => {
+				const attributions = root.sessionManager
+					.getEntries()
+					.filter((entry) => entry.type === "child_usage_attributed");
+				expect(attributions.map((entry) => [entry.childUsage.input, entry.childUsage.output])).toEqual([
+					[3, 3],
+					[4, 4],
+				]);
+				expect(attributions.map((entry) => entry.origin)).toEqual(["spawn_task", "spawn_task"]);
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("gets and persists per-chat max-depth changes without transcript messages", async () => {
 		const root = createSession();
 		const originalMessages = [...root.messages];

--- a/packages/coding-agent/test/daemon-session-summarizer-lifecycle.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer-lifecycle.test.ts
@@ -26,6 +26,7 @@ function makeState(
 				sessionManager: {
 					appendAgentStatus: (s: unknown) => appended.push(s),
 					getLatestAgentStatus: () => opts.persisted,
+					getLeafId: () => null,
 				},
 			},
 		},

--- a/packages/coding-agent/test/daemon-session-summarizer.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer.test.ts
@@ -162,6 +162,7 @@ describe("daemon session summarizer", () => {
 			summaryState?: AgentStatus;
 			persistedStatus?: AgentStatus;
 			appendAgentStatus?: (status: AgentStatus) => void;
+			getLeafId?: () => string | null;
 		}): ActiveSessionState {
 			return {
 				activeSessionId: "active-1",
@@ -175,6 +176,7 @@ describe("daemon session summarizer", () => {
 						sessionManager: {
 							appendAgentStatus: options.appendAgentStatus ?? (() => {}),
 							getLatestAgentStatus: () => options.persistedStatus,
+							getLeafId: options.getLeafId ?? (() => null),
 						},
 					},
 				},
@@ -226,8 +228,13 @@ describe("daemon session summarizer", () => {
 			expect(state.summaryState).toEqual({ summary: "", taskState: "needs_input", basedOnMessageCount: 1 });
 		});
 
-		test("the idle retry ceiling re-arms when the settled content changes at the same length", async () => {
-			const state = makeState({ messages: [userMessage("hi")], isSessionActive: false });
+		test("the idle retry ceiling re-arms when branch navigation moves the leaf at the same length", async () => {
+			let leafId = "leaf-a";
+			const state = makeState({
+				messages: [userMessage("hi")],
+				isSessionActive: false,
+				getLeafId: () => leafId,
+			});
 			const generate = vi.fn(async () => undefined);
 			const summarizer = new DaemonSessionSummarizer(() => [state], undefined, generate);
 			const internal = summarizer as unknown as { summarize(state: ActiveSessionState): Promise<void> };
@@ -237,9 +244,9 @@ describe("daemon session summarizer", () => {
 			}
 			expect(generate).toHaveBeenCalledTimes(3);
 
-			// A branch/edit can land back on the same message count with new content.
-			const replacement = { ...userMessage("hi again"), timestamp: 42 } as AgentMessage;
-			(state.runtime.session as unknown as { messages: AgentMessage[] }).messages = [replacement];
+			// Branch navigation to a sibling can keep the count and even the
+			// message timestamps; only the leaf entry id reliably moves.
+			leafId = "leaf-b";
 			await internal.summarize(state);
 			expect(generate).toHaveBeenCalledTimes(4);
 		});

--- a/packages/coding-agent/test/daemon-session-summarizer.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer.test.ts
@@ -160,6 +160,8 @@ describe("daemon session summarizer", () => {
 			messages: AgentMessage[];
 			isSessionActive: boolean;
 			summaryState?: AgentStatus;
+			persistedStatus?: AgentStatus;
+			appendAgentStatus?: (status: AgentStatus) => void;
 		}): ActiveSessionState {
 			return {
 				activeSessionId: "active-1",
@@ -170,7 +172,10 @@ describe("daemon session summarizer", () => {
 						messages: options.messages,
 						modelRegistry: {},
 						state: { streamingMessage: undefined },
-						sessionManager: { appendAgentStatus: () => {} },
+						sessionManager: {
+							appendAgentStatus: options.appendAgentStatus ?? (() => {}),
+							getLatestAgentStatus: () => options.persistedStatus,
+						},
 					},
 				},
 			} as unknown as ActiveSessionState;
@@ -199,6 +204,53 @@ describe("daemon session summarizer", () => {
 
 			expect(state.summaryState?.basedOnMessageCount).toBe(2);
 			expect(onStatusChanged).toHaveBeenCalledOnce();
+		});
+
+		test("a failing idle generation never persists its fabricated fallback and stops retrying", async () => {
+			const appendAgentStatus = vi.fn();
+			const state = makeState({
+				messages: [userMessage("hi")],
+				isSessionActive: false,
+				appendAgentStatus,
+			});
+			const generate = vi.fn(async () => undefined);
+			const summarizer = new DaemonSessionSummarizer(() => [state], undefined, generate);
+			const internal = summarizer as unknown as { summarize(state: ActiveSessionState): Promise<void> };
+
+			for (let sweep = 0; sweep < 5; sweep++) {
+				await internal.summarize(state);
+			}
+
+			expect(appendAgentStatus).not.toHaveBeenCalled();
+			expect(generate).toHaveBeenCalledTimes(3);
+			expect(state.summaryState).toEqual({ summary: "", taskState: "needs_input", basedOnMessageCount: 1 });
+		});
+
+		test("an idle re-settle matching the latest persisted status appends nothing", async () => {
+			const appendAgentStatus = vi.fn();
+			const persisted: AgentStatus = {
+				summary: "Awaiting review",
+				taskState: "needs_input",
+				basedOnMessageCount: 1,
+			};
+			const state = makeState({
+				messages: [userMessage("hi")],
+				isSessionActive: false,
+				persistedStatus: persisted,
+				appendAgentStatus,
+			});
+
+			const onStatusChanged = vi.fn();
+			const summarizer = new DaemonSessionSummarizer(
+				() => [state],
+				onStatusChanged,
+				async () => ({ summary: "Awaiting review", taskState: "needs_input" as const }),
+			);
+			await (summarizer as unknown as { summarize(state: ActiveSessionState): Promise<void> }).summarize(state);
+
+			expect(appendAgentStatus).not.toHaveBeenCalled();
+			expect(onStatusChanged).toHaveBeenCalledOnce();
+			expect(state.summaryState).toEqual(persisted);
 		});
 
 		test("a working refresh with unchanged text stays quiet", async () => {

--- a/packages/coding-agent/test/daemon-session-summarizer.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer.test.ts
@@ -226,6 +226,72 @@ describe("daemon session summarizer", () => {
 			expect(state.summaryState).toEqual({ summary: "", taskState: "needs_input", basedOnMessageCount: 1 });
 		});
 
+		test("the idle retry ceiling re-arms when the settled content changes at the same length", async () => {
+			const state = makeState({ messages: [userMessage("hi")], isSessionActive: false });
+			const generate = vi.fn(async () => undefined);
+			const summarizer = new DaemonSessionSummarizer(() => [state], undefined, generate);
+			const internal = summarizer as unknown as { summarize(state: ActiveSessionState): Promise<void> };
+
+			for (let sweep = 0; sweep < 4; sweep++) {
+				await internal.summarize(state);
+			}
+			expect(generate).toHaveBeenCalledTimes(3);
+
+			// A branch/edit can land back on the same message count with new content.
+			const replacement = { ...userMessage("hi again"), timestamp: 42 } as AgentMessage;
+			(state.runtime.session as unknown as { messages: AgentMessage[] }).messages = [replacement];
+			await internal.summarize(state);
+			expect(generate).toHaveBeenCalledTimes(4);
+		});
+
+		test("the idle retry ceiling expires after the backoff so external failures recover", async () => {
+			vi.useFakeTimers();
+			try {
+				const state = makeState({ messages: [userMessage("hi")], isSessionActive: false });
+				const generate = vi.fn(async () => undefined);
+				const summarizer = new DaemonSessionSummarizer(() => [state], undefined, generate);
+				const internal = summarizer as unknown as { summarize(state: ActiveSessionState): Promise<void> };
+
+				for (let sweep = 0; sweep < 4; sweep++) {
+					await internal.summarize(state);
+				}
+				expect(generate).toHaveBeenCalledTimes(3);
+
+				vi.setSystemTime(Date.now() + 31 * 60_000);
+				await internal.summarize(state);
+				expect(generate).toHaveBeenCalledTimes(4);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		test("a forget() during an in-flight idle generation leaves no failure record behind", async () => {
+			const state = makeState({ messages: [userMessage("hi")], isSessionActive: false });
+			let release!: () => void;
+			const gate = new Promise<void>((resolveGate) => {
+				release = resolveGate;
+			});
+			const summarizer = new DaemonSessionSummarizer(
+				() => [state],
+				undefined,
+				async () => {
+					await gate;
+					return undefined;
+				},
+			);
+			const internal = summarizer as unknown as {
+				summarize(state: ActiveSessionState): Promise<void>;
+				failedIdleGenerations: Map<string, unknown>;
+			};
+
+			const pass = internal.summarize(state);
+			summarizer.forget("active-1");
+			release();
+			await pass;
+
+			expect(internal.failedIdleGenerations.size).toBe(0);
+		});
+
 		test("an idle re-settle matching the latest persisted status appends nothing", async () => {
 			const appendAgentStatus = vi.fn();
 			const persisted: AgentStatus = {

--- a/packages/coding-agent/test/daemon-session-summarizer.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer.test.ts
@@ -208,88 +208,73 @@ describe("daemon session summarizer", () => {
 			expect(onStatusChanged).toHaveBeenCalledOnce();
 		});
 
-		test("a failing idle generation never persists its fabricated fallback and stops retrying", async () => {
-			const appendAgentStatus = vi.fn();
-			const state = makeState({
-				messages: [userMessage("hi")],
-				isSessionActive: false,
-				appendAgentStatus,
-			});
-			const generate = vi.fn(async () => undefined);
+		function failingIdleSetup(
+			stateOptions: Parameters<typeof makeState>[0],
+			generateFn: () => Promise<undefined> = async () => undefined,
+		) {
+			const state = makeState(stateOptions);
+			const generate = vi.fn(generateFn);
 			const summarizer = new DaemonSessionSummarizer(() => [state], undefined, generate);
-			const internal = summarizer as unknown as { summarize(state: ActiveSessionState): Promise<void> };
+			const internal = summarizer as unknown as {
+				summarize(state: ActiveSessionState): Promise<void>;
+				failedIdleGenerations: Map<string, unknown>;
+			};
+			return { state, generate, summarizer, internal };
+		}
 
-			for (let sweep = 0; sweep < 5; sweep++) {
-				await internal.summarize(state);
-			}
-
-			expect(appendAgentStatus).not.toHaveBeenCalled();
-			expect(generate).toHaveBeenCalledTimes(3);
-			expect(state.summaryState).toEqual({ summary: "", taskState: "needs_input", basedOnMessageCount: 1 });
-		});
-
-		test("the idle retry ceiling re-arms when branch navigation moves the leaf at the same length", async () => {
-			let leafId = "leaf-a";
-			const state = makeState({
-				messages: [userMessage("hi")],
-				isSessionActive: false,
-				getLeafId: () => leafId,
-			});
-			const generate = vi.fn(async () => undefined);
-			const summarizer = new DaemonSessionSummarizer(() => [state], undefined, generate);
-			const internal = summarizer as unknown as { summarize(state: ActiveSessionState): Promise<void> };
-
-			for (let sweep = 0; sweep < 4; sweep++) {
-				await internal.summarize(state);
-			}
-			expect(generate).toHaveBeenCalledTimes(3);
-
-			// Branch navigation to a sibling can keep the count and even the
-			// message timestamps; only the leaf entry id reliably moves.
-			leafId = "leaf-b";
-			await internal.summarize(state);
-			expect(generate).toHaveBeenCalledTimes(4);
-		});
-
-		test("the idle retry ceiling expires after the backoff so external failures recover", async () => {
+		// Warmup pins the ceiling itself: repeated failing idle sweeps stop paying
+		// after three attempts and never persist the fabricated in-memory fallback.
+		test.each([
+			{
+				rearm: "branch navigation moving the leaf at the same length",
+				trigger: (leaf: { id: string }) => {
+					leaf.id = "leaf-b";
+				},
+			},
+			{
+				rearm: "the backoff elapsing so external failures recover",
+				trigger: () => vi.setSystemTime(Date.now() + 31 * 60_000),
+			},
+		])("the exhausted idle retry ceiling re-arms on $rearm", async ({ trigger }) => {
 			vi.useFakeTimers();
 			try {
-				const state = makeState({ messages: [userMessage("hi")], isSessionActive: false });
-				const generate = vi.fn(async () => undefined);
-				const summarizer = new DaemonSessionSummarizer(() => [state], undefined, generate);
-				const internal = summarizer as unknown as { summarize(state: ActiveSessionState): Promise<void> };
+				const appendAgentStatus = vi.fn();
+				const leaf = { id: "leaf-a" };
+				const { state, generate, internal } = failingIdleSetup({
+					messages: [userMessage("hi")],
+					isSessionActive: false,
+					appendAgentStatus,
+					getLeafId: () => leaf.id,
+				});
 
-				for (let sweep = 0; sweep < 4; sweep++) {
+				for (let sweep = 0; sweep < 5; sweep++) {
 					await internal.summarize(state);
 				}
 				expect(generate).toHaveBeenCalledTimes(3);
+				expect(appendAgentStatus).not.toHaveBeenCalled();
+				expect(state.summaryState).toEqual({ summary: "", taskState: "needs_input", basedOnMessageCount: 1 });
 
-				vi.setSystemTime(Date.now() + 31 * 60_000);
+				trigger(leaf);
 				await internal.summarize(state);
 				expect(generate).toHaveBeenCalledTimes(4);
+				expect(appendAgentStatus).not.toHaveBeenCalled();
 			} finally {
 				vi.useRealTimers();
 			}
 		});
 
 		test("a forget() during an in-flight idle generation leaves no failure record behind", async () => {
-			const state = makeState({ messages: [userMessage("hi")], isSessionActive: false });
 			let release!: () => void;
 			const gate = new Promise<void>((resolveGate) => {
 				release = resolveGate;
 			});
-			const summarizer = new DaemonSessionSummarizer(
-				() => [state],
-				undefined,
+			const { state, summarizer, internal } = failingIdleSetup(
+				{ messages: [userMessage("hi")], isSessionActive: false },
 				async () => {
 					await gate;
 					return undefined;
 				},
 			);
-			const internal = summarizer as unknown as {
-				summarize(state: ActiveSessionState): Promise<void>;
-				failedIdleGenerations: Map<string, unknown>;
-			};
 
 			const pass = internal.summarize(state);
 			summarizer.forget("active-1");


### PR DESCRIPTION
## Purpose

Two derived-bookkeeping paths appended durable journal entries at the wrong granularity, growing parent session files without bound and (for one of them) re-paying model calls forever:

- Every child assistant `message_end` synchronously appended a `child_usage_attributed` entry to the parent journal and re-scanned the child transcript for the origin prompt — one journal append per model request of every RLM child, keeping parent files permanently "changed" for every metadata rescan (feeds the amplification fixed in #2043).
- The 25s summarizer sweep appended an `agent_status` entry on every idle pass: a session whose generation cannot succeed (no prime-inference auth, model resolution failure, persistent parse failure) fabricated a `needs_input` fallback whose empty summary re-armed the retry forever — one identical durable entry per idle session per 25s, a persisted verdict the model never produced, and a paid model call per sweep in the parse-failure case.

## Mechanism

- **Attribution (agent-session.ts)**: completions accumulate in memory (the parent's in-memory aggregate still updates per completion) and flush one summed entry per child `agent_end`, with a run-settlement backstop for error/cancel paths. All consumers fold attribution entries linearly (loader, scanner, context-tree), so the coalesced entry reloads to the same own-spend.
- **Agent status (daemon-session-summarizer.ts)**: persistence now requires a real generated classification that differs from the latest persisted entry (`getLatestAgentStatus`); fabricated fallbacks stay in memory only (the roster activity axis still settles); idle generations stop retrying after three failures on the same settled content until new activity arrives.

## Measurement

- One idle session without summary auth, one day of 25s sweeps (real `SessionManager` + summarizer driver): main appends 3456 `agent_status` entries (+591KB journal, unbounded); this PR appends 0 and stops generation after 3 attempts (3456 -> 3 generate calls — for persistent parse failures those are paid calls).
- A child tool-loop turn with N model requests appended N attribution entries; now 1 per turn (pinned: the 2-request loop test went 2 -> 1 with summed usage).

## Validation

- Three pins verified fail-unfixed on main: coalesced tool-loop attribution (2 entries -> 1, usage summed), fabricated fallback never persisted + retry ceiling (5 sweeps: main appends 5/generates 5; fixed appends 0/generates 3), idle re-settle matching the latest persisted status appends nothing.
- Suites: `agent-session-recursion` (115), `daemon-session-summarizer` (23), `daemon-session-summarizer-lifecycle`, `session-manager/agent-status` — all pass; root `npm run check` passes.

## LOC

Total src: **+128/−26 (net +102)**; tests: +200/−42 (net +158).
Src +64/−18 (net +46): both changes wire persistence to existing boundaries (child `agent_end` / run settlement; the summarizer's existing latest-persisted truth) rather than adding machinery. Tests +79/−9.

Squashes discussions #1788 and #1752; with #2043 this also removes the main journal-growth driver behind the #1503 worker OOM profile.

Linear: RES-1272 https://linear.app/primeintellect/issue/RES-1272

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches durable session journal semantics for billing attribution and agent-status history; behavior is covered by new tests but incorrect coalescing or persistence gating could skew cost totals or dashboard status replay.
> 
> **Overview**
> Stops **unbounded parent session journal growth** from two bookkeeping paths that were appending on every child model turn and every 25s idle sweep.
> 
> **RLM child usage:** Child assistant completions no longer call `appendChildUsageAttribution` on each `message_end`. Usage is **accumulated in memory by origin** (`spawn_task`, `agent_message`, `direct_user`) and **flushed once per settle boundary** (child `agent_end`, run cleanup, staleness after 60s, or a timer backstop). In-memory parent totals still update per completion; reload semantics stay consistent because consumers fold attribution entries linearly.
> 
> **Daemon idle status:** The summarizer **caps failed idle model calls** (3 attempts per settled content key, 30-minute backoff keyed by leaf id + message count) and **only persists `agent_status` when the model actually returned a classification** that **differs** from `getLatestAgentStatus`. Fabricated `needs_input` fallbacks remain in memory for the roster but no longer duplicate into the journal on unchanged idle sweeps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b0af5d2679ddff987ef3b4d43235a872fe2b315. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Coalesce child-usage attribution in `AgentSession` and gate idle status persistence on real changes
> - `AgentSession.runRlmChild` now aggregates multiple per-request child usage records into one attribution entry per origin, flushing at child-turn settlement, cleanup, or after a 60-second `RLM_CHILD_USAGE_FLUSH_MAX_PENDING_MS` backstop. Failed bookkeeping appends no longer interrupt run settlement.
> - `DaemonSessionSummarizer.summarize` now caps idle-generation retries at three failed attempts per content key with a 30-minute backoff, and suppresses persisting fallback `needs_input` verdicts or duplicate settled statuses. Idle statuses are persisted only when the summary, task state, or message count differs from the latest persisted status.
> - Risk: The new 60-second flush timer in `runRlmChild` is unref'ed, so it will not keep the process alive; pending attribution can be lost on crash beyond the 60s window. The `DaemonSessionSummarizer` now relies on `getLeafId` from the session manager for content-key identity, so any caller not providing this mock data in tests will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b0af5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->