### PR TITLE
fix(coding-agent): initialize the headless theme in daemon session workers

### DIFF
--- a/packages/coding-agent/.changes/res-1315-worker-theme-init.md
+++ b/packages/coding-agent/.changes/res-1315-worker-theme-init.md
@@ -1,0 +1,1 @@
+- Fixed daemon session workers crashing when a hosted extension touched `ctx.ui.theme` (theme was never initialized in the worker process); workers now initialize the settings theme headlessly at startup, without a theme file watcher.

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -111,6 +111,7 @@ import {
 } from "../../core/session-manager.js";
 import { resolveSessionPath } from "../../core/session-resolver.js";
 import type { SessionStats } from "../../core/session-stats.js";
+import { SettingsManager } from "../../core/settings-manager.js";
 import { type SideQuestionRun, startSideQuestion } from "../../core/side-question.js";
 import { isProcessAlive, spawnHidden, waitForChildProcess } from "../../utils/child-process.js";
 import { tryAcquireDirLock } from "../../utils/dir-lock.js";
@@ -123,6 +124,7 @@ import {
 import { createAgentConnectionToolDefinition } from "../agent-connection/tool-definition.js";
 import type { AgentConnectionHeartbeat, AgentConnectionRlmChildAgentSnapshot } from "../agent-connection/types.js";
 import { waitForHeadlessCompletion } from "../headless-completion.js";
+import { initTheme } from "../interactive/theme/theme.js";
 import { attachJsonlLineReader, serializeJsonLine } from "../rpc/jsonl.js";
 import { encodePrivateFrame, PrivateFrameDecoder } from "../session-worker/private-framing.js";
 import {
@@ -595,6 +597,13 @@ export class AgentDaemon {
 			throw new Error("Daemon config is missing agentDir");
 		}
 		this.agentDir = options.defaultSessionConfig.agentDir;
+		// Hosted extensions receive ctx.ui.theme; without a process-level init the
+		// first theme access throws and the uncaught handler kills the worker.
+		// Headless process: no theme file watcher.
+		initTheme(
+			SettingsManager.create(options.defaultSessionConfig.cwd ?? process.cwd(), this.agentDir).getTheme(),
+			false,
+		);
 		this.cronStore = options.worker
 			? AgentCronJobStore.forSessionArtifacts()
 			: new AgentCronJobStore(getCronJobsPath(this.agentDir));

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -597,9 +597,7 @@ export class AgentDaemon {
 			throw new Error("Daemon config is missing agentDir");
 		}
 		this.agentDir = options.defaultSessionConfig.agentDir;
-		// Hosted extensions receive ctx.ui.theme; without a process-level init the
-		// first theme access throws and the uncaught handler kills the worker.
-		// Headless process: no theme file watcher.
+		// Hosted extensions get ctx.ui.theme; init it headlessly (no TTY, watcher off) or their first access kills the worker.
 		initTheme(
 			SettingsManager.create(options.defaultSessionConfig.cwd ?? process.cwd(), this.agentDir).getTheme(),
 			false,

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -85,10 +85,9 @@ describe("daemon mode helpers", () => {
 				defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
 				createRuntime: vi.fn(),
 			});
-			// Watcher off: the worker has no TTY and must not hold a theme file watcher.
+			// Extensions receive this proxy via ctx.ui.theme; the watcher stays off in the headless worker.
 			expect(initSpy).toHaveBeenCalledOnce();
 			expect(initSpy.mock.calls[0]?.[1]).toBe(false);
-			// ctx.ui.theme hands extensions this proxy; the first access must not throw.
 			expect(() => themeModule.theme.fg("dim", "worker")).not.toThrow();
 		} finally {
 			initSpy.mockRestore();

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -75,8 +75,26 @@ import { activeActivityForSession, type SessionSummary } from "../src/modes/daem
 import { DAEMON_WORKER_SUPERVISOR_SOCKET_ENV } from "../src/modes/daemon/daemon-worker-protocol.js";
 import { RlmSpawnLedger } from "../src/modes/daemon/rlm-ledger.js";
 import { WorkerRecoveryJournal } from "../src/modes/daemon/worker-recovery-journal.js";
+import * as themeModule from "../src/modes/interactive/theme/theme.js";
 
 describe("daemon mode helpers", () => {
+	it("initializes the headless theme for hosted extensions", () => {
+		const initSpy = vi.spyOn(themeModule, "initTheme");
+		try {
+			new AgentDaemon("/tmp/unused-daemon.sock", {
+				defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+				createRuntime: vi.fn(),
+			});
+			// Watcher off: the worker has no TTY and must not hold a theme file watcher.
+			expect(initSpy).toHaveBeenCalledOnce();
+			expect(initSpy.mock.calls[0]?.[1]).toBe(false);
+			// ctx.ui.theme hands extensions this proxy; the first access must not throw.
+			expect(() => themeModule.theme.fg("dim", "worker")).not.toThrow();
+		} finally {
+			initSpy.mockRestore();
+		}
+	});
+
 	it("preserves envelope client identity while registering prompt admission", () => {
 		const daemon = new AgentDaemon("/tmp/unused-daemon.sock", {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },


### PR DESCRIPTION
Fixes a field-reported daemon worker crash: a worker-hosted extension touched `ctx.ui.theme` from a timer, the theme proxy threw `Theme not initialized. Call initTheme() first.`, the exception escaped to the worker's `uncaughtException` handler, and the worker terminated and stayed failed across reconnects (v0.9.3, `extensions/tok-s.ts` timer).

Linear: https://linear.app/primeintellect/issue/RES-1315

## LOC

+28/-0 total: src +11 (one file, `daemon-mode.ts`), tests +16 (one existing file), +1 changelog fragment.

## Root cause and owning layer

`main.ts` initializes the theme in every client mode entrypoint (interactive/agents-view with the watcher, non-interactive without), but the daemon branch returns before any `initTheme` call — and the daemon worker hosts extensions, which receive `ctx.ui.theme` through the extension runner's headless UI context (`noOpUIContext.theme` returns the global theme proxy). The first theme access in the worker process therefore threw.

`AgentDaemon` is the single owner of the process that hosts sessions and their extensions, so its constructor now initializes the settings theme (from the daemon config's `cwd`/`agentDir`, the same settings source `main.ts` uses) — headlessly: `enableWatcher: false`, mirroring `main.ts`'s non-interactive choice; a worker has no TTY and must not hold a theme file watcher.

## Scope: extension-timer blast radius

The report's second half — an exception escaping an extension timer terminates the worker — has **no existing containment seam**: the extension context exposes no timer API (extensions use raw global `setTimeout`), and `ExtensionRunner`'s error listeners only wrap its own handler invocations. Building a timer-wrapping host layer is out of scope for this fix; the boundary question is filed as a follow-up comment on RES-1315.

## Tests

One pin in `daemon-mode.test.ts` (fail-unfixed verified: `initTheme` uncalled and the theme proxy throws before the fix): constructing `AgentDaemon` initializes the theme exactly once with the watcher off, and the proxy extensions receive (`theme.fg`) works.

Validation: sandbox run of daemon-mode, daemon-agent-roster, agent-connection-daemon, 4602, interactive-mode-compaction — 333 passed / 1 skipped; `npm run check` green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized startup change that mirrors existing non-interactive theme initialization; no auth, data, or session protocol changes.
> 
> **Overview**
> Fixes daemon **session workers** crashing when a hosted extension first uses **`ctx.ui.theme`** (e.g. from a timer): the worker process never called **`initTheme`**, so the global theme proxy threw and took down the worker.
> 
> **`AgentDaemon`** now initializes the settings-backed theme in its constructor—**`initTheme(..., false)`** so there is no TTY theme file watcher, matching the non-interactive entry path—before cron/session setup. A **daemon-mode** test asserts **`initTheme`** runs once with the watcher off and that **`theme.fg`** is safe afterward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f3bda554f227502d72153167747b39134dc817b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Initialize headless theme in `AgentDaemon` constructor for daemon session workers
> Loads the settings theme during daemon construction using the configured working and agent directories, then calls `initTheme` with the file watcher disabled. This ensures worker-side theme access (e.g. `ctx.ui.theme`) works after daemon startup. Risk: `initTheme` is now invoked during `AgentDaemon` construction; any failure in settings theme loading will block daemon startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f3bda5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->