### PR TITLE
fix(ai): preserve incomplete Responses usage and reject premature EOF

### DIFF
--- a/packages/ai/.changes/responses-terminal-accounting.md
+++ b/packages/ai/.changes/responses-terminal-accounting.md
@@ -1,0 +1,2 @@
+- Fixed missing usage and incorrect success reporting for incomplete OpenAI Responses streams, including content-filtered responses.
+- Fixed OpenAI Responses streams reporting success when they end without a terminal event.

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -489,7 +489,11 @@ async function* mapCodexEvents(events: AsyncIterable<Record<string, unknown>>): 
 			const normalizedResponse = response
 				? { ...response, status: normalizeCodexStatus(response.status) }
 				: response;
-			yield { ...event, type: "response.completed", response: normalizedResponse } as ResponseStreamEvent;
+			yield {
+				...event,
+				type: type === "response.incomplete" ? type : "response.completed",
+				response: normalizedResponse,
+			} as ResponseStreamEvent;
 			return;
 		}
 

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -276,6 +276,7 @@ export async function processResponsesStream<TApi extends Api>(
 	let currentBlock: ThinkingContent | TextContent | (ToolCall & { partialJson: string }) | null = null;
 	const blocks = output.content;
 	const blockIndex = () => blocks.length - 1;
+	let receivedTerminalEvent = false;
 
 	for await (const event of openaiStream) {
 		if (event.type === "response.created") {
@@ -469,7 +470,8 @@ export async function processResponsesStream<TApi extends Api>(
 				currentBlock = null;
 				stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
 			}
-		} else if (event.type === "response.completed") {
+		} else if (event.type === "response.completed" || event.type === "response.incomplete") {
+			receivedTerminalEvent = true;
 			const response = event.response;
 			if (response?.id) {
 				output.responseId = response.id;
@@ -494,10 +496,21 @@ export async function processResponsesStream<TApi extends Api>(
 				options.applyServiceTierPricing(output.usage, serviceTier);
 			}
 			output.stopReason = mapStopReason(response?.status);
+			if (event.type === "response.incomplete" || response?.status === "incomplete") {
+				const reason = response?.incomplete_details?.reason;
+				output.stopReason = reason === "content_filter" ? "error" : "length";
+				output.stopReasonRaw = reason ?? "incomplete";
+				if (reason === "content_filter") {
+					throw new StreamFailureError("Response blocked by provider safety filters (content_filter)", {
+						kind: "safety",
+						providerErrorType: reason,
+					});
+				}
+			}
 			if (output.content.some((b) => b.type === "toolCall") && output.stopReason === "stop") {
 				output.stopReason = "toolUse";
 			}
-			if (output.stopReason === "error" && response?.status) {
+			if (output.stopReason === "error" && response?.status && !output.stopReasonRaw) {
 				output.stopReasonRaw = response.status;
 			}
 		} else if (event.type === "error") {
@@ -519,6 +532,12 @@ export async function processResponsesStream<TApi extends Api>(
 				providerErrorType,
 			});
 		}
+	}
+	if (!receivedTerminalEvent) {
+		throw new StreamFailureError("OpenAI Responses stream ended before a terminal event", {
+			kind: "malformed_response",
+			providerErrorType: "missing_terminal_event",
+		});
 	}
 }
 

--- a/packages/ai/test/openai-responses-partial-json-cleanup.test.ts
+++ b/packages/ai/test/openai-responses-partial-json-cleanup.test.ts
@@ -57,6 +57,10 @@ async function* createFunctionCallEvents(argumentsJson: string): AsyncIterable<R
 			arguments: argumentsJson,
 		},
 	} as ResponseStreamEvent;
