### PR TITLE
feat(coding-agent): restore the reviewed agents-view usage columns

### DIFF
--- a/packages/coding-agent/.changes/agents-view-always-show-inactive.md
+++ b/packages/coding-agent/.changes/agents-view-always-show-inactive.md
@@ -1,0 +1,1 @@
+- Removed the inactive-session collapse (Alt+I): inactive sessions always render in the agents view, and search remains the filter.

--- a/packages/coding-agent/.changes/agents-view-restore-usage-columns.md
+++ b/packages/coding-agent/.changes/agents-view-restore-usage-columns.md
@@ -1,0 +1,1 @@
+- Restored the reviewed agents-view usage columns (`↑in ↓out · $agent · #sub · $total · age`) with per-section alignment and bold header legends, alongside the model column.

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -48,7 +48,6 @@ export interface AppKeybindings {
 	"app.agents.delete": true;
 	"app.agents.program": true;
 	"app.agents.rename": true;
-	"app.agents.inactiveCollapse": true;
 	"app.agents.expand": true;
 	"app.tree.foldOrUp": true;
 	"app.tree.unfoldOrDown": true;
@@ -161,7 +160,6 @@ export const KEYBINDINGS = {
 	"app.agents.delete": { defaultKeys: "ctrl+x", description: "Stop or delete selected agent" },
 	"app.agents.program": { defaultKeys: "ctrl+o", description: "Show the program that spawned subagents" },
 	"app.agents.rename": { defaultKeys: "ctrl+r", description: "Rename selected agent session" },
-	"app.agents.inactiveCollapse": { defaultKeys: "alt+i", description: "Show or hide inactive sessions" },
 	"app.agents.expand": { defaultKeys: "alt+right", description: "Expand or collapse selected agent subagents" },
 	"app.tree.foldOrUp": {
 		defaultKeys: ["ctrl+left", "alt+left"],

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -45,6 +45,7 @@ import {
 	listDaemonSavedSessions,
 	renameDaemonSavedSession,
 } from "../daemon/saved-session-catalog.js";
+import { formatTokenCount } from "../interactive/agent-activity.js";
 import { CustomEditor } from "../interactive/components/custom-editor.js";
 import { keyText } from "../interactive/components/keybinding-hints.js";
 import { BrandSplashHeader, InteractiveMode } from "../interactive/interactive-mode.js";
@@ -83,6 +84,7 @@ import {
 	getAgentsViewSummaryIdentity as getSummaryIdentity,
 	getUnifiedSessionAncestorSessionIds,
 	hasUnifiedSessionChildren,
+	isEmptyAgentsViewSession,
 	migrateAgentsViewIdentitySet,
 	reconcileUnifiedSessions,
 	resolveAgentsViewLeftResult,
@@ -2508,9 +2510,7 @@ export class AgentsViewMode implements Component, Focusable {
 		if (displayItems.length === 0) {
 			return [theme.fg("dim", "No sessions match your search.")];
 		}
-		// Reserve the shared column header before calculating the selection viewport.
-		const headerRows = maxRows > 1 ? 1 : 0;
-		const visibleRows = maxRows - headerRows;
+		const visibleRows = maxRows;
 		const selectedIdentity = this.rows[this.selectedIndex]?.identity;
 		const selectedDisplayIndex = displayItems.findIndex(
 			(item) => item.type === "row" && item.row.identity === selectedIdentity,
@@ -2534,13 +2534,20 @@ export class AgentsViewMode implements Component, Focusable {
 				);
 			}
 			if (item.type === "heading") {
-				return theme.bold(truncateToWidth(`${sectionTitle(item.section)} (${counts[item.section]})`, width));
+				// The legend is right-aligned to the same edge as the usage cells and
+				// bold like the title, so its columns sit exactly above the rows'.
+				const title = `${sectionTitle(item.section)} (${counts[item.section]})`;
+				const legend = layout.legends.get(item.section) ?? "";
+				const gap = width - visibleWidth(title) - visibleWidth(legend);
+				if (legend.length === 0 || gap < 2) {
+					return theme.bold(truncateToWidth(title, width, ""));
+				}
+				return `${theme.bold(title)}${" ".repeat(gap)}${theme.bold(legend)}`;
 			}
 			return this.renderRow(item.row, width, layout);
 		});
 		if (showLeadingEllipsis) lines.unshift(theme.fg("dim", "  ..."));
 		if (showTrailingEllipsis) lines.push(theme.fg("dim", "  ..."));
-		if (headerRows > 0) lines.unshift(theme.fg("muted", layout.legend));
 		return lines;
 	}
 
@@ -2579,8 +2586,11 @@ export class AgentsViewMode implements Component, Focusable {
 			formatTableCell(theme.fg("muted", formatSessionModel(row.summary)), layout.modelWidth),
 		];
 		if (layout.activityWidth > 0) cells.push(formatTableCell(theme.fg("dim", activity), layout.activityWidth));
-		cells.push(details);
-		return markRow(formatTableCell(cells.join("  "), width));
+		const left = cells.join("  ");
+		// Usage cells right-align to the terminal edge so every section's age
+		// column ends at the same column even when section widths differ.
+		const line = `${left}  ${padCellStart(details, Math.max(0, width - visibleWidth(left) - 2))}`;
+		return markRow(formatTableCell(line, width));
 	}
 
 	private renderActions(width: number): string[] {
@@ -2804,24 +2814,102 @@ function hasLiveWork(row: AgentsViewRow): boolean {
 	return row.section === "running" || row.runningSubagentCount > 0 || row.summary.hasRunningRlmChildren === true;
 }
 
+interface AgentsViewUsageParts {
+	inTokens: string;
+	outTokens: string;
+	agentCost: string;
+	count: string;
+	totalCost: string;
+	age: string;
+}
+
+const AGENTS_VIEW_USAGE_LABELS: AgentsViewUsageParts = {
+	inTokens: "↑in",
+	outTokens: "↓out",
+	agentCost: "$agent",
+	count: "#sub",
+	totalCost: "$total",
+	age: "age",
+};
+
+const AGENTS_VIEW_USAGE_COLUMNS = Object.keys(AGENTS_VIEW_USAGE_LABELS) as (keyof AgentsViewUsageParts)[];
+
 export interface AgentsViewUsageLayout {
-	legend: string;
+	/** Usage legend per section, padded to that section's column widths. */
+	legends: ReadonlyMap<AgentsViewSection, string>;
+	/** Usage details per row identity, padded to its section's column widths. */
 	details: ReadonlyMap<string, string>;
 	nameWidth: number;
 	modelWidth: number;
 	activityWidth: number;
+	/** Widest section's usage cell; the left columns size against it. */
+	detailsWidth: number;
 }
 
+/**
+ * One shared usage-column layout per section for the header legend and every
+ * row: each column is as wide as the section's widest value or its legend
+ * label, everything right-aligned, so the ` · ` separators land in the same
+ * terminal column for the legend and every row of that section. Empty sessions
+ * render only the age, aligned to the age column. The Session/Model/Activity
+ * columns on the left size against the widest section; Activity shrinks first.
+ */
 export function buildCompactAgentsViewLayout(rows: readonly AgentsViewRow[], width = 120): AgentsViewUsageLayout {
+	// Nested rows render inside their top-level agent's section block, so group
+	// by the block's section rather than each row's own.
+	const rowsBySection = new Map<AgentsViewSection, AgentsViewRow[]>();
+	let blockSection: AgentsViewSection = "running";
+	for (const row of rows) {
+		if (row.depth === 0) blockSection = row.section;
+		if (row.kind !== "agent" && row.kind !== "subagent") continue;
+		const sectionRows = rowsBySection.get(blockSection) ?? [];
+		sectionRows.push(row);
+		rowsBySection.set(blockSection, sectionRows);
+	}
+	const legends = new Map<AgentsViewSection, string>();
+	const details = new Map<string, string>();
+	let detailsWidth = 0;
+	for (const section of ["running", "idle", "inactive"] as const) {
+		const entries = (rowsBySection.get(section) ?? []).map((row) => {
+			const usage = row.summary.usage;
+			const parts: AgentsViewUsageParts = {
+				inTokens: `↑${formatTokenCount(usage?.inputTokens ?? 0)}`,
+				outTokens: `↓${formatTokenCount(usage?.outputTokens ?? 0)}`,
+				agentCost: `$${(usage?.cost ?? 0).toFixed(2)}`,
+				count: String(row.descendantCount),
+				totalCost: `$${row.recursiveCost.toFixed(2)}`,
+				age: formatSessionDuration(row.summary),
+			};
+			return { identity: row.identity, empty: isEmptyAgentsViewSession(row.summary), parts };
+		});
+		const widths = {} as Record<keyof AgentsViewUsageParts, number>;
+		for (const column of AGENTS_VIEW_USAGE_COLUMNS) {
+			let columnWidth = visibleWidth(AGENTS_VIEW_USAGE_LABELS[column]);
+			for (const entry of entries) {
+				// Empty sessions render no usage segment; only their age takes space.
+				if (entry.empty && column !== "age") continue;
+				columnWidth = Math.max(columnWidth, visibleWidth(entry.parts[column]));
+			}
+			widths[column] = columnWidth;
+		}
+		const pad = (parts: AgentsViewUsageParts, column: keyof AgentsViewUsageParts): string =>
+			padCellStart(parts[column], widths[column]);
+		const formatLine = (parts: AgentsViewUsageParts): string =>
+			[
+				`${pad(parts, "inTokens")} ${pad(parts, "outTokens")}`,
+				pad(parts, "agentCost"),
+				pad(parts, "count"),
+				pad(parts, "totalCost"),
+				pad(parts, "age"),
+			].join(" · ");
+		const legend = formatLine(AGENTS_VIEW_USAGE_LABELS);
+		legends.set(section, legend);
+		detailsWidth = Math.max(detailsWidth, visibleWidth(legend));
+		for (const entry of entries) {
+			details.set(entry.identity, entry.empty ? pad(entry.parts, "age") : formatLine(entry.parts));
+		}
+	}
 	const sessions = rows.filter((row) => row.kind === "agent" || row.kind === "subagent");
-	const entries = sessions.map((row) => ({
-		identity: row.identity,
-		cost: `$${row.recursiveCost.toFixed(2)}`,
-		age: formatSessionDuration(row.summary),
-	}));
-	const costWidth = entries.reduce((size, entry) => Math.max(size, visibleWidth(entry.cost)), 4);
-	const ageWidth = entries.reduce((size, entry) => Math.max(size, visibleWidth(entry.age)), 3);
-	const detailsWidth = costWidth + 2 + ageWidth;
 	const available = Math.max(0, width - detailsWidth - 4);
 	const desiredModelWidth = sessions.reduce(
 		(size, row) => Math.max(size, visibleWidth(formatSessionModel(row.summary))),
@@ -2830,17 +2918,7 @@ export function buildCompactAgentsViewLayout(rows: readonly AgentsViewRow[], wid
 	const modelWidth = Math.min(desiredModelWidth, 32, Math.max(0, available - 12));
 	const nameWidth = Math.min(28, Math.max(0, available - modelWidth));
 	const activityWidth = Math.max(0, available - modelWidth - nameWidth - 2);
-	const detailLine = (cost: string, age: string) => `${padCellStart(cost, costWidth)}  ${padCellStart(age, ageWidth)}`;
-	const headings = [formatTableCell("Session", nameWidth), formatTableCell("Model", modelWidth)];
-	if (activityWidth > 0) headings.push(formatTableCell("Activity", activityWidth));
-	headings.push(detailLine("Cost", "Age"));
-	return {
-		legend: formatTableCell(headings.join("  "), width),
-		details: new Map(entries.map((entry) => [entry.identity, detailLine(entry.cost, entry.age)])),
-		nameWidth,
-		modelWidth,
-		activityWidth,
-	};
+	return { legends, details, nameWidth, modelWidth, activityWidth, detailsWidth };
 }
 
 function padCellStart(value: string, width: number): string {

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -2760,8 +2760,7 @@ type DisplayItem =
 	| { type: "running-subagents"; row: AgentsViewRow }
 	| { type: "row"; row: AgentsViewRow };
 
-// Summary rows fold into the running-subagents display items; session rows
-// themselves always render — inactive included, search is the filter.
+// Summary rows fold into the running-subagents display items.
 function compactSessionRows(rows: readonly AgentsViewRow[]): AgentsViewRow[] {
 	return rows.filter((row) => row.kind !== "subagent-summary");
 }

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -2534,8 +2534,7 @@ export class AgentsViewMode implements Component, Focusable {
 				);
 			}
 			if (item.type === "heading") {
-				// The legend is right-aligned to the same edge as the usage cells and
-				// bold like the title, so its columns sit exactly above the rows'.
+				// Right-aligned to the usage cells' edge so legend columns sit above the rows'.
 				const title = `${sectionTitle(item.section)} (${counts[item.section]})`;
 				const legend = layout.legends.get(item.section) ?? "";
 				const gap = width - visibleWidth(title) - visibleWidth(legend);
@@ -2587,8 +2586,7 @@ export class AgentsViewMode implements Component, Focusable {
 		];
 		if (layout.activityWidth > 0) cells.push(formatTableCell(theme.fg("dim", activity), layout.activityWidth));
 		const left = cells.join("  ");
-		// Usage cells right-align to the terminal edge so every section's age
-		// column ends at the same column even when section widths differ.
+		// Right-aligned to the terminal edge: age columns line up across sections.
 		const line = `${left}  ${padCellStart(details, Math.max(0, width - visibleWidth(left) - 2))}`;
 		return markRow(formatTableCell(line, width));
 	}
@@ -2835,28 +2833,21 @@ const AGENTS_VIEW_USAGE_LABELS: AgentsViewUsageParts = {
 const AGENTS_VIEW_USAGE_COLUMNS = Object.keys(AGENTS_VIEW_USAGE_LABELS) as (keyof AgentsViewUsageParts)[];
 
 export interface AgentsViewUsageLayout {
-	/** Usage legend per section, padded to that section's column widths. */
 	legends: ReadonlyMap<AgentsViewSection, string>;
-	/** Usage details per row identity, padded to its section's column widths. */
 	details: ReadonlyMap<string, string>;
 	nameWidth: number;
 	modelWidth: number;
 	activityWidth: number;
-	/** Widest section's usage cell; the left columns size against it. */
 	detailsWidth: number;
 }
 
 /**
- * One shared usage-column layout per section for the header legend and every
- * row: each column is as wide as the section's widest value or its legend
- * label, everything right-aligned, so the ` · ` separators land in the same
- * terminal column for the legend and every row of that section. Empty sessions
- * render only the age, aligned to the age column. The Session/Model/Activity
- * columns on the left size against the widest section; Activity shrinks first.
+ * One usage-column layout per section, shared by the header legend and every
+ * row: column width = max(widest section value, legend label), right-aligned,
+ * so the ` · ` separators align; Activity shrinks first at narrow widths.
  */
 export function buildCompactAgentsViewLayout(rows: readonly AgentsViewRow[], width = 120): AgentsViewUsageLayout {
-	// Nested rows render inside their top-level agent's section block, so group
-	// by the block's section rather than each row's own.
+	// Nested rows render in their top-level agent's section block.
 	const rowsBySection = new Map<AgentsViewSection, AgentsViewRow[]>();
 	let blockSection: AgentsViewSection = "running";
 	for (const row of rows) {
@@ -2886,7 +2877,7 @@ export function buildCompactAgentsViewLayout(rows: readonly AgentsViewRow[], wid
 		for (const column of AGENTS_VIEW_USAGE_COLUMNS) {
 			let columnWidth = visibleWidth(AGENTS_VIEW_USAGE_LABELS[column]);
 			for (const entry of entries) {
-				// Empty sessions render no usage segment; only their age takes space.
+				// Empty sessions render only their age.
 				if (entry.empty && column !== "age") continue;
 				columnWidth = Math.max(columnWidth, visibleWidth(entry.parts[column]));
 			}

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -160,7 +160,6 @@ export type AgentsViewPersistentState = {
 	pendingExpandedAncestorSessionIds?: string[];
 	expandedSubagentParents?: Set<string>;
 	programShownParents?: Set<string>;
-	inactiveExpanded?: boolean;
 	statusMessage?: string;
 	// Gathered once and reused across agents-view instances so the notices survive
 	// re-entry and render the moment they resolve, even if the first view was left early.
@@ -979,13 +978,6 @@ export class AgentsViewMode implements Component, Focusable {
 				this.ui.requestRender();
 				return;
 			}
-			if (this.keybindings.matches(data, "app.agents.inactiveCollapse")) {
-				this.persistentState.inactiveExpanded = !this.persistentState.inactiveExpanded;
-				this.rebuildRows();
-				this.syncSelectedRowState();
-				this.ui.requestRender();
-				return;
-			}
 			if (this.keybindings.matches(data, "app.agents.expand")) {
 				const row = this.rows[this.selectedIndex];
 				if (row && row.descendantCount > 0) this.toggleSubagentList(row);
@@ -1328,12 +1320,7 @@ export class AgentsViewMode implements Component, Focusable {
 			computeRecursiveRollups(this.unifiedRecords, this.unifiedIndex),
 			this.anchorSessionId,
 		);
-		this.rows = compactSessionRows(
-			this.allRows,
-			this.persistentState.inactiveExpanded === true ||
-				((this.replyTarget || this.renameTarget ? this.actionModeSearchQuery : this.editor.getText()) ?? "").trim()
-					.length > 0,
-		);
+		this.rows = compactSessionRows(this.allRows);
 		const index =
 			selectedIdentity === undefined ? -1 : this.rows.findIndex((row) => row.identity === selectedIdentity);
 		if (index >= 0) {
@@ -2200,12 +2187,7 @@ export class AgentsViewMode implements Component, Focusable {
 			computeRecursiveRollups(this.unifiedRecords, this.unifiedIndex),
 			this.anchorSessionId,
 		);
-		this.rows = compactSessionRows(
-			this.allRows,
-			this.persistentState.inactiveExpanded === true ||
-				((this.replyTarget || this.renameTarget ? this.actionModeSearchQuery : this.editor.getText()) ?? "").trim()
-					.length > 0,
-		);
+		this.rows = compactSessionRows(this.allRows);
 		this.applyPendingAncestorExpansion();
 		this.restoreSelection();
 		this.ui.requestRender();
@@ -2552,13 +2534,7 @@ export class AgentsViewMode implements Component, Focusable {
 				);
 			}
 			if (item.type === "heading") {
-				const collapsed =
-					item.section === "inactive" && !this.rows.some((row) => row.depth === 0 && row.section === "inactive");
-				const prefix = item.section === "inactive" ? `${collapsed ? "▸" : "▾"} ` : "";
-				const hint = item.section === "inactive" ? ` · ${keyText("app.agents.inactiveCollapse")}` : "";
-				return theme.bold(
-					truncateToWidth(`${prefix}${sectionTitle(item.section)} (${counts[item.section]})${hint}`, width),
-				);
+				return theme.bold(truncateToWidth(`${sectionTitle(item.section)} (${counts[item.section]})`, width));
 			}
 			return this.renderRow(item.row, width, layout);
 		});
@@ -2612,8 +2588,8 @@ export class AgentsViewMode implements Component, Focusable {
 		const actions = [
 			`${keyText("tui.select.confirm")} open   ${keyText("app.agents.open")} open   ${keyText("app.agents.new")} new`,
 			`${keyText("app.agents.expand")} expand/collapse subagents   ${keyText("app.agents.program")} program`,
-			`${keyText("app.agents.inactiveCollapse")} show/hide inactive   ${keyText("app.shortcuts")} close actions`,
 			`${keyText("app.agents.reply")} reply/resume   ${keyText("app.agents.rename")} rename   ${keyText("app.agents.delete")} stop/delete`,
+			`${keyText("app.shortcuts")} close actions`,
 		];
 		if (row) {
 			const model = row.summary.model;
@@ -2784,12 +2760,10 @@ type DisplayItem =
 	| { type: "running-subagents"; row: AgentsViewRow }
 	| { type: "row"; row: AgentsViewRow };
 
-function compactSessionRows(rows: readonly AgentsViewRow[], showInactive: boolean): AgentsViewRow[] {
-	let visible = true;
-	return rows.filter((row) => {
-		if (row.depth === 0) visible = showInactive || row.section !== "inactive";
-		return visible && row.kind !== "subagent-summary";
-	});
+// Summary rows fold into the running-subagents display items; session rows
+// themselves always render — inactive included, search is the filter.
+function compactSessionRows(rows: readonly AgentsViewRow[]): AgentsViewRow[] {
+	return rows.filter((row) => row.kind !== "subagent-summary");
 }
 
 // Nested rows (subagent summaries and expanded subagents) always render in

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -786,37 +786,57 @@ describe("AgentsViewMode", () => {
 			model: { ...getModel("openai", "gpt-4o"), provider: "prime-inference", id: "glm-5.2-fast" },
 			usage: { inputTokens: 900, outputTokens: 80, cost: 123.45 },
 		});
-		const rows = buildAgentsViewRows([parent, child, inactive]);
+		const empty = summary({
+			id: "empty-draft",
+			activeSessionId: undefined,
+			sessionId: "empty-draft-session",
+			sessionFile: "/tmp/empty-draft.jsonl",
+			rosterStatus: "inactive",
+			messageCount: 0,
+			modified: created,
+		});
+		const rows = buildAgentsViewRows([parent, child, inactive, empty]);
 		const view = new AgentsViewMode({ config: {}, uiServices: createUiServices() }, {});
 		Reflect.set(view, "rows", rows);
 		Reflect.set(view, "selectedIndex", -1);
 		try {
 			const parentRow = rows.find((row) => row.summary.sessionId === parent.sessionId)!;
 			const savedRow = rows.find((row) => row.summary.sessionId === inactive.sessionId)!;
+			const layout = buildCompactAgentsViewLayout(rows, 120);
 			const render = (row: AgentsViewRow, width: number) =>
 				stripAnsi(invoke("renderRow", view, row, width, buildCompactAgentsViewLayout(rows, width)) as string);
 			const parentLine = render(parentRow, 120);
 			const savedLine = render(savedRow, 120);
 			expect(parentLine).toContain("gpt-5.6-sol");
 			expect(savedLine).toContain("glm-5.2-fast");
-			expect(parentLine).toContain("$1.10");
-			expect(parentLine).not.toContain("$0.42");
-			expect(parentLine).not.toMatch(/[↑↓]/);
-			expect(parentLine).toMatch(/2m\s*$/);
-			expect(parentLine.indexOf("$1.10") + "$1.10".length).toBe(savedLine.indexOf("$123.45") + "$123.45".length);
-			for (const width of [60, 80]) {
-				const narrow = render(parentRow, width);
-				expect(narrow).toContain("gpt-5.6-sol");
-				expect(narrow).toContain("$1.10");
-				expect(narrow).toMatch(/2m\s*$/);
-				expect(narrow.length).toBeLessThanOrEqual(width);
-			}
+			// Full #2056 usage cell: tokens, own cost, explicit descendant count, total.
+			expect(parentLine).toContain("↑12k ↓1.2k");
+			expect(parentLine).toMatch(/\$0\.42 ·\s+1 ·\s+\$1\.10 ·\s+2m\s*$/);
+			// Every section's age column ends at the terminal edge.
+			expect(savedLine).toMatch(/\$123\.45 ·\s+2m\s*$/);
+			expect(parentLine.length).toBe(savedLine.length);
+			// The ` · ` separators land in the same column for a section's legend
+			// and each of its rows.
+			const dotColumns = (text: string) => [...text].flatMap((ch, index) => (ch === "·" ? [index] : []));
+			expect(dotColumns(layout.details.get(parentRow.identity)!)).toEqual(dotColumns(layout.legends.get("idle")!));
+			expect(dotColumns(layout.details.get(savedRow.identity)!)).toEqual(
+				dotColumns(layout.legends.get("inactive")!),
+			);
+			// Empty sessions keep only their age, aligned to the age column.
+			const emptyDetails = layout.details.get(rows.find((row) => row.summary.messageCount === 0)!.identity)!;
+			expect(emptyDetails.trim()).toBe("2m");
+			expect(emptyDetails).not.toContain("$");
+			// Activity shrinks first at narrow widths; model and usage survive at 80.
+			const narrow = render(parentRow, 80);
+			expect(narrow).toContain("gpt-5.6-sol");
+			expect(narrow).toMatch(/\$1\.10 ·\s+2m\s*$/);
+			expect(narrow.length).toBeLessThanOrEqual(80);
 		} finally {
 			stopThemeWatcher();
 		}
 	});
 
-	it("renders one column header across status groups without repeating subagent hints", () => {
+	it("puts the bold usage legend on each section header without repeating subagent hints", () => {
 		const summaries = [
 			summary({
 				id: "busy",
@@ -849,10 +869,12 @@ describe("AgentsViewMode", () => {
 			Reflect.set(view, "ui", { terminal: { rows: 60 }, requestRender: () => {} });
 			const rendered = invoke("renderSessionRows", view, 120, 40) as string[];
 			const lines = rendered.map(stripAnsi);
-			expect(lines.filter((line) => /Model/.test(line) && /Age/i.test(line))).toHaveLength(1);
-			expect(lines.some((line) => line.startsWith("Running"))).toBe(true);
-			expect(lines.some((line) => line.startsWith("Idle"))).toBe(true);
-			expect(lines.join("\n")).not.toMatch(/show program|#sub|\$agent|↑in|↓out/);
+			const headings = lines.filter((line) => /^(Running|Idle|Inactive) \(\d+\)/.test(line));
+			expect(headings.length).toBeGreaterThanOrEqual(2);
+			for (const heading of headings) {
+				expect(heading).toMatch(/↑in\s+↓out ·\s+\$agent ·\s+#sub ·\s+\$total ·\s+age$/);
+			}
+			expect(lines.join("\n")).not.toMatch(/show program|Session\s+Model/);
 			const rows = Reflect.get(view, "rows") as AgentsViewRow[];
 			expect(rows.filter((row) => row.kind === "subagent-summary")).toHaveLength(0);
 			for (const line of rendered) {
@@ -963,7 +985,7 @@ describe("AgentsViewMode", () => {
 			Reflect.set(view, "selectedIndex", rows.length - 1);
 			Reflect.set(view, "ui", { terminal: { rows: 13 }, requestRender: () => {} });
 			const lines = (invoke("renderSessionRows", view, 120, 4) as string[]).map(stripAnsi);
-			expect(lines[1]).toContain("...");
+			expect(lines[0]).toContain("...");
 			expect(lines).toHaveLength(4);
 			const lastTitle = rows.at(-1)!.title;
 			expect(lines.some((line) => line.includes(lastTitle))).toBe(true);

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -808,25 +808,18 @@ describe("AgentsViewMode", () => {
 			const parentLine = render(parentRow, 120);
 			const savedLine = render(savedRow, 120);
 			expect(parentLine).toContain("gpt-5.6-sol");
-			expect(savedLine).toContain("glm-5.2-fast");
-			// Full #2056 usage cell: tokens, own cost, explicit descendant count, total.
-			expect(parentLine).toContain("↑12k ↓1.2k");
-			expect(parentLine).toMatch(/\$0\.42 ·\s+1 ·\s+\$1\.10 ·\s+2m\s*$/);
-			// Every section's age column ends at the terminal edge.
+			expect(parentLine).toMatch(/↑12k ↓1\.2k ·\s+\$0\.42 ·\s+1 ·\s+\$1\.10 ·\s+2m\s*$/);
+			// Sections size their columns independently but share the right edge.
 			expect(savedLine).toMatch(/\$123\.45 ·\s+2m\s*$/);
 			expect(parentLine.length).toBe(savedLine.length);
-			// The ` · ` separators land in the same column for a section's legend
-			// and each of its rows.
+			// Separators land in the same column for a section's legend and rows.
 			const dotColumns = (text: string) => [...text].flatMap((ch, index) => (ch === "·" ? [index] : []));
-			expect(dotColumns(layout.details.get(parentRow.identity)!)).toEqual(dotColumns(layout.legends.get("idle")!));
 			expect(dotColumns(layout.details.get(savedRow.identity)!)).toEqual(
 				dotColumns(layout.legends.get("inactive")!),
 			);
-			// Empty sessions keep only their age, aligned to the age column.
 			const emptyDetails = layout.details.get(rows.find((row) => row.summary.messageCount === 0)!.identity)!;
 			expect(emptyDetails.trim()).toBe("2m");
-			expect(emptyDetails).not.toContain("$");
-			// Activity shrinks first at narrow widths; model and usage survive at 80.
+			// Activity shrinks first: model and usage survive at 80 columns.
 			const narrow = render(parentRow, 80);
 			expect(narrow).toContain("gpt-5.6-sol");
 			expect(narrow).toMatch(/\$1\.10 ·\s+2m\s*$/);

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -874,7 +874,7 @@ describe("AgentsViewMode", () => {
 			rosterStatus: "inactive",
 			lifecycle: "archived",
 		});
-		// A stale inactiveExpanded flag from an older session must be ignored.
+		// The stale pre-removal collapse flag must be ignored.
 		const persistentState = { savedCatalogLoaded: true, inactiveExpanded: false } as AgentsViewPersistentState;
 		const view = new AgentsViewMode({ config: {}, uiServices: createUiServices() }, persistentState);
 		const rows = () => Reflect.get(view, "rows") as AgentsViewRow[];
@@ -896,11 +896,9 @@ describe("AgentsViewMode", () => {
 			]);
 			invoke("reconcileCatalogs", view);
 			expect(showsSaved()).toBe(true);
-			// The removed Alt+I collapse chord must not hide anything anymore.
+			// The removed Alt+I chord must not hide anything.
 			view.handleInput("\x1bi");
 			expect(showsSaved()).toBe(true);
-			invoke("setSearchQuery", view, "archive-match");
-			expect(rows().map((row) => row.summary.sessionId)).toEqual([saved.sessionId]);
 			invoke("setSearchQuery", view, "no-such-session");
 			expect(showsSaved()).toBe(false);
 		} finally {

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -863,7 +863,7 @@ describe("AgentsViewMode", () => {
 		}
 	});
 
-	it("keeps collapsed inactive sessions out of navigation and reveals them for search", () => {
+	it("always renders inactive sessions; search is the only filter", () => {
 		const live = summary({ sessionName: "live" });
 		const saved = summary({
 			id: "saved",
@@ -874,8 +874,11 @@ describe("AgentsViewMode", () => {
 			rosterStatus: "inactive",
 			lifecycle: "archived",
 		});
-		const view = new AgentsViewMode({ config: {}, uiServices: createUiServices() }, { savedCatalogLoaded: true });
+		// A stale inactiveExpanded flag from an older session must be ignored.
+		const persistentState = { savedCatalogLoaded: true, inactiveExpanded: false } as AgentsViewPersistentState;
+		const view = new AgentsViewMode({ config: {}, uiServices: createUiServices() }, persistentState);
 		const rows = () => Reflect.get(view, "rows") as AgentsViewRow[];
+		const showsSaved = () => rows().some((row) => row.summary.sessionId === saved.sessionId);
 		try {
 			Reflect.set(view, "lastListedSummaries", [live]);
 			Reflect.set(view, "savedSessions", [
@@ -892,17 +895,14 @@ describe("AgentsViewMode", () => {
 				},
 			]);
 			invoke("reconcileCatalogs", view);
-			expect(rows().map((row) => row.summary.sessionId)).toEqual([live.sessionId]);
-			invoke("moveSelection", view, 1);
-			expect(rows()[Reflect.get(view, "selectedIndex") as number]?.summary.sessionId).toBe(live.sessionId);
+			expect(showsSaved()).toBe(true);
+			// The removed Alt+I collapse chord must not hide anything anymore.
 			view.handleInput("\x1bi");
-			expect(rows().some((row) => row.summary.sessionId === saved.sessionId)).toBe(true);
-			view.handleInput("\x1bi");
-			expect(rows().some((row) => row.summary.sessionId === saved.sessionId)).toBe(false);
+			expect(showsSaved()).toBe(true);
 			invoke("setSearchQuery", view, "archive-match");
-			expect(rows().some((row) => row.summary.sessionId === saved.sessionId)).toBe(true);
-			invoke("setSearchQuery", view, "");
-			expect(rows().some((row) => row.summary.sessionId === saved.sessionId)).toBe(false);
+			expect(rows().map((row) => row.summary.sessionId)).toEqual([saved.sessionId]);
+			invoke("setSearchQuery", view, "no-such-session");
+			expect(showsSaved()).toBe(false);
 		} finally {
 			stopThemeWatcher();
 		}

--- a/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
+++ b/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
@@ -453,7 +453,7 @@ describe("#502 unified session view regressions", () => {
 				50,
 			),
 		);
-		expect(rendered).toMatch(/\$0\.00\s+2h\s*$/);
+		expect(rendered).toMatch(/\$0\.00 ·\s+2h\s*$/);
 	});
 
 	test("rows keep compact model IDs visible on every row kind", () => {
@@ -500,10 +500,13 @@ describe("#502 unified session view regressions", () => {
 
 		const full = render(160);
 		expect(full).toMatch(/Inspect agents view\s+gpt-5\.6-terra\s+Investigate a variable background status/);
-		for (const width of [60, 80, 120]) {
+		for (const width of [80, 120]) {
 			expect(render(width)).toContain("gpt-5.6-terra");
 			expect(render(width)).toHaveLength(width);
 		}
+		// Below ~70 columns the model column truncates before the usage cell does.
+		expect(render(60)).toContain("gpt-5");
+		expect(render(60)).toHaveLength(60);
 		const narrow = render(100);
 		expect(narrow).toContain("gpt-5.6-terra");
 		expect(narrow).not.toContain("prime-inference/");

--- a/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
+++ b/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
@@ -504,7 +504,7 @@ describe("#502 unified session view regressions", () => {
 			expect(render(width)).toContain("gpt-5.6-terra");
 			expect(render(width)).toHaveLength(width);
 		}
-		// Below ~70 columns the model column truncates before the usage cell does.
+		// Below ~70 columns the model truncates before the usage cell.
 		expect(render(60)).toContain("gpt-5");
 		expect(render(60)).toHaveLength(60);
 		const narrow = render(100);


### PR DESCRIPTION
Fixes RES-1317

**Stacked on #2091** (`fix/agents-view-always-show-inactive`) — merge that first; this branch is based on it.

## Purpose

Restores the #2056 agents-view row format (reviewed in #2056) that #2087's consolidation replaced, and keeps the redesign's other features.

## Row format

`↑in ↓out · $agent · #sub · $total · age` per session row:
- One shared column layout per section: each column is as wide as the section's widest value or its legend label, everything right-aligned, so the ` · ` separators land in the same terminal column for the legend and every row of that section. A $100+ row widens only its own section.
- Bold usage legend right-aligned on every section header (`Running (n)` ... `↑in ↓out · $agent · #sub · $total · age`), replacing the single global `Session Model Activity Cost Age` header line.
- `#sub` is the total descendant count (explicit `0`); `$total` the recursive cost; branch/fork lineage stays excluded (state layer untouched).
- Empty sessions (no messages) render only their age, aligned to the age column.
- Usage cells right-align to the terminal edge, so every section's age column ends at the same column.

## Model column placement (decision)

The Model column (compact ids, from the redesign) stays as a column between the session title and the usage cell — it composes cleanly with the usage columns at 120 and 80 columns. The #2056 alternative (model in the dim suffix) would compete with the Activity text. Shrink order at narrow widths keeps #2087's rule: Activity shrinks first (dropped at 0), then Model truncates, then the session title; the usage cell keeps its columns. Tradeoff: below ~70 columns the model id truncates (e.g. `gpt-5…` at 60 cols) — the usage columns take priority per the restored format.

## Kept from the redesign

Expandable child sessions (Alt+Right), the transient running-subagents line, the actions/usage breakdown behind `?`, compact model IDs, empty-session sort + entered-from anchor exception, always-show-inactive (#2091).

## Tests

- Re-pinned the #2056 behaviors in the existing tests (no new files): full usage cell with explicit `0` and `$agent` alongside `$total`; separator-column equality between each section's legend and rows; empty sessions age-only; per-section headers carry the bold legend; right-edge alignment across sections; narrow-width behavior (80 keeps model + usage; 60 documents the truncation tradeoff). Branch-lineage exclusion pins were untouched in the state suite.
- Fail-unfixed: reverting the src hunks fails exactly the four re-pinned tests.

## LOC

Total src: **+96/−27 (net +69)**; tests: +40/−22 (net +18). Src restores the #2056 usage-column rendering (per-section shared layouts + legends) over #2087's single-header format; state layer untouched. +1 changelog fragment.

## Validation

- `npm run check` green (pre-commit hook).
- agents-view-mode (36), agents-view-state (77), 502 regressions (15), roster, search, inactive-reply, missing-cwd green locally; sandbox run reported in checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal UI and layout logic only in agents-view; exported `AgentsViewUsageLayout` drops `legend` for `legends` map, but usage is confined to this package.
> 
> **Overview**
> Brings back the compact agents-view usage strip **`↑in ↓out · $agent · #sub · $total · age`** on each session row (alongside the model column), replacing the simplified **Cost / Age** suffix from the recent consolidation.
> 
> **Layout and headers:** Drops the single global **Session · Model · Activity** header row and reserves the full list viewport for sessions. Each section heading (**Running**, **Idle**, **Inactive**) now carries a **bold, right-aligned usage legend** aligned with that section’s columns. **`buildCompactAgentsViewLayout`** computes column widths **per section** (widest value or label), right-aligns cells so **` · `** separators line up, and keeps the **age** column flush to the terminal edge across sections. **Empty sessions** (no messages) show **age only** in the usage cell.
> 
> **Rendering:** Row usage is padded to the right edge; **Activity** still shrinks first at narrow widths; tests document model truncation below ~70 columns while usage columns stay prioritized.
> 
> **Tests:** Existing agents-view and regression tests are updated for full usage strings, legend/row separator alignment, per-section headers, empty-session behavior, and ellipsis viewport indexing without the reserved header row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a869165271972812003bdb64f0c6c2b4e08535c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore agents-view usage columns and remove inactive-session collapse
> - Removes the `app.agents.inactiveCollapse` keybinding, `Alt+I` default, and `inactiveExpanded` persistent state from `AgentsViewMode`; inactive sessions are now always shown and search is the only filter.
> - Restores multi-column usage details (`↑in`, `↓out`, `$agent`, `#sub`, `$total`, `age`) computed per section by `buildCompactAgentsViewLayout`, with each section heading rendering its own bold right-aligned legend instead of a single global header row.
> - `compactSessionRows` drops its `showInactive` parameter and now retains all top-level sessions, filtering only `subagent-summary` rows.
> - Risk: `AgentsViewPersistentState` loses the `inactiveExpanded` field; any persisted state from older builds carrying that property is ignored. Removing the global header row shifts viewport offsets by one line, which is covered by updated tests in [agents-view-mode.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2092/files#diff-bbeca49f58d79eef24abf26818a4a4fd8cd2e0d319e8c4629a58dab7af006a3b).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a869165.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->