### PR TITLE
fix(coding-agent): trim whitespace-only path env vars instead of treating them as valid paths

### DIFF
--- a/packages/coding-agent/.changes/1811-trim-env-paths.md
+++ b/packages/coding-agent/.changes/1811-trim-env-paths.md
@@ -1,0 +1,1 @@
+- Fixed whitespace-only package, agent, and session directory environment variables producing invalid relative paths instead of using configured fallbacks ([#1811](https://github.com/PrimeIntellect-ai/prime-agent/issues/1811)).

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -364,7 +364,7 @@ export function getUpdateInstruction(packageName: string): string {
  */
 export function getPackageDir(): string {
 	// Allow override via environment variable (useful for Nix/Guix where store paths tokenize poorly)
-	const envDir = process.env.PI_PACKAGE_DIR;
+	const envDir = getEnvPath("PI_PACKAGE_DIR");
 	if (envDir) {
 		if (envDir === "~") return homedir();
 		if (envDir.startsWith("~/")) return homedir() + envDir.slice(1);
@@ -509,6 +509,11 @@ export function expandTildePath(path: string): string {
 	return path;
 }
 
+function getEnvPath(name: string): string | undefined {
+	const value = process.env[name]?.trim();
+	return value || undefined;
+}
+
 const DEFAULT_SHARE_VIEWER_URL = "https://pi.dev/session/";
 
 /** Get the share viewer URL for a gist ID */
@@ -523,7 +528,7 @@ export function getShareViewerUrl(gistId: string): string {
 
 /** Get the agent config directory (e.g., ~/.prime/agent/) */
 export function getAgentDir(): string {
-	const envDir = process.env[ENV_AGENT_DIR];
+	const envDir = getEnvPath(ENV_AGENT_DIR);
 	if (envDir) {
 		return expandTildePath(envDir);
 	}
@@ -626,7 +631,7 @@ export function getSessionsDir(agentDir: string = getAgentDir()): string {
 }
 
 export function getSessionDirEnvOverride(): string | undefined {
-	const envDir = process.env[ENV_SESSION_DIR] ?? process.env[ENV_LEGACY_SESSION_DIR];
+	const envDir = getEnvPath(ENV_SESSION_DIR) ?? getEnvPath(ENV_LEGACY_SESSION_DIR);
 	return envDir ? expandTildePath(envDir) : undefined;
 }
 

--- a/packages/coding-agent/test/config.test.ts
+++ b/packages/coding-agent/test/config.test.ts
@@ -3,10 +3,14 @@ import { homedir, tmpdir } from "os";
 import { delimiter, join } from "path";
 import { afterEach, describe, expect, test } from "vitest";
 import {
+	CONFIG_DIR_NAME,
 	detectInstallMethod,
+	ENV_AGENT_DIR,
 	ENV_LEGACY_SESSION_DIR,
 	ENV_SESSION_DIR,
+	getAgentDir,
 	getDaemonLogPath,
+	getPackageDir,
 	getSelfUpdateCommand,
 	getSelfUpdateUnavailableInstruction,
 	getSessionsDir,
@@ -17,6 +21,7 @@ import { getDefaultSessionDir } from "../src/core/session-manager.js";
 const execPathDescriptor = Object.getOwnPropertyDescriptor(process, "execPath");
 const originalPath = process.env.PATH;
 const originalPiPackageDir = process.env.PI_PACKAGE_DIR;
+const originalAgentDir = process.env[ENV_AGENT_DIR];
 const originalSessionDir = process.env[ENV_SESSION_DIR];
 const originalLegacySessionDir = process.env[ENV_LEGACY_SESSION_DIR];
 let tempDir: string | undefined;
@@ -41,6 +46,11 @@ afterEach(() => {
 		delete process.env.PI_PACKAGE_DIR;
 	} else {
 		process.env.PI_PACKAGE_DIR = originalPiPackageDir;
+	}
+	if (originalAgentDir === undefined) {
+		delete process.env[ENV_AGENT_DIR];
+	} else {
+		process.env[ENV_AGENT_DIR] = originalAgentDir;
 	}
 	if (originalSessionDir === undefined) {
 		delete process.env[ENV_SESSION_DIR];
@@ -445,6 +455,43 @@ describe("session paths", () => {
 		const sessionDir = getDefaultSessionDir(cwd, join(tempDir, "agent"));
 
 		expect(sessionDir).toBe(sessionRoot);
+	});
+});
+
+describe("env path trimming", () => {
+	test("getAgentDir ignores whitespace-only env var and falls back to default", () => {
+		process.env[ENV_AGENT_DIR] = "   ";
+		expect(getAgentDir()).toBe(join(homedir(), CONFIG_DIR_NAME));
+	});
+
+	test("getAgentDir trims surrounding whitespace from a valid override", () => {
+		const dir = join(tmpdir(), `pi-agent-dir-${Date.now()}`);
+		process.env[ENV_AGENT_DIR] = `  ${dir}  `;
+		expect(getAgentDir()).toBe(dir);
+	});
+
+	test("getSessionsDir ignores whitespace-only session env var", () => {
+		delete process.env[ENV_LEGACY_SESSION_DIR];
+		process.env[ENV_SESSION_DIR] = "   ";
+		expect(getSessionsDir("/agent")).toBe(join("/agent", "sessions"));
+	});
+
+	test("getSessionsDir falls back to legacy env var when primary is whitespace-only", () => {
+		const legacy = join(tmpdir(), `pi-legacy-${Date.now()}`);
+		process.env[ENV_SESSION_DIR] = "   ";
+		process.env[ENV_LEGACY_SESSION_DIR] = legacy;
+		expect(getSessionsDir("/agent")).toBe(legacy);
+	});
+
+	test("getPackageDir ignores whitespace-only env var and trims valid overrides", () => {
+		delete process.env.PI_PACKAGE_DIR;
+		const expected = getPackageDir();
+		process.env.PI_PACKAGE_DIR = "   ";
+		expect(getPackageDir()).toBe(expected);
+		const temp = mkdtempSync(join(tmpdir(), "pi-pkg-"));
+		tempDir = temp;
+		process.env.PI_PACKAGE_DIR = `  ${temp}  `;
+		expect(getPackageDir()).toBe(temp);
 	});
 });
 


### PR DESCRIPTION
## Summary

- Whitespace-only values in `PRIME_AGENT_CODING_AGENT_DIR`, `PRIME_AGENT_SESSION_DIR` (and its legacy alias `PRIME_AGENT_CODING_AGENT_SESSION_DIR`), and `PI_PACKAGE_DIR` were truthy and produced invalid relative paths (e.g. `"   "`) instead of falling back to configured defaults. This bites Docker/container setups where env vars may be set to empty or whitespace.
- Adds a small `getEnvPath(name)` helper in `packages/coding-agent/src/config.ts` that trims the value and treats empty/whitespace-only as unset, then uses it at the three affected call sites (`getPackageDir`, `getAgentDir`, `getSessionDirEnvOverride`).
- Normal (non-whitespace) path values are unchanged. The only behavioral change beyond the whitespace fix: when the modern `PRIME_AGENT_SESSION_DIR` is blank/whitespace-only and the legacy `PRIME_AGENT_CODING_AGENT_SESSION_DIR` is set, the legacy var is now used as the fallback (previously the blank primary short-circuited the `??` and the legacy var was ignored). This is the correct behavior per the issue.

fixes #1811

## Test plan

- [x] Added 5 focused regression tests in `packages/coding-agent/test/config.test.ts` covering: whitespace-only fallback for `getAgentDir`/`getSessionsDir`/`getPackageDir`, trimming of valid overrides, and legacy-var fallback when the primary session var is whitespace-only.
- [x] `npx tsx ../../node_modules/vitest/dist/cli.js --run test/config.test.ts` — 27/27 passed (22 existing + 5 new).
- [x] Related path-sensitive suites pass: `package-command-paths.test.ts`, `package-self-update-daemon.test.ts` (69/69 combined).
- [x] `npm run check` passes (biome, tsgo typecheck, installer check, browser-smoke).
- [x] Pre-commit hook re-ran `npm run check` on commit — passed.

Generated with [Devin](https://devin.ai)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trim whitespace-only path env vars in `coding-agent` config resolvers
> - Adds `getEnvPath` helper that trims env var values and returns `undefined` for absent or whitespace-only values
> - Applies the helper to `getPackageDir`, `getAgentDir`, and `getSessionDirEnvOverride` so whitespace-only overrides fall back to configured defaults instead of producing invalid relative paths
> - `getSessionDirEnvOverride` can now select a valid legacy session override when the primary value is whitespace-only
> - Behavioral Change: env vars like `PI_PACKAGE_DIR`, the agent-directory variable, and session-directory variables that previously contained only whitespace now resolve to fallback defaults rather than being used as-is
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7463f78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->