### PR TITLE
fix(coding-agent): always render inactive sessions in the agents view

### DIFF
--- a/packages/coding-agent/.changes/agents-view-always-show-inactive.md
+++ b/packages/coding-agent/.changes/agents-view-always-show-inactive.md
@@ -1,0 +1,1 @@
+- Removed the inactive-session collapse (Alt+I): inactive sessions always render in the agents view, and search remains the filter.

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -48,7 +48,6 @@ export interface AppKeybindings {
 	"app.agents.delete": true;
 	"app.agents.program": true;
 	"app.agents.rename": true;
-	"app.agents.inactiveCollapse": true;
 	"app.agents.expand": true;
 	"app.tree.foldOrUp": true;
 	"app.tree.unfoldOrDown": true;
@@ -161,7 +160,6 @@ export const KEYBINDINGS = {
 	"app.agents.delete": { defaultKeys: "ctrl+x", description: "Stop or delete selected agent" },
 	"app.agents.program": { defaultKeys: "ctrl+o", description: "Show the program that spawned subagents" },
 	"app.agents.rename": { defaultKeys: "ctrl+r", description: "Rename selected agent session" },
-	"app.agents.inactiveCollapse": { defaultKeys: "alt+i", description: "Show or hide inactive sessions" },
 	"app.agents.expand": { defaultKeys: "alt+right", description: "Expand or collapse selected agent subagents" },
 	"app.tree.foldOrUp": {
 		defaultKeys: ["ctrl+left", "alt+left"],

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -2760,8 +2760,7 @@ type DisplayItem =
 	| { type: "running-subagents"; row: AgentsViewRow }
 	| { type: "row"; row: AgentsViewRow };
 
-// Summary rows fold into the running-subagents display items; session rows
-// themselves always render — inactive included, search is the filter.
+// Summary rows fold into the running-subagents display items.
 function compactSessionRows(rows: readonly AgentsViewRow[]): AgentsViewRow[] {
 	return rows.filter((row) => row.kind !== "subagent-summary");
 }

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -160,7 +160,6 @@ export type AgentsViewPersistentState = {
 	pendingExpandedAncestorSessionIds?: string[];
 	expandedSubagentParents?: Set<string>;
 	programShownParents?: Set<string>;
-	inactiveExpanded?: boolean;
 	statusMessage?: string;
 	// Gathered once and reused across agents-view instances so the notices survive
 	// re-entry and render the moment they resolve, even if the first view was left early.
@@ -979,13 +978,6 @@ export class AgentsViewMode implements Component, Focusable {
 				this.ui.requestRender();
 				return;
 			}
-			if (this.keybindings.matches(data, "app.agents.inactiveCollapse")) {
-				this.persistentState.inactiveExpanded = !this.persistentState.inactiveExpanded;
-				this.rebuildRows();
-				this.syncSelectedRowState();
-				this.ui.requestRender();
-				return;
-			}
 			if (this.keybindings.matches(data, "app.agents.expand")) {
 				const row = this.rows[this.selectedIndex];
 				if (row && row.descendantCount > 0) this.toggleSubagentList(row);
@@ -1328,12 +1320,7 @@ export class AgentsViewMode implements Component, Focusable {
 			computeRecursiveRollups(this.unifiedRecords, this.unifiedIndex),
 			this.anchorSessionId,
 		);
-		this.rows = compactSessionRows(
-			this.allRows,
-			this.persistentState.inactiveExpanded === true ||
-				((this.replyTarget || this.renameTarget ? this.actionModeSearchQuery : this.editor.getText()) ?? "").trim()
-					.length > 0,
-		);
+		this.rows = compactSessionRows(this.allRows);
 		const index =
 			selectedIdentity === undefined ? -1 : this.rows.findIndex((row) => row.identity === selectedIdentity);
 		if (index >= 0) {
@@ -2200,12 +2187,7 @@ export class AgentsViewMode implements Component, Focusable {
 			computeRecursiveRollups(this.unifiedRecords, this.unifiedIndex),
 			this.anchorSessionId,
 		);
-		this.rows = compactSessionRows(
-			this.allRows,
-			this.persistentState.inactiveExpanded === true ||
-				((this.replyTarget || this.renameTarget ? this.actionModeSearchQuery : this.editor.getText()) ?? "").trim()
-					.length > 0,
-		);
+		this.rows = compactSessionRows(this.allRows);
 		this.applyPendingAncestorExpansion();
 		this.restoreSelection();
 		this.ui.requestRender();
@@ -2552,13 +2534,7 @@ export class AgentsViewMode implements Component, Focusable {
 				);
 			}
 			if (item.type === "heading") {
-				const collapsed =
-					item.section === "inactive" && !this.rows.some((row) => row.depth === 0 && row.section === "inactive");
-				const prefix = item.section === "inactive" ? `${collapsed ? "▸" : "▾"} ` : "";
-				const hint = item.section === "inactive" ? ` · ${keyText("app.agents.inactiveCollapse")}` : "";
-				return theme.bold(
-					truncateToWidth(`${prefix}${sectionTitle(item.section)} (${counts[item.section]})${hint}`, width),
-				);
+				return theme.bold(truncateToWidth(`${sectionTitle(item.section)} (${counts[item.section]})`, width));
 			}
 			return this.renderRow(item.row, width, layout);
 		});
@@ -2612,8 +2588,8 @@ export class AgentsViewMode implements Component, Focusable {
 		const actions = [
 			`${keyText("tui.select.confirm")} open   ${keyText("app.agents.open")} open   ${keyText("app.agents.new")} new`,
 			`${keyText("app.agents.expand")} expand/collapse subagents   ${keyText("app.agents.program")} program`,
-			`${keyText("app.agents.inactiveCollapse")} show/hide inactive   ${keyText("app.shortcuts")} close actions`,
 			`${keyText("app.agents.reply")} reply/resume   ${keyText("app.agents.rename")} rename   ${keyText("app.agents.delete")} stop/delete`,
+			`${keyText("app.shortcuts")} close actions`,
 		];
 		if (row) {
 			const model = row.summary.model;
@@ -2784,12 +2760,10 @@ type DisplayItem =
 	| { type: "running-subagents"; row: AgentsViewRow }
 	| { type: "row"; row: AgentsViewRow };
 
-function compactSessionRows(rows: readonly AgentsViewRow[], showInactive: boolean): AgentsViewRow[] {
-	let visible = true;
-	return rows.filter((row) => {
-		if (row.depth === 0) visible = showInactive || row.section !== "inactive";
-		return visible && row.kind !== "subagent-summary";
-	});
+// Summary rows fold into the running-subagents display items; session rows
+// themselves always render — inactive included, search is the filter.
+function compactSessionRows(rows: readonly AgentsViewRow[]): AgentsViewRow[] {
+	return rows.filter((row) => row.kind !== "subagent-summary");
 }
 
 // Nested rows (subagent summaries and expanded subagents) always render in

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -874,7 +874,7 @@ describe("AgentsViewMode", () => {
 			rosterStatus: "inactive",
 			lifecycle: "archived",
 		});
-		// A stale inactiveExpanded flag from an older session must be ignored.
+		// The stale pre-removal collapse flag must be ignored.
 		const persistentState = { savedCatalogLoaded: true, inactiveExpanded: false } as AgentsViewPersistentState;
 		const view = new AgentsViewMode({ config: {}, uiServices: createUiServices() }, persistentState);
 		const rows = () => Reflect.get(view, "rows") as AgentsViewRow[];
@@ -896,11 +896,9 @@ describe("AgentsViewMode", () => {
 			]);
 			invoke("reconcileCatalogs", view);
 			expect(showsSaved()).toBe(true);
-			// The removed Alt+I collapse chord must not hide anything anymore.
+			// The removed Alt+I chord must not hide anything.
 			view.handleInput("\x1bi");
 			expect(showsSaved()).toBe(true);
-			invoke("setSearchQuery", view, "archive-match");
-			expect(rows().map((row) => row.summary.sessionId)).toEqual([saved.sessionId]);
 			invoke("setSearchQuery", view, "no-such-session");
 			expect(showsSaved()).toBe(false);
 		} finally {

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -863,7 +863,7 @@ describe("AgentsViewMode", () => {
 		}
 	});
 
-	it("keeps collapsed inactive sessions out of navigation and reveals them for search", () => {
+	it("always renders inactive sessions; search is the only filter", () => {
 		const live = summary({ sessionName: "live" });
 		const saved = summary({
 			id: "saved",
@@ -874,8 +874,11 @@ describe("AgentsViewMode", () => {
 			rosterStatus: "inactive",
 			lifecycle: "archived",
 		});
-		const view = new AgentsViewMode({ config: {}, uiServices: createUiServices() }, { savedCatalogLoaded: true });
+		// A stale inactiveExpanded flag from an older session must be ignored.
+		const persistentState = { savedCatalogLoaded: true, inactiveExpanded: false } as AgentsViewPersistentState;
+		const view = new AgentsViewMode({ config: {}, uiServices: createUiServices() }, persistentState);
 		const rows = () => Reflect.get(view, "rows") as AgentsViewRow[];
+		const showsSaved = () => rows().some((row) => row.summary.sessionId === saved.sessionId);
 		try {
 			Reflect.set(view, "lastListedSummaries", [live]);
 			Reflect.set(view, "savedSessions", [
@@ -892,17 +895,14 @@ describe("AgentsViewMode", () => {
 				},
 			]);
 			invoke("reconcileCatalogs", view);
-			expect(rows().map((row) => row.summary.sessionId)).toEqual([live.sessionId]);
-			invoke("moveSelection", view, 1);
-			expect(rows()[Reflect.get(view, "selectedIndex") as number]?.summary.sessionId).toBe(live.sessionId);
+			expect(showsSaved()).toBe(true);
+			// The removed Alt+I collapse chord must not hide anything anymore.
 			view.handleInput("\x1bi");
-			expect(rows().some((row) => row.summary.sessionId === saved.sessionId)).toBe(true);
-			view.handleInput("\x1bi");
-			expect(rows().some((row) => row.summary.sessionId === saved.sessionId)).toBe(false);
+			expect(showsSaved()).toBe(true);
 			invoke("setSearchQuery", view, "archive-match");
-			expect(rows().some((row) => row.summary.sessionId === saved.sessionId)).toBe(true);
-			invoke("setSearchQuery", view, "");
-			expect(rows().some((row) => row.summary.sessionId === saved.sessionId)).toBe(false);
+			expect(rows().map((row) => row.summary.sessionId)).toEqual([saved.sessionId]);
+			invoke("setSearchQuery", view, "no-such-session");
+			expect(showsSaved()).toBe(false);
 		} finally {
 			stopThemeWatcher();
 		}


### PR DESCRIPTION
Fixes RES-1316

## Purpose

Inactive sessions must always render in the agents view; search is the filter. This partially reverts #2087's inactive-collapse ("Collapsed inactive sessions by default. Search still includes them; Alt+I toggles the section."), which was merged via the #2068 consolidation. Beyond the product decision, the Alt+I toggle is unreachable on default macOS terminals: the composed character goes to the always-focused search editor, so users could not reveal the hidden sessions.

## Changes (surgical revert of one feature; everything else from the #2068 consolidation stays)

- `compactSessionRows` no longer gates depth-0 blocks on the inactive section; it keeps folding `subagent-summary` rows (that folding serves the running-subagents display items, which remain).
- Both call sites lose the `showInactive` plumbing (the query no longer doubles as a reveal switch — it filters, as before the collapse).
- Removed the `app.agents.inactiveCollapse` keybinding (type map + `alt+i` default), its input handler, the Inactive-header `▸/▾` prefix + Alt+I hint, and the actions-panel line.
- Removed `persistentState.inactiveExpanded` (writer + type). The state object is in-process only — it is never serialized to disk — so a stale property from an older view instance is simply never read; nothing needs migration.

## Tests

- Flipped the collapse pin to the new contract: inactive rows render immediately with fresh persistent state (fails on current main), a stale `inactiveExpanded: false` is ignored, the old Alt+I chord hides nothing, and search still narrows to matches only.

## LOC

Total src: **+7/−36 (net -29)**; tests: +10/−12 (net -2). Net-negative surgical revert: the inactive-collapse gating, `alt+i` keybinding, header hint, actions line, and persisted flag deleted; kept consolidation features untouched. +1 changelog fragment.

## Validation

- `npm run check` green (pre-commit hook).
- agents-view-mode (36), agents-view-state (77), 502 regressions (15), keybinding-hints green; reverting the src hunks fails exactly the flipped pin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Agents-view UI and list filtering only; no auth, daemon protocol, or persistence migration changes.
> 
> **Overview**
> **Inactive sessions are always visible** in the agents view; the **Alt+I collapse toggle is removed** because it was hard to reach when search input captures keys on macOS.
> 
> Row building no longer hides the inactive section: `compactSessionRows` only drops `subagent-summary` rows, and search text **filters** the list instead of acting as a reveal switch. UI cleanup removes the inactive header **▸/▾** affordance, the actions-panel hint, and **`app.agents.inactiveCollapse`** from keybindings. **`inactiveExpanded`** is dropped from in-process persistent state (stale values are ignored).
> 
> Tests now assert inactive rows appear on load, Alt+I does nothing, and only a non-matching search hides them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12fefcd4e86918f74bdc90398f7d5eca3f47edf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Always render inactive sessions in `agents-view-mode`
> Removes the collapse/expand toggle for inactive sessions in the agents view so they always render. Search remains the only way to filter sessions out.
> - Deletes the `app.agents.inactiveCollapse` keybinding (Alt+I) from [keybindings.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2091/files#diff-f93dc44960592e9f476dd0994e2f5f2f96756644ce1c9ffaa4e45dab0db65739) and the `inactiveExpanded` persistent-state property from [agents-view-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2091/files#diff-116f4364505fa125d57532296cde69f9a73543363de3d3cd48bd4f48b2ee6e10)
> - Strips the `showInactive` parameter from `compactSessionRows`; inactive top-level rows are always retained and only subagent-summary rows are folded
> - Removes collapse/expand markers and the Alt+I hint from section headings and the actions panel
> - Risk: any persisted `inactiveExpanded` state from older sessions is now ignored; no migration is performed, but the stale value has no effect
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12fefcd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->