### PR TITLE
chore: prepare v0.9.3 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prime-agent",
-	"version": "0.9.2",
+	"version": "0.9.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prime-agent",
-			"version": "0.9.2",
+			"version": "0.9.3",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -15,7 +15,7 @@
 				"packages/coding-agent/examples/extensions/sandbox"
 			],
 			"dependencies": {
-				"@earendil-works/pi-coding-agent": "^0.9.2",
+				"@earendil-works/pi-coding-agent": "^0.9.3",
 				"get-east-asian-width": "^1.6.0"
 			},
 			"devDependencies": {
@@ -5597,10 +5597,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "0.9.2",
+			"version": "0.9.3",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.9.2",
+				"@earendil-works/pi-ai": "^0.9.3",
 				"typebox": "^1.3.9"
 			},
 			"devDependencies": {
@@ -5631,7 +5631,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "0.9.2",
+			"version": "0.9.3",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
@@ -5677,14 +5677,14 @@
 		},
 		"packages/coding-agent": {
 			"name": "@earendil-works/pi-coding-agent",
-			"version": "0.9.2",
+			"version": "0.9.3",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"@agentclientprotocol/sdk": "^1.3.0",
-				"@earendil-works/pi-agent-core": "^0.9.2",
-				"@earendil-works/pi-ai": "^0.9.2",
-				"@earendil-works/pi-tui": "^0.9.2",
+				"@earendil-works/pi-agent-core": "^0.9.3",
+				"@earendil-works/pi-ai": "^0.9.3",
+				"@earendil-works/pi-tui": "^0.9.3",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
@@ -5728,18 +5728,18 @@
 		},
 		"packages/coding-agent/examples/extensions/custom-provider-anthropic": {
 			"name": "pi-extension-custom-provider-anthropic",
-			"version": "0.9.2",
+			"version": "0.9.3",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.52.0"
 			}
 		},
 		"packages/coding-agent/examples/extensions/custom-provider-gitlab-duo": {
 			"name": "pi-extension-custom-provider-gitlab-duo",
-			"version": "0.9.2"
+			"version": "0.9.3"
 		},
 		"packages/coding-agent/examples/extensions/sandbox": {
 			"name": "pi-extension-sandbox",
-			"version": "0.9.2",
+			"version": "0.9.3",
 			"dependencies": {
 				"@anthropic-ai/sandbox-runtime": "^0.0.55"
 			}
@@ -5779,7 +5779,7 @@
 		},
 		"packages/coding-agent/examples/extensions/with-deps": {
 			"name": "pi-extension-with-deps",
-			"version": "0.9.2",
+			"version": "0.9.3",
 			"dependencies": {
 				"ms": "^2.1.3"
 			},
@@ -5813,7 +5813,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "0.9.2",
+			"version": "0.9.3",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
 	"engines": {
 		"node": ">=22.8.0"
 	},
-	"version": "0.9.2",
+	"version": "0.9.3",
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "^0.9.2",
+		"@earendil-works/pi-coding-agent": "^0.9.3",
 		"get-east-asian-width": "^1.6.0"
 	},
 	"overrides": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-agent-core",
