### PR TITLE
fix(ai): detect LiteLLM context-overflow errors

### DIFF
--- a/packages/ai/.changes/fix-litellm-overflow-detection.md
+++ b/packages/ai/.changes/fix-litellm-overflow-detection.md
@@ -1,0 +1,1 @@
+- Fixed context-overflow recovery not triggering behind LiteLLM proxies, which report "Requested token count exceeds the model's maximum context length" instead of a recognized overflow error.

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -27,6 +27,7 @@ import type { AssistantMessage } from "../types.js";
  *   with output=0 (no room left to generate). Detected via stopReason "length" + zero output +
  *   input filling the context window.
  * - Ollama: Some deployments truncate silently, others return errors like "prompt too long; exceeded max context length by X tokens"
+ * - LiteLLM (proxy/gateway in front of vLLM, OpenAI, etc.): "Requested token count exceeds the model's maximum context length of X tokens. You requested a total of Y tokens: Z tokens from the input messages and W tokens for the completion."
  */
 const OVERFLOW_PATTERNS = [
 	/prompt is too long/i, // Anthropic token overflow
@@ -45,6 +46,7 @@ const OVERFLOW_PATTERNS = [
 	/too large for model with \d+ maximum context length/i, // Mistral
 	/model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
 	/prompt too long; exceeded (?:max )?context length/i, // Ollama explicit overflow error
+	/requested token count exceeds/i, // LiteLLM proxy (vLLM/OpenAI backends): "Requested token count exceeds the model's maximum context length of X tokens"
 	/context[_ ]length[_ ]exceeded/i, // Generic fallback
 	/too many tokens/i, // Generic fallback
 	/token limit exceeded/i, // Generic fallback

--- a/packages/ai/test/overflow.test.ts
+++ b/packages/ai/test/overflow.test.ts
@@ -35,6 +35,13 @@ describe("isContextOverflow", () => {
 		expect(isContextOverflow(message, 32768)).toBe(true);
 	});
 
+	it("detects LiteLLM proxy token-count errors", () => {
+		const message = createErrorMessage(
+			"400 litellm.BadRequestError: OpenAIException - Requested token count exceeds the model's maximum context length of 262144 tokens. You requested a total of 270128 tokens: 261936 tokens from the input messages and 8192 tokens for the completion. Please reduce the number of tokens in the input messages or the completion to fit within the limit.. Received Model Group=qwen3.8-27b-nvfp4",
+		);
+		expect(isContextOverflow(message, 262144)).toBe(true);
+	});
+
 	it("does not treat generic non-overflow Ollama errors as overflow", () => {
 		const message = createErrorMessage("500 `model runner crashed unexpectedly`");
 		expect(isContextOverflow(message, 32768)).toBe(false);


### PR DESCRIPTION
## Problem

Servers fronted by a LiteLLM proxy (vLLM, OpenAI-compatible gateways) reject an over-limit request with:

```
400 litellm.BadRequestError: OpenAIException - Requested token count exceeds the model's maximum context length of 262144 tokens. You requested a total of 270128 tokens: 261936 tokens from the input messages and 8192 tokens for the completion.
```

No regex in `OVERFLOW_PATTERNS` (`packages/ai/src/utils/overflow.ts`) matches this wording, so `isContextOverflow()` returns false. Two failure modes follow:

1. `_isRetryableError()` classifies the 400 as retryable, so the same over-limit request is re-sent.
2. Overflow recovery in `AgentSession._checkCompaction` (Case 1) never runs, so no auto-compaction + retry happens and the session hard-fails at the context limit instead of compacting and continuing.

This is easy to hit in practice: threshold compaction only runs at turn boundaries, so a single turn whose tool outputs grow the context past the hard limit produces exactly this unrecoverable error.

## Change

- Add `/requested token count exceeds/i` to `OVERFLOW_PATTERNS`, covering the LiteLLM message for its vLLM/OpenAI backends. The patterns are only evaluated for `stopReason: "error"` messages, so there is no false-positive risk on success paths.
- Regression test in `packages/ai/test/overflow.test.ts` using the real error text from a LiteLLM-fronted vLLM server.

Verified locally against a LiteLLM-fronted vLLM instance (`qwen3.8-27b-nvfp4`, 256K context): before the patch the session died with the raw 400 retry loop; after the patch the overflow is recognized and recovery compaction triggers.

## Notes

- Changelog fragment included: `packages/ai/.changes/fix-litellm-overflow-detection.md`
- Labels: `pkg:ai`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add LiteLLM context-overflow detection to `isContextOverflow`
> Extends context-overflow detection in [overflow.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2086/files#diff-30f350598d8206d5cab80b09f21240a7cdb6b646e81506389f7884f7d0013680) to recognize LiteLLM proxy 400 errors. Adds a case-insensitive pattern matching "requested token count exceeds" to the existing checks. Includes a regression test for the LiteLLM error format in [overflow.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2086/files#diff-272681e52108eeedd8e703d382ed7ebef05ebd883e7328f2402c8eb5da361c20).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8bac4b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->