### PR TITLE
feat(acp): expose model and reasoning configuration

### DIFF
--- a/packages/coding-agent/.changes/acp-session-config.md
+++ b/packages/coding-agent/.changes/acp-session-config.md
@@ -1,0 +1,1 @@
+- Added ACP model and reasoning selectors through session config options, with dependent option updates when switching models.

--- a/packages/coding-agent/docs/acp.md
+++ b/packages/coding-agent/docs/acp.md
@@ -20,6 +20,7 @@ Use ACP mode when something external needs to *drive* a session interactively: p
 |---|---|
 | `initialize` | Returns protocol version, capabilities, and agent info. |
 | `session/new` | Creates the session. One session per connection. |
+| `session/set_config_option` | Selects the model or reasoning level and returns the complete configuration. |
 | `session/prompt` | Runs one turn and resolves with a stop reason. |
 | `session/cancel` | Notification; aborts the addressed session's turn. |
 | `session/close` | Releases the session and frees the connection for a new one. |
@@ -27,6 +28,37 @@ Use ACP mode when something external needs to *drive* a session interactively: p
 One session per connection is a deliberate limit: Prime Agent's underlying session is fixed at process startup, so a second concurrent session would silently share its conversation, working directory, and model. A second `session/new` is refused rather than pretending to isolate. Start another process for a second session.
 
 Likewise `session/prompt` refuses a concurrent turn while one is running, and the working directory cannot be changed after startup — a client-supplied `cwd` that differs from the agent's real one is reported back in `_meta` rather than silently ignored.
