### PR TITLE
Simplify the agents view

### DIFF
--- a/packages/coding-agent/.changes/compact-agents-view.md
+++ b/packages/coding-agent/.changes/compact-agents-view.md
@@ -1,0 +1,1 @@
+- Simplified the agents view with per-session models, total cost and age, one column header, and collapsed inactive sessions while keeping the logo, startup metadata, and search.

--- a/packages/coding-agent/.changes/compact-agents-view.md
+++ b/packages/coding-agent/.changes/compact-agents-view.md
@@ -1,1 +1,2 @@
 - Simplified the agents view with per-session models, total cost and age, one column header, and collapsed inactive sessions while keeping the logo, startup metadata, and search.
+- Kept a running-subagent count beneath collapsed agents while their subagents are working.

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -48,6 +48,8 @@ export interface AppKeybindings {
 	"app.agents.delete": true;
 	"app.agents.program": true;
 	"app.agents.rename": true;
+	"app.agents.inactiveCollapse": true;
+	"app.agents.expand": true;
 	"app.tree.foldOrUp": true;
 	"app.tree.unfoldOrDown": true;
 	"app.tree.editLabel": true;
@@ -159,6 +161,8 @@ export const KEYBINDINGS = {
 	"app.agents.delete": { defaultKeys: "ctrl+x", description: "Stop or delete selected agent" },
 	"app.agents.program": { defaultKeys: "ctrl+o", description: "Show the program that spawned subagents" },
 	"app.agents.rename": { defaultKeys: "ctrl+r", description: "Rename selected agent session" },
+	"app.agents.inactiveCollapse": { defaultKeys: "alt+i", description: "Show or hide inactive sessions" },
+	"app.agents.expand": { defaultKeys: "alt+right", description: "Expand or collapse selected agent subagents" },
 	"app.tree.foldOrUp": {
 		defaultKeys: ["ctrl+left", "alt+left"],
 		description: "Fold tree branch or move up",

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -44,7 +44,6 @@ import {
 	listDaemonSavedSessions,
 	renameDaemonSavedSession,
 } from "../daemon/saved-session-catalog.js";
-import { formatTokenCount } from "../interactive/agent-activity.js";
 import { CustomEditor } from "../interactive/components/custom-editor.js";
 import { keyText } from "../interactive/components/keybinding-hints.js";
 import { BrandSplashHeader, InteractiveMode } from "../interactive/interactive-mode.js";
@@ -83,8 +82,6 @@ import {
 	getAgentsViewSummaryIdentity as getSummaryIdentity,
 	getUnifiedSessionAncestorSessionIds,
 	hasUnifiedSessionChildren,
-	isEmptyAgentsViewSession,
-	isSubagentSummary,
 	migrateAgentsViewIdentitySet,
 	reconcileUnifiedSessions,
 	resolveAgentsViewLeftResult,
@@ -162,6 +159,7 @@ export type AgentsViewPersistentState = {
 	pendingExpandedAncestorSessionIds?: string[];
 	expandedSubagentParents?: Set<string>;
 	programShownParents?: Set<string>;
+	inactiveExpanded?: boolean;
 	statusMessage?: string;
 	// Gathered once and reused across agents-view instances so the notices survive
 	// re-entry and render the moment they resolve, even if the first view was left early.
@@ -659,6 +657,8 @@ export class AgentsViewMode implements Component, Focusable {
 	private deleteConfirmTimer: ReturnType<typeof setTimeout> | undefined;
 	private workingIconFrame = 0;
 	private rows: AgentsViewRow[] = [];
+	private allRows: AgentsViewRow[] = [];
+	private showActions = false;
 	private lastListedSummaries: SessionSummary[] = [];
 	private lastVisibleSummaries: SessionSummary[] = [];
 	private savedSessions: AgentConnectionSavedSessionInfo[] = [];
@@ -914,6 +914,12 @@ export class AgentsViewMode implements Component, Focusable {
 
 	handleInput(data: string): void {
 		this.clearStickyStatusMessage();
+		if (this.showActions) {
+			this.showActions = false;
+			this.ui.requestRender();
+			if (this.keybindings.matches(data, "app.shortcuts") || this.keybindings.matches(data, "tui.select.cancel"))
+				return;
+		}
 		if (this.renameTarget) {
 			if (this.keybindings.matches(data, "tui.select.cancel")) {
 				this.exitRenameMode();
@@ -957,6 +963,25 @@ export class AgentsViewMode implements Component, Focusable {
 		if (this.editor.getText().length === 0 && this.keybindings.matches(data, "app.agents.program")) {
 			this.cycleProgramForSelected();
 			return;
+		}
+		if (!this.replyTarget && this.editor.getText().length === 0) {
+			if (this.keybindings.matches(data, "app.shortcuts")) {
+				this.showActions = !this.showActions;
+				this.ui.requestRender();
+				return;
+			}
+			if (this.keybindings.matches(data, "app.agents.inactiveCollapse")) {
+				this.persistentState.inactiveExpanded = !this.persistentState.inactiveExpanded;
+				this.rebuildRows();
+				this.syncSelectedRowState();
+				this.ui.requestRender();
+				return;
+			}
+			if (this.keybindings.matches(data, "app.agents.expand")) {
+				const row = this.rows[this.selectedIndex];
+				if (row && row.descendantCount > 0) this.toggleSubagentList(row);
+				return;
+			}
 		}
 		if (!this.replyTarget && this.keybindings.matches(data, "app.agents.open")) {
 			if (this.editor.getText().length === 0 || this.isSearchCursorAtEnd()) {
@@ -1286,13 +1311,19 @@ export class AgentsViewMode implements Component, Focusable {
 	/** Rebuild rows from the last fetched summaries, keeping selection on the same row. */
 	private rebuildRows(): void {
 		const selectedIdentity = this.rows[this.selectedIndex]?.identity;
-		this.rows = buildAgentsViewRows(
+		this.allRows = buildAgentsViewRows(
 			this.getFilteredRecords(),
 			this.expandedSubagentParents,
 			this.programShownParents,
 			this.scopeKey,
 			computeRecursiveRollups(this.unifiedRecords, this.unifiedIndex),
 			this.anchorSessionId,
+		);
+		this.rows = compactSessionRows(
+			this.allRows,
+			this.persistentState.inactiveExpanded === true ||
+				((this.replyTarget || this.renameTarget ? this.actionModeSearchQuery : this.editor.getText()) ?? "").trim()
+					.length > 0,
 		);
 		const index =
 			selectedIdentity === undefined ? -1 : this.rows.findIndex((row) => row.identity === selectedIdentity);
@@ -1377,10 +1408,6 @@ export class AgentsViewMode implements Component, Focusable {
 			this.setStatusMessage("Waiting for the selected session to load");
 			return;
 		}
-		if (row.kind === "subagent-summary") {
-			this.toggleSubagentList(row);
-			return;
-		}
 		if (row.kind === "subagent") {
 			this.openSelectedSubagent(row);
 			return;
@@ -1401,16 +1428,12 @@ export class AgentsViewMode implements Component, Focusable {
 	}
 
 	private toggleSubagentList(row: AgentsViewRow): void {
-		if (!row.parentIdentity) {
-			return;
-		}
-		if (this.expandedSubagentParents.has(row.parentIdentity)) {
-			this.expandedSubagentParents.delete(row.parentIdentity);
-			// A collapsed agent's revealed program collapses with it, so reopening
-			// starts from the hidden state rather than a stale reveal.
-			this.programShownParents.delete(row.parentIdentity);
+		const target = row.identity;
+		if (this.expandedSubagentParents.has(target)) {
+			this.expandedSubagentParents.delete(target);
+			this.programShownParents.delete(target);
 		} else {
-			this.expandedSubagentParents.add(row.parentIdentity);
+			this.expandedSubagentParents.add(target);
 		}
 		this.rebuildRows();
 		this.syncSelectedRowState();
@@ -1449,7 +1472,7 @@ export class AgentsViewMode implements Component, Focusable {
 
 	/** Whether any subagent under the given agent identity carries spawn code. */
 	private targetHasSpawnCode(target: string): boolean {
-		for (const row of this.rows) {
+		for (const row of this.allRows) {
 			if (row.parentIdentity !== target) {
 				continue;
 			}
@@ -1461,16 +1484,6 @@ export class AgentsViewMode implements Component, Focusable {
 			}
 		}
 		return false;
-	}
-
-	/** True when the selected row exposes the "show program" affordance. */
-	private selectedRowCanShowProgram(): boolean {
-		const row = this.rows[this.selectedIndex];
-		if (!row) {
-			return false;
-		}
-		const target = row.kind === "agent" ? row.identity : row.parentIdentity;
-		return target !== undefined && this.targetHasSpawnCode(target);
 	}
 
 	private openSelectedSubagent(row: AgentsViewRow): void {
@@ -2174,13 +2187,19 @@ export class AgentsViewMode implements Component, Focusable {
 			}
 		}
 		this.scopedRecords = scopeToSessionSubtree(this.unifiedRecords, this.scopeKey, this.unifiedIndex);
-		this.rows = buildAgentsViewRows(
+		this.allRows = buildAgentsViewRows(
 			this.getFilteredRecords(),
 			this.expandedSubagentParents,
 			this.programShownParents,
 			this.scopeKey,
 			computeRecursiveRollups(this.unifiedRecords, this.unifiedIndex),
 			this.anchorSessionId,
+		);
+		this.rows = compactSessionRows(
+			this.allRows,
+			this.persistentState.inactiveExpanded === true ||
+				((this.replyTarget || this.renameTarget ? this.actionModeSearchQuery : this.editor.getText()) ?? "").trim()
+					.length > 0,
 		);
 		this.applyPendingAncestorExpansion();
 		this.restoreSelection();
@@ -2474,151 +2493,121 @@ export class AgentsViewMode implements Component, Focusable {
 	}
 
 	private getAgentCountsText(): string {
-		const counts = countRowsBySection(this.rows);
+		const counts = countRowsBySection(this.allRows);
 		return `${counts.running} running, ${counts.idle} idle, ${counts.inactive} inactive`;
 	}
 
 	private renderSessionRows(width: number, maxRows: number): string[] {
-		if (maxRows <= 0) {
-			return [];
+		if (maxRows <= 0) return [];
+		if (this.showActions) return this.renderActions(width).slice(0, maxRows);
+		const layout = buildCompactAgentsViewLayout(this.rows, width);
+		const displayItems: DisplayItem[] = [];
+		const counts = countRowsBySection(this.allRows.length > 0 ? this.allRows : this.rows);
+		for (const section of ["running", "idle", "inactive"] as const) {
+			if (counts[section] === 0) continue;
+			if (displayItems.length > 0) displayItems.push({ type: "spacer" });
+			displayItems.push({ type: "heading", section });
+			for (const row of getDisplayRowsForSection(this.rows, section)) {
+				displayItems.push({ type: "row", row });
+			}
 		}
-		if (this.rows.length === 0) {
-			const emptyLegend = buildAgentsViewUsageLayout([]).legends.get("running") ?? "";
-			return [
-				this.renderSectionHeading("running", width, emptyLegend),
-				theme.fg("dim", "  No sessions match your search."),
-			].slice(0, maxRows);
+		if (displayItems.length === 0) {
+			return [theme.fg("dim", "No sessions match your search.")];
 		}
-
-		const displayItems = buildDisplayItems(this.rows);
-		const usageLayout = buildAgentsViewUsageLayout(this.rows);
+		// Reserve the shared column header before calculating the selection viewport.
+		const headerRows = maxRows > 1 ? 1 : 0;
+		const visibleRows = maxRows - headerRows;
 		const selectedIdentity = this.rows[this.selectedIndex]?.identity;
 		const selectedDisplayIndex = displayItems.findIndex(
 			(item) => item.type === "row" && item.row.identity === selectedIdentity,
 		);
-		const visibleRows = Math.min(maxRows, this.visibleListRows());
 		const start = Math.max(
 			0,
 			Math.min(displayItems.length - visibleRows, selectedDisplayIndex - Math.floor(visibleRows / 2)),
 		);
-		const showLeadingEllipsis = start > 0;
-		let showTrailingEllipsis = start + visibleRows < displayItems.length;
-		if ((showLeadingEllipsis ? 1 : 0) + (showTrailingEllipsis ? 1 : 0) >= visibleRows) {
-			showTrailingEllipsis = false;
-		}
-		const contentVisibleRows = Math.max(
-			0,
-			visibleRows - (showLeadingEllipsis ? 1 : 0) - (showTrailingEllipsis ? 1 : 0),
-		);
-		// The prepended ellipsis consumes a viewport line; shift the window down
-		// so a selection at the very end is not pushed out of the slice.
-		const sliceStart =
-			selectedDisplayIndex >= start + contentVisibleRows ? selectedDisplayIndex - contentVisibleRows + 1 : start;
-		const visibleItems = displayItems.slice(sliceStart, sliceStart + contentVisibleRows);
-		const lines = visibleItems.map((item) => {
-			if (item.type === "spacer") {
-				return "";
-			}
+		const showLeadingEllipsis = start > 0 && visibleRows > 1;
+		const showTrailingEllipsis = start + visibleRows < displayItems.length && visibleRows > 2;
+		const contentRows = visibleRows - Number(showLeadingEllipsis) - Number(showTrailingEllipsis);
+		const sliceStart = selectedDisplayIndex >= start + contentRows ? selectedDisplayIndex - contentRows + 1 : start;
+		const lines = displayItems.slice(sliceStart, sliceStart + contentRows).map((item) => {
+			if (item.type === "spacer") return "";
 			if (item.type === "heading") {
-				return this.renderSectionHeading(item.section, width, usageLayout.legends.get(item.section) ?? "");
+				const collapsed =
+					item.section === "inactive" && !this.rows.some((row) => row.depth === 0 && row.section === "inactive");
+				const prefix = item.section === "inactive" ? `${collapsed ? "▸" : "▾"} ` : "";
+				const hint = item.section === "inactive" ? ` · ${keyText("app.agents.inactiveCollapse")}` : "";
+				return theme.bold(
+					truncateToWidth(`${prefix}${sectionTitle(item.section)} (${counts[item.section]})${hint}`, width),
+				);
 			}
-			if (item.type === "empty") {
-				return theme.fg("dim", "  No agents");
-			}
-			return this.renderRow(item.row, width, usageLayout.details);
+			return this.renderRow(item.row, width, layout);
 		});
-		if (showLeadingEllipsis) {
-			lines.unshift(theme.fg("dim", "  ..."));
-		}
-		if (showTrailingEllipsis) {
-			lines.push(theme.fg("dim", "  ..."));
-		}
+		if (showLeadingEllipsis) lines.unshift(theme.fg("dim", "  ..."));
+		if (showTrailingEllipsis) lines.push(theme.fg("dim", "  ..."));
+		if (headerRows > 0) lines.unshift(theme.fg("muted", layout.legend));
 		return lines;
 	}
 
 	private renderRow(
 		row: AgentsViewRow,
 		width: number,
-		rowDetails: ReadonlyMap<string, string> = buildAgentsViewUsageLayout([row]).details,
+		layout: AgentsViewUsageLayout = buildCompactAgentsViewLayout(this.rows.length > 0 ? this.rows : [row], width),
 	): string {
 		const selected = row.selectable && row.identity === this.rows[this.selectedIndex]?.identity;
 		const markRow = (line: string): string => (selected ? `${SELECTED_ROW_MARKER}${line}` : line);
-		if (row.kind === "subagent-code") {
-			return this.renderCodeRow(row);
-		}
-		if (row.kind === "subagent-summary") {
-			const indent = "  ".repeat(row.depth);
-			const hint = row.hasSpawnCode ? theme.fg("dim", ` · ${keyText("app.agents.program")} show program`) : "";
-			const titleColor = row.runningSubagentCount > 0 ? ("success" as const) : ("dim" as const);
-			const label = `${theme.fg(titleColor, `${row.expanded ? "▾" : "▸"} ${row.title}`)}${hint}`;
-			const line = padLine(truncateToWidth(`${indent}${label}`, width, ""), width);
-			return markRow(line);
-		}
+		if (row.kind === "subagent-code") return this.renderCodeRow(row);
 		const pendingDelete = row.kind === "agent" && this.isPendingDeleteRow(row);
 		const pendingKill = row.kind === "subagent" && this.isPendingKillSubagentRow(row);
-		const rawIcon = this.getRowIcon(row.section);
-		const icon = this.formatRowIcon(row.section, rawIcon);
-		const indent = "  ".repeat(row.depth);
-		const details = rowDetails.get(row.identity) ?? "";
-		const detailsWidth = Math.max(10, visibleWidth(details));
-		const heartbeatBadge = !pendingDelete && !pendingKill ? formatHeartbeatBadge(row.heartbeat) : "";
-		const heartbeatPausedOnly = (row.heartbeat?.activeCount ?? 0) < 1;
-		const heartbeatCell = heartbeatBadge ? theme.fg(heartbeatPausedOnly ? "dim" : "error", heartbeatBadge) : "";
-		const heartbeatWidth = visibleWidth(heartbeatBadge);
-		const titleWidth = Math.max(
-			0,
-			width -
-				visibleWidth(indent) -
-				visibleWidth(rawIcon) -
-				detailsWidth -
-				2 -
-				(heartbeatWidth > 0 ? heartbeatWidth + 1 : 0),
-		);
-		const armedHeartbeat = row.summary.hasActiveHeartbeat === true || (row.heartbeat?.activeCount ?? 0) > 0;
-		const heartbeatWarning = armedHeartbeat ? "has an armed heartbeat — " : "";
-		const title = pendingDelete
-			? `${heartbeatWarning}${this.getPendingDeleteTitle()}`
-			: pendingKill
-				? `${heartbeatWarning}${keyText("app.agents.delete")} again to ${hasLiveWork(row) ? "stop" : "delete"}`
-				: styleRowTitle(row);
-		// Keep stable model information ahead of the variable summary so narrow rows truncate the summary first.
-		const summaryText = !pendingDelete && !pendingKill ? row.summary.summary : undefined;
-		const modelLabel =
-			isSubagentSummary(row.summary) && !pendingDelete && !pendingKill && row.summary.model
-				? `${row.summary.model.provider}/${row.summary.model.id}${row.summary.thinkingLevel && row.summary.thinkingLevel !== "off" ? `:${row.summary.thinkingLevel}` : ""}`
-				: undefined;
-		const statusLabel =
-			!pendingDelete &&
-			!pendingKill &&
-			(row.summary.statusLabel !== undefined || row.summary.lastHeardFromAt !== undefined)
+		const details = layout.details.get(row.identity) ?? "";
+		if (pendingDelete || pendingKill) {
+			const armed = row.summary.hasActiveHeartbeat === true || (row.heartbeat?.activeCount ?? 0) > 0;
+			const title =
+				(armed ? "has an armed heartbeat — " : "") +
+				(pendingDelete
+					? this.getPendingDeleteTitle()
+					: `${keyText("app.agents.delete")} again to ${hasLiveWork(row) ? "stop" : "delete"}`);
+			return markRow(formatTableCell(theme.fg("error", title), width));
+		}
+		const icon = this.formatRowIcon(row.section, this.getRowIcon(row.section));
+		const expand = row.descendantCount > 0 ? (this.expandedSubagentParents.has(row.identity) ? "▾" : "▸") : " ";
+		const badge = formatHeartbeatBadge(row.heartbeat);
+		const heartbeat = badge ? `${theme.fg((row.heartbeat?.activeCount ?? 0) > 0 ? "error" : "dim", badge)} ` : "";
+		const title = `${"  ".repeat(row.depth)}${icon}${expand} ${heartbeat}${styleRowTitle(row)}`;
+		const status =
+			row.summary.statusLabel !== undefined || row.summary.lastHeardFromAt !== undefined
 				? row.statusLabel
 				: undefined;
-		const suffixes = [statusLabel, modelLabel, summaryText].filter(
-			(suffix): suffix is string => suffix !== undefined && suffix.length > 0,
-		);
-		const titleContent = suffixes.length > 0 ? `${title} ${theme.fg("dim", `· ${suffixes.join(" · ")}`)}` : title;
-		const titleCell = formatTableCell(titleContent, titleWidth);
+		const activity = [status, row.summary.summary].filter(Boolean).join(" · ");
 		const cells = [
-			icon,
-			pendingDelete || pendingKill ? theme.fg("error", titleCell) : titleCell,
-			formatRightTableCell(details, detailsWidth),
+			formatTableCell(title, layout.nameWidth),
+			formatTableCell(theme.fg("muted", row.summary.model?.id ?? "-"), layout.modelWidth),
 		];
-		const base = `${indent}${cells[0]} ${heartbeatCell ? `${heartbeatCell} ` : ""}${cells[1]} ${cells[2]}`;
-		const line = padLine(truncateToWidth(base, width, ""), width);
-		return markRow(line);
+		if (layout.activityWidth > 0) cells.push(formatTableCell(theme.fg("dim", activity), layout.activityWidth));
+		cells.push(details);
+		return markRow(formatTableCell(cells.join("  "), width));
 	}
 
-	// Bold like the section title so the legend reads as part of the header line.
-	// The legend is right-aligned to the same edge as the row details cells, so
-	// its columns sit exactly above the row columns.
-	private renderSectionHeading(section: AgentsViewSection, width: number, legend: string): string {
-		const counts = countRowsBySection(this.rows);
-		const title = `${sectionTitle(section)} (${counts[section]})`;
-		const gap = width - visibleWidth(title) - visibleWidth(legend);
-		if (legend.length === 0 || gap < 2) {
-			return theme.bold(truncateToWidth(title, width, ""));
+	private renderActions(width: number): string[] {
+		const row = this.rows[this.selectedIndex];
+		const actions = [
+			`${keyText("tui.select.confirm")} open   ${keyText("app.agents.open")} open   ${keyText("app.agents.new")} new`,
+			`${keyText("app.agents.expand")} expand/collapse subagents   ${keyText("app.agents.program")} program`,
+			`${keyText("app.agents.inactiveCollapse")} show/hide inactive   ${keyText("app.shortcuts")} close actions`,
+			`${keyText("app.agents.reply")} reply/resume   ${keyText("app.agents.rename")} rename   ${keyText("app.agents.delete")} stop/delete`,
+		];
+		if (row) {
+			const model = row.summary.model;
+			const usage = row.summary.usage;
+			actions.push(
+				"",
+				row.title,
+				`Model: ${model ? `${model.provider}/${model.id}` : "unknown"}${row.summary.thinkingLevel ? ` · ${row.summary.thinkingLevel}` : ""}`,
+				`Directory: ${row.summary.cwd}`,
+				`Tokens: ${usage?.inputTokens ?? 0} in · ${usage?.outputTokens ?? 0} out`,
+				`Cost: $${(usage?.cost ?? 0).toFixed(2)} session · $${row.recursiveCost.toFixed(2)} including subagents`,
+			);
 		}
-		return `${theme.bold(title)}${" ".repeat(gap)}${theme.bold(legend)}`;
+		return actions.flatMap((line) => wrapTextWithAnsi(theme.fg("muted", line), width));
 	}
 
 	// Spawn-code rows are read-only context. They render deemphasized — muted
@@ -2700,32 +2689,7 @@ export class AgentsViewMode implements Component, Focusable {
 		if (this.replyTarget) {
 			return truncateToWidth(theme.fg("muted", this.renderReplyComposerHints()), width);
 		}
-		// Replying is reserved for top-level agents; subagents can be stopped or deleted.
-		const selectedRow = this.rows[this.selectedIndex];
-		const selectedAgent = selectedRow?.kind === "agent";
-		const selectedSubagent = selectedRow?.kind === "subagent";
-		const selectedSummary = selectedRow?.kind === "subagent-summary";
-		const hints = [
-			`${keyText("tui.select.up")}/${keyText("tui.select.down")} move`,
-			selectedSummary
-				? `${keyText("tui.select.confirm")} ${selectedRow?.expanded ? "collapse" : "expand"}`
-				: `${keyText("tui.select.confirm")} open`,
-			selectedSummary ? undefined : `${keyText("app.agents.open")} open`,
-			selectedAgent
-				? `${keyText("app.agents.reply")} ${selectedRow?.section === "inactive" ? "resume" : "reply"}`
-				: undefined,
-			`${keyText("app.agents.new")} new`,
-			selectedAgent ? `${keyText("app.agents.rename")} rename` : undefined,
-			selectedAgent
-				? `${keyText("app.agents.delete")} ${selectedRow?.section === "inactive" ? "delete" : "stop/deactivate"}`
-				: undefined,
-			selectedSubagent
-				? `${keyText("app.agents.delete")} ${selectedRow.section === "running" ? "stop" : "delete"}`
-				: undefined,
-			this.selectedRowCanShowProgram() ? `${keyText("app.agents.program")} program` : undefined,
-		]
-			.filter((hint): hint is string => hint !== undefined)
-			.join("   ");
+		const hints = `${keyText("tui.select.up")}/${keyText("tui.select.down")} navigate   ${keyText("tui.select.confirm")} open   ${keyText("app.agents.new")} new   ${keyText("app.shortcuts")} actions`;
 		return truncateToWidth(theme.fg("muted", hints), width);
 	}
 
@@ -2797,27 +2761,14 @@ export class AgentsViewMode implements Component, Focusable {
 type DisplayItem =
 	| { type: "spacer" }
 	| { type: "heading"; section: AgentsViewSection }
-	| { type: "empty"; section: AgentsViewSection }
 	| { type: "row"; row: AgentsViewRow };
 
-function buildDisplayItems(rows: readonly AgentsViewRow[]): DisplayItem[] {
-	const items: DisplayItem[] = [];
-	const sections: AgentsViewSection[] = ["running", "idle", "inactive"];
-	for (const [index, section] of sections.entries()) {
-		if (index > 0) {
-			items.push({ type: "spacer" });
-		}
-		items.push({ type: "heading", section });
-		const sectionRows = getDisplayRowsForSection(rows, section);
-		if (sectionRows.length === 0) {
-			items.push({ type: "empty", section });
-			continue;
-		}
-		for (const row of sectionRows) {
-			items.push({ type: "row", row });
-		}
-	}
-	return items;
+function compactSessionRows(rows: readonly AgentsViewRow[], showInactive: boolean): AgentsViewRow[] {
+	let visible = true;
+	return rows.filter((row) => {
+		if (row.depth === 0) visible = showInactive || row.section !== "inactive";
+		return visible && row.kind !== "subagent-summary";
+	});
 }
 
 // Nested rows (subagent summaries and expanded subagents) always render in
@@ -2859,93 +2810,43 @@ function hasLiveWork(row: AgentsViewRow): boolean {
 	return row.section === "running" || row.runningSubagentCount > 0 || row.summary.hasRunningRlmChildren === true;
 }
 
-interface AgentsViewUsageParts {
-	inTokens: string;
-	outTokens: string;
-	agentCost: string;
-	count: string;
-	totalCost: string;
-	age: string;
-}
-
-const AGENTS_VIEW_USAGE_LABELS: AgentsViewUsageParts = {
-	inTokens: "↑in",
-	outTokens: "↓out",
-	agentCost: "$agent",
-	count: "#sub",
-	totalCost: "$total",
-	age: "age",
-};
-
-const AGENTS_VIEW_USAGE_COLUMNS = Object.keys(AGENTS_VIEW_USAGE_LABELS) as (keyof AgentsViewUsageParts)[];
-
 export interface AgentsViewUsageLayout {
-	/** Legend line per section, padded to that section's column widths. */
-	legends: ReadonlyMap<AgentsViewSection, string>;
-	/** Details string per row identity, padded to its section's column widths. */
+	legend: string;
 	details: ReadonlyMap<string, string>;
+	nameWidth: number;
+	modelWidth: number;
+	activityWidth: number;
 }
 
-/**
- * One shared column layout per section for the header legend and every row:
- * each column is as wide as the section's widest value or its legend label,
- * everything right-aligned, so the ` · ` separators land in the same terminal
- * column for the legend and every row. Empty sessions render only the age,
- * aligned to the age column.
- */
-export function buildAgentsViewUsageLayout(rows: readonly AgentsViewRow[]): AgentsViewUsageLayout {
-	const rowsBySection = new Map<AgentsViewSection, AgentsViewRow[]>();
-	// Nested rows render inside their top-level agent's section block, so group
-	// by the block's section rather than each row's own.
-	let blockSection: AgentsViewSection = "running";
-	for (const row of rows) {
-		if (row.depth === 0) blockSection = row.section;
-		if (row.kind !== "agent" && row.kind !== "subagent") continue;
-		const sectionRows = rowsBySection.get(blockSection) ?? [];
-		sectionRows.push(row);
-		rowsBySection.set(blockSection, sectionRows);
-	}
-	const legends = new Map<AgentsViewSection, string>();
-	const details = new Map<string, string>();
-	for (const section of ["running", "idle", "inactive"] as const) {
-		const entries = (rowsBySection.get(section) ?? []).map((row) => {
-			const usage = row.summary.usage;
-			const parts: AgentsViewUsageParts = {
-				inTokens: `↑${formatTokenCount(usage?.inputTokens ?? 0)}`,
-				outTokens: `↓${formatTokenCount(usage?.outputTokens ?? 0)}`,
-				agentCost: `$${(usage?.cost ?? 0).toFixed(2)}`,
-				count: String(row.descendantCount),
-				totalCost: `$${row.recursiveCost.toFixed(2)}`,
-				age: formatSessionDuration(row.summary),
-			};
-			return { identity: row.identity, empty: isEmptyAgentsViewSession(row.summary), parts };
-		});
-		const widths = {} as Record<keyof AgentsViewUsageParts, number>;
-		for (const column of AGENTS_VIEW_USAGE_COLUMNS) {
-			let width = visibleWidth(AGENTS_VIEW_USAGE_LABELS[column]);
-			for (const entry of entries) {
-				// Empty sessions render no usage segment; only their age takes space.
-				if (entry.empty && column !== "age") continue;
-				width = Math.max(width, visibleWidth(entry.parts[column]));
-			}
-			widths[column] = width;
-		}
-		const pad = (parts: AgentsViewUsageParts, column: keyof AgentsViewUsageParts): string =>
-			padCellStart(parts[column], widths[column]);
-		const formatLine = (parts: AgentsViewUsageParts): string =>
-			[
-				`${pad(parts, "inTokens")} ${pad(parts, "outTokens")}`,
-				pad(parts, "agentCost"),
-				pad(parts, "count"),
-				pad(parts, "totalCost"),
-				pad(parts, "age"),
-			].join(" · ");
-		legends.set(section, formatLine(AGENTS_VIEW_USAGE_LABELS));
-		for (const entry of entries) {
-			details.set(entry.identity, entry.empty ? pad(entry.parts, "age") : formatLine(entry.parts));
-		}
-	}
-	return { legends, details };
+export function buildCompactAgentsViewLayout(rows: readonly AgentsViewRow[], width = 120): AgentsViewUsageLayout {
+	const sessions = rows.filter((row) => row.kind === "agent" || row.kind === "subagent");
+	const entries = sessions.map((row) => ({
+		identity: row.identity,
+		cost: `$${row.recursiveCost.toFixed(2)}`,
+		age: formatSessionDuration(row.summary),
+	}));
+	const costWidth = entries.reduce((size, entry) => Math.max(size, visibleWidth(entry.cost)), 4);
+	const ageWidth = entries.reduce((size, entry) => Math.max(size, visibleWidth(entry.age)), 3);
+	const detailsWidth = costWidth + 2 + ageWidth;
+	const available = Math.max(0, width - detailsWidth - 4);
+	const desiredModelWidth = sessions.reduce(
+		(size, row) => Math.max(size, visibleWidth(row.summary.model?.id ?? "-")),
+		12,
+	);
+	const modelWidth = Math.min(desiredModelWidth, 32, Math.max(0, available - 12));
+	const nameWidth = Math.min(28, Math.max(0, available - modelWidth));
+	const activityWidth = Math.max(0, available - modelWidth - nameWidth - 2);
+	const detailLine = (cost: string, age: string) => `${padCellStart(cost, costWidth)}  ${padCellStart(age, ageWidth)}`;
+	const headings = [formatTableCell("Session", nameWidth), formatTableCell("Model", modelWidth)];
+	if (activityWidth > 0) headings.push(formatTableCell("Activity", activityWidth));
+	headings.push(detailLine("Cost", "Age"));
+	return {
+		legend: formatTableCell(headings.join("  "), width),
+		details: new Map(entries.map((entry) => [entry.identity, detailLine(entry.cost, entry.age)])),
+		nameWidth,
+		modelWidth,
+		activityWidth,
+	};
 }
 
 function padCellStart(value: string, width: number): string {
@@ -2967,11 +2868,6 @@ function styleRowTitle(row: AgentsViewRow): string {
 function formatTableCell(value: string, width: number): string {
 	const truncated = truncateToWidth(value, width, "");
 	return truncated + " ".repeat(Math.max(0, width - visibleWidth(truncated)));
-}
-
-function formatRightTableCell(value: string, width: number): string {
-	const truncated = truncateToWidth(value, width, "");
-	return " ".repeat(Math.max(0, width - visibleWidth(truncated))) + truncated;
 }
 
 function formatSessionDuration(summary: SessionSummary): string {

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -2509,6 +2509,13 @@ export class AgentsViewMode implements Component, Focusable {
 			displayItems.push({ type: "heading", section });
 			for (const row of getDisplayRowsForSection(this.rows, section)) {
 				displayItems.push({ type: "row", row });
+				if (
+					(row.kind === "agent" || row.kind === "subagent") &&
+					row.runningSubagentCount > 0 &&
+					!this.expandedSubagentParents.has(row.identity)
+				) {
+					displayItems.push({ type: "running-subagents", row });
+				}
 			}
 		}
 		if (displayItems.length === 0) {
@@ -2531,6 +2538,14 @@ export class AgentsViewMode implements Component, Focusable {
 		const sliceStart = selectedDisplayIndex >= start + contentRows ? selectedDisplayIndex - contentRows + 1 : start;
 		const lines = displayItems.slice(sliceStart, sliceStart + contentRows).map((item) => {
 			if (item.type === "spacer") return "";
+			if (item.type === "running-subagents") {
+				const count = item.row.runningSubagentCount;
+				const indent = "  ".repeat(item.row.depth + 1);
+				return theme.fg(
+					"success",
+					truncateToWidth(`${indent}${count} subagent${count === 1 ? "" : "s"} running`, width),
+				);
+			}
 			if (item.type === "heading") {
 				const collapsed =
 					item.section === "inactive" && !this.rows.some((row) => row.depth === 0 && row.section === "inactive");
@@ -2761,6 +2776,7 @@ export class AgentsViewMode implements Component, Focusable {
 type DisplayItem =
 	| { type: "spacer" }
 	| { type: "heading"; section: AgentsViewSection }
+	| { type: "running-subagents"; row: AgentsViewRow }
 	| { type: "row"; row: AgentsViewRow };
 
 function compactSessionRows(rows: readonly AgentsViewRow[], showInactive: boolean): AgentsViewRow[] {

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -1,3 +1,4 @@
+import { getModel } from "@earendil-works/pi-ai";
 import { setKeybindings } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -9,7 +10,7 @@ import type { AgentConnectionSavedSessionInfo } from "../src/modes/agent-connect
 import {
 	AgentsViewMode,
 	type AgentsViewPersistentState,
-	buildAgentsViewUsageLayout,
+	buildCompactAgentsViewLayout,
 	combineAgentsViewStartupNotices,
 	createInitialAgentsViewPersistentState,
 	runAgentsViewMode,
@@ -643,7 +644,7 @@ describe("AgentsViewMode", () => {
 				expect(parentRow?.identity).toBe("session:root-session");
 				expandedSubagentParents.add(parentRow!.identity);
 				invoke("reconcileCatalogs", self);
-				expect(rowsOf(self).some((row) => row.kind === "subagent-summary" && row.expanded)).toBe(true);
+				expect(rowsOf(self).some((row) => row.kind === "subagent")).toBe(true);
 			}
 			// The runtime flushes the session file; the record identity flips to file:.
 			self.lastListedSummaries = [{ ...parent, sessionFile: "/tmp/root.jsonl" }, child];
@@ -656,7 +657,7 @@ describe("AgentsViewMode", () => {
 		expect(
 			expandedRows.find((row) => row.kind === "agent" && row.summary.sessionId === "root-session")?.identity,
 		).toBe("file:/tmp/root.jsonl");
-		expect(expandedRows.some((row) => row.kind === "subagent-summary" && row.expanded)).toBe(true);
+		expect(expandedRows.some((row) => row.kind === "subagent-summary")).toBe(false);
 		expect(expandedRows.some((row) => row.kind === "subagent" && row.summary.sessionId === "child-session")).toBe(
 			true,
 		);
@@ -669,7 +670,7 @@ describe("AgentsViewMode", () => {
 		expect(collapsedView.expandedSubagentParents.size).toBe(0);
 	});
 
-	it("toggles subagent list expansion from the summary row", () => {
+	it("toggles subagent list expansion from the parent row", () => {
 		const expandedSubagentParents = new Set(["root-row"]);
 		const programShownParents = new Set(["root-row"]);
 		const persistentState: AgentsViewPersistentState = {
@@ -684,7 +685,7 @@ describe("AgentsViewMode", () => {
 			syncSelectedRowState: vi.fn(),
 			ui: { requestRender: vi.fn() },
 		};
-		const summaryRow = { kind: "subagent-summary", parentIdentity: "root-row", expanded: true };
+		const summaryRow = { kind: "agent", identity: "root-row", expanded: true };
 
 		invoke("toggleSubagentList", self, summaryRow);
 		expect(expandedSubagentParents.size).toBe(0);
@@ -718,144 +719,193 @@ describe("AgentsViewMode", () => {
 		}
 	});
 
-	it("renders aligned usage columns with an explicit subagent count and drops the message count", () => {
+	it("shows each session model and aligned total cost including collapsed descendants", () => {
+		const created = new Date(Date.now() - 120_000).toISOString();
 		const parent = summary({
 			id: "spender",
 			activeSessionId: "spender",
 			sessionId: "spender-session",
+			sessionName: "spender",
+			model: { ...getModel("openai", "gpt-4o"), id: "gpt-5.6-sol" },
+			created,
+			summary: "Analyzing runtime composition",
 			usage: { inputTokens: 12437, outputTokens: 1234, cost: 0.42 },
 		});
 		const child = summary({
-			id: "spender-child",
-			activeSessionId: "spender-child",
-			sessionId: "spender-child-session",
-			sessionFile: "/tmp/spender-child.jsonl",
+			id: "child",
+			activeSessionId: "child",
+			sessionId: "child-session",
+			sessionFile: "/tmp/child.jsonl",
 			runtimeKind: "subagent",
 			parentActiveSessionId: "spender",
+			model: { ...getModel("openai", "gpt-4o"), provider: "prime-inference", id: "glm-5.2-fast" },
+			created,
 			usage: { inputTokens: 500, outputTokens: 50, cost: 0.68 },
 		});
 		const inactive = summary({
-			id: "saved-only",
+			id: "saved",
 			activeSessionId: undefined,
-			sessionId: "saved-only-session",
-			sessionFile: "/tmp/saved-only.jsonl",
+			sessionId: "saved-session",
+			sessionFile: "/tmp/saved.jsonl",
 			rosterStatus: "inactive",
-			messageCount: 7,
+			created,
+			model: { ...getModel("openai", "gpt-4o"), provider: "prime-inference", id: "glm-5.2-fast" },
+			usage: { inputTokens: 900, outputTokens: 80, cost: 123.45 },
 		});
-		const empty = summary({
-			id: "empty-draft",
-			activeSessionId: undefined,
-			sessionId: "empty-draft-session",
-			sessionFile: "/tmp/empty-draft.jsonl",
-			rosterStatus: "inactive",
-			messageCount: 0,
-			modified: new Date(Date.now() - 120_000).toISOString(),
-		});
+		const rows = buildAgentsViewRows([parent, child, inactive]);
 		const view = new AgentsViewMode({ config: {}, uiServices: createUiServices() }, {});
-
+		Reflect.set(view, "rows", rows);
+		Reflect.set(view, "selectedIndex", -1);
 		try {
-			const collapsed = buildAgentsViewRows([parent, child, inactive, empty]);
-			const rows = buildAgentsViewRows(
-				[parent, child, inactive, empty],
-				new Set(collapsed.map((row) => row.identity)),
-			);
-			Reflect.set(view, "rows", rows);
-			const layout = buildAgentsViewUsageLayout(rows);
-			const line = (row: AgentsViewRow | undefined) =>
-				stripAnsi(invoke("renderRow", view, row, 200, layout.details) as string);
-			const byId = (sessionId: string, kind?: string) =>
-				rows.find((row) => row.summary.sessionId === sessionId && (!kind || row.kind === kind));
-
-			// Shared per-section layout: every column right-aligned to
-			// max(widest section value, legend label width).
-			expect(line(byId("spender-session"))).toContain("↑12k ↓1.2k ·  $0.42 ·    1 ·  $1.10 ·");
-			expect(line(byId("spender-child-session", "subagent"))).toContain("↑500   ↓50 ·  $0.68 ·    0 ·  $0.68 ·");
-			const inactiveLine = line(byId("saved-only-session"));
-			expect(inactiveLine).toContain("↑0   ↓0 ·  $0.00 ·    0 ·  $0.00 ·");
-			expect(inactiveLine).not.toContain("7 ·");
-			// The ` · ` separators land in the same column for the legend and every
-			// row of its section.
-			const dotColumns = (text: string) => [...text].flatMap((ch, index) => (ch === "·" ? [index] : []));
-			for (const [section, sessionId] of [
-				["idle", "spender-session"],
-				["idle", "spender-child-session"],
-				["inactive", "saved-only-session"],
-			] as const) {
-				const detail = layout.details.get(byId(sessionId)!.identity)!;
-				expect(dotColumns(detail)).toEqual(dotColumns(layout.legends.get(section)!));
+			const parentRow = rows.find((row) => row.summary.sessionId === parent.sessionId)!;
+			const savedRow = rows.find((row) => row.summary.sessionId === inactive.sessionId)!;
+			const render = (row: AgentsViewRow, width: number) =>
+				stripAnsi(invoke("renderRow", view, row, width, buildCompactAgentsViewLayout(rows, width)) as string);
+			const parentLine = render(parentRow, 120);
+			const savedLine = render(savedRow, 120);
+			expect(parentLine).toContain("gpt-5.6-sol");
+			expect(savedLine).toContain("glm-5.2-fast");
+			expect(parentLine).toContain("$1.10");
+			expect(parentLine).not.toContain("$0.42");
+			expect(parentLine).not.toMatch(/[↑↓]/);
+			expect(parentLine).toMatch(/2m\s*$/);
+			expect(parentLine.indexOf("$1.10") + "$1.10".length).toBe(savedLine.indexOf("$123.45") + "$123.45".length);
+			for (const width of [60, 80]) {
+				const narrow = render(parentRow, width);
+				expect(narrow).toContain("gpt-5.6-sol");
+				expect(narrow).toContain("$1.10");
+				expect(narrow).toMatch(/2m\s*$/);
+				expect(narrow.length).toBeLessThanOrEqual(width);
 			}
-			// Empty sessions keep the age but drop the whole usage segment.
-			const emptyLine = line(byId("empty-draft-session"));
-			expect(emptyLine).not.toContain("↑");
-			expect(emptyLine).not.toContain("$");
-			expect(emptyLine).toMatch(/\d+[smhd]\s*$/);
-			// Without a shared layout the row pads only against its own section of one.
-			const bare = { ...byId("spender-session")!, summary: { ...parent, usage: undefined } };
-			expect(stripAnsi(invoke("renderRow", view, bare, 200) as string)).toContain(
-				" ↑0   ↓0 ·  $0.00 ·    1 ·  $1.10 ·",
-			);
 		} finally {
 			stopThemeWatcher();
 		}
 	});
 
-	it("shows the bold usage legend on every section header", () => {
-		const running = (id: string, created: string) =>
+	it("renders one column header across status groups without repeating subagent hints", () => {
+		const summaries = [
 			summary({
-				id,
-				activeSessionId: id,
-				sessionId: `${id}-session`,
-				sessionName: id,
+				id: "busy",
+				activeSessionId: "busy",
+				sessionId: "busy-session",
+				sessionName: "busy",
 				activity: "working",
 				isStreaming: true,
-				created,
-			});
-		const parent = running("busy-parent", "2026-01-01T00:00:00Z");
-		const child = summary({
-			id: "busy-child",
-			activeSessionId: "busy-child",
-			sessionId: "busy-child-session",
-			sessionName: "busy-child",
-			sessionFile: "/tmp/busy-child.jsonl",
-			runtimeKind: "subagent",
-			parentActiveSessionId: "busy-parent",
-		});
-		const summaries = [
-			running("busy-solo", "2026-01-02T00:00:00Z"),
-			parent,
-			child,
-			summary({ id: "idle-a", activeSessionId: "idle-a", sessionId: "idle-a-session", sessionName: "idle-a" }),
-			summary({ id: "idle-b", activeSessionId: "idle-b", sessionId: "idle-b-session", sessionName: "idle-b" }),
+			}),
+			summary({
+				id: "idle",
+				activeSessionId: "idle",
+				sessionId: "idle-session",
+				sessionName: "idle",
+				sessionFile: "/tmp/idle.jsonl",
+			}),
+			summary({
+				id: "child",
+				sessionId: "child-session",
+				sessionFile: "/tmp/child.jsonl",
+				runtimeKind: "subagent",
+				parentActiveSessionId: "busy",
+			}),
 		];
-		const parentIdentity = buildAgentsViewRows(summaries).find(
-			(row) => row.summary.sessionId === "busy-parent-session",
-		)!.identity;
-		const rows = buildAgentsViewRows(summaries, new Set([parentIdentity]));
 		const view = new AgentsViewMode({ config: {}, uiServices: createUiServices() }, {});
-
 		try {
-			Reflect.set(view, "rows", rows);
+			Reflect.set(view, "lastListedSummaries", summaries);
+			invoke("reconcileCatalogs", view);
 			Reflect.set(view, "selectedIndex", -1);
 			Reflect.set(view, "ui", { terminal: { rows: 60 }, requestRender: () => {} });
 			const rendered = invoke("renderSessionRows", view, 120, 40) as string[];
 			const lines = rendered.map(stripAnsi);
-			const headings = lines.filter((line) => /^(Running|Idle|Inactive) \(\d+\)/.test(line));
-			expect(headings).toHaveLength(3);
-			for (const heading of headings) {
-				expect(heading).toMatch(/↑in\s+↓out ·\s+\$agent ·\s+#sub ·\s+\$total ·\s+age$/);
+			expect(lines.filter((line) => /Model/.test(line) && /Age/i.test(line))).toHaveLength(1);
+			expect(lines.some((line) => line.startsWith("Running"))).toBe(true);
+			expect(lines.some((line) => line.startsWith("Idle"))).toBe(true);
+			expect(lines.join("\n")).not.toMatch(/show program|#sub|\$agent|↑in|↓out/);
+			const rows = Reflect.get(view, "rows") as AgentsViewRow[];
+			expect(rows.filter((row) => row.kind === "subagent-summary")).toHaveLength(0);
+			for (const line of rendered) {
+				expect(invoke("finalizeRenderedLine", view, line, 120)).not.toContain("\x1b[48");
 			}
-			// Same bold weight for title and legend.
-			const runningLegend = buildAgentsViewUsageLayout(rows).legends.get("running")!;
-			expect(invoke("renderSectionHeading", view, "running", 120, runningLegend)).toContain(
-				theme.bold(runningLegend),
-			);
+		} finally {
+			stopThemeWatcher();
+		}
+	});
 
-			// Session rows carry no background of their own; only the selection
-			// highlight may paint one.
-			const finalized = rendered.map((line) => invoke("finalizeRenderedLine", view, line, 120) as string);
-			for (const line of finalized) {
-				expect(line).not.toContain("\x1b[48");
-			}
+	it("keeps collapsed inactive sessions out of navigation and reveals them for search", () => {
+		const live = summary({ sessionName: "live" });
+		const saved = summary({
+			id: "saved",
+			activeSessionId: undefined,
+			sessionId: "saved-session",
+			sessionName: "archive-match",
+			sessionFile: "/tmp/saved.jsonl",
+			rosterStatus: "inactive",
+			lifecycle: "archived",
+		});
+		const view = new AgentsViewMode({ config: {}, uiServices: createUiServices() }, { savedCatalogLoaded: true });
+		const rows = () => Reflect.get(view, "rows") as AgentsViewRow[];
+		try {
+			Reflect.set(view, "lastListedSummaries", [live]);
+			Reflect.set(view, "savedSessions", [
+				{
+					path: saved.sessionFile!,
+					id: saved.sessionId,
+					cwd: saved.cwd,
+					name: saved.sessionName,
+					created: new Date(),
+					modified: new Date(),
+					messageCount: 1,
+					firstMessage: "archive-match",
+					allMessagesText: "archive-match",
+				},
+			]);
+			invoke("reconcileCatalogs", view);
+			expect(rows().map((row) => row.summary.sessionId)).toEqual([live.sessionId]);
+			invoke("moveSelection", view, 1);
+			expect(rows()[Reflect.get(view, "selectedIndex") as number]?.summary.sessionId).toBe(live.sessionId);
+			view.handleInput("\x1bi");
+			expect(rows().some((row) => row.summary.sessionId === saved.sessionId)).toBe(true);
+			view.handleInput("\x1bi");
+			expect(rows().some((row) => row.summary.sessionId === saved.sessionId)).toBe(false);
+			invoke("setSearchQuery", view, "archive-match");
+			expect(rows().some((row) => row.summary.sessionId === saved.sessionId)).toBe(true);
+			invoke("setSearchQuery", view, "");
+			expect(rows().some((row) => row.summary.sessionId === saved.sessionId)).toBe(false);
+		} finally {
+			stopThemeWatcher();
+		}
+	});
+
+	it("opens a parent with Enter and reveals its spawn program only on request", () => {
+		const parent = summary({ sessionName: "parent" });
+		const child = summary({
+			id: "child",
+			activeSessionId: "child",
+			sessionId: "child-session",
+			sessionFile: "/tmp/child.jsonl",
+			runtimeKind: "subagent",
+			parentActiveSessionId: parent.activeSessionId,
+			spawnCode: 'await rlm("Inspect the code")',
+		});
+		const view = new AgentsViewMode({ config: {}, uiServices: createUiServices() }, {});
+		const rows = () => Reflect.get(view, "rows") as AgentsViewRow[];
+		try {
+			Reflect.set(view, "lastListedSummaries", [parent, child]);
+			invoke("reconcileCatalogs", view);
+			expect(rows().map((row) => row.kind)).toEqual(["agent"]);
+			const finish = vi.fn();
+			Reflect.set(view, "finish", finish);
+			invoke("openSelected", view);
+			expect(finish).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "open",
+					summary: expect.objectContaining({ sessionId: parent.sessionId }),
+				}),
+			);
+			invoke("cycleProgramForSelected", view);
+			expect(rows().some((row) => row.kind === "subagent-code" && row.code === child.spawnCode)).toBe(true);
+			expect(rows().some((row) => row.kind === "subagent" && row.summary.sessionId === child.sessionId)).toBe(true);
+			expect(rows().some((row) => row.kind === "subagent-summary")).toBe(false);
+			invoke("cycleProgramForSelected", view);
+			expect(rows().some((row) => row.kind === "subagent-code")).toBe(false);
 		} finally {
 			stopThemeWatcher();
 		}
@@ -881,7 +931,8 @@ describe("AgentsViewMode", () => {
 			Reflect.set(view, "selectedIndex", rows.length - 1);
 			Reflect.set(view, "ui", { terminal: { rows: 13 }, requestRender: () => {} });
 			const lines = (invoke("renderSessionRows", view, 120, 4) as string[]).map(stripAnsi);
-			expect(lines[0]).toContain("...");
+			expect(lines[1]).toContain("...");
+			expect(lines).toHaveLength(4);
 			const lastTitle = rows.at(-1)!.title;
 			expect(lines.some((line) => line.includes(lastTitle))).toBe(true);
 		} finally {
@@ -889,33 +940,51 @@ describe("AgentsViewMode", () => {
 		}
 	});
 
-	it("renders a collapsed group's busy-subagent badge legibly instead of dimmed", () => {
-		const parent = summary({ id: "parent", activeSessionId: "parent", sessionId: "parent-session" });
-		const busyChild = summary({
-			id: "busy-child",
-			activeSessionId: "busy-child",
-			sessionId: "busy-child-session",
-			sessionFile: "/tmp/busy-child.jsonl",
+	it("reveals usage details through actions and closes them before searching", () => {
+		const view = new AgentsViewMode({ config: {}, uiServices: createUiServices() }, { savedCatalogLoaded: true });
+		try {
+			Reflect.set(view, "lastListedSummaries", [
+				summary({ sessionName: "parent", usage: { inputTokens: 1234, outputTokens: 56, cost: 1.23 } }),
+			]);
+			invoke("reconcileCatalogs", view);
+			view.handleInput("?");
+			const actions = (invoke("renderSessionRows", view, 120, 20) as string[]).map(stripAnsi).join("\n");
+			expect(actions).toContain("1234 in");
+			expect(actions).toContain("$1.23");
+			view.handleInput("p");
+			expect(Reflect.get(view, "showActions")).toBe(false);
+			const rows = (invoke("renderSessionRows", view, 120, 20) as string[]).map(stripAnsi).join("\n");
+			expect(rows).toContain("parent");
+			expect(rows).not.toContain("1234 in");
+		} finally {
+			stopThemeWatcher();
+		}
+	});
+
+	it("expands subagents from the parent row without an extra summary row", () => {
+		const parent = summary({ sessionName: "parent" });
+		const child = summary({
+			id: "child",
+			activeSessionId: "child",
+			sessionId: "child-session",
+			sessionFile: "/tmp/child.jsonl",
 			runtimeKind: "subagent",
-			parentActiveSessionId: "parent",
+			parentActiveSessionId: parent.activeSessionId,
 			activity: "working",
-			isSessionActive: true,
 			isStreaming: true,
 		});
-		const idleChild = { ...busyChild, activity: "idle" as const, isSessionActive: false, isStreaming: false };
 		const view = new AgentsViewMode({ config: {}, uiServices: createUiServices() }, {});
-
+		const rows = () => Reflect.get(view, "rows") as AgentsViewRow[];
 		try {
-			const busyRows = buildAgentsViewRows([parent, busyChild]);
-			const busySummaryRow = busyRows.find((row) => row.kind === "subagent-summary");
-			expect(busySummaryRow).toMatchObject({ section: "idle", title: "1 subagent running" });
-			Reflect.set(view, "rows", busyRows);
-			expect(invoke("renderRow", view, busySummaryRow, 160)).toContain(theme.fg("success", "▸ 1 subagent running"));
-
-			const idleRows = buildAgentsViewRows([parent, idleChild]);
-			const idleSummaryRow = idleRows.find((row) => row.kind === "subagent-summary");
-			Reflect.set(view, "rows", idleRows);
-			expect(invoke("renderRow", view, idleSummaryRow, 160)).toContain(theme.fg("dim", "▸ 1 subagent"));
+			Reflect.set(view, "lastListedSummaries", [parent, child]);
+			invoke("reconcileCatalogs", view);
+			expect(rows()).toHaveLength(1);
+			expect(invoke("renderRow", view, rows()[0], 120)).toContain("▸");
+			view.handleInput("\x1b[1;3C");
+			expect(rows().map((row) => row.kind)).toEqual(["agent", "subagent"]);
+			expect(invoke("renderRow", view, rows()[0], 120)).toContain("▾");
+			view.handleInput("\x1b[1;3C");
+			expect(rows()).toHaveLength(1);
 		} finally {
 			stopThemeWatcher();
 		}

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -961,7 +961,7 @@ describe("AgentsViewMode", () => {
 		}
 	});
 
-	it("expands subagents from the parent row without an extra summary row", () => {
+	it("shows running-subagent counts only while collapsed and work remains", () => {
 		const parent = summary({ sessionName: "parent" });
 		const child = summary({
 			id: "child",
@@ -973,18 +973,44 @@ describe("AgentsViewMode", () => {
 			activity: "working",
 			isStreaming: true,
 		});
+		const secondChild = {
+			...child,
+			id: "child-2",
+			activeSessionId: "child-2",
+			sessionId: "child-session-2",
+			sessionFile: "/tmp/child-2.jsonl",
+		};
 		const view = new AgentsViewMode({ config: {}, uiServices: createUiServices() }, {});
 		const rows = () => Reflect.get(view, "rows") as AgentsViewRow[];
+		const lines = () => (invoke("renderSessionRows", view, 120, 20) as string[]).map(stripAnsi);
 		try {
-			Reflect.set(view, "lastListedSummaries", [parent, child]);
+			Reflect.set(view, "lastListedSummaries", [parent, child, secondChild]);
 			invoke("reconcileCatalogs", view);
 			expect(rows()).toHaveLength(1);
 			expect(invoke("renderRow", view, rows()[0], 120)).toContain("▸");
+			const collapsed = lines();
+			const parentIndex = collapsed.findIndex((line) => line.includes("parent"));
+			expect(collapsed[parentIndex + 1]).toBe("  2 subagents running");
+			invoke("moveSelection", view, 1);
+			expect(Reflect.get(view, "selectedIndex")).toBe(0);
 			view.handleInput("\x1b[1;3C");
-			expect(rows().map((row) => row.kind)).toEqual(["agent", "subagent"]);
+			expect(rows().map((row) => row.kind)).toEqual(["agent", "subagent", "subagent"]);
+			expect(lines().join("\n")).not.toContain("subagents running");
 			expect(invoke("renderRow", view, rows()[0], 120)).toContain("▾");
 			view.handleInput("\x1b[1;3C");
 			expect(rows()).toHaveLength(1);
+			expect(lines()).toContain("  2 subagents running");
+			const idleChild = { ...child, activity: "idle", isStreaming: false };
+			Reflect.set(view, "lastListedSummaries", [parent, idleChild, secondChild]);
+			invoke("reconcileCatalogs", view);
+			expect(lines()).toContain("  1 subagent running");
+			Reflect.set(view, "lastListedSummaries", [
+				parent,
+				idleChild,
+				{ ...secondChild, activity: "idle", isStreaming: false },
+			]);
+			invoke("reconcileCatalogs", view);
+			expect(lines().join("\n")).not.toMatch(/subagents? running/);
 		} finally {
 			stopThemeWatcher();
 		}


### PR DESCRIPTION
## Summary
- Kept the logo, startup metadata, and search.
- Added aligned Session, Model, Activity, Cost, and Age columns. Cost includes subagents. Activity shrinks first on narrow terminals.
- Removed token columns, separate agent/subagent costs, and repeated headers. Collapsed agents show a short `N subagents running` line only while subagents are working; expanded agents and idle subagent lists have no extra summary line.
- Collapsed inactive sessions by default. Search still includes them; Alt+I toggles the section.
- Added Alt+Right to expand subagents from their parent row. Enter and Right still open sessions. Ctrl+O still shows the spawn program.
- Moved less-used actions and the usage breakdown behind `?`.

Model IDs use existing session metadata. Sessions without model metadata show `-`; full provider/model and reasoning level are available in details. No daemon protocol changes.

## Validation
- `npm run check`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/agents-view-mode.test.ts` (from `packages/coding-agent`)
- Covered compact columns at 60/80/120 columns, recursive costs, inactive navigation/search, inline expansion, program access, action details, and selection in a short viewport.

## Rendered preview
Fixture sessions at 80 columns (logo, metadata, and search remain above the table):

```text
Session                       Model         Activity                   Cost  Age
Running (2)
◇  BUN FORK                   glm-5.2-fast  Fixing GitHub authent   $259.84   4d
◇  sandbox                    gpt-5.6-sol   Analyzing runtime com  $2204.89   4d

Idle (1)
●  REVIEW                     gpt-5.6-sol   Review complete          $50.27   4d
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes in the agents view TUI with no daemon protocol changes; behavior shifts (hidden inactive sessions, Enter opens parents) are covered by updated tests.
> 
> **Overview**
> Redesigns the **agents view** into a compact table while keeping the splash, startup notices, and search.
> 
> **Layout and columns:** Per-section token/`$agent` legends and **`subagent-summary`** rows are gone. One shared header (**Session · Model · Activity · Cost · Age**) sits above Running/Idle/Inactive blocks. Rows show model id, activity text, **recursive cost** (includes subagents), and age; token columns are removed. Collapsed parents with running subagents get a short **“N subagents running”** line instead of a summary row.
> 
> **Navigation and keys:** Inactive top-level sessions are **hidden by default** (`compactSessionRows`); **Alt+I** toggles them (search still surfaces matches). **Alt+Right** expands/collapses subagents from the **parent** row; **Enter** on a parent **opens** the session (no longer toggles a summary row). **`?`** opens an actions overlay (shortcuts plus token/cost details for the selection) and closes on the next keypress.
> 
> **Persistence:** `inactiveExpanded` and split **`allRows` / `rows`** keep counts accurate while the visible list stays compact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc67428af10b1b2fbe63d996e52ede6116bb4d62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Simplify agents view with compact layout, collapsed inactive sessions, and actions panel
> - Replaces the per-section token/cost usage layout with a single shared Session/Model/Activity/Cost/Age header across all status sections, showing recursive total cost and relative age instead of per-agent token counts.
> - Collapses inactive sessions by default; `Alt+I` toggles their visibility and search queries reveal them automatically. Inactive state persists across rebuilds via `AgentsViewPersistentState.inactiveExpanded`.
> - Moves subagent expansion from a separate summary row to the parent agent row; `Alt+Right` toggles descendants on the selected row, and `Enter` now opens the parent session directly.
> - Adds an actions panel (`?`) that shows key commands plus selected-session metadata (model, thinking level, directory, token counts, session cost, recursive cost). The first input after opening the panel closes it.
> - Inserts a running-subagent count line beneath collapsed parents that still have active subagents; the line disappears on expansion or when all children go idle.
> - Behavioral Change: `Enter` on a parent agent no longer toggles a subagent-summary row (those rows are removed); `targetHasSpawnCode` and `getAgentCountsText` now read from `allRows` (the unfiltered set) rather than visible compact rows; the default footer advertises generic navigation/open/actions instead of context-specific commands. The single column header consumes one viewport row, shifting existing viewport/ellipsis expectations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc67428.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->