### PR TITLE
fix(coding-agent): never block opening the visible agents-view row on a pending selection anchor

### DIFF
--- a/packages/coding-agent/.changes/agents-view-anchor-open-block.md
+++ b/packages/coding-agent/.changes/agents-view-anchor-open-block.md
@@ -1,0 +1,1 @@
+- Fixed the agents view blocking Enter with "Waiting for the selected session to load" while the remembered selection was still loading; opening the visible row now always works, and entering a subagents view no longer arms that wait at all.

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -279,12 +279,16 @@ export function createInitialAgentsViewPersistentState(
 	options: Pick<AgentsViewModeOptions, "initialScopeKey" | "initialSession">,
 ): AgentsViewPersistentState {
 	const initialSession = options.initialSession;
+	// A scoped view excludes its root from its own rows, so anchoring the
+	// selection on the entered-from chat could never resolve there and would
+	// only arm the pending-anchor state for the whole catalog scan.
+	const seedSelection = initialSession && !options.initialScopeKey;
 	return {
-		...(initialSession
+		...(initialSession ? { backSession: initialSession } : {}),
+		...(seedSelection
 			? {
 					selectedRowIdentity: getSummaryIdentity(initialSession),
 					selectedSessionKey: getAgentsViewSelectionKey(initialSession),
-					backSession: initialSession,
 				}
 			: {}),
 		...(options.initialScopeKey
@@ -1272,9 +1276,9 @@ export class AgentsViewMode implements Component, Focusable {
 		this.persistentState.query = this.editor.getText();
 		this.armSavedSearchFetch();
 		this.rebuildRows();
-		// Typing must not claim the visible fallback row while the restored
-		// anchor is still waiting for its catalog row.
-		if (!this.selectionAnchorPending) this.syncSelectedRowState();
+		// Searching is explicit user intent: claim the visible row as the new
+		// anchor even if a remembered one is still waiting for its catalog row.
+		this.syncSelectedRowState();
 		this.ui.requestRender();
 	}
 
@@ -1371,10 +1375,6 @@ export class AgentsViewMode implements Component, Focusable {
 	private openSelected(): void {
 		const row = this.rows[this.selectedIndex];
 		if (!row?.selectable || this.isPendingDeleteRow(row)) {
-			return;
-		}
-		if (this.selectionAnchorPending) {
-			this.setStatusMessage("Waiting for the selected session to load");
 			return;
 		}
 		if (row.kind === "subagent-summary") {

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -105,6 +105,9 @@ describe("AgentsViewMode", () => {
 			editor: { getText: () => "matching query" },
 			persistentState: { query: "" },
 			savedSearchFetchStarted: true,
+			// Searching claims the visible row even while a remembered anchor is
+			// still waiting for its catalog row: user intent supersedes restore.
+			selectionAnchorPending: true,
 			selectedIndex: 4,
 			rebuildRows: vi.fn(),
 			syncSelectedRowState: vi.fn(),
@@ -119,6 +122,7 @@ describe("AgentsViewMode", () => {
 		expect(self.persistentState.query).toBe("matching query");
 		expect(self.rebuildRows).toHaveBeenCalledOnce();
 		expect(self.selectedIndex).toBe(4);
+		expect(self.syncSelectedRowState).toHaveBeenCalledOnce();
 	});
 
 	it("loads the saved catalog on view entry without a search query", () => {

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -1645,6 +1645,14 @@ describe("agents view state", () => {
 			});
 			const handoffFrame = persistentState.scopeFrames?.at(-1);
 
+			// The scope root is never a row of its own children view: seeding it as
+			// the selection anchor would only arm pending-anchor for the whole scan.
+			expect(persistentState.selectedRowIdentity).toBeUndefined();
+			expect(persistentState.selectedSessionKey).toBeUndefined();
+			expect(persistentState.backSession).toBe(chat);
+			const unscoped = createInitialAgentsViewPersistentState({ initialSession: chat });
+			expect(unscoped.selectedRowIdentity).toBeDefined();
+
 			expect(handoffFrame).toEqual({ scope: rootScope, returnChat: chat });
 			expect(createInitialAgentsViewScopeFrames(rootScope, persistentState.backSession)).toEqual([handoffFrame]);
 			expect(createInitialAgentsViewScopeFrames(rootScope, makeSummary({ sessionId: "stale-session" }))).toEqual([

--- a/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
+++ b/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
@@ -1,6 +1,7 @@
 import stripAnsi from "strip-ansi";
 import { describe, expect, test, vi } from "vitest";
 import { AgentsViewMode } from "../../../src/modes/agents-view/agents-view-mode.js";
+import { buildUnifiedSessionIndex } from "../../../src/modes/agents-view/agents-view-state.js";
 import type { SessionSummary } from "../../../src/modes/daemon/daemon-session-list.js";
 import { initTheme } from "../../../src/modes/interactive/theme/theme.js";
 import { createDeferred as deferred } from "../scheduling.js";
@@ -304,7 +305,7 @@ describe("#502 unified session view regressions", () => {
 		expect(harness.setStatusMessage).not.toHaveBeenCalled();
 	});
 
-	test("a missing selection anchor blocks open only until both catalogs settle", () => {
+	test("a pending selection anchor never blocks opening the visible row", () => {
 		const finish = vi.fn();
 		const fallback = summary("fallback");
 		const harness = {
@@ -314,21 +315,26 @@ describe("#502 unified session view regressions", () => {
 			selectedActiveSessionId: undefined as string | undefined,
 			selectedRowIdentity: "identity-intended",
 			rows: [{ selectable: true, kind: "agent", summary: fallback }],
+			unifiedRecords: [],
+			unifiedIndex: buildUnifiedSessionIndex([]),
 			isPendingDeleteRow: () => false,
 			setStatusMessage: vi.fn(),
 			finish,
 		};
 
+		// Enter acts on the row under the cursor even while the anchor waits.
 		privateMethod<(this: typeof harness) => void>("openSelected").call(harness);
-		expect(finish).not.toHaveBeenCalled();
+		expect(finish).toHaveBeenCalledWith(expect.objectContaining({ type: "open", summary: fallback }));
+		expect(harness.setStatusMessage).not.toHaveBeenCalled();
+
+		// Untouched, the anchor restore still waits for the saved catalog...
 		privateMethod<(this: typeof harness) => void>("resolveMissingSelectionAnchor").call(harness);
 		expect(harness.selectionAnchorPending).toBe(true);
 		harness.savedCatalogRefreshPending = false;
 		privateMethod<(this: typeof harness) => void>("resolveMissingSelectionAnchor").call(harness);
-		// Open unblocks on the visible fallback row...
 		expect(harness.selectionAnchorPending).toBe(false);
 		expect(harness.selectedActiveSessionId).toBe(fallback.activeSessionId ?? fallback.id);
-		// ...but the restored anchor identity survives so a late poll can still re-anchor.
+		// ...and the restored anchor identity survives so a late poll can still re-anchor.
 		expect(harness.selectedRowIdentity).toBe("identity-intended");
 	});
 	test("rename uses the captured row after refresh removes it", async () => {


### PR DESCRIPTION
Fixes RES-1314

## Purpose

Opening a row in the agents view could be blocked for 5-10s+ with "Waiting for the selected session to load" — very frequently in a subagents (scoped) view, almost never in the main view. User intent now supersedes selection-anchor restoration: what you see is what Enter opens.

## Root cause and asymmetry

`restoreSelection()` arms `selectionAnchorPending` whenever the remembered anchor (`selectedRowIdentity`/`selectedSessionKey`, incl. persisted state) cannot resolve against the current rows, and `openSelected()` blocked EVERY open while pending; the flag only cleared in `resolveMissingSelectionAnchor()` after the saved-catalog refresh settled.

Why the subagents view, specifically:
1. Entering a scoped view seeded the anchor with the entered-from chat — the scope ROOT — which is excluded from its own children view by design, so the anchor could NEVER resolve there; every scoped entry armed the wait for the full catalog scan.
2. Re-entering after opening a subagent anchors on that subagent, whose row lives only in the slow saved-catalog path (artifact-dir scan). Main-view anchors are usually daemon-resident rows that resolve instantly from the roster push, so the gate rarely armed there.

## Changes (blocking semantics only; saved-catalog latency is #2043/#2051's scope)

- `openSelected()`: the pending gate and its status message are deleted. The handler is synchronous from keypress to `finish()` and acts on the row captured at entry (`this.rows[this.selectedIndex]`), so there is no window in which rows can reshuffle under the open; the "temporary fallback" row is a real rendered summary and opening it opens exactly that session. No residual case needs the message.
- `queryChanged()`: searching now claims the visible row as the new anchor (unconditional `syncSelectedRowState`), instead of preserving a stale anchor that could later yank the selection mid-search. Arrow-key navigation already claimed the row (`moveSelection` → `syncSelectedRowState`), which clears the pending flag — traced, unchanged.
- `createInitialAgentsViewPersistentState()`: a scoped entry no longer seeds the scope root as the selection anchor (it keeps `backSession` for Escape). This removes the guaranteed-unresolvable anchor from every subagents-view entry.
- Untouched sessions keep the restore behavior: while the user does nothing, `restoreSelection` keeps trying the remembered anchor on each catalog update and still lands on it when its row streams in; `resolveMissingSelectionAnchor` still adopts the fallback only after the saved catalog settles.

## Tests (one pin per behavior, each proven fail-unfixed against the old code)

- 502 regression: Enter while the anchor is pending opens the visible row (was: pinned the blocking); same test still pins that the anchor identity survives for late re-anchoring and that fallback adoption waits for the catalog.
- Mode test: `queryChanged` claims the selection while the anchor is pending (extends the existing query test).
- State test: scoped entry seeds no selection anchor while unscoped entry still does (extends the existing scoped-navigation test); `backSession` retained.

## LOC

Total src: +13/-12 (net +1); tests: +18/-1; changelog fragment +1.

## Validation

- `npm run check` green (pre-commit hook); rebased onto v0.9.3 main (915c78f42).
- agents-view-state (76), agents-view-mode (32), 502 regressions (15) green; reverting the src hunks fails exactly the three new pins.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX/selection-restore behavior change in agents view only; no auth, data, or security paths touched.
> 
> **Overview**
> Fixes agents view **Enter** being blocked for seconds with *"Waiting for the selected session to load"* while a remembered selection was still resolving against the saved catalog—especially when opening a **scoped (subagents) view**.
> 
> **Opening:** `openSelected()` no longer gates on `selectionAnchorPending`; it always acts on the row under the cursor.
> 
> **Scoped entry:** `createInitialAgentsViewPersistentState()` stops seeding the scope root as the selection anchor (that row is excluded from its own children list, so the anchor could never resolve). `backSession` for Escape/back navigation is unchanged.
> 
> **Search:** `queryChanged()` always runs `syncSelectedRowState()` so typing a query adopts the visible row instead of holding a stale anchor.
> 
> Passive restore still re-anchors when the remembered row appears after catalog load; tests cover open-while-pending, search-while-pending, and scoped vs unscoped seeding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5b49266b5829a4ea8f46ad76b525e0e560ace03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AgentsViewMode.openSelected` to not block on pending selection anchor
> - Removes the guard in `AgentsViewMode.openSelected` that showed a waiting status and returned early when a remembered selection anchor was still pending; selectable rows now open immediately
> - Makes `AgentsViewMode.queryChanged` always sync selection to visible rows after a query change, instead of skipping sync while an anchor is pending
> - Changes `createInitialAgentsViewPersistentState` so scoped agents-view initialization no longer seeds the entered-from session as a selected-row anchor; the session remains available as `backSession` for scope navigation
> - Behavioral Change: Enter on a pending-anchor row now performs the row's normal open or toggle action instead of emitting a waiting message; query changes always resync selection to the visible row
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d5b4926.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->