### PR TITLE
fix(ai): add GPT-6 Astra to Codex OAuth

### DIFF
--- a/packages/ai/.changes/2062-codex-astra.md
+++ b/packages/ai/.changes/2062-codex-astra.md
@@ -1,0 +1,1 @@
+- Added GPT-6 Astra to the ChatGPT OAuth model catalog with reasoning levels from low through max ([#2062](https://github.com/PrimeIntellect-ai/prime-agent/discussions/2062)).

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -307,7 +307,9 @@ function applyThinkingLevelMetadata(model: Model<any>): void {
 		mergeThinkingLevelMap(model, { minimal: null, xhigh: "xhigh", max: "max" });
 	}
 	if (
-		(model.api === "openai-responses" || model.api === "azure-openai-responses") &&
+		(model.api === "openai-responses" ||
+			model.api === "azure-openai-responses" ||
+			model.api === "openai-codex-responses") &&
 		model.id.startsWith("gpt-6")
 	) {
 		mergeThinkingLevelMap(model, { off: null });
@@ -1969,6 +1971,18 @@ async function generateModels() {
 	const CODEX_CONTEXT = 272000;
 	const CODEX_MAX_TOKENS = 128000;
 	const codexModels: Model<"openai-codex-responses">[] = [
+		{
+			id: "gpt-6-astra",
+			name: "GPT-6 Astra",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: CODEX_BASE_URL,
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+			contextWindow: CODEX_CONTEXT,
+			maxTokens: CODEX_MAX_TOKENS,
+		},
 		{
 			id: "gpt-5.1",
 			name: "GPT-5.1",

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -8934,6 +8934,24 @@ export const MODELS = {
 			contextWindow: 272000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-codex-responses">,
+		"gpt-6-astra": {
+			id: "gpt-6-astra",
+			name: "GPT-6 Astra",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			thinkingLevelMap: {"minimal":null,"xhigh":"xhigh","max":"max","off":null},
+			input: ["text", "image"],
+			cost: {
+				input: 10,
+				output: 50,
+				cacheRead: 1,
+				cacheWrite: 12.5,
+			},
+			contextWindow: 272000,
+			maxTokens: 128000,
+		} satisfies Model<"openai-codex-responses">,
 	},
 	"opencode": {
 		"big-pickle": {

--- a/packages/coding-agent/.changes/2062-codex-astra.md
+++ b/packages/coding-agent/.changes/2062-codex-astra.md
@@ -1,0 +1,1 @@
+- Fixed GPT-6 Astra discovery for ChatGPT OAuth subagents on accounts with access ([#2062](https://github.com/PrimeIntellect-ai/prime-agent/discussions/2062)).

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -379,7 +379,7 @@ function readOpenAICodexAccountId(token: string): string | undefined {
  *
  * Catalog behaviour measured 2026-08-13; see #702.
  */
-const OPENAI_CODEX_CLIENT_VERSION = "0.147.0";
+const OPENAI_CODEX_CLIENT_VERSION = "0.153.3";
 
 function openAICodexModelsUrl(baseUrl: string): string {
 	const normalized = baseUrl.replace(/\/+$/, "");


### PR DESCRIPTION
GPT-6 Astra was missing from the ChatGPT OAuth catalog, so it could not be selected without a custom model entry or discovered for subagents. This change adds it to the built-in Codex catalog and updates discovery so accounts with access can resolve it.

- Added the Astra catalog entry with the existing Codex context limits and reasoning levels from `low` through `max`.
- Updated the Codex discovery client version to `0.153.3`, retaining account-based model filtering.
- Added changelog fragments for the AI and coding-agent packages.

Addresses [discussion #2062](https://github.com/PrimeIntellect-ai/prime-agent/discussions/2062#discussioncomment-18308084).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog and discovery metadata only; no auth or request-path changes beyond which OAuth models are listed and intersected with the Codex API.
> 
> **Overview**
> Adds **GPT-6 Astra** to the explicit ChatGPT OAuth (`openai-codex`) model list with Codex context limits, pricing, and **gpt-6** reasoning metadata (mandatory reasoning; **xhigh**/**max** supported; **off**/**minimal** disabled). The generator now applies the gpt-6 “no off” rule to **`openai-codex-responses`** as well as other Responses APIs, and **`models.generated.ts`** is updated accordingly.
> 
> In the coding agent, **Codex catalog discovery** bumps the reported client version from **0.147.0** to **0.153.3** so accounts with access see Astra in the server catalog and **`getExecutableModels()`** (subagents, **`find_models()`**) can keep it instead of filtering it out. Changelog notes were added for the **ai** and **coding-agent** packages ([#2062](https://github.com/PrimeIntellect-ai/prime-agent/discussions/2062)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4435633e3eeb515d0ae641802c701e304bbab62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `gpt-6-astra` to Codex OAuth and bump client version to `0.153.3`
> - Adds `gpt-6-astra` to the Codex ChatGPT OAuth model list in [generate-models.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2077/files#diff-89e0723f62b802c23d445c0de0813e3c9a937463cdc57f1585eedd07c9a4635c) with a 272k context window and 128k output limit.
> - Extends `applyThinkingLevelMetadata` to assign an `off` reasoning level mapping for GPT-6 models using the `openai-codex-responses` API.
> - Bumps `OPENAI_CODEX_CLIENT_VERSION` in [model-registry.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2077/files#diff-2fd8c4a2672b4ce27e73d494479df612c8b30ebac3dda5a160e2d861c612f453) from `0.147.0` to `0.153.3` to allow discovery of the new model.
> - Behavioral Change: Codex backend requests now report client version `0.153.3`, which alters the remote model catalog used for executable-model discovery.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e443563.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->