+	yield {
+		type: "response.completed",
+		response: { id: "resp_test", status: "completed" },
+	} as ResponseStreamEvent;
 }
 
 describe("openai responses partialJson cleanup", () => {

--- a/packages/ai/test/openai-responses-terminal-events.test.ts
+++ b/packages/ai/test/openai-responses-terminal-events.test.ts
@@ -1,0 +1,239 @@
+import type { Response as OpenAIResponse, ResponseStreamEvent } from "openai/resources/responses/responses.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { streamOpenAICodexResponses } from "../src/providers/openai-codex-responses.js";
+import { streamOpenAIResponses } from "../src/providers/openai-responses.js";
+import type { AssistantMessageEvent, Model } from "../src/types.js";
+
+const model: Model<"openai-responses"> = {
+	id: "test-model",
+	name: "Test model",
+	api: "openai-responses",
+	provider: "openai",
+	baseUrl: "https://example.invalid/v1",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0 },
+	contextWindow: 128000,
+	maxTokens: 16384,
+};
+
+function response(overrides: Partial<OpenAIResponse> = {}): OpenAIResponse {
+	return {
+		id: "resp_terminal",
+		object: "response",
+		created_at: 1,
+		model: model.id,
+		status: "completed",
+		output: [],
+		output_text: "",
+		error: null,
+		incomplete_details: null,
+		instructions: null,
+		metadata: null,
+		parallel_tool_calls: true,
+		temperature: 1,
+		top_p: 1,
+		tool_choice: "auto",
+		tools: [],
+		usage: {
+			input_tokens: 120,
+			input_tokens_details: { cached_tokens: 100, cache_write_tokens: 0 },
+			output_tokens: 16384,
+			output_tokens_details: { reasoning_tokens: 16384 },
+			total_tokens: 16504,
+		},
+		...overrides,
+	};
+}
+
+function terminal(
+	type: "response.completed" | "response.incomplete",
+	overrides: Partial<OpenAIResponse> = {},
+): ResponseStreamEvent {
+	return {
+		type,
+		sequence_number: 10,
+		response: response({
+			status: type === "response.incomplete" ? "incomplete" : "completed",
+			incomplete_details: type === "response.incomplete" ? { reason: "max_output_tokens" } : null,
+			...overrides,
+		}),
+	};
+}
+
+function toolEvents(): ResponseStreamEvent[] {
+	const item = { type: "function_call" as const, id: "fc_test", call_id: "call_test", name: "read", arguments: "{}" };
+	return [
+		{ type: "response.output_item.added", sequence_number: 1, output_index: 0, item },
+		{ type: "response.output_item.done", sequence_number: 2, output_index: 0, item },
+	];
+}
+
+async function run(events: ResponseStreamEvent[], abort = false) {
+	const body = `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`;
+	vi.spyOn(globalThis, "fetch").mockResolvedValue(
+		new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } }),
+	);
+	const controller = new AbortController();
+	const stream = streamOpenAIResponses(
+		model,
+		{ messages: [{ role: "user", content: "Synthetic test", timestamp: 1 }] },
+		{
+			apiKey: "test-key",
+			maxRetries: 0,
+			signal: controller.signal,
+			onResponse: () => {
+				if (abort) controller.abort();
+			},
+		},
+	);
+	const emitted: AssistantMessageEvent[] = [];
+	for await (const event of stream) emitted.push(event);
+	return { result: await stream.result(), emitted };
+}
+
+describe("OpenAI Responses terminal events", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it.each(["response.completed", "response.incomplete"] as const)(
+		"preserves terminal ID and usage for %s",
+		async (type) => {
+			const { result, emitted } = await run([terminal(type)]);
+			expect(result.responseId).toBe("resp_terminal");
+			expect(result.usage).toMatchObject({
+				input: 20,
+				cacheRead: 100,
+				cacheWrite: 0,
+				output: 16384,
+				totalTokens: 16504,
+			});
+			expect(result.usage.cost.input).toBeCloseTo(0.00002, 10);
+			expect(result.usage.cost.cacheRead).toBeCloseTo(0.00005, 10);
+			expect(result.usage.cost.output).toBeCloseTo(0.032768, 10);
+			expect(result.stopReason).toBe(type === "response.incomplete" ? "length" : "stop");
+			expect(emitted.at(-1)?.type).toBe("done");
+		},
+	);
+
+	it.each([
+		["response.completed", "toolUse"],
+		["response.incomplete", "length"],
+	] as const)("uses %s as the final authority for tool-call completion", async (type, reason) => {
+		const { result } = await run([...toolEvents(), terminal(type)]);
+		expect(result.content[0]).toMatchObject({ type: "toolCall", arguments: {} });
+		expect(result.stopReason).toBe(reason);
+	});
+
+	it.each(["response.completed", "response.incomplete"] as const)(
+		"reports content filtering as an error for %s",
+		async (type) => {
+			const { result, emitted } = await run([
+				...toolEvents(),
+				terminal(type, { status: "incomplete", incomplete_details: { reason: "content_filter" } }),
+			]);
+			expect(result.stopReason).toBe("error");
+			expect(result.stopReasonRaw).toBe("content_filter");
+			expect(result.usage.totalTokens).toBe(16504);
+			expect(result.diagnostics).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						details: expect.objectContaining({ kind: "safety", providerErrorType: "content_filter" }),
+					}),
+				]),
+			);
+			expect(emitted.at(-1)?.type).toBe("error");
+		},
+	);
+
+	it("does not promote an incomplete event without optional status or reason to success", async () => {
+		const { result } = await run([
+			...toolEvents(),
+			terminal("response.incomplete", { status: undefined, incomplete_details: null }),
+		]);
+		expect(result.stopReason).toBe("length");
+	});
+
+	it.each([
+		["empty stream", []],
+		[
+			"response.created only",
+			[
+				{
+					type: "response.created",
+					sequence_number: 0,
+					response: response({ status: "in_progress", usage: undefined }),
+				},
+			],
+		],
+		["finished tool item without response terminal", toolEvents()],
+	] satisfies [string, ResponseStreamEvent[]][])("rejects EOF after %s", async (_name, events) => {
+		const { result, emitted } = await run(events);
+		expect(result.stopReason).toBe("error");
+		expect(result.diagnostics).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					details: expect.objectContaining({
+						kind: "malformed_response",
+						providerErrorType: "missing_terminal_event",
+					}),
+				}),
+			]),
+		);
+		expect(emitted.some((event) => event.type === "done")).toBe(false);
+		expect(emitted.at(-1)?.type).toBe("error");
+	});
+
+	it("preserves provider failures instead of replacing them with a missing-terminal error", async () => {
+		const { result } = await run([
+			{
+				type: "response.failed",
+				sequence_number: 1,
+				response: response({ status: "failed", error: { code: "server_error", message: "Synthetic failure" } }),
+			},
+		]);
+		expect(result.stopReason).toBe("error");
+		expect(result.diagnostics).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					details: expect.objectContaining({ kind: "server_error", providerErrorType: "server_error" }),
+				}),
+			]),
+		);
+	});
+
+	it("preserves user cancellation without a provider-failure diagnostic", async () => {
+		const { result } = await run([], true);
+		expect(result.stopReason).toBe("aborted");
+		expect(result.diagnostics).toBeUndefined();
+	});
+
+	it.each([
+		["content_filter", "incomplete", "error", "error"],
+		["max_output_tokens", undefined, "length", "done"],
+	] as const)("preserves Codex SSE %s terminal semantics", async (reason, status, stopReason, eventType) => {
+		const event = terminal("response.incomplete", { status, incomplete_details: { reason } });
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(`data: ${JSON.stringify(event)}\n\n`, {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+		const payload = Buffer.from(
+			JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "test-account" } }),
+		).toString("base64");
+		const stream = streamOpenAICodexResponses(
+			{ ...model, api: "openai-codex-responses", provider: "openai-codex", compat: undefined },
+			{ messages: [{ role: "user", content: "Synthetic test", timestamp: 1 }] },
+			{ apiKey: `test.${payload}.test`, transport: "sse" },
+		);
+		const emitted: AssistantMessageEvent[] = [];
+		for await (const next of stream) emitted.push(next);
+		const result = await stream.result();
+		expect(result.stopReason).toBe(stopReason);
+		expect(result.responseId).toBe("resp_terminal");
+		expect(result.usage.totalTokens).toBe(16504);
+		expect(result.stopReasonRaw).toBe(reason);
+		expect(emitted.at(-1)?.type).toBe(eventType);
+		if (eventType === "error") expect(emitted.some((next) => next.type === "done")).toBe(false);
+	});
+});