+
+## Session configuration
+
+`session/new` returns standard ACP `configOptions` for the current model and, when
+multiple levels are supported, its reasoning level. Model values use `provider/model-id`;
+reasoning values are the levels supported by the selected model.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "session/set_config_option",
+  "params": {
+    "sessionId": "<session-id>",
+    "configId": "thought_level",
+    "value": "high"
+  }
+}
+```
+
+Use `configId: "model"` to select a model. Both selectors accept only advertised
+values. Changes can be made during a prompt and use the same session settings as
+the terminal UI. Switching models updates the available reasoning levels and may
+adjust the current level. Every successful response contains all config options.
+
+Changes are also published as `config_option_update` notifications. The adapter
+refreshes configuration on reasoning changes, session replacement or resynchronization,
+and turn boundaries. A model-only change from another client may become visible at
+the next refresh because the connection has no dedicated model-change event.
+If the model catalog cannot be read during setup, the session remains usable with
+an empty configuration list. No permission modes are introduced by these selectors.
 
 ## MCP servers
 

--- a/packages/coding-agent/src/modes/acp/acp-config.ts
+++ b/packages/coding-agent/src/modes/acp/acp-config.ts
@@ -1,0 +1,123 @@
+import { RequestError, type SessionConfigOption } from "@agentclientprotocol/sdk";
+import type { AgentConnection, AgentConnectionModel } from "../agent-connection/types.js";
+
+function modelValue(model: AgentConnectionModel): string {
+	return `${model.provider}/${model.id}`;
+}
+
+export class AcpSessionConfig {
+	private tail: Promise<void> = Promise.resolve();
+	private current: SessionConfigOption[] = [];
+	private closed = false;
+	private refreshPending = false;
+
+	constructor(
+		private readonly connection: AgentConnection,
+		private readonly publish: (configOptions: SessionConfigOption[]) => Promise<boolean>,
+	) {}
+
+	async initialize(): Promise<SessionConfigOption[]> {
+		this.current = await this.read();
+		return this.current;
+	}
+
+	refresh(): Promise<void> {
+		if (this.closed || this.refreshPending) return this.tail;
+		this.refreshPending = true;
+		return this.enqueue(async () => {
+			this.refreshPending = false;
+			if (!this.closed) await this.update();
+		});
+	}
+
+	set(configId: string, value: string | boolean): Promise<SessionConfigOption[]> {
+		return this.enqueue(async () => {
+			this.assertOpen();
+			const configOptions = await this.read();
+			this.assertOpen();
+			const option = configOptions.find((candidate) => candidate.id === configId);
+			if (
+				!option ||
+				option.type !== "select" ||
+				!option.options.some((candidate) => "value" in candidate && candidate.value === value)
+			) {
+				throw RequestError.invalidParams({ reason: `Invalid value for ACP config option ${configId}: ${value}` });
+			}
+			if (configId === "model") {
+				const models = await this.connection.getAvailableModels();
+				this.assertOpen();
+				const model = models.find((candidate) => modelValue(candidate) === value);
+				if (!model) throw RequestError.invalidParams({ reason: `Model is not available: ${value}` });
+				await this.connection.setModel(model.provider, model.id);
+			} else {
+				const state = await this.connection.getState();
+				this.assertOpen();
+				const level = state.availableThinkingLevels.find((candidate) => candidate === value);
+				if (!level) throw RequestError.invalidParams({ reason: `Reasoning level is not available: ${value}` });
+				await this.connection.setThinkingLevel(level);
+			}
+			return this.update();
+		});
+	}
+
+	async close(): Promise<void> {
+		this.closed = true;
+		await this.tail;
+	}
+
+	private assertOpen(): void {
+		if (this.closed) throw RequestError.invalidParams({ reason: "ACP session configuration is closed" });
+	}
+
+	private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this.tail.then(operation);
+		this.tail = result.then(
+			() => {},
+			() => {},
+		);
+		return result;
+	}
+
+	private async read(): Promise<SessionConfigOption[]> {
+		let state = await this.connection.getState();
+		if (!state.model) return [];
+		const models = await this.connection.getAvailableModels();
+		state = await this.connection.getState();
+		if (!state.model) return [];
+		const values = new Map(models.map((model) => [modelValue(model), model]));
+		// Keep the current selection representable even if its credentials just expired.
+		values.set(modelValue(state.model), state.model);
+		const configOptions: SessionConfigOption[] = [
+			{
+				id: "model",
+				name: "Model",
+				category: "model",
+				type: "select",
+				currentValue: modelValue(state.model),
+				options: [...values.values()].map((model) => ({
+					value: modelValue(model),
+					name: `${model.name} (${model.provider})`,
+				})),
+			},
+		];
+		if (state.availableThinkingLevels.length > 1) {
+			configOptions.push({
+				id: "thought_level",
+				name: "Reasoning level",
+				category: "thought_level",
+				type: "select",
+				currentValue: state.thinkingLevel,
+				options: state.availableThinkingLevels.map((level) => ({ value: level, name: level })),
+			});
+		}
+		return configOptions;
+	}
+
+	private async update(): Promise<SessionConfigOption[]> {
+		const configOptions = await this.read();
+		if (!this.closed && JSON.stringify(configOptions) !== JSON.stringify(this.current)) {
+			if (await this.publish(configOptions)) this.current = configOptions;
+		}
+		return configOptions;
+	}
+}

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -17,6 +17,7 @@ import type {
 	AgentConnectionSessionInputPause,
 } from "../agent-connection/types.js";
 import { latestAutonomousGateAttempt } from "../headless-completion.js";
+import { AcpSessionConfig } from "./acp-config.js";
 import { type AcpEventMappingState, acpUpdatesForSessionEvent } from "./acp-events.js";
 import { resolveAcpMcpServers } from "./acp-mcp.js";
 import { PRIME_AGENT_META_NAMESPACE, type PrimeAgentAutonomousMeta, primeAgentMeta } from "./acp-meta.js";
@@ -131,6 +132,7 @@ interface AcpSessionEntry {
 	resolvePromptTask: (() => void) | undefined;
 	unsubscribe: (() => void) | undefined;
 	producer: AcpUpdateProducer;
+	config: AcpSessionConfig;
 }
 
 /**
@@ -768,6 +770,9 @@ export async function runAcpModeWithConnection(
 					resolvePromptTask: undefined,
 					unsubscribe: undefined,
 					producer,
+					config: new AcpSessionConfig(connection, (configOptions) =>
+						producer.publish({ sessionUpdate: "config_option_update", configOptions }, 0, "event"),
+					),
 				};
 				// Subscribe for the session lifetime, not per prompt turn: prime-agent
 				// subagents are fire-and-forget and keep reporting after the spawning turn
@@ -776,7 +781,23 @@ export async function runAcpModeWithConnection(
 				// the run that produced it.
 				const mappingState: AcpEventMappingState = {};
 				const observedChildren = new Map<string, unknown>();
+				const refreshConfig = () => {
+					void entry.config.refresh().catch((error: unknown) => {
+						console.error(`Failed to refresh ACP configuration: ${String(error)}`);
+					});
+				};
 				const unsubscribe = connection.subscribe((event) => {
+					if (
+						session === entry &&
+						(event.type === "session_replaced" ||
+							event.type === "session_resynced" ||
+							(event.type === "session_event" &&
+								(event.event.type === "thinking_level_changed" ||
+									event.event.type === "agent_start" ||
+									event.event.type === "agent_end")))
+					) {
+						refreshConfig();
+					}
 					// Heartbeats are connection-scoped, including if one races a prompt.
 					// They therefore intentionally use origin turn 0.
 					if (event.type === "heartbeats_changed") {
@@ -796,10 +817,15 @@ export async function runAcpModeWithConnection(
 						void producer.publish(update, turnId, "event");
 					}
 				});
+				let configOptions: acp.SessionConfigOption[] = [];
 				try {
 					// Reconcile after subscribing so updates cannot be lost while the snapshot
 					// request is in flight. Do not turn a failed read into an empty roster.
 					const initialSnapshot = await connection.getInitialSnapshot();
+					configOptions = await entry.config.initialize().catch((error: unknown) => {
+						console.error(`Failed to load ACP configuration: ${String(error)}`);
+						return [];
+					});
 					for (const child of initialSnapshot.children ?? []) {
 						if (observedChildren.has(child.id)) continue;
 						observedChildren.set(child.id, child);
@@ -812,6 +838,7 @@ export async function runAcpModeWithConnection(
 				} catch (error) {
 					producer.failSessionNewAdmission();
 					unsubscribe();
+					await entry.config.close();
 					await clearAcpMcpServers().catch(() => undefined);
 					throw error;
 				}
@@ -821,6 +848,7 @@ export async function runAcpModeWithConnection(
 				session = entry;
 				const response = {
 					sessionId,
+					configOptions,
 					...(cwdMismatch ? { _meta: primeAgentMeta({ cwd: cwdMismatch }) } : {}),
 				};
 				// The stream wrapper commits this gate after this exact response has
@@ -835,6 +863,14 @@ export async function runAcpModeWithConnection(
 			} finally {
 				sessionNewInFlight = false;
 			}
+		})
+		.onRequest("session/set_config_option", async (ctx) => {
+			const params = ctx.params as acp.SetSessionConfigOptionRequest;
+			const entry = session?.id === params.sessionId ? session : undefined;
+			if (!entry || sessionCloseInFlight || entry.cancelling || entry.stopFailure) {
+				throw acp.RequestError.invalidParams({ reason: `ACP session is unavailable: ${params.sessionId}` });
+			}
+			return { configOptions: await entry.config.set(params.configId, params.value) };
 		})
 		.onRequest("session/prompt", async (ctx: any) => {
 			const params = ctx.params as { sessionId: string; prompt: readonly unknown[] };
@@ -1014,6 +1050,7 @@ export async function runAcpModeWithConnection(
 					if (!inputPauseKey) throw new Error("Missing ACP close input-pause key");
 					await stopSessionWork(pending, promptTask);
 					closing.unsubscribe?.();
+					await closing.config.close();
 					// Keep the backing session fenced until a replacement ACP session is admitted.
 					await closing.producer.close();
 					// Host credentials are already gone before kernel release runs. Do not
@@ -1095,6 +1132,7 @@ export async function runAcpModeWithConnection(
 	await handle.closed.catch(() => undefined);
 	session?.abort?.abort();
 	session?.unsubscribe?.();
+	await session?.config.close();
 	await session?.inputPause?.release().catch(() => undefined);
 	session = undefined;
 	await closedInputPause?.release().catch(() => undefined);

--- a/packages/coding-agent/test/suite/acp-config.test.ts
+++ b/packages/coding-agent/test/suite/acp-config.test.ts
@@ -1,0 +1,281 @@
+import * as acp from "@agentclientprotocol/sdk";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentSessionRuntime } from "../../src/core/agent-session-runtime.js";
+import { runAcpModeWithConnection } from "../../src/modes/acp/acp-mode.js";
+import { InProcessAgentConnection } from "../../src/modes/agent-connection/in-process-agent-connection.js";
+import { createHarness } from "./harness.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+	for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+	vi.restoreAllMocks();
+});
+
+async function createClient() {
+	const harness = await createHarness({
+		models: [
+			{ id: "reasoning/model", name: "Reasoning", reasoning: true },
+			{ id: "plain", name: "Plain", reasoning: false },
+		],
+	});
+	const runtime = {
+		session: harness.session,
+		setRebindSession() {},
+		setBeforeSessionInvalidate() {},
+		async dispose() {},
+	} as unknown as AgentSessionRuntime;
+	const connection = new InProcessAgentConnection(runtime);
+	let inputController!: TransformStreamDefaultController<Uint8Array>;
+	const toAgent = new TransformStream<Uint8Array, Uint8Array>({
+		start(controller) {
+			inputController = controller;
+		},
+	});
+	const toClient = new TransformStream<Uint8Array, Uint8Array>();
+	const updates: acp.SessionNotification[] = [];
+	const running = runAcpModeWithConnection(connection, {
+		stream: acp.ndJsonStream(toClient.writable, toAgent.readable),
+	});
+	const handle = acp
+		.client({ name: "config-test" })
+		.onNotification("session/update", (ctx) => {
+			updates.push(ctx.params as acp.SessionNotification);
+		})
+		.connect(acp.ndJsonStream(toAgent.writable, toClient.readable));
+	cleanups.push(async () => {
+		handle.close();
+		inputController.terminate();
+		await running;
+		harness.cleanup();
+	});
+	await handle.agent.request("initialize", {
+		protocolVersion: acp.PROTOCOL_VERSION,
+		clientCapabilities: {},
+	});
+	const configUpdates = () =>
+		updates.flatMap(({ update }) => (update.sessionUpdate === "config_option_update" ? [update.configOptions] : []));
+	return { harness, connection, client: handle.agent, updates, configUpdates };
+}
+
+async function createSession() {
+	const fixture = await createClient();
+	const session = await fixture.client.request("session/new", { cwd: fixture.harness.tempDir, mcpServers: [] });
+	return { ...fixture, session };
+}
+
+describe("ACP session configuration", () => {
+	it("advertises selectable models and supported reasoning levels with current values", async () => {
+		const { harness, session } = await createSession();
+		expect(session.configOptions).toEqual([
+			{
+				id: "model",
+				name: "Model",
+				category: "model",
+				type: "select",
+				currentValue: `${harness.getModel().provider}/reasoning/model`,
+				options: harness.models.map((model) => ({
+					value: `${model.provider}/${model.id}`,
+					name: `${model.name} (${model.provider})`,
+				})),
+			},
+			{
+				id: "thought_level",
+				name: "Reasoning level",
+				category: "thought_level",
+				type: "select",
+				currentValue: harness.session.thinkingLevel,
+				options: harness.session.getAvailableThinkingLevels().map((level) => ({ value: level, name: level })),
+			},
+		]);
+	});
+
+	it("sets reasoning, then returns dependent configuration when switching models", async () => {
+		const { harness, client, session, configUpdates } = await createSession();
+		const reasoning = await client.request("session/set_config_option", {
+			sessionId: session.sessionId,
+			configId: "thought_level",
+			value: "high",
+		});
+		expect(harness.session.thinkingLevel).toBe("high");
+		expect(reasoning.configOptions).toHaveLength(2);
+		expect(reasoning.configOptions[1]?.currentValue).toBe("high");
+		const switched = await client.request("session/set_config_option", {
+			sessionId: session.sessionId,
+			configId: "model",
+			value: `${harness.getModel().provider}/plain`,
+		});
+		expect(harness.session.model?.id).toBe("plain");
+		expect(harness.session.thinkingLevel).toBe("off");
+		expect(switched.configOptions.map((option) => option.id)).toEqual(["model"]);
+		expect(configUpdates().at(-1)).toEqual(switched.configOptions);
+		const restored = await client.request("session/set_config_option", {
+			sessionId: session.sessionId,
+			configId: "model",
+			value: `${harness.getModel().provider}/reasoning/model`,
+		});
+		expect(restored.configOptions[1]?.currentValue).toBe("high");
+	});
+
+	it.each([
+		{ configId: "unknown", value: "high" },
+		{ configId: "model", value: "unknown/model" },
+		{ configId: "thought_level", value: "extreme" },
+	])("rejects invalid configuration without changing the session: $configId=$value", async (params) => {
+		const { harness, client, session } = await createSession();
+		const previousModel = harness.session.model;
+		const previousLevel = harness.session.thinkingLevel;
+		await expect(
+			client.request("session/set_config_option", { sessionId: session.sessionId, ...params }),
+		).rejects.toMatchObject({ code: -32602 });
+		expect(harness.session.model).toBe(previousModel);
+		expect(harness.session.thinkingLevel).toBe(previousLevel);
+	});
+
+	it("rejects boolean values and unknown or closed sessions", async () => {
+		const { client, session } = await createSession();
+		await expect(
+			client.request("session/set_config_option", {
+				sessionId: session.sessionId,
+				configId: "thought_level",
+				type: "boolean",
+				value: true,
+			}),
+		).rejects.toMatchObject({ code: -32602 });
+		await expect(
+			client.request("session/set_config_option", {
+				sessionId: "missing",
+				configId: "thought_level",
+				value: "high",
+			}),
+		).rejects.toMatchObject({ code: -32602 });
+		await client.request("session/close", { sessionId: session.sessionId });
+		await expect(
+			client.request("session/set_config_option", {
+				sessionId: session.sessionId,
+				configId: "thought_level",
+				value: "high",
+			}),
+		).rejects.toMatchObject({ code: -32602 });
+	});
+
+	it("publishes agent-side reasoning changes without duplicate notifications", async () => {
+		const { harness, configUpdates, client, session } = await createSession();
+		harness.session.setThinkingLevel("high");
+		await vi.waitFor(() => expect(configUpdates().at(-1)?.[1]?.currentValue).toBe("high"));
+		const count = configUpdates().length;
+		await client.request("session/set_config_option", {
+			sessionId: session.sessionId,
+			configId: "thought_level",
+			value: "high",
+		});
+		expect(configUpdates()).toHaveLength(count);
+	});
+
+	it("serializes concurrent selections and recovers after a failed mutation", async () => {
+		const { client, connection, session, harness } = await createSession();
+		vi.spyOn(connection, "setModel").mockRejectedValueOnce(new Error("model unavailable"));
+		await expect(
+			client.request("session/set_config_option", {
+				sessionId: session.sessionId,
+				configId: "model",
+				value: `${harness.getModel().provider}/plain`,
+			}),
+		).rejects.toMatchObject({ code: -32603 });
+		const results = await Promise.all(
+			["low", "high"].map((value) =>
+				client.request("session/set_config_option", {
+					sessionId: session.sessionId,
+					configId: "thought_level",
+					value,
+				}),
+			),
+		);
+		expect(results.map((result) => result.configOptions[1]?.currentValue)).toEqual(["low", "high"]);
+		expect(harness.session.thinkingLevel).toBe("high");
+	});
+
+	it("accepts model configuration while a prompt is still running", async () => {
+		const { client, session, harness } = await createSession();
+		let finishResponse!: () => void;
+		const responseReady = new Promise<void>((resolve) => {
+			finishResponse = resolve;
+		});
+		harness.setResponses([
+			async () => {
+				await responseReady;
+				return fauxAssistantMessage("done");
+			},
+		]);
+		const prompt = client.request("session/prompt", {
+			sessionId: session.sessionId,
+			prompt: [{ type: "text", text: "wait" }],
+		});
+		try {
+			await vi.waitFor(() => expect(harness.session.isStreaming).toBe(true));
+			const result = await client.request("session/set_config_option", {
+				sessionId: session.sessionId,
+				configId: "model",
+				value: `${harness.getModel().provider}/plain`,
+			});
+			expect(result.configOptions[0]?.currentValue).toBe(`${harness.getModel().provider}/plain`);
+			expect(harness.session.isStreaming).toBe(true);
+		} finally {
+			finishResponse();
+			await prompt;
+		}
+	});
+
+	it("waits for an admitted configuration change before closing the session", async () => {
+		const { client, connection, session, harness, configUpdates } = await createSession();
+		let finishChange!: () => void;
+		const changeReady = new Promise<void>((resolve) => {
+			finishChange = resolve;
+		});
+		const setModel = connection.setModel.bind(connection);
+		const changing = vi.spyOn(connection, "setModel").mockImplementation(async (provider, modelId) => {
+			await changeReady;
+			return setModel(provider, modelId);
+		});
+		const mutation = client.request("session/set_config_option", {
+			sessionId: session.sessionId,
+			configId: "model",
+			value: `${harness.getModel().provider}/plain`,
+		});
+		await vi.waitFor(() => expect(changing).toHaveBeenCalledOnce());
+		const closing = client.request("session/close", { sessionId: session.sessionId });
+		try {
+			await expect(
+				client.request("session/set_config_option", {
+					sessionId: session.sessionId,
+					configId: "thought_level",
+					value: "low",
+				}),
+			).rejects.toMatchObject({ code: -32602 });
+		} finally {
+			finishChange();
+			await mutation;
+			await closing;
+		}
+		const count = configUpdates().length;
+		const next = await client.request("session/new", { cwd: harness.tempDir, mcpServers: [] });
+		expect(next.configOptions?.[0]?.currentValue).toBe(`${harness.getModel().provider}/plain`);
+		expect(configUpdates()).toHaveLength(count);
+	});
+
+	it("keeps session startup and prompts usable when the model catalog fails", async () => {
+		const { client, connection, harness } = await createClient();
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.spyOn(connection, "getAvailableModels").mockRejectedValue(new Error("catalog unavailable"));
+		const session = await client.request("session/new", { cwd: harness.tempDir, mcpServers: [] });
+		expect(session.configOptions).toEqual([]);
+		harness.setResponses([fauxAssistantMessage("hello")]);
+		await expect(
+			client.request("session/prompt", {
+				sessionId: session.sessionId,
+				prompt: [{ type: "text", text: "hello" }],
+			}),
+		).resolves.toMatchObject({ stopReason: "end_turn" });
+	});
+});

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -8,7 +8,7 @@ import { join } from "node:path";
 import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
 import { Agent } from "@earendil-works/pi-agent-core";
 import type { FauxModelDefinition, FauxProviderRegistration, FauxResponseStep, Model } from "@earendil-works/pi-ai";
-import { registerFauxProvider } from "@earendil-works/pi-ai";
+import { getApiProvider, registerFauxProvider } from "@earendil-works/pi-ai";
 import type { AgentSessionMessageController } from "../../src/core/agent-messages.js";
 import type { AgentObserveController } from "../../src/core/agent-observe.js";
 import { AgentSession, type AgentSessionEvent, type AutoRefineReviewer } from "../../src/core/agent-session.js";
@@ -114,6 +114,7 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 	});
 	fauxProvider.setResponses([]);
 	const model = fauxProvider.getModel();
+	const fauxStreamSimple = getApiProvider(fauxProvider.api)?.streamSimple;
 	const toolMap = options.tools ? Object.fromEntries(options.tools.map((tool) => [tool.name, tool])) : undefined;
 	const withConfiguredAuth = options.withConfiguredAuth ?? true;
 	const extensionRunnerRef: { current?: ExtensionRunner } = {};
@@ -133,6 +134,7 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 			baseUrl: model.baseUrl,
 			apiKey: "faux-key",
 			api: fauxProvider.api,
+			streamSimple: fauxStreamSimple,
 			models: fauxProvider.models.map((registeredModel) => ({
 				id: registeredModel.id,
 				name: registeredModel.name,


### PR DESCRIPTION
## Context

No-Ticket: ACP clients currently cannot discover or change the session model and reasoning level through standard session configuration options.

## Changes

- Return model and reasoning selectors in `session/new` and implement `session/set_config_option` with full `config_option_update` notifications.
- Validate and serialize changes, update dependent reasoning choices after model switches, and drain pending operations when closing a session.
- Keep session creation usable if the optional model catalog fails. Reuse existing agent connection methods without changing the daemon protocol.
- Document the configuration API and its current synchronization limit: model-only changes from another client may appear on the next refresh or turn.
- Preserve the faux provider across model catalog refreshes in the test harness.

## Validation

- `npm run check` passed.
- From `packages/coding-agent`: `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/acp-config.test.ts test/suite/acp-mode.test.ts test/suite/acp-features.test.ts` — 64 tests passed across 3 files.
- Added 11 configuration tests covering selectors, dependent options, invalid requests, concurrent changes, active prompts, shutdown, and catalog failures, using the faux provider without paid API calls.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `session/set_config_option` to ACP for model and reasoning configuration
> - Adds the `AcpSessionConfig` coordinator in [acp-config.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2105/files#diff-8eb03e83259eefaca8e03d04617185b869dd8392b2d3204674ae983ff24f324d) to advertise model and reasoning-level select options, validate incoming selections, and apply them through `AgentConnection`
> - Integrates configuration into [acp-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2105/files#diff-473a1e95bcc808978b4a7a178715a63a4641e6fd423612a47c6ecdcdb5d111ae): `session/new` returns current options, `session/set_config_option` mutates them, and connection events (replacement, resync, thinking-level change, agent start/end) trigger coalesced refreshes
> - Mutations are serialized via a promise-tail queue; invalid option ids or values return `invalid-params` before any session state changes; dependent reasoning options are reread after a model switch
> - The current model is retained in the advertised list even when the catalog no longer returns it; model-catalog setup failure leaves the session usable with an empty option list
> - Risk: `AcpSessionConfig.close` waits for admitted operations and fences new ones with `invalid-params`; reviewers should confirm shutdown ordering in [acp-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2105/files#diff-473a1e95bcc808978b4a7a178715a63a4641e6fd423612a47c6ecdcdb5d111ae) does not deadlock when a blocked mutation is in-flight
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72a68d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->