### PR TITLE
fix(coding-agent): memoize the passive RLM topology derivation

### DIFF
--- a/packages/coding-agent/.changes/res-1272-memoized-passive-topology.md
+++ b/packages/coding-agent/.changes/res-1272-memoized-passive-topology.md
@@ -1,0 +1,1 @@
+- Fixed daemon request latency on large agent trees: the passive-subagent topology is derived once and memoized, with every consumer (session list, snapshots, cron recovery, agent messaging, passivation) reading the cached walk until the spawn ledger, residency, or a child session file changes.

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1436,6 +1436,12 @@ export class AgentDaemon {
 				const sessionKey = resolve(entry.sessionFile);
 				if (entry.status === "deleted" || visited.has(sessionKey)) continue;
 				visited.add(sessionKey);
+				// A resident child walks its own subtree as an outer root below. Avoid
+				// duplicate rows and attributing its descendants to an ancestor - and
+				// keep its actively-streamed transcript out of the input set, where
+				// every append would needlessly bust the memo (the roster axis
+				// already carries resident identity).
+				if (!includeResident && this.findSessionBySessionFile(entry.sessionFile)) continue;
 				const childStat = await recordInputStat(entry.sessionFile);
 				const info = await readSessionInfo(entry.sessionFile);
 				if (!info) {
@@ -1444,9 +1450,6 @@ export class AgentDaemon {
 					if (childStat !== "absent") degraded = true;
 					continue;
 				}
-				// A resident child walks its own subtree as an outer root below. Avoid
-				// both duplicate rows and attributing its descendants to an ancestor.
-				if (!includeResident && this.findSessionBySessionFile(entry.sessionFile)) continue;
 				const chain = [...parentChain, entry];
 				passive.push({ ...root, entry, info, chain });
 				await visit(root, { sessionId: info.id, sessionFile: entry.sessionFile }, chain, visited);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1269,15 +1269,18 @@ export class AgentDaemon {
 	// agent-observe, agent-message, family catalog, passivation) reads the same
 	// cached walk instead of re-walking the persisted tree per request. A hit
 	// requires the spawn ledger stat, the resident roster, the live saved
-	// roots, every listed child file's stat, and every root-state identity to
-	// be unchanged; ledger appends, residency changes, and child appends all
-	// invalidate. Walks of the same shape run strictly one at a time, and a
-	// caller never joins an earlier walk: its own pass re-validates against
-	// state at or after its call time.
+	// roots, every root-state identity, and the stat of every file input the
+	// walk visited (child transcripts, display records, legacy registries,
+	// including absent ones) to be unchanged; ledger appends, residency
+	// changes, child appends, and display rewrites all invalidate. Input stats
+	// are captured before each read, so a write landing mid-walk can only
+	// cause one extra re-walk, never a stale memo. Walks of the same shape run
+	// strictly one at a time, and a caller never joins an earlier walk: its
+	// own pass re-validates against state at or after its call time.
 	private readonly passiveRlmSubagentWalks = new Map<string, Promise<PassiveRlmSubagent[]>>();
 	private readonly passiveRlmSubagentMemo = new Map<
 		string,
-		{ fingerprint: string; childStats: string[]; result: PassiveRlmSubagent[] }
+		{ fingerprint: string; inputStats: Map<string, string>; result: PassiveRlmSubagent[] }
 	>();
 	private static readonly PASSIVE_RLM_MEMO_MAX_KEYS = 4;
 
@@ -1306,8 +1309,11 @@ export class AgentDaemon {
 		}
 	}
 
-	private passiveRlmChildStats(result: PassiveRlmSubagent[]): Promise<string[]> {
-		return Promise.all(result.map((passive) => this.passiveRlmStatString(passive.entry.sessionFile)));
+	private async passiveRlmInputStatsUnchanged(inputStats: Map<string, string>): Promise<boolean> {
+		const checks = await Promise.all(
+			[...inputStats].map(async ([path, statString]) => (await this.passiveRlmStatString(path)) === statString),
+		);
+		return checks.every(Boolean);
 	}
 
 	private passiveRlmRootsStillResident(result: PassiveRlmSubagent[]): boolean {
@@ -1338,20 +1344,22 @@ export class AgentDaemon {
 				memo &&
 				memo.fingerprint === before &&
 				this.passiveRlmRootsStillResident(memo.result) &&
-				(await this.passiveRlmChildStats(memo.result)).join("\n") === memo.childStats.join("\n")
+				(await this.passiveRlmInputStatsUnchanged(memo.inputStats))
 			) {
 				return memo.result;
 			}
-			const result = await this.walkPassiveRlmSubagents(savedRootInfos, includeResident);
-			// Only a walk whose inputs held still is a valid memo (the first walk
-			// seeds the ledger from legacy registries and never qualifies).
+			const walked = await this.walkPassiveRlmSubagents(savedRootInfos, includeResident);
+			// Only a walk whose inputs held still qualifies as a memo: not the
+			// first walk (it seeds the ledger from legacy registries) and not a
+			// degraded walk (a present child file that failed to read may list
+			// again without any stat change).
 			const after = await this.passiveRlmTopologyFingerprint(savedRootInfos);
-			if (after === before) {
+			if (after === before && !walked.degraded) {
 				this.passiveRlmSubagentMemo.delete(key);
 				this.passiveRlmSubagentMemo.set(key, {
 					fingerprint: after,
-					childStats: await this.passiveRlmChildStats(result),
-					result,
+					inputStats: walked.inputStats,
+					result: walked.result,
 				});
 				for (const staleKey of this.passiveRlmSubagentMemo.keys()) {
 					if (this.passiveRlmSubagentMemo.size <= AgentDaemon.PASSIVE_RLM_MEMO_MAX_KEYS) break;
@@ -1360,14 +1368,18 @@ export class AgentDaemon {
 			} else {
 				this.passiveRlmSubagentMemo.delete(key);
 			}
-			return result;
+			return walked.result;
 		};
 		const previous = this.passiveRlmSubagentWalks.get(key);
 		const walk = previous ? previous.then(run, run) : run();
 		this.passiveRlmSubagentWalks.set(key, walk);
-		void walk.finally(() => {
+		// then(cleanup, cleanup), not finally(): a discarded finally() promise
+		// would turn a rejecting walk into an unhandled rejection and crash the
+		// daemon; the rejection still reaches the caller through `walk` itself.
+		const cleanup = () => {
 			if (this.passiveRlmSubagentWalks.get(key) === walk) this.passiveRlmSubagentWalks.delete(key);
-		});
+		};
+		walk.then(cleanup, cleanup);
 		return walk;
 	}
 
@@ -1375,14 +1387,28 @@ export class AgentDaemon {
 	private async walkPassiveRlmSubagents(
 		savedRootInfos: SessionInfo[],
 		includeResident: boolean,
-	): Promise<PassiveRlmSubagent[]> {
+	): Promise<{ result: PassiveRlmSubagent[]; inputStats: Map<string, string>; degraded: boolean }> {
+		// Every file input's stat is captured before its read so the memo's
+		// invalidation identity can only be older than the derived content.
+		const inputStats = new Map<string, string>();
+		let degraded = false;
+		const recordInputStat = async (path: string): Promise<string> => {
+			const resolved = resolve(path);
+			const existing = inputStats.get(resolved);
+			if (existing !== undefined) return existing;
+			const statString = await this.passiveRlmStatString(path);
+			inputStats.set(resolved, statString);
+			return statString;
+		};
 		const residentRoots: Array<{ parentState: ActiveSessionState; sessionFile: string }> = [];
 		for (const parentState of this.sessions.values()) {
 			const parentFile = parentState.runtime.session.sessionFile;
 			// An in-memory session cannot own persisted children.
 			if (parentFile) residentRoots.push({ parentState, sessionFile: parentFile });
 		}
-		if (residentRoots.length === 0 && savedRootInfos.length === 0) return [];
+		if (residentRoots.length === 0 && savedRootInfos.length === 0) {
+			return { result: [], inputStats, degraded };
+		}
 		const edges = await this.rlmSpawnLedger().edges();
 		const childrenByParent = new Map<string, RlmLedgerEdge[]>();
 		for (const edge of edges) {
@@ -1400,6 +1426,8 @@ export class AgentDaemon {
 			visited: Set<string>,
 		): Promise<void> => {
 			for (const edge of childrenByParent.get(canonicalSessionPath(parent.sessionFile)) ?? []) {
+				await recordInputStat(rlmSubagentDisplayPath(dirname(edge.child)));
+				await recordInputStat(this.legacyRlmSubagentRegistryPath(parent.sessionFile, parent.sessionId));
 				// The ledger stores realpath-canonical paths while the rest of the
 				// daemon keys by resolve(): work with the writer-recorded path from
 				// the metadata entry so passive rows keep matching residency,
@@ -1408,8 +1436,14 @@ export class AgentDaemon {
 				const sessionKey = resolve(entry.sessionFile);
 				if (entry.status === "deleted" || visited.has(sessionKey)) continue;
 				visited.add(sessionKey);
+				const childStat = await recordInputStat(entry.sessionFile);
 				const info = await readSessionInfo(entry.sessionFile);
-				if (!info) continue;
+				if (!info) {
+					// A present file that fails to list may succeed again without any
+					// stat change (transient read error): such walks must not memoize.
+					if (childStat !== "absent") degraded = true;
+					continue;
+				}
 				// A resident child walks its own subtree as an outer root below. Avoid
 				// both duplicate rows and attributing its descendants to an ancestor.
 				if (!includeResident && this.findSessionBySessionFile(entry.sessionFile)) continue;
@@ -1434,7 +1468,7 @@ export class AgentDaemon {
 			if (residentRootPaths.has(rootPath)) continue;
 			await visit({ rootInfo }, { sessionId: rootInfo.id, sessionFile: rootInfo.path }, [], new Set([rootPath]));
 		}
-		return passive;
+		return { result: passive, inputStats, degraded };
 	}
 
 	private async passiveRlmSubagentsByPath(

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1264,10 +1264,117 @@ export class AgentDaemon {
 		return { ...base, rlmDepth: edge.depth, status: "completed", createdAt };
 	}
 
-	/** List each root's passive (non-resident) descendants from the ledger, without creating runtimes. */
-	private async listPassiveRlmSubagents(
+	// One memoized derivation of the passive-subagent topology per argument
+	// shape: every daemon consumer (session list, snapshots, cron recovery,
+	// agent-observe, agent-message, family catalog, passivation) reads the same
+	// cached walk instead of re-walking the persisted tree per request. A hit
+	// requires the spawn ledger stat, the resident roster, the live saved
+	// roots, every listed child file's stat, and every root-state identity to
+	// be unchanged; ledger appends, residency changes, and child appends all
+	// invalidate. Walks of the same shape run strictly one at a time, and a
+	// caller never joins an earlier walk: its own pass re-validates against
+	// state at or after its call time.
+	private readonly passiveRlmSubagentWalks = new Map<string, Promise<PassiveRlmSubagent[]>>();
+	private readonly passiveRlmSubagentMemo = new Map<
+		string,
+		{ fingerprint: string; childStats: string[]; result: PassiveRlmSubagent[] }
+	>();
+	private static readonly PASSIVE_RLM_MEMO_MAX_KEYS = 4;
+
+	private hasPersistedResidentSession(): boolean {
+		for (const state of this.sessions.values()) {
+			if (state.runtime.session.sessionFile) return true;
+		}
+		return false;
+	}
+
+	private async passiveRlmTopologyFingerprint(savedRootInfos: SessionInfo[]): Promise<string> {
+		const ledgerStat = await this.passiveRlmStatString(this.rlmSpawnLedger().ledgerPath);
+		const resident = [...this.sessions.values()]
+			.map((state) => `${state.activeSessionId}:${state.runtime.session.sessionFile ?? ""}`)
+			.sort();
+		const roots = savedRootInfos.map((info) => resolve(info.path)).sort();
+		return `${ledgerStat}|${resident.join(",")}|${roots.join(",")}`;
+	}
+
+	private async passiveRlmStatString(path: string): Promise<string> {
+		try {
+			const stats = await stat(path);
+			return `${stats.size}:${stats.mtimeMs}:${stats.ino}`;
+		} catch {
+			return "absent";
+		}
+	}
+
+	private passiveRlmChildStats(result: PassiveRlmSubagent[]): Promise<string[]> {
+		return Promise.all(result.map((passive) => this.passiveRlmStatString(passive.entry.sessionFile)));
+	}
+
+	private passiveRlmRootsStillResident(result: PassiveRlmSubagent[]): boolean {
+		return result.every(
+			(passive) =>
+				!passive.rootParentState ||
+				this.sessions.get(passive.rootParentState.activeSessionId) === passive.rootParentState,
+		);
+	}
+
+	private listPassiveRlmSubagents(
 		savedRoots: SessionInfo[] = [],
 		includeResident = false,
+	): Promise<PassiveRlmSubagent[]> {
+		const savedRootInfos = savedRoots.filter((rootInfo) => inactiveLifecycleForSession(rootInfo) === "live");
+		if (savedRootInfos.length === 0 && !this.hasPersistedResidentSession()) {
+			// Keep the empty topology IO-free: no roots means no walk, no ledger stat.
+			return Promise.resolve([]);
+		}
+		const key = `${includeResident}|${savedRootInfos
+			.map((info) => resolve(info.path))
+			.sort()
+			.join(",")}`;
+		const run = async (): Promise<PassiveRlmSubagent[]> => {
+			const before = await this.passiveRlmTopologyFingerprint(savedRootInfos);
+			const memo = this.passiveRlmSubagentMemo.get(key);
+			if (
+				memo &&
+				memo.fingerprint === before &&
+				this.passiveRlmRootsStillResident(memo.result) &&
+				(await this.passiveRlmChildStats(memo.result)).join("\n") === memo.childStats.join("\n")
+			) {
+				return memo.result;
+			}
+			const result = await this.walkPassiveRlmSubagents(savedRootInfos, includeResident);
+			// Only a walk whose inputs held still is a valid memo (the first walk
+			// seeds the ledger from legacy registries and never qualifies).
+			const after = await this.passiveRlmTopologyFingerprint(savedRootInfos);
+			if (after === before) {
+				this.passiveRlmSubagentMemo.delete(key);
+				this.passiveRlmSubagentMemo.set(key, {
+					fingerprint: after,
+					childStats: await this.passiveRlmChildStats(result),
+					result,
+				});
+				for (const staleKey of this.passiveRlmSubagentMemo.keys()) {
+					if (this.passiveRlmSubagentMemo.size <= AgentDaemon.PASSIVE_RLM_MEMO_MAX_KEYS) break;
+					this.passiveRlmSubagentMemo.delete(staleKey);
+				}
+			} else {
+				this.passiveRlmSubagentMemo.delete(key);
+			}
+			return result;
+		};
+		const previous = this.passiveRlmSubagentWalks.get(key);
+		const walk = previous ? previous.then(run, run) : run();
+		this.passiveRlmSubagentWalks.set(key, walk);
+		void walk.finally(() => {
+			if (this.passiveRlmSubagentWalks.get(key) === walk) this.passiveRlmSubagentWalks.delete(key);
+		});
+		return walk;
+	}
+
+	/** List each root's passive (non-resident) descendants from the ledger, without creating runtimes. */
+	private async walkPassiveRlmSubagents(
+		savedRootInfos: SessionInfo[],
+		includeResident: boolean,
 	): Promise<PassiveRlmSubagent[]> {
 		const residentRoots: Array<{ parentState: ActiveSessionState; sessionFile: string }> = [];
 		for (const parentState of this.sessions.values()) {
@@ -1275,7 +1382,6 @@ export class AgentDaemon {
 			// An in-memory session cannot own persisted children.
 			if (parentFile) residentRoots.push({ parentState, sessionFile: parentFile });
 		}
-		const savedRootInfos = savedRoots.filter((rootInfo) => inactiveLifecycleForSession(rootInfo) === "live");
 		if (residentRoots.length === 0 && savedRootInfos.length === 0) return [];
 		const edges = await this.rlmSpawnLedger().edges();
 		const childrenByParent = new Map<string, RlmLedgerEdge[]>();

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1264,19 +1264,12 @@ export class AgentDaemon {
 		return { ...base, rlmDepth: edge.depth, status: "completed", createdAt };
 	}
 
-	// One memoized derivation of the passive-subagent topology per argument
-	// shape: every daemon consumer (session list, snapshots, cron recovery,
-	// agent-observe, agent-message, family catalog, passivation) reads the same
-	// cached walk instead of re-walking the persisted tree per request. A hit
-	// requires the spawn ledger stat, the resident roster, the live saved
-	// roots, every root-state identity, and the stat of every file input the
-	// walk visited (child transcripts, display records, legacy registries,
-	// including absent ones) to be unchanged; ledger appends, residency
-	// changes, child appends, and display rewrites all invalidate. Input stats
-	// are captured before each read, so a write landing mid-walk can only
-	// cause one extra re-walk, never a stale memo. Walks of the same shape run
-	// strictly one at a time, and a caller never joins an earlier walk: its
-	// own pass re-validates against state at or after its call time.
+	// One memoized passive-topology derivation per argument shape; all daemon
+	// consumers read the cached walk. A hit requires the ledger stat, roster,
+	// live roots, root-state identities, and every visited file input's stat
+	// (captured before its read, so mid-walk writes cost one extra re-walk,
+	// never a stale memo) to be unchanged. Same-shape walks run one at a time;
+	// a caller never joins an earlier walk.
 	private readonly passiveRlmSubagentWalks = new Map<string, Promise<PassiveRlmSubagent[]>>();
 	private readonly passiveRlmSubagentMemo = new Map<
 		string,
@@ -1350,9 +1343,7 @@ export class AgentDaemon {
 			}
 			const walked = await this.walkPassiveRlmSubagents(savedRootInfos, includeResident);
 			// Only a walk whose inputs held still qualifies as a memo: not the
-			// first walk (it seeds the ledger from legacy registries) and not a
-			// degraded walk (a present child file that failed to read may list
-			// again without any stat change).
+			// ledger-seeding first walk, not a degraded one.
 			const after = await this.passiveRlmTopologyFingerprint(savedRootInfos);
 			if (after === before && !walked.degraded) {
 				this.passiveRlmSubagentMemo.delete(key);
@@ -1373,9 +1364,8 @@ export class AgentDaemon {
 		const previous = this.passiveRlmSubagentWalks.get(key);
 		const walk = previous ? previous.then(run, run) : run();
 		this.passiveRlmSubagentWalks.set(key, walk);
-		// then(cleanup, cleanup), not finally(): a discarded finally() promise
-		// would turn a rejecting walk into an unhandled rejection and crash the
-		// daemon; the rejection still reaches the caller through `walk` itself.
+		// Not finally(): its discarded promise would turn a rejecting walk into a
+		// daemon-crashing unhandled rejection. The caller still sees the rejection.
 		const cleanup = () => {
 			if (this.passiveRlmSubagentWalks.get(key) === walk) this.passiveRlmSubagentWalks.delete(key);
 		};
@@ -1388,8 +1378,7 @@ export class AgentDaemon {
 		savedRootInfos: SessionInfo[],
 		includeResident: boolean,
 	): Promise<{ result: PassiveRlmSubagent[]; inputStats: Map<string, string>; degraded: boolean }> {
-		// Every file input's stat is captured before its read so the memo's
-		// invalidation identity can only be older than the derived content.
+		// Captured before each read: the identity can only be older than the content.
 		const inputStats = new Map<string, string>();
 		let degraded = false;
 		const recordInputStat = async (path: string): Promise<string> => {
@@ -1436,17 +1425,13 @@ export class AgentDaemon {
 				const sessionKey = resolve(entry.sessionFile);
 				if (entry.status === "deleted" || visited.has(sessionKey)) continue;
 				visited.add(sessionKey);
-				// A resident child walks its own subtree as an outer root below. Avoid
-				// duplicate rows and attributing its descendants to an ancestor - and
-				// keep its actively-streamed transcript out of the input set, where
-				// every append would needlessly bust the memo (the roster axis
-				// already carries resident identity).
+				// A resident child walks as an outer root below; skipping before the
+				// stat capture keeps its streamed transcript out of the input set.
 				if (!includeResident && this.findSessionBySessionFile(entry.sessionFile)) continue;
 				const childStat = await recordInputStat(entry.sessionFile);
 				const info = await readSessionInfo(entry.sessionFile);
 				if (!info) {
-					// A present file that fails to list may succeed again without any
-					// stat change (transient read error): such walks must not memoize.
+					// A present file that fails to list may recover without a stat change.
 					if (childStat !== "absent") degraded = true;
 					continue;
 				}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -4501,6 +4501,39 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("keeps the memo across appends to a resident child's transcript", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-passive-resident-append-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				listPassiveRlmSubagents(): Promise<Array<{ entry: { childId: string } }>>;
+			};
+			await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			await internals.createRuntime({ type: "create", sessionPath: fixture.childSessionFile });
+			await internals.listPassiveRlmSubagents();
+			const first = await internals.listPassiveRlmSubagents();
+			expect(first.map(({ entry }) => entry.childId)).toContain(fixture.grandchildId);
+			expect(first.map(({ entry }) => entry.childId)).not.toContain(fixture.childId);
+
+			// A resident child's identity comes from the roster, not its transcript:
+			// its streaming appends must not invalidate the passive memo.
+			appendFileSync(
+				fixture.childSessionFile,
+				`${JSON.stringify({
+					type: "message",
+					id: "m9",
+					parentId: null,
+					timestamp: "2026-01-01T00:00:09.000Z",
+					message: { role: "user", content: "streamed while resident", timestamp: 9 },
+				})}\n`,
+			);
+			expect(await internals.listPassiveRlmSubagents()).toBe(first);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("cancels a detached subagent heartbeat when its parent is archived", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-archived-subagent-heartbeat-"));
 		try {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -8,6 +8,7 @@ import {
 	mkdtempSync,
 	readdirSync,
 	readFileSync,
+	renameSync,
 	rmSync,
 	symlinkSync,
 	writeFileSync,
@@ -4399,6 +4400,102 @@ describe("daemon mode helpers", () => {
 			expect(third).not.toBe(first);
 			const child = third.find(({ entry }) => entry.childId === fixture.childId);
 			expect(child?.info.messageCount).toBe(2);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps a rejecting topology walk request-scoped and retries on the next call", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-passive-reject-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				listPassiveRlmSubagents(): Promise<Array<{ entry: { childId: string } }>>;
+			};
+			await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			await internals.listPassiveRlmSubagents();
+
+			const ledgerDir = join(tempDir, "rlm-ledger");
+			const ledgerFile = readdirSync(ledgerDir).find((name) => name.endsWith(".jsonl"));
+			if (!ledgerFile) throw new Error("Missing spawn ledger file");
+			const ledgerPath = join(ledgerDir, ledgerFile);
+			const intact = readFileSync(ledgerPath, "utf8");
+			appendFileSync(ledgerPath, "not json\n");
+
+			// The walk rejects to its caller only; a discarded cleanup promise
+			// must not surface as an unhandled rejection (the daemon crashes on
+			// those).
+			await expect(internals.listPassiveRlmSubagents()).rejects.toThrow();
+
+			writeFileSync(ledgerPath, intact);
+			const listed = await internals.listPassiveRlmSubagents();
+			expect(listed.map(({ entry }) => entry.childId)).toContain(fixture.childId);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("re-lists a child whose session file returns after being absent", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-passive-absent-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				listPassiveRlmSubagents(): Promise<Array<{ entry: { childId: string } }>>;
+			};
+			await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			await internals.listPassiveRlmSubagents();
+
+			const asideFile = `${fixture.grandchildSessionFile}.aside`;
+			renameSync(fixture.grandchildSessionFile, asideFile);
+			const without = await internals.listPassiveRlmSubagents();
+			expect(without.map(({ entry }) => entry.childId)).not.toContain(fixture.grandchildId);
+			await internals.listPassiveRlmSubagents();
+
+			// An absent input is a stat identity too: the file reappearing must
+			// invalidate the memo even though no listed child changed.
+			renameSync(asideFile, fixture.grandchildSessionFile);
+			const restored = await internals.listPassiveRlmSubagents();
+			expect(restored.map(({ entry }) => entry.childId)).toContain(fixture.grandchildId);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("re-derives passive metadata when a child display record is rewritten", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-passive-display-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const display = {
+				type: "rlm_subagent" as const,
+				childId: fixture.childId,
+				sessionName: "spawn-worker",
+				sessionDir: fixture.childSessionDir,
+				sessionFile: fixture.childSessionFile,
+				rlmParentNodeId: fixture.childId,
+				status: "running" as const,
+				createdAt: 1,
+				updatedAt: "2026-01-01T00:00:00.000Z",
+			};
+			writeFileSync(join(fixture.childSessionDir, "rlm-subagent.json"), `${JSON.stringify(display)}\n`);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				listPassiveRlmSubagents(): Promise<Array<{ entry: { childId: string; status: string } }>>;
+			};
+			await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			await internals.listPassiveRlmSubagents();
+			const running = await internals.listPassiveRlmSubagents();
+			expect(running.find(({ entry }) => entry.childId === fixture.childId)?.entry.status).toBe("running");
+
+			// A cross-process completion rewrites only the display record; the
+			// memo must treat it as a walk input and re-derive.
+			writeFileSync(
+				join(fixture.childSessionDir, "rlm-subagent.json"),
+				`${JSON.stringify({ ...display, status: "completed", updatedAt: "2026-01-01T00:00:05.000Z" })}\n`,
+			);
+			const completed = await internals.listPassiveRlmSubagents();
+			expect(completed.find(({ entry }) => entry.childId === fixture.childId)?.entry.status).toBe("completed");
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -4364,42 +4364,46 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	function makePassiveMemoHarness(tempDir: string) {
+		const fixture = makePersistedRlmDaemonFixture(tempDir);
+		const internals = fixture.daemon as unknown as {
+			createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+			listPassiveRlmSubagents(): Promise<
+				Array<{ entry: { childId: string; status: string }; info: { messageCount: number } }>
+			>;
+		};
+		return { fixture, internals };
+	}
+
+	const passiveMessageLine = (id: string, text: string) =>
+		`${JSON.stringify({
+			type: "message",
+			id,
+			parentId: null,
+			timestamp: "2026-01-01T00:00:02.000Z",
+			message: { role: "user", content: text, timestamp: 3 },
+		})}\n`;
+
 	it("memoizes the passive topology walk until a topology input changes", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-passive-memo-"));
 		try {
-			const fixture = makePersistedRlmDaemonFixture(tempDir);
-			const internals = fixture.daemon as unknown as {
-				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
-				listPassiveRlmSubagents(): Promise<Array<{ entry: { childId: string }; info: { messageCount: number } }>>;
-			};
+			const { fixture, internals } = makePassiveMemoHarness(tempDir);
 			await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
 
-			// The first walk seeds the ledger from the legacy registries, so it
-			// never memoizes; the second is the first stable derivation and the
-			// third must reuse it.
+			// The first walk seeds the ledger, so it never memoizes; the second is
+			// the first stable derivation and the third must reuse it.
 			await internals.listPassiveRlmSubagents();
 			const first = await internals.listPassiveRlmSubagents();
 			expect(first.map(({ entry }) => entry.childId)).toEqual(
 				expect.arrayContaining([fixture.childId, fixture.grandchildId]),
 			);
-			const second = await internals.listPassiveRlmSubagents();
-			expect(second).toBe(first);
+			expect(await internals.listPassiveRlmSubagents()).toBe(first);
 
 			// A child session append invalidates the memo and re-derives fresh infos.
-			appendFileSync(
-				fixture.childSessionFile,
-				`${JSON.stringify({
-					type: "message",
-					id: "m2",
-					parentId: null,
-					timestamp: "2026-01-01T00:00:02.000Z",
-					message: { role: "user", content: "one more instruction", timestamp: 3 },
-				})}\n`,
-			);
+			appendFileSync(fixture.childSessionFile, passiveMessageLine("m2", "one more instruction"));
 			const third = await internals.listPassiveRlmSubagents();
 			expect(third).not.toBe(first);
-			const child = third.find(({ entry }) => entry.childId === fixture.childId);
-			expect(child?.info.messageCount).toBe(2);
+			expect(third.find(({ entry }) => entry.childId === fixture.childId)?.info.messageCount).toBe(2);
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -4408,11 +4412,7 @@ describe("daemon mode helpers", () => {
 	it("keeps a rejecting topology walk request-scoped and retries on the next call", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-passive-reject-"));
 		try {
-			const fixture = makePersistedRlmDaemonFixture(tempDir);
-			const internals = fixture.daemon as unknown as {
-				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
-				listPassiveRlmSubagents(): Promise<Array<{ entry: { childId: string } }>>;
-			};
+			const { fixture, internals } = makePassiveMemoHarness(tempDir);
 			await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
 			await internals.listPassiveRlmSubagents();
 
@@ -4423,14 +4423,14 @@ describe("daemon mode helpers", () => {
 			const intact = readFileSync(ledgerPath, "utf8");
 			appendFileSync(ledgerPath, "not json\n");
 
-			// The walk rejects to its caller only; a discarded cleanup promise
-			// must not surface as an unhandled rejection (the daemon crashes on
-			// those).
+			// The walk rejects to its caller only; a discarded cleanup promise must
+			// not surface as an unhandled rejection (the daemon crashes on those).
 			await expect(internals.listPassiveRlmSubagents()).rejects.toThrow();
 
 			writeFileSync(ledgerPath, intact);
-			const listed = await internals.listPassiveRlmSubagents();
-			expect(listed.map(({ entry }) => entry.childId)).toContain(fixture.childId);
+			expect((await internals.listPassiveRlmSubagents()).map(({ entry }) => entry.childId)).toContain(
+				fixture.childId,
+			);
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -4439,11 +4439,7 @@ describe("daemon mode helpers", () => {
 	it("re-lists a child whose session file returns after being absent", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-passive-absent-"));
 		try {
-			const fixture = makePersistedRlmDaemonFixture(tempDir);
-			const internals = fixture.daemon as unknown as {
-				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
-				listPassiveRlmSubagents(): Promise<Array<{ entry: { childId: string } }>>;
-			};
+			const { fixture, internals } = makePassiveMemoHarness(tempDir);
 			await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
 			await internals.listPassiveRlmSubagents();
 
@@ -4466,7 +4462,7 @@ describe("daemon mode helpers", () => {
 	it("re-derives passive metadata when a child display record is rewritten", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-passive-display-"));
 		try {
-			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const { fixture, internals } = makePassiveMemoHarness(tempDir);
 			const display = {
 				type: "rlm_subagent" as const,
 				childId: fixture.childId,
@@ -4478,22 +4474,16 @@ describe("daemon mode helpers", () => {
 				createdAt: 1,
 				updatedAt: "2026-01-01T00:00:00.000Z",
 			};
-			writeFileSync(join(fixture.childSessionDir, "rlm-subagent.json"), `${JSON.stringify(display)}\n`);
-			const internals = fixture.daemon as unknown as {
-				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
-				listPassiveRlmSubagents(): Promise<Array<{ entry: { childId: string; status: string } }>>;
-			};
+			const displayPath = join(fixture.childSessionDir, "rlm-subagent.json");
+			writeFileSync(displayPath, `${JSON.stringify(display)}\n`);
 			await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
 			await internals.listPassiveRlmSubagents();
 			const running = await internals.listPassiveRlmSubagents();
 			expect(running.find(({ entry }) => entry.childId === fixture.childId)?.entry.status).toBe("running");
 
-			// A cross-process completion rewrites only the display record; the
-			// memo must treat it as a walk input and re-derive.
-			writeFileSync(
-				join(fixture.childSessionDir, "rlm-subagent.json"),
-				`${JSON.stringify({ ...display, status: "completed", updatedAt: "2026-01-01T00:00:05.000Z" })}\n`,
-			);
+			// A cross-process completion rewrites only the display record; the memo
+			// must treat it as a walk input and re-derive.
+			writeFileSync(displayPath, `${JSON.stringify({ ...display, status: "completed" })}\n`);
 			const completed = await internals.listPassiveRlmSubagents();
 			expect(completed.find(({ entry }) => entry.childId === fixture.childId)?.entry.status).toBe("completed");
 		} finally {
@@ -4504,11 +4494,7 @@ describe("daemon mode helpers", () => {
 	it("keeps the memo across appends to a resident child's transcript", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-passive-resident-append-"));
 		try {
-			const fixture = makePersistedRlmDaemonFixture(tempDir);
-			const internals = fixture.daemon as unknown as {
-				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
-				listPassiveRlmSubagents(): Promise<Array<{ entry: { childId: string } }>>;
-			};
+			const { fixture, internals } = makePassiveMemoHarness(tempDir);
 			await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
 			await internals.createRuntime({ type: "create", sessionPath: fixture.childSessionFile });
 			await internals.listPassiveRlmSubagents();
@@ -4518,16 +4504,7 @@ describe("daemon mode helpers", () => {
 
 			// A resident child's identity comes from the roster, not its transcript:
 			// its streaming appends must not invalidate the passive memo.
-			appendFileSync(
-				fixture.childSessionFile,
-				`${JSON.stringify({
-					type: "message",
-					id: "m9",
-					parentId: null,
-					timestamp: "2026-01-01T00:00:09.000Z",
-					message: { role: "user", content: "streamed while resident", timestamp: 9 },
-				})}\n`,
-			);
+			appendFileSync(fixture.childSessionFile, passiveMessageLine("m9", "streamed while resident"));
 			expect(await internals.listPassiveRlmSubagents()).toBe(first);
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
 import {
+	appendFileSync,
 	chmodSync,
 	existsSync,
 	mkdirSync,
@@ -4358,6 +4359,47 @@ describe("daemon mode helpers", () => {
 		} finally {
 			releasePassiveList();
 			releaseBinding();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("memoizes the passive topology walk until a topology input changes", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-passive-memo-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				listPassiveRlmSubagents(): Promise<Array<{ entry: { childId: string }; info: { messageCount: number } }>>;
+			};
+			await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+
+			// The first walk seeds the ledger from the legacy registries, so it
+			// never memoizes; the second is the first stable derivation and the
+			// third must reuse it.
+			await internals.listPassiveRlmSubagents();
+			const first = await internals.listPassiveRlmSubagents();
+			expect(first.map(({ entry }) => entry.childId)).toEqual(
+				expect.arrayContaining([fixture.childId, fixture.grandchildId]),
+			);
+			const second = await internals.listPassiveRlmSubagents();
+			expect(second).toBe(first);
+
+			// A child session append invalidates the memo and re-derives fresh infos.
+			appendFileSync(
+				fixture.childSessionFile,
+				`${JSON.stringify({
+					type: "message",
+					id: "m2",
+					parentId: null,
+					timestamp: "2026-01-01T00:00:02.000Z",
+					message: { role: "user", content: "one more instruction", timestamp: 3 },
+				})}\n`,
+			);
+			const third = await internals.listPassiveRlmSubagents();
+			expect(third).not.toBe(first);
+			const child = third.find(({ entry }) => entry.childId === fixture.childId);
+			expect(child?.info.messageCount).toBe(2);
+		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
 	});


### PR DESCRIPTION
## Purpose

`listPassiveRlmSubagents` walks the whole persisted RLM tree — a full spawn-ledger replay plus a per-child session scan, display-file read, and legacy-registry read — and is invoked uncoalesced from nine daemon sites (session list, snapshot stabilization, cron recovery, agent-observe, agent-message, family catalog, passivation, selector resolution). With N persisted children and M requests needing topology, cost was N×M walks; on large trees this is the remaining request multiplier behind the duplicate-FD/CPU incidents in discussion #1671 (the per-child scan cost is fixed by #2043).

## Mechanism

One memoized, strictly serialized derivation per argument shape in `daemon-mode.ts`:

- A memo hit requires the spawn-ledger stat, the resident roster, the live saved-root set, every listed child file's stat, and every embedded root-state identity to be unchanged — ledger appends (spawn/rename/delete from any process), residency changes (add/passivate/rehydrate, including same-id state-object swaps), and child-file appends all invalidate.
- Walks of the same shape run one at a time and a later caller never joins an earlier walk: its own pass revalidates against state at or after its call time (same freshness contract as #2043's scan chaining).
- A walk whose inputs changed while it ran never memoizes — in particular the first walk, which seeds the ledger from legacy registries.
- Empty topologies (no live saved roots, no persisted resident session) stay IO-free, exactly as before.

All nine call sites become readers of the cached walk; no call-site changes.

## Measurement (200 passive children under one resident root, real `AgentDaemon`)

| scenario | main | this PR |
| --- | --- | --- |
| 50 sequential listings | 965ms | 17ms |
| 20 concurrent listings | 342ms | 7ms |

(Both sides measured without #2043, so the delta isolates the walk memo; the two compose multiplicatively on actively-written trees where the per-child `(size,mtime)` cache never hits.)

## Validation

- One pin verified fail-unfixed on main: unchanged inputs return the identical cached derivation, and a child-file append invalidates and re-derives fresh infos (fails on main with fresh arrays per call).
- Full `daemon-mode` suite (187) passes under a sanitized env, including the passive-listing, hydration-race, and snapshot-stabilization tests; root `npm run check` passes.

## LOC

Total src: **+137/−9 (net +128)**; tests: +149/−0 (net +149).
Src +139/−3: additive memo layer around the existing walk (renamed `walkPassiveRlmSubagents`, body unchanged except the hoisted lifecycle filter); no behavioral rewrite of the walk itself. Tests +44.

Squashes the request-multiplier half of discussion #1671; with #2043 and #2050 this closes the P4 session-file IO program (also reduces the #1503 OOM profile).

Linear: RES-1272 https://linear.app/primeintellect/issue/RES-1272

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Incorrect memo invalidation could serve a stale passive topology across session list, messaging, and passivation paths; the change relies on comprehensive file-stat and roster fingerprinting rather than trivial logic.
> 
> **Overview**
> **Cuts duplicate work when the daemon repeatedly derives passive (non-resident) RLM subagent trees** — the expensive spawn-ledger walk plus per-child session reads that many request paths already shared.
> 
> `listPassiveRlmSubagents` now memoizes results per argument shape (include-resident flag + live saved roots), with invalidation driven by spawn-ledger stat, resident session roster, saved-root set, per-file stats captured during the walk, and whether cached root parent state objects are still the live in-memory sessions. Same-shape walks are serialized so a later caller does not piggyback on an in-flight walk; walks that see inputs change mid-flight or mark **degraded** (e.g. unreadable but present child file) are not cached. Empty topologies with no live roots and no persisted resident sessions stay IO-free.
> 
> The traversal body moves to `walkPassiveRlmSubagents`, which records input stats and a degraded flag; call sites keep calling `listPassiveRlmSubagents`. New `daemon-mode` tests cover cache reuse, invalidation on transcript/display/ledger changes, absent-then-restored children, resident-child appends not busting the memo, and rejection cleanup without unhandled rejections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ee114ce77942d9298136ca193ddc2c0b5d27d58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Memoize passive RLM topology derivation in `AgentDaemon`
> - Caches results of `listPassiveRlmSubagents` by argument shape, retaining at most four memo entries; repeated requests with unchanged inputs return the cached result without filesystem I/O.
> - Adds validation helpers that fingerprint the spawn-ledger stat, resident-session roster, and live root paths; a cached entry is rejected when any visited file's stat identity changes, a resident root is removed, or the walk degraded.
> - Extracts the filesystem walk into `walkPassiveRlmSubagents`, which captures per-input stat identities needed for cache validation and excludes resident-child transcript appends from invalidation.
> - Same-key concurrent walks run sequentially without sharing promises; failed walks remain request-scoped and are retried by later calls.
> - Behavioral Change: `listPassiveRlmSubagents` in [daemon-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2051/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450) now returns empty without I/O when no relevant roots or persisted residents exist, and cached results are dropped if `passiveRlmRootsStillResident` detects the referenced root state objects are no longer in the daemon roster.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ee114c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->