-	"version": "0.9.2",
+	"version": "0.9.3",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,7 +17,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-ai": "^0.9.2",
+		"@earendil-works/pi-ai": "^0.9.3",
 		"typebox": "^1.3.9"
 	},
 	"keywords": [

--- a/packages/ai/.changes/res-1311-bump-impersonated-client-versions.md
+++ b/packages/ai/.changes/res-1311-bump-impersonated-client-versions.md
@@ -1,1 +1,0 @@
-- Bumped the impersonated client versions: Claude Code 2.1.257 -> 2.1.261 and GitHub Copilot Chat 0.35.0 -> 0.48.1 on VS Code 1.136.1, keeping OAuth traffic accepted as a current client; the Copilot client identity now has a single owner shared by the OAuth flow and the generated catalog headers.

--- a/packages/ai/.changes/res-1312-codex-gpt6-astra.md
+++ b/packages/ai/.changes/res-1312-codex-gpt6-astra.md
@@ -1,1 +1,0 @@
-- Added GPT-6 Astra to the Codex/ChatGPT OAuth catalog with its mandatory-reasoning effort levels, and bumped the Codex discovery client version to 0.153.4 so account discovery lists it (reported by endcycles and api-moose in discussion #2062).

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.9.3] - 2026-09-06
+
+- Added GPT-6 Astra to the Codex/ChatGPT OAuth catalog with its mandatory-reasoning effort levels, and bumped the Codex discovery client version to 0.153.4 so account discovery lists it (reported by endcycles and api-moose in discussion #2062).
+- Bumped the impersonated client versions: Claude Code 2.1.257 -> 2.1.261 and GitHub Copilot Chat 0.35.0 -> 0.48.1 on VS Code 1.136.1, keeping OAuth traffic accepted as a current client; the Copilot client identity now has a single owner shared by the OAuth flow and the generated catalog headers.
+
 ## [0.9.2] - 2026-09-05
 
 - Fixed Claude Fable 5.x failing over Anthropic OAuth with "Claude Code 2.1.75 does not support this model" by bumping the impersonated Claude Code version to 2.1.257 ([#1962](https://github.com/PrimeIntellect-ai/prime-agent/issues/1962))

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-ai",
-	"version": "0.9.2",
+	"version": "0.9.3",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/.changes/res-1312-codex-client-version.md
+++ b/packages/coding-agent/.changes/res-1312-codex-client-version.md
@@ -1,1 +1,0 @@
-- Fixed ChatGPT OAuth model discovery hiding GPT-6 Astra by advertising Codex CLI 0.153.4 instead of 0.147.0.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.9.3] - 2026-09-06
+
+- Fixed ChatGPT OAuth model discovery hiding GPT-6 Astra by advertising Codex CLI 0.153.4 instead of 0.147.0.
+
 ## [0.9.2] - 2026-09-05
 
 - Fixed daemon session creation after macOS timezone changes ([#879](https://github.com/PrimeIntellect-ai/prime-agent/issues/879))

--- a/packages/coding-agent/examples/extensions/custom-provider-anthropic/package-lock.json
+++ b/packages/coding-agent/examples/extensions/custom-provider-anthropic/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-extension-custom-provider",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-extension-custom-provider",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0"
       }

--- a/packages/coding-agent/examples/extensions/custom-provider-anthropic/package.json
+++ b/packages/coding-agent/examples/extensions/custom-provider-anthropic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-extension-custom-provider-anthropic",
   "private": true,
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "scripts": {
     "clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/examples/extensions/custom-provider-gitlab-duo/package.json
+++ b/packages/coding-agent/examples/extensions/custom-provider-gitlab-duo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-extension-custom-provider-gitlab-duo",
   "private": true,
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "scripts": {
     "clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/examples/extensions/sandbox/package-lock.json
+++ b/packages/coding-agent/examples/extensions/sandbox/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-extension-sandbox",
-	"version": "0.9.2",
+	"version": "0.9.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-extension-sandbox",
-			"version": "0.9.2",
+			"version": "0.9.3",
 			"dependencies": {
 				"@anthropic-ai/sandbox-runtime": "^0.0.55"
 			}

--- a/packages/coding-agent/examples/extensions/sandbox/package.json
+++ b/packages/coding-agent/examples/extensions/sandbox/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pi-extension-sandbox",
 	"private": true,
-	"version": "0.9.2",
+	"version": "0.9.3",
 	"type": "module",
 	"scripts": {
 		"clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/examples/extensions/with-deps/package-lock.json
+++ b/packages/coding-agent/examples/extensions/with-deps/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-extension-with-deps",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-extension-with-deps",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "ms": "^2.1.3"
       },

--- a/packages/coding-agent/examples/extensions/with-deps/package.json
+++ b/packages/coding-agent/examples/extensions/with-deps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-extension-with-deps",
   "private": true,
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "scripts": {
     "clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-coding-agent",
-	"version": "0.9.2",
+	"version": "0.9.3",
 	"description": "Coding agent CLI with a persistent Python REPL kernel and session management",
 	"type": "module",
 	"piConfig": {
@@ -48,9 +48,9 @@
 	},
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^1.3.0",
-		"@earendil-works/pi-agent-core": "^0.9.2",
-		"@earendil-works/pi-ai": "^0.9.2",
-		"@earendil-works/pi-tui": "^0.9.2",
+		"@earendil-works/pi-agent-core": "^0.9.3",
+		"@earendil-works/pi-ai": "^0.9.3",
+		"@earendil-works/pi-tui": "^0.9.3",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-tui",
-	"version": "0.9.2",
+	"version": "0.9.3",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Fixes RES-1313

## Purpose

Prepares the v0.9.3 patch release: every package bumps 0.9.2 → 0.9.3 in lockstep and the 3 pending changelog fragments fold into their `[0.9.3] - 2026-09-06` sections. Prepare-only — no tag, no publish, no runtime code.

## What ships in 0.9.3 (2 changes on top of v0.9.2)

- **GPT-6 Astra reaches ChatGPT-plan subscribers** (#2074, discussion #2062): the hand-maintained Codex OAuth catalog gains the Astra entry with its mandatory-reasoning levels, and discovery now advertises Codex CLI `0.153.4` instead of `0.147.0` — the backend filters an account's model list by claimed client version, so the old value hid Astra even from entitled accounts. Reported by endcycles and api-moose.
- **Impersonated client versions current everywhere** (#2069): Claude Code `2.1.257 → 2.1.261`, GitHub Copilot Chat `0.35.0 → 0.48.1` on VS Code `1.136.1`, with the Copilot identity extracted to a single owner shared by the OAuth flow and generated catalog headers. Ride-along: OpenRouter time-windowed tariffs (hy3, deepseek-v4-flash-vision-exp) now commit their peak values via a per-field max derivation — regens are hour-independent and cost display never undercounts.

## LOC

Total src: **+0/−0 (net 0)**; version/changelog-only. Lockstep bump across root + workspaces + example extensions; 3 fragments consumed (2 ai, 1 coding-agent); lockfiles refreshed via `--package-lock-only` (no third-party drift).

## Validation

- root `npm run check` (biome, tsgo, installer render, browser smoke) green after bump + aggregation
- `node scripts/sync-versions.js` lockstep confirmed (all packages 0.9.3, cross-deps ^0.9.3)
- full-suite sandbox gate at the release head: running, result will be posted as a PR comment before merge

## Release sequencing

Prepare-only: no tag, no publish. After merge: tag `v0.9.3`, `npm run publish`, update the stable channel file.

Linear: [RES-1313](https://linear.app/primeintellect/issue/RES-1313)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only changes with no application source edits in the diff; release metadata and dependency alignment only.
> 
> **Overview**
> Prepares the **v0.9.3** patch release with no runtime diffs in this PR: every workspace package and example extension moves **0.9.2 → 0.9.3** in lockstep, internal `@earendil-works/*` dependencies align on **^0.9.3**, and lockfiles refresh accordingly.
> 
> Pending **`.changes/`** fragments are folded into dated **`[0.9.3] - 2026-09-06`** changelog sections (then removed). **@earendil-works/pi-ai** documents GPT-6 Astra in the Codex/ChatGPT OAuth catalog, Codex discovery client **0.153.4**, and refreshed impersonated client strings (Claude Code **2.1.261**, Copilot Chat **0.48.1** on VS Code **1.136.1**) with a single Copilot identity owner. **@earendil-works/pi-coding-agent** notes the matching discovery fix (Codex CLI **0.153.4** vs **0.147.0**) so entitled ChatGPT-plan accounts can see Astra.
> 
> Prepare-only: tagging and npm publish happen after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b422a27f336e034fec46829477ae99e8309358d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prepare v0.9.3 release across all packages
> - Bumps version from 0.9.2 to 0.9.3 in root, `agent`, `ai`, `coding-agent`, and `tui` package manifests, plus example extensions, and raises internal dependency ranges accordingly
> - Adds 0.9.3 sections to the `ai` and `coding-agent` changelogs documenting GPT-6 Astra, mandatory-reasoning effort levels, Codex discovery client version 0.153.4, impersonated Claude Code 2.1.261, and GitHub Copilot Chat 0.48.1 on VS Code 1.136.1
> - Deletes consumed release-note fragments under `.changes/`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b422a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->