### PR DESCRIPTION
OpenAI Responses streams ending with `response.incomplete` currently skip terminal usage accounting. A synthetic response with 120 input tokens (100 cached) and 16,384 output tokens returns `stop` with zero usage. Streams ending before a response terminal event also return success, even after a tool item has finished.

This change accounts for both completed and incomplete terminals, preserves the response ID and raw incomplete reason, returns `length` for output exhaustion, and raises a structured safety failure for `content_filter`. A clean EOF without a terminal event raises a structured malformed-response failure. The Codex event mapper retains `response.incomplete` when the optional embedded status is absent. No public stop-reason type or retry policy changes.

Related: #914 (closed without merge) and #1623. This includes the shared-parser caller fix needed to prevent Codex from emitting a `done` event for content-filtered output.

Validation:
- Added 14 deterministic regressions using synthetic SSE and mocked HTTP transport; no provider credentials or paid calls. The initial 12 cases reproduced eight failures; two added Codex cases also failed before their fixes.
- Relevant AI package tests: 94 passed, 4 skipped (live-provider tests).
- `npm run check`: passed, including formatting, lint, type checking, installer checks, and browser smoke checks.
- Independently verified the official v0.9.3 installed library and CLI bundle: the same 28 cases across both artifacts went from 20 failures before the local patch to 28 passing after it. The patched functions were checked against the reviewed source before installation.

Reproduce from `packages/ai`:
```sh
npx tsx ../../node_modules/vitest/dist/cli.js --run test/openai-responses-terminal-events.test.ts test/openai-responses-partial-json-cleanup.test.ts test/openai-responses-tool-result-images.test.ts test/openai-responses-foreign-toolcall-id.test.ts test/openai-responses-copilot-provider.test.ts test/openai-responses-empty-tool-result.test.ts test/openai-codex-stream.test.ts test/azure-openai-base-url.test.ts test/stream-failure.test.ts
```


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OpenAI Responses handling of incomplete streams and missing terminal events
> - `processResponsesStream` now records usage and response metadata for both `response.completed` and `response.incomplete` terminal events, mapping incomplete responses to `length` or `error` based on `incomplete_details.reason` and classifying content-filtered responses as safety errors.
> - Streams that end without a terminal event now throw a `malformed_response` `StreamFailureError` instead of completing successfully.
> - `mapCodexEvents` preserves the original `response.incomplete` event type rather than normalizing it to `response.completed`.
> - Risk: downstream consumers expecting every terminal event to be `response.completed` (or expecting silent success on truncated streams) will see `response.incomplete` events and `malformed_response` errors instead. The partial-JSON cleanup test was updated to append a terminal event, signaling that any in-tree fixture omitting one will now fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd1f46a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->