### PR TITLE
feat(tui): open local file links

### DIFF
--- a/packages/tui/.changes/local-file-links.md
+++ b/packages/tui/.changes/local-file-links.md
@@ -1,0 +1,1 @@
+- Added support for opening file links from the fullscreen terminal UI.

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -768,7 +768,7 @@ export class TUI extends Container {
 		let href: string;
 		try {
 			const parsed = new URL(url);
-			if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return;
+			if (parsed.protocol !== "http:" && parsed.protocol !== "https:" && parsed.protocol !== "file:") return;
 			href = parsed.href;
 		} catch {
 			return;

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -1066,9 +1066,11 @@ describe("TUI fullscreen mode", () => {
 		tui.stop();
 	});
 
-	it("ignores clicked hyperlinks with non-http schemes", async () => {
+	it("opens file hyperlinks and ignores unsupported schemes", async () => {
 		const transcript = lines(20);
-		transcript[12] = "\x1b]8;;file:///etc/passwd\x1b\\secrets\x1b]8;;\x1b\\";
+		transcript[12] =
+			"\x1b]8;;file:///tmp/example%20file.txt\x1b\\file\x1b]8;;\x1b\\ " +
+			"\x1b]8;;ssh://example.com\x1b\\remote\x1b]8;;\x1b\\";
 		const { terminal, tui, chat, dock } = setup(transcript);
 		const opened: string[] = [];
 		tui.onOpenUrl = (url) => opened.push(url);
@@ -1077,8 +1079,10 @@ describe("TUI fullscreen mode", () => {
 
 		terminal.sendInput("\x1b[<0;3;1M");
 		terminal.sendInput("\x1b[<0;3;1m");
+		terminal.sendInput("\x1b[<0;7;1M");
+		terminal.sendInput("\x1b[<0;7;1m");
 		await terminal.waitForRender();
-		assert.deepStrictEqual(opened, []);
+		assert.deepStrictEqual(opened, ["file:///tmp/example%20file.txt"]);
 
 		tui.stop();
 	});


### PR DESCRIPTION
## Context

Prime Agent already renders `file://` Markdown links as OSC 8 hyperlinks, but fullscreen mode rejected them when it handled mouse clicks. This made local file links do nothing while website links worked.

No-Ticket: requested directly.

## Changes

- Allow `file:` links through the existing fullscreen hyperlink handler.
- Keep unsupported schemes blocked.
- Use the existing platform opener on macOS, Windows, and Linux.

## Validation

- `cd packages/tui && node --test --import tsx test/fullscreen.test.ts` (46 passed)
- `npm run check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-protocol allowlist change in the TUI hyperlink handler with updated tests; no auth or data-path changes.
> 
> **Overview**
> **Fullscreen OSC 8 clicks now open `file://` links**, matching behavior for http(s) links when mouse reporting prevents the terminal from handling links natively.
> 
> `openHyperlink` still rejects unsupported schemes (e.g. `ssh://`), malformed URLs, and URLs containing control characters. Opening uses the existing `onOpenUrl` hook or the platform default (`open`, `xdg-open`, Windows file handler).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6e83f0f2db71c705d48ef14b499a513c1506f4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `file:` protocol support to `TUI.openHyperlink` opener
> Extends the hyperlink opener in the fullscreen TUI to accept `file:` URLs in addition to HTTP and HTTPS. File links are dispatched through the existing open-URL callback or platform opener, while other non-HTTP(S) schemes remain rejected. Tests now cover a percent-encoded `file:` URL and an unsupported `ssh:` URL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6e83f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->