### PR TITLE
TelemusAI: Fix Astra compaction, recovery, and Fast mode

### DIFF
--- a/packages/ai/.changes/astra-compaction.md
+++ b/packages/ai/.changes/astra-compaction.md
@@ -1,0 +1,2 @@
+- Added explicit Astra server compaction for OpenAI API keys and ChatGPT login, with opaque checkpoint replay, response validation, and input-limit metadata.
+- Enabled Astra Fast mode for OpenAI providers.

--- a/packages/ai/src/api-registry.ts
+++ b/packages/ai/src/api-registry.ts
@@ -1,3 +1,4 @@
+import type { CompactFunction } from "./compaction.js";
 import type {
 	Api,
 	AssistantMessageEventStream,
@@ -24,12 +25,16 @@ export interface ApiProvider<TApi extends Api = Api, TOptions extends StreamOpti
 	api: TApi;
 	stream: StreamFunction<TApi, TOptions>;
 	streamSimple: StreamFunction<TApi, SimpleStreamOptions>;
+	compact?: CompactFunction<TApi>;
+	supportsCompaction?: (model: Model<TApi>) => boolean;
 }
 
 interface ApiProviderInternal {
 	api: Api;
 	stream: ApiStreamFunction;
 	streamSimple: ApiStreamSimpleFunction;
+	compact?: CompactFunction;
+	supportsCompaction?: (model: Model<Api>) => boolean;
 }
 
 type RegisteredApiProvider = {
@@ -72,6 +77,15 @@ export function registerApiProvider<TApi extends Api, TOptions extends StreamOpt
 			api: provider.api,
 			stream: wrapStream(provider.api, provider.stream),
 			streamSimple: wrapStreamSimple(provider.api, provider.streamSimple),
+			supportsCompaction: provider.supportsCompaction
+				? (model) => model.api === provider.api && provider.supportsCompaction!(model as Model<TApi>)
+				: undefined,
+			compact: provider.compact
+				? (model, context, options) => {
+						if (model.api !== provider.api) throw new Error(`Mismatched compaction api: ${model.api}`);
+						return provider.compact!(model as Model<TApi>, context, options);
+					}
+				: undefined,
 		},
 		sourceId,
 	});

--- a/packages/ai/src/compaction.ts
+++ b/packages/ai/src/compaction.ts
@@ -1,0 +1,58 @@
+import type { Api, Context, Model, SimpleStreamOptions, Usage } from "./types.js";
+
+/** An opaque provider checkpoint; replay the entire window without rewriting its items. */
+export interface ProviderCompactionCheckpoint {
+	version: 1;
+	provider: string;
+	api: Api;
+	model: string;
+	baseUrl: string;
+	items: Record<string, unknown>[];
+	estimatedTokens: number;
+}
+
+export interface ProviderCompactionResult {
+	checkpoint: ProviderCompactionCheckpoint;
+	usage?: Usage;
+}
+
+export interface CompactionOptions extends SimpleStreamOptions {
+	customInstructions?: string;
+}
+
+/** Undefined means unsupported; failures must leave the caller's history intact. */
+export type CompactFunction<TApi extends Api = Api> = (
+	model: Model<TApi>,
+	context: Context,
+	options?: CompactionOptions,
+) => Promise<ProviderCompactionResult | undefined>;
+
+export function isCompactionCheckpoint(value: unknown): value is ProviderCompactionCheckpoint {
+	if (!value || typeof value !== "object") return false;
+	const checkpoint = value as Partial<ProviderCompactionCheckpoint>;
+	return (
+		checkpoint.version === 1 &&
+		typeof checkpoint.provider === "string" &&
+		typeof checkpoint.api === "string" &&
+		typeof checkpoint.model === "string" &&
+		typeof checkpoint.baseUrl === "string" &&
+		typeof checkpoint.estimatedTokens === "number" &&
+		Number.isFinite(checkpoint.estimatedTokens) &&
+		checkpoint.estimatedTokens >= 0 &&
+		Array.isArray(checkpoint.items) &&
+		checkpoint.items.length > 0 &&
+		checkpoint.items.every((item) => item !== null && typeof item === "object" && !Array.isArray(item))
+	);
+}
+
+export function compactionMatchesModel(
+	checkpoint: ProviderCompactionCheckpoint,
+	model: Pick<Model<Api>, "provider" | "id"> & Partial<Pick<Model<Api>, "api" | "baseUrl">>,
+): boolean {
+	return (
+		checkpoint.provider === model.provider &&
+		checkpoint.model === model.id &&
+		(model.api === undefined || checkpoint.api === model.api) &&
+		(model.baseUrl === undefined || checkpoint.baseUrl.replace(/\/+$/, "") === model.baseUrl.replace(/\/+$/, ""))
+	);
+}

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -2,6 +2,7 @@ export type { Static, TSchema } from "typebox";
 export { Type } from "typebox";
 
 export * from "./api-registry.js";
+export * from "./compaction.js";
 export * from "./env-api-keys.js";
 export * from "./log.js";
 export * from "./models.js";

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -37,11 +37,29 @@ export function getModels<TProvider extends KnownProvider>(
 
 export function supportsFastMode<TApi extends Api>(model: Model<TApi>): boolean {
 	const eligibleId =
-		model.id === "gpt-5.4" || model.id === "gpt-5.5" || model.id === "gpt-5.6" || model.id.startsWith("gpt-5.6-");
+		model.id === "gpt-5.4" ||
+		model.id === "gpt-5.5" ||
+		model.id === "gpt-5.6" ||
+		model.id.startsWith("gpt-5.6-") ||
+		model.id === "gpt-6-astra";
 	return (
 		eligibleId &&
 		((model.provider === "openai-codex" && model.api === "openai-codex-responses") ||
 			(model.provider === "openai" && model.api === "openai-responses"))
+	);
+}
+
+/** Input limits can be smaller than the total input + output context window. */
+export function getModelInputLimit<TApi extends Api>(model: Model<TApi>): number {
+	const astraLimit =
+		model.provider === "openai" && model.api === "openai-responses" && model.id === "gpt-6-astra"
+			? 922_000
+			: model.contextWindow;
+	const configured = model.maxInputTokens;
+	return Math.min(
+		model.contextWindow,
+		astraLimit,
+		configured !== undefined && Number.isFinite(configured) && configured > 0 ? configured : model.contextWindow,
 	);
 }
 

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -20,6 +20,7 @@ if (typeof process !== "undefined" && (process.versions?.node || process.version
 	});
 }
 
+import type { CompactFunction } from "../compaction.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { clampThinkingLevel } from "../models.js";
 import { registerSessionResourceCleanup } from "../session-resources.js";
@@ -41,8 +42,86 @@ import {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
 import { parseRetryAfterMs, recordStreamFailure } from "../utils/stream-failure.js";
+import {
+	buildCodexCompactedWindow,
+	CompactionRequestError,
+	requestOpenAICompaction,
+	supportsOpenAICompaction,
+} from "./openai-compaction.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions } from "./simple-options.js";
+
+export const compactOpenAICodexResponses: CompactFunction<"openai-codex-responses"> = async (
+	model,
+	context,
+	options,
+) => {
+	if (!supportsOpenAICompaction(model)) return undefined;
+	const apiKey = options?.apiKey || getEnvApiKey(model.provider);
+	if (!apiKey) throw new Error(`No API key for provider: ${model.provider}`);
+	const headers = buildSSEHeaders(
+		model.headers,
+		options?.headers,
+		extractAccountId(apiKey),
+		apiKey,
+		options?.sessionId,
+	);
+	const instructions = [context.systemPrompt, options?.customInstructions].filter(Boolean).join("\n\n");
+	const body = buildRequestBody(
+		model,
+		{ ...context, systemPrompt: instructions },
+		{
+			...options,
+			reasoningEffort:
+				options?.reasoning && options.reasoning !== "off"
+					? (clampThinkingLevel(model, options.reasoning) as OpenAICodexResponsesOptions["reasoningEffort"])
+					: undefined,
+		},
+	);
+	const input = body.input as unknown as Record<string, unknown>[];
+	// This is a request control, never part of the durable checkpoint window.
+	body.input = [...input, { type: "compaction_trigger" }] as unknown as ResponseInput;
+	const result = await requestOpenAICompaction(
+		model,
+		resolveCodexUrl(model.baseUrl),
+		headers,
+		{ ...body },
+		options,
+		async (response) => {
+			const checkpoints: Record<string, unknown>[] = [];
+			let completed: Record<string, unknown> | undefined;
+			for await (const event of parseSSE(response)) {
+				if (event.type === "response.output_item.done" && event.item && typeof event.item === "object") {
+					const item = event.item as Record<string, unknown>;
+					if (item.type === "compaction" || item.type === "compaction_summary")
+						checkpoints.push({ ...item, type: "compaction" });
+				} else if (event.type === "response.completed" || event.type === "response.done") {
+					completed = event.response as Record<string, unknown> | undefined;
+					break;
+				} else if (["error", "response.failed", "response.incomplete"].includes(String(event.type))) {
+					const failedResponse = event.response as { error?: { code?: string } } | undefined;
+					const error = event.error as { code?: string } | undefined;
+					const code = error?.code ?? failedResponse?.error?.code ?? event.code;
+					if (code === "context_length_exceeded") return undefined;
+					if (code === "rate_limit_exceeded" || code === "server_error") {
+						throw new CompactionRequestError(
+							"Server compaction stream failed",
+							code === "rate_limit_exceeded" ? 429 : 503,
+						);
+					}
+					throw new Error("Server compaction stream failed before completion");
+				}
+			}
+			if (!completed) throw new CompactionRequestError("Server compaction stream closed before completion", 502);
+			if ((completed.status !== undefined && completed.status !== "completed") || checkpoints.length !== 1) {
+				throw new Error("Server compaction requires a completed response with exactly one encrypted checkpoint");
+			}
+			return { output: buildCodexCompactedWindow(input, checkpoints[0]), usage: completed.usage };
+		},
+	);
+	if (result?.usage) applyServiceTierPricing(result.usage, options?.serviceTier, model);
+	return result;
+};
 
 const DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const JWT_CLAIM_PATH = "https://api.openai.com/auth" as const;

--- a/packages/ai/src/providers/openai-compaction.ts
+++ b/packages/ai/src/providers/openai-compaction.ts
@@ -1,0 +1,177 @@
+import type { CompactionOptions, ProviderCompactionResult } from "../compaction.js";
+import { calculateCost } from "../models.js";
+import type { Api, Model, Usage } from "../types.js";
+import { headersToRecord } from "../utils/headers.js";
+import { parseRetryAfterMs } from "../utils/stream-failure.js";
+
+export class CompactionRequestError extends Error {
+	constructor(
+		message: string,
+		readonly status: number,
+		readonly retryAfterMs?: number,
+	) {
+		super(message);
+		this.name = "CompactionRequestError";
+	}
+}
+
+export function supportsOpenAICompaction(model: Model<Api>): boolean {
+	return (
+		model.id === "gpt-6-astra" &&
+		((model.provider === "openai" && model.api === "openai-responses") ||
+			(model.provider === "openai-codex" && model.api === "openai-codex-responses"))
+	);
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function tokenCount(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+function estimatedWindowChars(items: Record<string, unknown>[]): number {
+	let images = 0;
+	const serialized = JSON.stringify(items, (key, value: unknown) => {
+		if ((key === "image_url" || key === "url") && typeof value === "string" && value.startsWith("data:image/")) {
+			images++;
+			return "(image)";
+		}
+		return value;
+	});
+	// Match Prime's image heuristic; base64 byte length is not model token usage.
+	return serialized.length + images * 4800;
+}
+
+/** Shared unary transport. Unsupported endpoints fall back; invalid checkpoints never commit. */
+export async function requestOpenAICompaction(
+	model: Model<Api>,
+	url: string,
+	headers: Headers,
+	body: Record<string, unknown>,
+	options?: CompactionOptions,
+	decode: (response: Response) => Promise<unknown> = (response) => response.json(),
+): Promise<ProviderCompactionResult | undefined> {
+	const timeout = AbortSignal.timeout(options?.timeoutMs ?? 600_000);
+	const signal = options?.signal ? AbortSignal.any([options.signal, timeout]) : timeout;
+	const replacement = await options?.onPayload?.(body, model);
+	const response = await fetch(url, {
+		method: "POST",
+		headers,
+		body: JSON.stringify(replacement ?? body),
+		signal,
+	});
+	await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
+	if ([404, 405, 501].includes(response.status)) {
+		await response.body?.cancel();
+		return undefined;
+	}
+	if (!response.ok) {
+		// Do not include response bodies: providers may echo prompt or credential data.
+		if (response.status === 400 || response.status === 413) {
+			const failure: unknown = await response.json().catch(() => undefined);
+			signal.throwIfAborted();
+			if (
+				response.status === 413 ||
+				(record(failure) && record(failure.error) && failure.error.code === "context_length_exceeded")
+			)
+				return undefined;
+		} else {
+			await response.body?.cancel();
+		}
+		throw new CompactionRequestError(
+			`Server compaction failed (HTTP ${response.status})`,
+			response.status,
+			parseRetryAfterMs(response.headers),
+		);
+	}
+	const payload: unknown = await decode(response);
+	signal.throwIfAborted();
+	if (payload === undefined) return undefined;
+	if (
+		!record(payload) ||
+		!Array.isArray(payload.output) ||
+		!payload.output.every(record) ||
+		!payload.output.some(
+			(item) =>
+				item.type === "compaction" &&
+				typeof item.encrypted_content === "string" &&
+				item.encrypted_content.length > 0,
+		)
+	) {
+		throw new Error("Server compaction returned no valid encrypted checkpoint");
+	}
+	const rawUsage = record(payload.usage) ? payload.usage : undefined;
+	let usage: Usage | undefined;
+	if (rawUsage) {
+		const inputDetails = record(rawUsage.input_tokens_details) ? rawUsage.input_tokens_details : undefined;
+		const input = tokenCount(rawUsage.input_tokens);
+		const cached = Math.min(input, tokenCount(inputDetails?.cached_tokens));
+		usage = {
+			input: input - cached,
+			output: tokenCount(rawUsage.output_tokens),
+			cacheRead: cached,
+			cacheWrite: 0,
+			totalTokens: tokenCount(rawUsage.total_tokens) || input + tokenCount(rawUsage.output_tokens),
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+		calculateCost(model, usage);
+	}
+	return {
+		checkpoint: {
+			version: 1,
+			provider: model.provider,
+			api: model.api,
+			model: model.id,
+			baseUrl: model.baseUrl,
+			items: payload.output,
+			estimatedTokens: Math.max(usage?.output ?? 0, Math.ceil(estimatedWindowChars(payload.output) / 4)),
+		},
+		usage,
+	};
+}
+
+/** Codex v2 returns one checkpoint; the client retains up to 64k tokens of recent user context. */
+export function buildCodexCompactedWindow(
+	input: Record<string, unknown>[],
+	checkpoint: Record<string, unknown>,
+): Record<string, unknown>[] {
+	let remainingChars = 64_000 * 4;
+	const retained: Record<string, unknown>[] = [];
+	for (let i = input.length - 1; i >= 0 && remainingChars > 0; i--) {
+		const item = input[i];
+		if (
+			(item.type !== undefined && item.type !== "message") ||
+			!["user", "developer", "system"].includes(String(item.role))
+		)
+			continue;
+		const size = estimatedWindowChars([item]);
+		if (size <= remainingChars) {
+			retained.push(item);
+			remainingChars -= size;
+			continue;
+		}
+		// Only the boundary message is shortened. Preserve complete image blocks when
+		// they fit; never slice image data or serialized provider items.
+		const content: Record<string, unknown>[] = [];
+		const blocks = typeof item.content === "string" ? [{ type: "input_text", text: item.content }] : item.content;
+		if (Array.isArray(blocks)) {
+			for (let j = blocks.length - 1; j >= 0 && remainingChars > 128; j--) {
+				const block: unknown = blocks[j];
+				if (!record(block)) continue;
+				const blockSize = estimatedWindowChars([block]);
+				if (blockSize <= remainingChars - 128) {
+					content.unshift(block);
+					remainingChars -= blockSize;
+				} else if (block.type === "input_text" && typeof block.text === "string") {
+					content.unshift({ ...block, text: block.text.slice(-(remainingChars - 128)) });
+					remainingChars = 0;
+				}
+			}
+		}
+		if (content.length > 0) retained.push({ ...item, content });
+		remainingChars = 0;
+	}
+	return [...retained.reverse(), checkpoint];
+}

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -127,6 +127,11 @@ export function convertResponsesMessages<TApi extends Api>(
 	let msgIndex = 0;
 	for (const msg of transformedMessages) {
 		if (msg.role === "user") {
+			if (msg.providerContext) {
+				// The server owns this opaque window; SDK unions can lag new response item types.
+				messages.push(...(msg.providerContext.items as unknown as ResponseInput));
+				continue;
+			}
 			if (typeof msg.content === "string") {
 				messages.push({
 					role: "user",

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -1,5 +1,6 @@
 import OpenAI from "openai";
 import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
+import type { CompactFunction } from "../compaction.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { clampThinkingLevel } from "../models.js";
 import type {
@@ -23,8 +24,34 @@ import {
 } from "../utils/stream-failure.js";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
+import { requestOpenAICompaction, supportsOpenAICompaction } from "./openai-compaction.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions } from "./simple-options.js";
+
+export const compactOpenAIResponses: CompactFunction<"openai-responses"> = async (model, context, options) => {
+	if (!supportsOpenAICompaction(model)) return undefined;
+	const apiKey = options?.apiKey || getEnvApiKey(model.provider);
+	if (!apiKey) throw new Error(`No API key for provider: ${model.provider}`);
+	const headers = new Headers({ ...model.headers, ...options?.headers });
+	headers.set("Authorization", `Bearer ${apiKey}`);
+	headers.set("Content-Type", "application/json");
+	const instructions = [context.systemPrompt, options?.customInstructions].filter(Boolean).join("\n\n");
+	const result = await requestOpenAICompaction(
+		model,
+		`${model.baseUrl.replace(/\/+$/, "")}/responses/compact`,
+		headers,
+		{
+			model: model.id,
+			input: convertResponsesMessages(model, context, OPENAI_TOOL_CALL_PROVIDERS, { includeSystemPrompt: false }),
+			instructions,
+			prompt_cache_key: options?.sessionId,
+			service_tier: options?.serviceTier,
+		},
+		options,
+	);
+	if (result?.usage) applyServiceTierPricing(result.usage, options?.serviceTier, model);
+	return result;
+};
 
 const OPENAI_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]);
 

--- a/packages/ai/src/providers/register-builtins.ts
+++ b/packages/ai/src/providers/register-builtins.ts
@@ -1,4 +1,5 @@
 import { clearApiProviders, registerApiProvider } from "../api-registry.js";
+import type { CompactFunction } from "../compaction.js";
 import type {
 	Api,
 	AssistantMessage,
@@ -17,6 +18,7 @@ import type { GoogleOptions } from "./google.js";
 import type { GoogleVertexOptions } from "./google-vertex.js";
 import type { MistralOptions } from "./mistral.js";
 import type { OpenAICodexResponsesOptions } from "./openai-codex-responses.js";
+import { supportsOpenAICompaction } from "./openai-compaction.js";
 import type { OpenAICompletionsOptions } from "./openai-completions.js";
 import type { OpenAIResponsesOptions } from "./openai-responses.js";
 
@@ -25,6 +27,7 @@ interface LazyProviderModule<
 	TOptions extends StreamOptions,
 	TSimpleOptions extends SimpleStreamOptions,
 > {
+	compact?: CompactFunction<TApi>;
 	stream: (model: Model<TApi>, context: Context, options?: TOptions) => AsyncIterable<AssistantMessageEvent>;
 	streamSimple: (
 		model: Model<TApi>,
@@ -59,6 +62,7 @@ interface MistralProviderModule {
 }
 
 interface OpenAICodexResponsesProviderModule {
+	compactOpenAICodexResponses: CompactFunction<"openai-codex-responses">;
 	streamOpenAICodexResponses: StreamFunction<"openai-codex-responses", OpenAICodexResponsesOptions>;
 	streamSimpleOpenAICodexResponses: StreamFunction<"openai-codex-responses", SimpleStreamOptions>;
 }
@@ -69,6 +73,7 @@ interface OpenAICompletionsProviderModule {
 }
 
 interface OpenAIResponsesProviderModule {
+	compactOpenAIResponses: CompactFunction<"openai-responses">;
 	streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIResponsesOptions>;
 	streamSimpleOpenAIResponses: StreamFunction<"openai-responses", SimpleStreamOptions>;
 }
@@ -273,6 +278,7 @@ function loadOpenAICodexResponsesProviderModule(): Promise<
 		return {
 			stream: provider.streamOpenAICodexResponses,
 			streamSimple: provider.streamSimpleOpenAICodexResponses,
+			compact: provider.compactOpenAICodexResponses,
 		};
 	});
 	return openAICodexResponsesProviderModulePromise;
@@ -299,6 +305,7 @@ function loadOpenAIResponsesProviderModule(): Promise<
 		return {
 			stream: provider.streamOpenAIResponses,
 			streamSimple: provider.streamSimpleOpenAIResponses,
+			compact: provider.compactOpenAIResponses,
 		};
 	});
 	return openAIResponsesProviderModulePromise;
@@ -360,8 +367,11 @@ export function registerBuiltInApiProviders(): void {
 
 	registerApiProvider({
 		api: "openai-responses",
+		supportsCompaction: supportsOpenAICompaction,
 		stream: streamOpenAIResponses,
 		streamSimple: streamSimpleOpenAIResponses,
+		compact: async (model, context, options) =>
+			(await loadOpenAIResponsesProviderModule()).compact?.(model, context, options),
 	});
 
 	registerApiProvider({
@@ -372,8 +382,11 @@ export function registerBuiltInApiProviders(): void {
 
 	registerApiProvider({
 		api: "openai-codex-responses",
+		supportsCompaction: supportsOpenAICompaction,
 		stream: streamOpenAICodexResponses,
 		streamSimple: streamSimpleOpenAICodexResponses,
+		compact: async (model, context, options) =>
+			(await loadOpenAICodexResponsesProviderModule()).compact?.(model, context, options),
 	});
 
 	registerApiProvider({

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -1,3 +1,4 @@
+import { compactionMatchesModel } from "../compaction.js";
 import type {
 	Api,
 	AssistantMessage,
@@ -71,6 +72,11 @@ export function transformMessages<TApi extends Api>(
 
 	const transformed = imageAwareMessages.map((msg) => {
 		if (msg.role === "user") {
+			if (msg.providerContext && !compactionMatchesModel(msg.providerContext, model)) {
+				throw new Error(
+					"Compaction checkpoint belongs to another model or provider; rebuild context from the session transcript",
+				);
+			}
 			return msg;
 		}
 

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1,6 +1,7 @@
 import "./providers/register-builtins.js";
 
 import { getApiProvider } from "./api-registry.js";
+import type { CompactionOptions, ProviderCompactionResult } from "./compaction.js";
 import type {
 	Api,
 	AssistantMessage,
@@ -13,6 +14,20 @@ import type {
 } from "./types.js";
 
 export { getEnvApiKey } from "./env-api-keys.js";
+
+export function supportsCompaction<TApi extends Api>(model: Model<TApi>): boolean {
+	const provider = resolveApiProvider(model.api);
+	return provider.compact !== undefined && (provider.supportsCompaction?.(model) ?? true);
+}
+
+export async function compactSimple<TApi extends Api>(
+	model: Model<TApi>,
+	context: Context,
+	options?: CompactionOptions,
+): Promise<ProviderCompactionResult | undefined> {
+	if (!supportsCompaction(model)) return undefined;
+	return resolveApiProvider(model.api).compact?.(model, context, options);
+}
 
 function resolveApiProvider(api: Api) {
 	const provider = getApiProvider(api);

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -1,3 +1,4 @@
+import type { ProviderCompactionCheckpoint } from "./compaction.js";
 import type { AssistantMessageDiagnostic } from "./utils/diagnostics.js";
 import type { AssistantMessageEventStream } from "./utils/event-stream.js";
 
@@ -206,6 +207,8 @@ export type StopReason = "stop" | "length" | "toolUse" | "error" | "aborted";
 export interface UserMessage {
 	role: "user";
 	content: string | (TextContent | ImageContent)[];
+	/** Provider-owned replacement for this message, supplied by a durable compaction checkpoint. */
+	providerContext?: ProviderCompactionCheckpoint;
 	timestamp: number; // Unix timestamp in milliseconds
 }
 
@@ -444,6 +447,8 @@ export interface Model<TApi extends Api> {
 		cacheWrite: number; // $/million tokens
 	};
 	contextWindow: number;
+	/** Separate input ceiling when the provider reserves part of the context for output. */
+	maxInputTokens?: number;
 	maxTokens: number;
 	/** Flagship model surfaced above non-featured models of the same provider in pickers. */
 	featured?: boolean;

--- a/packages/ai/test/fast-mode.test.ts
+++ b/packages/ai/test/fast-mode.test.ts
@@ -19,7 +19,7 @@ function model(provider: string, id: string, api: Api): Model<Api> {
 }
 
 describe("Fast mode", () => {
-	it.each(["gpt-5.4", "gpt-5.5", "gpt-5.6-luna"])("supports %s through ChatGPT auth", (id) => {
+	it.each(["gpt-5.4", "gpt-5.5", "gpt-5.6-luna", "gpt-6-astra"])("supports %s through ChatGPT auth", (id) => {
 		expect(supportsFastMode(model("openai-codex", id, "openai-codex-responses"))).toBe(true);
 	});
 
@@ -31,7 +31,7 @@ describe("Fast mode", () => {
 	});
 
 	it("admits API-key models and forwards priority", () => {
-		const testModel = model("openai", "gpt-5.5", "openai-responses");
+		const testModel = model("openai", "gpt-6-astra", "openai-responses");
 		expect(supportsFastMode(testModel)).toBe(true);
 		expect(buildBaseOptions(testModel, { serviceTier: "priority" }).serviceTier).toBe("priority");
 	});

--- a/packages/ai/test/openai-compaction.test.ts
+++ b/packages/ai/test/openai-compaction.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { compactionMatchesModel, isCompactionCheckpoint } from "../src/compaction.js";
+import { getModel, getModelInputLimit } from "../src/models.js";
+import { buildCodexCompactedWindow } from "../src/providers/openai-compaction.js";
+import { convertResponsesMessages } from "../src/providers/openai-responses-shared.js";
+import { compactSimple, supportsCompaction } from "../src/stream.js";
+import type { Context } from "../src/types.js";
+
+const token = `test.${Buffer.from(JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "test-account" } })).toString("base64url")}.signature`;
+const output = [
+	{ type: "message", role: "user", content: [{ type: "input_text", text: "Keep this request" }] },
+	{ type: "compaction", id: "cmp_test", encrypted_content: "opaque-checkpoint" },
+	{
+		type: "message",
+		role: "assistant",
+		phase: "commentary",
+		content: [{ type: "output_text", text: "Retained context" }],
+	},
+];
+const context: Context = {
+	systemPrompt: "Use the existing tools.",
+	messages: [{ role: "user", content: "Remember the project", timestamp: 1 }],
+};
+
+function sse(events: Record<string, unknown>[]): Response {
+	return new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""), {
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("Astra server compaction", () => {
+	it.each(["openai", "openai-codex"] as const)("compacts and replays the complete %s window", async (provider) => {
+		const model = getModel(provider, "gpt-6-astra");
+		const usage = {
+			input_tokens: 100,
+			output_tokens: 20,
+			total_tokens: 120,
+			input_tokens_details: { cached_tokens: 30 },
+		};
+		const expectedWindow =
+			provider === "openai"
+				? output
+				: [{ role: "user", content: [{ type: "input_text", text: "Remember the project" }] }, output[1]];
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+			provider === "openai"
+				? Response.json({ output, usage })
+				: sse([
+						{ type: "response.output_item.done", item: output[1] },
+						{ type: "response.completed", response: { id: "resp_test", status: "completed", usage } },
+					]),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		expect(supportsCompaction(model)).toBe(true);
+		const result = await compactSimple(model, context, {
+			apiKey: token,
+			sessionId: "test-session",
+			customInstructions: "Keep paths",
+			serviceTier: "priority",
+		});
+		expect(result?.checkpoint.items).toEqual(expectedWindow);
+		expect(result?.usage).toMatchObject({ input: 70, cacheRead: 30, output: 20, totalTokens: 120 });
+		expect(result?.usage?.cost.total).toBeGreaterThan(0);
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe(
+			provider === "openai"
+				? "https://api.openai.com/v1/responses/compact"
+				: "https://chatgpt.com/backend-api/codex/responses",
+		);
+		expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer ${token}`);
+		if (provider === "openai-codex")
+			expect(new Headers(init?.headers).get("chatgpt-account-id")).toBe("test-account");
+		if (provider === "openai-codex")
+			expect(JSON.parse(String(init?.body)).input.at(-1)).toEqual({ type: "compaction_trigger" });
+		expect(JSON.parse(String(init?.body))).toMatchObject({
+			model: "gpt-6-astra",
+			instructions: "Use the existing tools.\n\nKeep paths",
+			prompt_cache_key: "test-session",
+			service_tier: "priority",
+		});
+		const checkpoint = result!.checkpoint;
+		expect(isCompactionCheckpoint(JSON.parse(JSON.stringify(checkpoint)))).toBe(true);
+		const replay = convertResponsesMessages(
+			model,
+			{
+				messages: [
+					{ role: "user", content: "Display marker only", providerContext: checkpoint, timestamp: 2 },
+					{ role: "user", content: "Continue", timestamp: 3 },
+				],
+			},
+			new Set([provider]),
+		);
+		expect(replay.slice(0, expectedWindow.length)).toEqual(expectedWindow);
+		expect(replay).toHaveLength(expectedWindow.length + 1);
+		expect(JSON.stringify(replay)).not.toContain("Display marker");
+		expect(compactionMatchesModel(checkpoint, { ...model, baseUrl: `${model.baseUrl}/` })).toBe(true);
+		expect(() =>
+			convertResponsesMessages(
+				{ ...model, id: "other-model" },
+				{ messages: [{ role: "user", content: "marker", providerContext: checkpoint, timestamp: 2 }] },
+				new Set([provider]),
+			),
+		).toThrow(/rebuild context/);
+		expect(compactionMatchesModel(checkpoint, { ...model, baseUrl: "https://another.example/v1" })).toBe(false);
+	});
+
+	it.each([404, 405, 501])("permits local fallback for unsupported HTTP %s", async (status) => {
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("unsupported", { status })));
+		expect(await compactSimple(getModel("openai", "gpt-6-astra"), context, { apiKey: token })).toBeUndefined();
+	});
+
+	it.each([401, 403, 429, 500])("preserves failures for HTTP %s without echoing response bodies", async (status) => {
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValue(new Response("sensitive provider body", { status, headers: { "retry-after": "2" } })),
+		);
+		await expect(compactSimple(getModel("openai", "gpt-6-astra"), context, { apiKey: token })).rejects.toMatchObject({
+			status,
+			retryAfterMs: 2000,
+			message: `Server compaction failed (HTTP ${status})`,
+		});
+	});
+
+	it.each([{}, { output: [] }, { output: [{ type: "compaction", encrypted_content: "" }] }, { output: [null] }])(
+		"rejects malformed output %#",
+		async (payload) => {
+			vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json(payload)));
+			await expect(compactSimple(getModel("openai", "gpt-6-astra"), context, { apiKey: token })).rejects.toThrow(
+				/valid encrypted checkpoint/,
+			);
+		},
+	);
+
+	it("honors cancellation even when a response races the abort", async () => {
+		const abort = new AbortController();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation(async () => {
+				abort.abort();
+				return Response.json({ output });
+			}),
+		);
+		await expect(
+			compactSimple(getModel("openai", "gpt-6-astra"), context, { apiKey: token, signal: abort.signal }),
+		).rejects.toMatchObject({ name: "AbortError" });
+	});
+
+	it("keeps unrelated providers on their existing compaction path", () => {
+		expect(supportsCompaction(getModel("openai", "gpt-5.5"))).toBe(false);
+		expect(supportsCompaction({ ...getModel("openai", "gpt-6-astra"), provider: "gateway" })).toBe(false);
+	});
+
+	it.each(
+		[
+			[],
+			[{ type: "response.output_item.done", item: output[1] }],
+			[{ type: "response.completed", response: { status: "completed" } }],
+			[
+				{ type: "response.output_item.done", item: output[1] },
+				{ type: "response.output_item.done", item: output[1] },
+				{ type: "response.completed", response: { status: "completed" } },
+			],
+			[
+				{ type: "response.output_item.done", item: output[1] },
+				{ type: "response.incomplete", response: { status: "incomplete" } },
+			],
+		].map((events) => ({ events })),
+	)("rejects incomplete or ambiguous Codex compaction streams %#", async ({ events }) => {
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(sse(events)));
+		await expect(compactSimple(getModel("openai-codex", "gpt-6-astra"), context, { apiKey: token })).rejects.toThrow(
+			/compaction/,
+		);
+	});
+
+	it("retains recent user context within the Codex v2 budget without carrying old assistant/tool/checkpoint items", () => {
+		const window = buildCodexCompactedWindow(
+			[
+				{ role: "user", content: "old user request" },
+				{ type: "compaction", encrypted_content: "old checkpoint" },
+				{ type: "function_call_output", call_id: "call-1", output: "tool result" },
+				{ role: "assistant", content: "assistant detail now in checkpoint" },
+				{ role: "user", content: [{ type: "input_text", text: `${"x".repeat(300_000)}LATEST` }] },
+			],
+			output[1],
+		);
+		expect(window).toHaveLength(2);
+		expect(JSON.stringify(window[0])).toContain("LATEST");
+		expect(JSON.stringify(window[0]).length).toBeLessThanOrEqual(64_000 * 4);
+		expect(window[1]).toEqual(output[1]);
+	});
+
+	it("allows bounded local recovery from an over-limit compact request", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(Response.json({ error: { code: "context_length_exceeded" } }, { status: 400 })),
+		);
+		expect(await compactSimple(getModel("openai", "gpt-6-astra"), context, { apiKey: token })).toBeUndefined();
+	});
+
+	it("retains complete images without charging their base64 bytes as text tokens", () => {
+		const imageMessage = {
+			role: "user",
+			content: [
+				{ type: "input_text", text: "Inspect this image" },
+				{ type: "input_image", image_url: `data:image/png;base64,${"a".repeat(500_000)}`, detail: "auto" },
+			],
+		};
+		expect(buildCodexCompactedWindow([imageMessage], output[1])).toEqual([imageMessage, output[1]]);
+	});
+
+	it("uses the API input ceiling without enlarging the ChatGPT context", () => {
+		const api = getModel("openai", "gpt-6-astra");
+		expect(api.contextWindow).toBe(1_050_000);
+		expect(getModelInputLimit(api)).toBe(922_000);
+		expect(getModelInputLimit({ ...api, maxInputTokens: 200_000 })).toBe(200_000);
+		expect(getModelInputLimit({ ...api, maxInputTokens: 2_000_000 })).toBe(922_000);
+		expect(getModelInputLimit(getModel("openai-codex", "gpt-6-astra"))).toBe(272_000);
+	});
+});

--- a/packages/coding-agent/.changes/astra-compaction.md
+++ b/packages/coding-agent/.changes/astra-compaction.md
@@ -1,0 +1,3 @@
+- Persisted Astra server compaction checkpoints across session resumes and rebuilt compatible context after model or endpoint changes.
+- Respected Astra input budgets, bounded local fallback summaries, and preserved history on compaction cancellation or persistence failure.
+- Added backward-compatible daemon metadata for provider checkpoints and model input limits.

--- a/packages/coding-agent/docs/astra.md
+++ b/packages/coding-agent/docs/astra.md
@@ -1,0 +1,19 @@
+# Astra support
+
+`gpt-6-astra` supports Fast mode and server compaction through both `openai` (API key) and `openai-codex` (ChatGPT login). The existing `/compact` command and automatic compaction use the same session lifecycle, extension hooks, and kernel preservation behavior.
+
+For ChatGPT login, Prime sends Codex's explicit `compaction_trigger` control through the streaming Responses endpoint. A successful response must finish and contain exactly one encrypted compaction item. Prime retains up to 64,000 estimated tokens of recent user context alongside that checkpoint. The separate `/responses/compact` endpoint is used for API-key authentication; Prime preserves its complete returned window without rewriting the items.
+
+Checkpoints are stored in `CompactionEntry.details.providerCheckpoint`. They include the provider, model, API, endpoint, complete replay window, and a token estimate. Reopening the session restores that window. The readable compaction message is display text; it is never substituted for the encrypted context. The original session transcript remains on disk.
+
+Switching models or endpoints reconstructs context from the original transcript and compatible local summaries. Unknown checkpoint versions are also ignored during reconstruction. Local fallback summaries are generated in bounded requests when restored history exceeds the destination model's input budget. Unsupported compact endpoints and explicit input-limit rejections use this fallback. Authentication failures, malformed output, cancellation, and exhausted transient retries preserve the current history. Checkpoint writes roll back on persistence failure.
+
+Automatic compaction respects input limits separately from total context. Astra's API-key input ceiling is 922,000 tokens within its 1,050,000-token total context; the default 16,384-token reserve puts the compaction threshold at 905,616. ChatGPT's existing 272,000-token window stays unchanged and compacts at 90% (244,800 tokens), or earlier if a larger reserve is configured. Custom models and overrides may set a positive integer `maxInputTokens` to lower their input budget.
+
+Fast mode forwards `service_tier: "priority"` for Astra on both OpenAI providers. Existing reasoning levels, ordinary encrypted reasoning replay, commentary/final phases, tool calls, and persistent Python kernel behavior remain in use. This change does not add Ultra, enlarge the ChatGPT context default, or enable automatic inline `context_management` compaction.
+
+Daemon schema revision 28 adds optional `providerContext` message metadata and `maxInputTokens` model metadata. These are backward-compatible response fields: existing clients can render the summary and existing workers can continue using local compaction. No new capability or startup version requirement is imposed. Resume encrypted checkpoints with a Prime version that supports them; older workers do not understand their session-file metadata.
+
+The same worker/session implementation serves the terminal, daemon clients, RPC, and SDK. No separate native 3D surface exists in this repository.
+
+References: [OpenAI compaction](https://developers.openai.com/api/docs/guides/compaction), [Astra model limits](https://developers.openai.com/api/docs/models/gpt-6-astra), and [Codex remote compaction v2](https://github.com/openai/codex/blob/ef6c0582028ff8e1228e6031465c1c2d9d5d51b6/codex-rs/core/src/compact_remote_v2.rs).

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -28,6 +28,7 @@ import type {
 import {
 	clampThinkingLevel,
 	cleanupSessionResources,
+	getModelInputLimit,
 	getSupportedThinkingLevels,
 	isContextOverflow,
 	modelsAreEqual,
@@ -92,6 +93,7 @@ import {
 	setAutonomousEnabled,
 } from "./autonomous.js";
 import { type BashResult, executeBashWithOperations } from "./bash-executor.js";
+import { hasProviderCheckpoint } from "./compaction/checkpoint.js";
 import {
 	COMPACT_SKILL_NAME,
 	type CompactionResult,
@@ -99,10 +101,11 @@ import {
 	collectEntriesForBranchSummary,
 	compact,
 	estimateContextTokens,
+	estimateTokens,
 	generateBranchSummary,
 	prepareCompaction,
 	serializeConversation,
-	shouldCompact,
+	shouldCompactForModel,
 } from "./compaction/index.js";
 import {
 	type ContextTreeNode,
@@ -1397,6 +1400,7 @@ export class AgentSession {
 			activeToolNames: this._initialActiveToolNames,
 			includeAllExtensionTools: true,
 		});
+		this._restoreProviderContextForModel();
 	}
 
 	/** Refreshes MCP provider registrations without rebuilding the session runtime. */
@@ -2850,15 +2854,13 @@ export class AgentSession {
 		const settings = this.settingsManager.getCompactionSettings();
 		if (!settings.enabled) return false;
 
-		const contextWindow = this.model?.contextWindow ?? 0;
-		const compactionEntry = getLatestCompactionEntry(this.sessionManager.getBranch());
-		const compactionTimestamp = compactionEntry ? new Date(compactionEntry.timestamp).getTime() : undefined;
+		const compactionTimestamp = this._activeCompactionTimestamp();
 		if (compactionTimestamp !== undefined && context.message.timestamp <= compactionTimestamp) {
 			return false;
 		}
 
 		const contextTokens = this._getThresholdContextTokens(context.message, compactionTimestamp);
-		if (contextTokens === undefined || !shouldCompact(contextTokens, contextWindow, settings)) {
+		if (contextTokens === undefined || !this.model || !shouldCompactForModel(contextTokens, this.model, settings)) {
 			return false;
 		}
 
@@ -4352,7 +4354,7 @@ export class AgentSession {
 	}
 
 	buildSessionContext(): SessionContext {
-		const context = this.sessionManager.buildSessionContext();
+		const context = this.sessionManager.buildSessionContext(this.model);
 		for (const message of context.messages) {
 			this._applyLateIpythonSentAgentMessages(message);
 		}
@@ -4571,7 +4573,18 @@ export class AgentSession {
 
 	private async _runPreTurnCompaction(): Promise<void> {
 		const lastAssistant = this._findLastAssistantMessage();
-		if (lastAssistant) await this._checkCompaction(lastAssistant, false, false);
+		if (lastAssistant) {
+			await this._checkCompaction(lastAssistant, false, false);
+		} else if (
+			this.model &&
+			shouldCompactForModel(
+				estimateContextTokens(this.agent.state.messages).tokens,
+				this.model,
+				this.settingsManager.getCompactionSettings(),
+			)
+		) {
+			await this._runAutoCompaction("threshold", false);
+		}
 	}
 
 	private async _prepareForCommit<TPrepared, TCommitted>(
@@ -7213,6 +7226,7 @@ export class AgentSession {
 		const serviceTier = this._getServiceTierForModelSwitch();
 		this.agent.state.model = model;
 		this.sessionManager.appendModelChange(model.provider, model.id);
+		this._restoreProviderContextForModel();
 		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
 
 		this.setThinkingLevel(thinkingLevel);
@@ -7280,6 +7294,7 @@ export class AgentSession {
 
 		this.agent.state.model = next.model;
 		this.sessionManager.appendModelChange(next.model.provider, next.model.id);
+		this._restoreProviderContextForModel();
 		this.settingsManager.setDefaultModelAndProvider(next.model.provider, next.model.id);
 
 		this.setThinkingLevel(thinkingLevel);
@@ -7319,6 +7334,7 @@ export class AgentSession {
 		const serviceTier = this._getServiceTierForModelSwitch();
 		this.agent.state.model = nextModel;
 		this.sessionManager.appendModelChange(nextModel.provider, nextModel.id);
+		this._restoreProviderContextForModel();
 		this.settingsManager.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
 
 		this.setThinkingLevel(thinkingLevel);
@@ -7710,6 +7726,14 @@ export class AgentSession {
 					this.thinkingLevel,
 					summaryCall,
 					providerRetryPolicy(this.settingsManager),
+					{
+						context: {
+							systemPrompt: this.agent.state.systemPrompt,
+							messages: convertToLlm(this.agent.state.messages),
+							tools: this.agent.state.tools,
+						},
+						options: { sessionId: this.sessionId, serviceTier: this.serviceTier, reasoning: this.thinkingLevel },
+					},
 				));
 			}
 
@@ -7745,10 +7769,10 @@ export class AgentSession {
 					error instanceof Error && (error.name === "AbortError" || error.message === "Compaction cancelled");
 				this._semanticEdges.finishCompaction(semanticCompaction.compactionId, cancelled ? "cancelled" : "failed");
 			}
-			throw error;
+			throw signal.aborted ? new Error("Compaction cancelled") : error;
 		}
 		const newEntries = this.sessionManager.getEntries();
-		this.agent.state.messages = this.sessionManager.buildSessionContext().messages;
+		this.agent.state.messages = this.sessionManager.buildSessionContext(this.model).messages;
 		this._mergeUnpersistedOutcomes(this.agent.state.messages);
 		this._restoreLateIpythonSentAgentMessages();
 
@@ -8624,6 +8648,29 @@ export class AgentSession {
 	 * @param assistantMessage The assistant message to check
 	 * @param skipAbortedCheck If false, include aborted messages (for pre-prompt check). Default: true
 	 */
+	private _providerContextRebuiltAt: number | undefined;
+
+	private _restoreProviderContextForModel(): void {
+		if (
+			!this.sessionManager
+				.getBranch()
+				.some((entry) => entry.type === "compaction" && hasProviderCheckpoint(entry.details))
+		)
+			return;
+		this.agent.state.messages = this.buildSessionContext().messages;
+		// Old usage may describe a window encrypted for a different model or endpoint.
+		this._providerContextRebuiltAt = Date.now();
+	}
+
+	private _activeCompactionTimestamp(): number | undefined {
+		const marker = this.agent.state.messages.find((message) => message.role === "compactionSummary");
+		if (marker) return marker.timestamp;
+		const branch = this.sessionManager.getBranch();
+		if (branch.some((entry) => entry.type === "compaction" && hasProviderCheckpoint(entry.details))) return undefined;
+		const entry = getLatestCompactionEntry(branch);
+		return entry ? new Date(entry.timestamp).getTime() : undefined;
+	}
+
 	private _getThresholdContextTokens(
 		assistantMessage: AssistantMessage,
 		compactionTimestamp: number | undefined,
@@ -8635,6 +8682,14 @@ export class AgentSession {
 			// have stale usage reflecting the old (larger) context and would falsely
 			// trigger compaction right after one just finished.
 			const usageMsg = messages[estimate.lastUsageIndex];
+			if (
+				usageMsg.role === "assistant" &&
+				((this._providerContextRebuiltAt !== undefined && usageMsg.timestamp <= this._providerContextRebuiltAt) ||
+					usageMsg.model !== this.model?.id ||
+					usageMsg.provider !== this.model?.provider)
+			) {
+				return messages.reduce((tokens, message) => tokens + estimateTokens(message), 0);
+			}
 			if (
 				compactionTimestamp !== undefined &&
 				usageMsg.role === "assistant" &&
@@ -8677,7 +8732,7 @@ export class AgentSession {
 		}
 
 		const settings = this.settingsManager.getCompactionSettings();
-		const contextWindow = this.model?.contextWindow ?? 0;
+		const contextWindow = this.model ? getModelInputLimit(this.model) : 0;
 
 		// Skip overflow check if the message came from a different model.
 		// This handles the case where user switched from a smaller-context model (e.g. opus)
@@ -8689,8 +8744,7 @@ export class AgentSession {
 		// Skip overflow/threshold checks if this assistant message is older than the
 		// latest compaction boundary. This prevents a stale pre-compaction usage/error
 		// from retriggering compaction on the first prompt after compaction.
-		const compactionEntry = getLatestCompactionEntry(this.sessionManager.getBranch());
-		const compactionTimestamp = compactionEntry ? new Date(compactionEntry.timestamp).getTime() : undefined;
+		const compactionTimestamp = this._activeCompactionTimestamp();
 		const assistantIsFromBeforeCompaction =
 			compactionTimestamp !== undefined && assistantMessage.timestamp <= compactionTimestamp;
 
@@ -8735,7 +8789,7 @@ export class AgentSession {
 		// assistant usage are included, matching the /usage context display.
 		const contextTokens = this._getThresholdContextTokens(assistantMessage, compactionTimestamp);
 		if (contextTokens === undefined) return false;
-		if (shouldCompact(contextTokens, contextWindow, settings)) {
+		if (this.model && shouldCompactForModel(contextTokens, this.model, settings)) {
 			if (queueAutonomousContinuation && this._queueGoalContinuationForThresholdCompaction(assistantMessage)) {
 				this._continueAfterThresholdCompaction = true;
 			} else if (
@@ -12027,7 +12081,7 @@ export class AgentSession {
 				this.sessionManager.appendLabelChange(targetId, label);
 			}
 
-			const sessionContext = this.sessionManager.buildSessionContext();
+			const sessionContext = this.sessionManager.buildSessionContext(this.model);
 			this.agent.state.messages = sessionContext.messages;
 			this._mergeUnpersistedOutcomes(this.agent.state.messages);
 			this._restoreLateIpythonSentAgentMessages();

--- a/packages/coding-agent/src/core/compaction/checkpoint.ts
+++ b/packages/coding-agent/src/core/compaction/checkpoint.ts
@@ -1,0 +1,10 @@
+import { isCompactionCheckpoint, type ProviderCompactionCheckpoint } from "@earendil-works/pi-ai";
+
+export function hasProviderCheckpoint(details: unknown): boolean {
+	return details !== null && typeof details === "object" && "providerCheckpoint" in details;
+}
+
+export function getProviderCheckpoint(details: unknown): ProviderCompactionCheckpoint | undefined {
+	if (details === null || typeof details !== "object" || !("providerCheckpoint" in details)) return undefined;
+	return isCompactionCheckpoint(details.providerCheckpoint) ? details.providerCheckpoint : undefined;
+}

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -6,17 +6,33 @@
  */
 
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
-import type { AssistantMessage, Model, Usage } from "@earendil-works/pi-ai";
-import { completeSimple } from "@earendil-works/pi-ai";
+import type {
+	Api,
+	AssistantMessage,
+	CompactionOptions,
+	Context,
+	Model,
+	ProviderCompactionCheckpoint,
+	Usage,
+} from "@earendil-works/pi-ai";
+import {
+	compactionMatchesModel,
+	compactSimple,
+	completeSimple,
+	getModelInputLimit,
+	isCompactionCheckpoint,
+	supportsCompaction,
+} from "@earendil-works/pi-ai";
 import {
 	convertToLlm,
 	createBranchSummaryMessage,
 	createCompactionSummaryMessage,
 	createCustomMessage,
 } from "../messages.js";
-import { completeWithProviderRetry, type ProviderRetryPolicy } from "../provider-retry.js";
+import { completeWithProviderRetry, type ProviderRetryPolicy, requestWithProviderRetry } from "../provider-retry.js";
 import { buildSessionContext, type CompactionEntry, type SessionEntry } from "../session-manager.js";
 import { addAssistantUsage, emptyUsage } from "../usage.js";
+import { hasProviderCheckpoint } from "./checkpoint.js";
 import {
 	computeFileLists,
 	createFileOps,
@@ -30,6 +46,7 @@ import {
 export interface CompactionDetails {
 	readFiles: string[];
 	modifiedFiles: string[];
+	providerCheckpoint?: ProviderCompactionCheckpoint;
 }
 
 export interface SummarySlice {
@@ -217,11 +234,23 @@ export function shouldCompact(contextTokens: number, contextWindow: number, sett
 	if (contextWindow <= 0) return false;
 	return contextTokens > contextWindow - settings.reserveTokens;
 }
+
+export function shouldCompactForModel(contextTokens: number, model: Model<Api>, settings: CompactionSettings): boolean {
+	const inputLimit = getModelInputLimit(model);
+	const reserveTokens =
+		model.provider === "openai-codex" && model.api === "openai-codex-responses" && model.id === "gpt-6-astra"
+			? Math.max(settings.reserveTokens, Math.ceil(inputLimit * 0.1))
+			: settings.reserveTokens;
+	return shouldCompact(contextTokens, inputLimit, { ...settings, reserveTokens });
+}
 /**
  * Estimate token count for a message using chars/4 heuristic.
  * This is conservative (overestimates tokens).
  */
 export function estimateTokens(message: AgentMessage): number {
+	if ((message.role === "user" || message.role === "compactionSummary") && message.providerContext) {
+		return message.providerContext.estimatedTokens;
+	}
 	let chars = 0;
 
 	switch (message.role) {
@@ -527,52 +556,93 @@ export async function generateSummary(
 	previousSummary?: string,
 	thinkingLevel?: ThinkingLevel,
 	retry?: ProviderRetryPolicy,
+	summaryCall: SummaryCallRunner = (call) => call(headers),
 ): Promise<SummarySlice> {
-	const maxTokens = Math.floor(0.8 * reserveTokens);
-
-	const basePrompt = buildSummarizationPrompt(customInstructions, previousSummary);
-	// Serialize before the LLM call so it summarizes rather than continues this conversation.
-	const llmMessages = convertToLlm(currentMessages);
-	const conversationText = serializeConversation(llmMessages);
-	let promptText = `<conversation>\n${conversationText}\n</conversation>\n\n`;
-	if (previousSummary) {
-		promptText += `<previous-summary>\n${previousSummary}\n</previous-summary>\n\n`;
-	}
-	promptText += basePrompt;
-
-	const summarizationMessages = [
-		{
-			role: "user" as const,
-			content: [{ type: "text" as const, text: promptText }],
-			timestamp: Date.now(),
-		},
-	];
-
-	const completionOptions =
-		model.reasoning && thinkingLevel && thinkingLevel !== "off"
-			? { maxTokens, signal, apiKey, headers, reasoning: thinkingLevel }
-			: { maxTokens, signal, apiKey, headers };
-
-	const response = await completeWithProviderRetry(
-		() =>
-			completeSimple(
-				model,
-				{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
-				completionOptions,
-			),
-		{ policy: retry, signal },
+	return generateBoundedSummary(
+		currentMessages,
+		model,
+		Math.floor(0.8 * reserveTokens),
+		apiKey,
+		signal,
+		thinkingLevel,
+		retry,
+		summaryCall,
+		(summary) => buildSummarizationPrompt(customInstructions, summary),
+		previousSummary,
 	);
+}
 
-	if (response.stopReason === "error") {
-		throw new Error(`Summarization failed: ${response.errorMessage || "Unknown error"}`);
-	}
-
-	const textContent = response.content
-		.filter((c): c is { type: "text"; text: string } => c.type === "text")
-		.map((c) => c.text)
-		.join("\n");
-
-	return { summary: textContent, usage: response.usage };
+/** Reconstructing history after a model switch can exceed the destination's input limit. */
+async function generateBoundedSummary(
+	messages: AgentMessage[],
+	model: Model<Api>,
+	requestedMaxTokens: number,
+	apiKey: string,
+	signal: AbortSignal | undefined,
+	thinkingLevel: ThinkingLevel | undefined,
+	retry: ProviderRetryPolicy | undefined,
+	summaryCall: SummaryCallRunner,
+	instructions: (previousSummary?: string) => string,
+	previousSummary?: string,
+): Promise<SummarySlice> {
+	const inputLimit = getModelInputLimit(model);
+	const maxTokens = Math.max(1, Math.min(requestedMaxTokens, model.maxTokens, Math.floor(inputLimit / 4)));
+	const conversation = serializeConversation(convertToLlm(messages));
+	let offset = 0;
+	let summary = previousSummary;
+	const usage = emptyUsage();
+	do {
+		signal?.throwIfAborted();
+		const suffix = `${summary ? `<previous-summary>\n${summary}\n</previous-summary>\n\n` : ""}${instructions(summary)}`;
+		// Leave output headroom and use a conservative chars/3 estimate for fallback calls.
+		const budget =
+			Math.floor((Math.min(inputLimit, model.contextWindow - maxTokens) - 1024) * 3) -
+			suffix.length -
+			SUMMARIZATION_SYSTEM_PROMPT.length -
+			64;
+		if (budget <= 0) throw new Error("Compaction instructions and previous summary exceed the model input budget");
+		const chunk = conversation.slice(offset, offset + budget);
+		offset += chunk.length;
+		const response = await summaryCall((callHeaders) =>
+			completeWithProviderRetry(
+				() =>
+					completeSimple(
+						model,
+						{
+							systemPrompt: SUMMARIZATION_SYSTEM_PROMPT,
+							messages: [
+								{
+									role: "user",
+									content: `<conversation>\n${chunk}\n</conversation>\n\n${suffix}`,
+									timestamp: Date.now(),
+								},
+							],
+						},
+						{
+							maxTokens,
+							signal,
+							apiKey,
+							headers: callHeaders,
+							...(model.reasoning && thinkingLevel && thinkingLevel !== "off"
+								? { reasoning: thinkingLevel }
+								: {}),
+						},
+					),
+				{ policy: retry, signal },
+			),
+		);
+		signal?.throwIfAborted();
+		if (response.stopReason === "error" || response.stopReason === "aborted") {
+			throw new Error(`Summarization failed: ${response.errorMessage || response.stopReason}`);
+		}
+		summary = response.content
+			.filter((part) => part.type === "text")
+			.map((part) => part.text)
+			.join("\n");
+		if (!summary.trim()) throw new Error("Summarization returned an empty summary");
+		addAssistantUsage(usage, response.usage);
+	} while (offset < conversation.length);
+	return { summary, usage };
 }
 export interface CompactionPreparation {
 	/** UUID of first entry to keep */
@@ -602,7 +672,8 @@ export function prepareCompaction(
 
 	let prevCompactionIndex = -1;
 	for (let i = pathEntries.length - 1; i >= 0; i--) {
-		if (pathEntries[i].type === "compaction") {
+		const entry = pathEntries[i];
+		if (entry.type === "compaction" && !hasProviderCheckpoint(entry.details)) {
 			prevCompactionIndex = i;
 			break;
 		}
@@ -701,6 +772,7 @@ export async function compact(
 	thinkingLevel?: ThinkingLevel,
 	summaryCall: SummaryCallRunner = (call) => call(headers),
 	retry?: ProviderRetryPolicy,
+	providerContext?: { context: Context; options?: CompactionOptions },
 ): Promise<CompactionResult> {
 	const {
 		firstKeptEntryId,
@@ -712,6 +784,36 @@ export async function compact(
 		fileOps,
 		settings,
 	} = preparation;
+	if (providerContext && supportsCompaction(model)) {
+		const remote = await summaryCall((callHeaders) =>
+			requestWithProviderRetry(
+				() =>
+					compactSimple(model, providerContext.context, {
+						...providerContext.options,
+						apiKey,
+						headers: callHeaders,
+						customInstructions,
+						signal,
+					}),
+				{ policy: retry, signal },
+			),
+		);
+		if (remote) {
+			signal?.throwIfAborted();
+			if (!isCompactionCheckpoint(remote.checkpoint) || !compactionMatchesModel(remote.checkpoint, model)) {
+				throw new Error("Provider compaction returned an incompatible checkpoint");
+			}
+			const { readFiles, modifiedFiles } = computeFileLists(fileOps);
+			return {
+				summary:
+					"Conversation compacted on the server. The original transcript remains available in session history.",
+				firstKeptEntryId,
+				tokensBefore,
+				usage: remote.usage,
+				details: { readFiles, modifiedFiles, providerCheckpoint: remote.checkpoint } satisfies CompactionDetails,
+			};
+		}
+	}
 	let summary: string;
 	const slices: SummarySlice[] = [];
 
@@ -719,50 +821,47 @@ export async function compact(
 		// Split turns make two wire calls with different bodies; each needs its own identity.
 		const [historyResult, turnPrefixResult] = await Promise.all([
 			messagesToSummarize.length > 0
-				? summaryCall((callHeaders) =>
-						generateSummary(
-							messagesToSummarize,
-							model,
-							settings.reserveTokens,
-							apiKey,
-							callHeaders,
-							signal,
-							customInstructions,
-							previousSummary,
-							thinkingLevel,
-							retry,
-						),
+				? generateSummary(
+						messagesToSummarize,
+						model,
+						settings.reserveTokens,
+						apiKey,
+						headers,
+						signal,
+						customInstructions,
+						previousSummary,
+						thinkingLevel,
+						retry,
+						summaryCall,
 					)
 				: Promise.resolve<SummarySlice>({ summary: "No prior history." }),
-			summaryCall((callHeaders) =>
-				generateTurnPrefixSummary(
-					turnPrefixMessages,
-					model,
-					settings.reserveTokens,
-					apiKey,
-					callHeaders,
-					signal,
-					thinkingLevel,
-					retry,
-				),
+			generateTurnPrefixSummary(
+				turnPrefixMessages,
+				model,
+				settings.reserveTokens,
+				apiKey,
+				headers,
+				signal,
+				thinkingLevel,
+				retry,
+				summaryCall,
 			),
 		]);
 		slices.push(historyResult, turnPrefixResult);
 		summary = `${historyResult.summary}\n\n---\n\n**Turn Context (split turn):**\n\n${turnPrefixResult.summary}`;
 	} else {
-		const result = await summaryCall((callHeaders) =>
-			generateSummary(
-				messagesToSummarize,
-				model,
-				settings.reserveTokens,
-				apiKey,
-				callHeaders,
-				signal,
-				customInstructions,
-				previousSummary,
-				thinkingLevel,
-				retry,
-			),
+		const result = await generateSummary(
+			messagesToSummarize,
+			model,
+			settings.reserveTokens,
+			apiKey,
+			headers,
+			signal,
+			customInstructions,
+			previousSummary,
+			thinkingLevel,
+			retry,
+			summaryCall,
 		);
 		slices.push(result);
 		summary = result.summary;
@@ -801,40 +900,17 @@ async function generateTurnPrefixSummary(
 	signal?: AbortSignal,
 	thinkingLevel?: ThinkingLevel,
 	retry?: ProviderRetryPolicy,
+	summaryCall: SummaryCallRunner = (call) => call(headers),
 ): Promise<SummarySlice> {
-	const maxTokens = Math.floor(0.5 * reserveTokens); // Smaller budget for turn prefix
-	const llmMessages = convertToLlm(messages);
-	const conversationText = serializeConversation(llmMessages);
-	const promptText = `<conversation>\n${conversationText}\n</conversation>\n\n${TURN_PREFIX_SUMMARIZATION_PROMPT}`;
-	const summarizationMessages = [
-		{
-			role: "user" as const,
-			content: [{ type: "text" as const, text: promptText }],
-			timestamp: Date.now(),
-		},
-	];
-
-	const response = await completeWithProviderRetry(
-		() =>
-			completeSimple(
-				model,
-				{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
-				model.reasoning && thinkingLevel && thinkingLevel !== "off"
-					? { maxTokens, signal, apiKey, headers, reasoning: thinkingLevel }
-					: { maxTokens, signal, apiKey, headers },
-			),
-		{ policy: retry, signal },
+	return generateBoundedSummary(
+		messages,
+		model,
+		Math.floor(0.5 * reserveTokens),
+		apiKey,
+		signal,
+		thinkingLevel,
+		retry,
+		summaryCall,
+		() => TURN_PREFIX_SUMMARIZATION_PROMPT,
 	);
-
-	if (response.stopReason === "error") {
-		throw new Error(`Turn prefix summarization failed: ${response.errorMessage || "Unknown error"}`);
-	}
-
-	return {
-		summary: response.content
-			.filter((c): c is { type: "text"; text: string } => c.type === "text")
-			.map((c) => c.text)
-			.join("\n"),
-		usage: response.usage,
-	};
 }

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { ImageContent, Message, TextContent } from "@earendil-works/pi-ai";
+import type { ImageContent, Message, ProviderCompactionCheckpoint, TextContent } from "@earendil-works/pi-ai";
 import type { AgentCronJob } from "./cron-jobs.js";
 import type { AppliedRefinementEdit, HarnessScope, RefinementResult } from "./refinement/refinement.js";
 import { isSessionSlashCommandName, parseSessionSlashCommand, type SessionSlashCommand } from "./slash-commands.js";
@@ -225,6 +225,8 @@ export interface BranchSummaryMessage {
 export interface CompactionSummaryMessage {
 	role: "compactionSummary";
 	summary: string;
+	/** Complete opaque provider window, used instead of the display summary. */
+	providerContext?: ProviderCompactionCheckpoint;
 	tokensBefore: number;
 	/** Number of retained messages that precede this summary in transcript presentation. */
 	retainedMessageCount?: number;
@@ -295,12 +297,14 @@ export function createCompactionSummaryMessage(
 	timestamp: string,
 	customInstructions?: string,
 	retainedMessageCount?: number,
+	providerContext?: ProviderCompactionCheckpoint,
 ): CompactionSummaryMessage {
 	return {
 		role: "compactionSummary",
 		summary,
 		tokensBefore,
 		retainedMessageCount,
+		providerContext,
 		customInstructions,
 		timestamp: new Date(timestamp).getTime(),
 	};
@@ -554,6 +558,7 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 				case "compactionSummary":
 					return {
 						role: "user",
+						providerContext: m.providerContext,
 						content: [
 							{ type: "text" as const, text: COMPACTION_SUMMARY_PREFIX + m.summary + COMPACTION_SUMMARY_SUFFIX },
 						],

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -166,6 +166,7 @@ const ModelDefinitionSchema = Type.Object({
 		}),
 	),
 	contextWindow: Type.Optional(Type.Number()),
+	maxInputTokens: Type.Optional(Type.Integer({ minimum: 1 })),
 	maxTokens: Type.Optional(Type.Number()),
 	headers: Type.Optional(Type.Record(Type.String(), Type.String())),
 	compat: Type.Optional(ProviderCompatSchema),
@@ -185,6 +186,7 @@ const ModelOverrideSchema = Type.Object({
 		}),
 	),
 	contextWindow: Type.Optional(Type.Number()),
+	maxInputTokens: Type.Optional(Type.Integer({ minimum: 1 })),
 	maxTokens: Type.Optional(Type.Number()),
 	headers: Type.Optional(Type.Record(Type.String(), Type.String())),
 	compat: Type.Optional(ProviderCompatSchema),
@@ -340,6 +342,7 @@ function applyModelOverride(model: Model<Api>, override: ModelOverride): Model<A
 	}
 	if (override.input !== undefined) result.input = override.input as ("text" | "image")[];
 	if (override.contextWindow !== undefined) result.contextWindow = override.contextWindow;
+	if (override.maxInputTokens !== undefined) result.maxInputTokens = override.maxInputTokens;
 	if (override.maxTokens !== undefined) result.maxTokens = override.maxTokens;
 
 	if (override.cost) {
@@ -779,6 +782,7 @@ export class ModelRegistry {
 					input: (modelDef.input ?? ["text"]) as ("text" | "image")[],
 					cost: modelDef.cost ?? defaultCost,
 					contextWindow: modelDef.contextWindow ?? 128000,
+					maxInputTokens: modelDef.maxInputTokens,
 					maxTokens: modelDef.maxTokens ?? 16384,
 					headers: undefined,
 					compat,
@@ -1681,6 +1685,7 @@ export class ModelRegistry {
 					input: modelDef.input as ("text" | "image")[],
 					cost: modelDef.cost,
 					contextWindow: modelDef.contextWindow,
+					maxInputTokens: modelDef.maxInputTokens,
 					maxTokens: modelDef.maxTokens,
 					headers: undefined,
 					compat: modelDef.compat,
@@ -1727,6 +1732,7 @@ export interface ProviderConfigInput {
 		input: ("text" | "image")[];
 		cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
 		contextWindow: number;
+		maxInputTokens?: number;
 		maxTokens: number;
 		headers?: Record<string, string>;
 		compat?: Model<Api>["compat"];

--- a/packages/coding-agent/src/core/provider-retry.ts
+++ b/packages/coding-agent/src/core/provider-retry.ts
@@ -125,3 +125,30 @@ export const DEFAULT_PROVIDER_RETRY_POLICY: ProviderRetryPolicy = {
 	baseDelayMs: 2000,
 	maxRetryDelayMs: 60000,
 };
+
+/** Unary provider requests throw instead of returning an assistant error message. */
+export async function requestWithProviderRetry<T>(
+	attemptRequest: () => Promise<T>,
+	options?: { policy?: ProviderRetryPolicy; signal?: AbortSignal },
+): Promise<T> {
+	const policy = options?.policy ?? DEFAULT_PROVIDER_RETRY_POLICY;
+	const maxRetries = policy.enabled ? policy.maxRetries : 0;
+	for (let attempt = 0; ; attempt++) {
+		options?.signal?.throwIfAborted();
+		try {
+			return await attemptRequest();
+		} catch (error) {
+			options?.signal?.throwIfAborted();
+			const status = error !== null && typeof error === "object" && "status" in error ? error.status : undefined;
+			const retryAfter =
+				error !== null && typeof error === "object" && "retryAfterMs" in error ? error.retryAfterMs : undefined;
+			const transient =
+				(typeof status === "number" && (status === 408 || status === 429 || status >= 500)) ||
+				(error instanceof TypeError && /fetch|network|socket/i.test(error.message));
+			if (!transient || attempt >= maxRetries) throw error;
+			const delay = providerRetryDelay(attempt + 1, typeof retryAfter === "number" ? retryAfter : undefined, policy);
+			if (delay.kind === "exceeds-cap") throw error;
+			await sleep(delay.delayMs, options?.signal);
+		}
+	}
+}

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1,5 +1,15 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { AssistantMessage, ImageContent, Message, ServiceTier, TextContent, Usage } from "@earendil-works/pi-ai";
+import {
+	type Api,
+	type AssistantMessage,
+	compactionMatchesModel,
+	type ImageContent,
+	type Message,
+	type Model,
+	type ServiceTier,
+	type TextContent,
+	type Usage,
+} from "@earendil-works/pi-ai";
 import { randomUUID } from "crypto";
 import {
 	appendFileSync,
@@ -21,6 +31,7 @@ import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.js"
 import { realpathIfPresentSync, writeFileAtomicSync } from "../utils/atomic-file.js";
 import { readBytesSync, readFirstLineSync, readLinesAsBuffers } from "../utils/file-lines.js";
 import { captureGitContext, type GitContext, gitContextsEqual } from "../utils/git.js";
+import { getProviderCheckpoint, hasProviderCheckpoint } from "./compaction/checkpoint.js";
 import {
 	type BashExecutionMessage,
 	type CustomMessage,
@@ -420,6 +431,7 @@ export function buildSessionContext(
 	entries: SessionEntry[],
 	leafId?: string | null,
 	byId?: Map<string, SessionEntry>,
+	targetModel?: Model<Api>,
 ): SessionContext {
 	if (!byId) {
 		byId = new Map<string, SessionEntry>();
@@ -466,9 +478,18 @@ export function buildSessionContext(
 			model = { provider: entry.provider, modelId: entry.modelId };
 		} else if (entry.type === "message" && entry.message.role === "assistant") {
 			model = { provider: entry.message.provider, modelId: entry.message.model };
-		} else if (entry.type === "compaction") {
-			compaction = entry;
 		}
+	}
+	// Opaque windows belong to one provider/model/endpoint. A switch or an unknown
+	// checkpoint version reconstructs context from the durable original transcript.
+	const checkpointModel = targetModel ?? (model ? { provider: model.provider, id: model.modelId } : undefined);
+	for (const entry of path) {
+		if (entry.type !== "compaction") continue;
+		if (hasProviderCheckpoint(entry.details)) {
+			const checkpoint = getProviderCheckpoint(entry.details);
+			if (!checkpoint || !checkpointModel || !compactionMatchesModel(checkpoint, checkpointModel)) continue;
+		}
+		compaction = entry;
 	}
 
 	// Build messages and collect corresponding entries
@@ -490,13 +511,14 @@ export function buildSessionContext(
 
 	if (compaction) {
 		const compactionIdx = path.findIndex((e) => e.type === "compaction" && e.id === compaction.id);
+		const providerContext = getProviderCheckpoint(compaction.details);
 
 		// Collect kept messages (before compaction, starting from firstKeptEntryId).
 		// The context remains summary-first for the model; retainedMessageCount records
 		// the exact chronological presentation boundary for clients.
 		const retainedMessages: AgentMessage[] = [];
 		let foundFirstKept = false;
-		for (let i = 0; i < compactionIdx; i++) {
+		for (let i = 0; !providerContext && i < compactionIdx; i++) {
 			const entry = path[i];
 			if (entry.id === compaction.firstKeptEntryId) {
 				foundFirstKept = true;
@@ -513,6 +535,7 @@ export function buildSessionContext(
 				compaction.timestamp,
 				compaction.customInstructions,
 				retainedMessages.length,
+				providerContext,
 			),
 			...retainedMessages,
 		);
@@ -1767,8 +1790,10 @@ export class SessionManager {
 			customInstructions,
 			usage,
 		};
-		this._appendEntry(entry);
-		return entry.id;
+		return this._appendEntryWithRollback(() => {
+			this._appendEntry(entry);
+			return entry.id;
+		});
 	}
 
 	appendCustomEntry(customType: string, data?: unknown): string {
@@ -2070,13 +2095,13 @@ export class SessionManager {
 		return path;
 	}
 
-	buildSessionContext(): SessionContext {
+	buildSessionContext(targetModel?: Model<Api>): SessionContext {
 		// Pass fileEntries directly rather than getEntries(): the resolved context
 		// is computed from the leaf-to-root walk over byId (which already excludes
 		// the header), so the entries argument is only a fallback for an undefined
 		// leaf — never hit here since leafId is always set or null. Avoids an O(n)
 		// array copy on every call (attach, get_session_context, agent init, ...).
-		return buildSessionContext(this.fileEntries as SessionEntry[], this.leafId, this.byId);
+		return buildSessionContext(this.fileEntries as SessionEntry[], this.leafId, this.byId, targetModel);
 	}
 
 	getHeader(): SessionHeader | null {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -73,8 +73,10 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 25 adds capability-gated direct worker peer transport discovery.
 // Revision 26 publishes own-session usage totals on session summary and saved-session rows.
 // Revision 27 adds structured session_recovering failure info for known-but-unaddressable sessions.
-export const DAEMON_SCHEMA_REVISION = 27;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-27-962b8b4c5e35";
+// Revision 28 adds optional providerContext to compaction summary messages and maxInputTokens to models.
+// Both are backward-compatible response metadata; older clients render the existing summary text.
+export const DAEMON_SCHEMA_REVISION = 28;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-28-962b8b4c5e35";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -1198,6 +1200,8 @@ export type DaemonOutbound =
 	  };
 
 export const DAEMON_OUTBOUND_COMPATIBILITY = {
+	// Revision 28's opaque context is owned by the worker. Message/snapshot consumers
+	// may ignore it, so response and session channels retain their protocol-7 floor.
 	response: LEGACY_DAEMON_COMMAND,
 	session_list_progress: LEGACY_DAEMON_COMMAND,
 	session_list_item: LEGACY_DAEMON_COMMAND,

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -22,6 +22,7 @@ import {
 	isDaemonCommandEnvelope,
 	isDaemonMutatingCommand,
 	isSessionPlaneDaemonCommand,
+	meetsDaemonCommandCompatibility,
 	salvageDaemonCommandId,
 } from "../src/modes/daemon/daemon-protocol.js";
 import {
@@ -30,6 +31,24 @@ import {
 } from "../src/modes/daemon/daemon-worker-protocol.js";
 
 describe("daemon protocol helpers", () => {
+	it("keeps provider compaction metadata optional for older clients and workers", () => {
+		const olderPeer = { protocol: { name: DAEMON_PROTOCOL_INFO.name, version: 7 }, schemaRevision: 27 };
+		for (const command of ["compact", "get_messages", "get_session_context"] as const) {
+			expect(meetsDaemonCommandCompatibility(olderPeer, DAEMON_COMMAND_COMPATIBILITY[command])).toBe(true);
+		}
+		for (const event of ["response", "session_event", "session_attached", "session_resynced"] as const) {
+			expect(meetsDaemonCommandCompatibility(olderPeer, DAEMON_OUTBOUND_COMPATIBILITY[event])).toBe(true);
+		}
+		// New readers accept a legacy summary without providerContext; old readers can
+		// continue rendering summary text from the extended JSON shape.
+		const legacy = { role: "compactionSummary", summary: "Readable summary", tokensBefore: 100, timestamp: 1 };
+		const extended = {
+			...legacy,
+			providerContext: { version: 1, items: [{ type: "compaction", encrypted_content: "opaque" }] },
+		};
+		expect(JSON.parse(JSON.stringify(extended)).summary).toBe(legacy.summary);
+		expect(JSON.parse(JSON.stringify(legacy)).providerContext).toBeUndefined();
+	});
 	it("serializes worker descriptors as identity-only version 2 state", () => {
 		const descriptor = {
 			version: 1,

--- a/packages/coding-agent/test/model-input-limit.test.ts
+++ b/packages/coding-agent/test/model-input-limit.test.ts
@@ -1,0 +1,50 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getModelInputLimit } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+
+const directories: string[] = [];
+afterEach(() => {
+	while (directories.length) rmSync(directories.pop()!, { recursive: true, force: true });
+});
+function registry(providers: Record<string, unknown>): ModelRegistry {
+	const directory = mkdtempSync(join(tmpdir(), "prime-input-limit-"));
+	directories.push(directory);
+	const path = join(directory, "models.json");
+	writeFileSync(path, JSON.stringify({ providers }));
+	return ModelRegistry.create(AuthStorage.inMemory(), path);
+}
+
+describe("model input budgets", () => {
+	it("loads input limits for custom models and built-in overrides", () => {
+		const models = registry({
+			local: {
+				apiKey: "test-key",
+				api: "openai-responses",
+				baseUrl: "https://example.test/v1",
+				models: [{ id: "local-model", contextWindow: 10000, maxInputTokens: 8000 }],
+			},
+			openai: { modelOverrides: { "gpt-6-astra": { maxInputTokens: 500000 } } },
+		}).getAll();
+		expect(getModelInputLimit(models.find((model) => model.id === "local-model")!)).toBe(8000);
+		expect(
+			getModelInputLimit(models.find((model) => model.provider === "openai" && model.id === "gpt-6-astra")!),
+		).toBe(500000);
+	});
+
+	it.each([0, -1, 1.5])("rejects invalid input limit %s", (maxInputTokens) => {
+		const models = registry({
+			local: {
+				apiKey: "test-key",
+				api: "openai-responses",
+				baseUrl: "https://example.test/v1",
+				models: [{ id: "invalid-input-model", maxInputTokens }],
+			},
+		});
+		expect(models.getAll().some((model) => model.id === "invalid-input-model")).toBe(false);
+		expect(models.getError()).toBeTruthy();
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-provider-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-provider-compaction.test.ts
@@ -1,0 +1,301 @@
+import { readFileSync } from "node:fs";
+import {
+	type AssistantMessage,
+	type CompactFunction,
+	type Context,
+	fauxAssistantMessage,
+	getApiProvider,
+	getModel,
+	type ProviderCompactionCheckpoint,
+	registerApiProvider,
+} from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getProviderCheckpoint } from "../../src/core/compaction/checkpoint.js";
+import {
+	DEFAULT_COMPACTION_SETTINGS,
+	generateSummary,
+	prepareCompaction,
+	shouldCompactForModel,
+} from "../../src/core/compaction/compaction.js";
+import { convertToLlm } from "../../src/core/messages.js";
+import { requestWithProviderRetry } from "../../src/core/provider-retry.js";
+import { SessionManager } from "../../src/core/session-manager.js";
+import { createHarness, getMessageText, type Harness } from "./harness.js";
+
+const harnesses: Harness[] = [];
+afterEach(() => {
+	vi.restoreAllMocks();
+	while (harnesses.length) harnesses.pop()?.cleanup();
+});
+
+async function seededHarness(): Promise<Harness> {
+	const harness = await createHarness({
+		persistSession: true,
+		models: [{ id: "faux-1" }, { id: "faux-2", contextWindow: 8000 }],
+		settings: {
+			compaction: { enabled: false, keepRecentTokens: 1 },
+			retry: { enabled: true, maxRetries: 2, baseDelayMs: 1 },
+		},
+	});
+	harnesses.push(harness);
+	harness.setResponses([fauxAssistantMessage("First response"), fauxAssistantMessage("Second response")]);
+	await harness.session.prompt("Remember original project paths");
+	await harness.session.prompt("Do the second task");
+	return harness;
+}
+
+function checkpointFor(harness: Harness): ProviderCompactionCheckpoint {
+	const model = harness.session.model!;
+	return {
+		version: 1,
+		provider: model.provider,
+		api: model.api,
+		model: model.id,
+		baseUrl: model.baseUrl,
+		estimatedTokens: 100,
+		items: [
+			{ type: "message", role: "user", content: [{ type: "input_text", text: "Retained user request" }] },
+			{ type: "compaction", id: "cmp_test", encrypted_content: "opaque" },
+		],
+	};
+}
+
+function installCompactor(harness: Harness, compact: CompactFunction): void {
+	const provider = getApiProvider(harness.session.model!.api)!;
+	registerApiProvider({ ...provider, compact });
+}
+
+describe("durable provider compaction", () => {
+	it.each(["openai", "openai-codex"] as const)(
+		"honors Astra Fast mode and the %s compaction budget",
+		async (provider) => {
+			const model = getModel(provider, "gpt-6-astra");
+			const harness = await createHarness({
+				api: model.api,
+				provider,
+				models: [{ id: model.id, contextWindow: model.contextWindow, maxTokens: model.maxTokens }],
+			});
+			harnesses.push(harness);
+			harness.session.setServiceTier("priority");
+			expect(harness.session.serviceTier).toBe("priority");
+			const threshold = provider === "openai" ? 905_616 : 244_800;
+			expect(shouldCompactForModel(threshold, model, DEFAULT_COMPACTION_SETTINGS)).toBe(false);
+			expect(shouldCompactForModel(threshold + 1, model, DEFAULT_COMPACTION_SETTINGS)).toBe(true);
+			const assistant: AssistantMessage = {
+				...fauxAssistantMessage("Large successful response"),
+				api: model.api,
+				provider,
+				model: model.id,
+				usage: {
+					input: threshold + 1,
+					output: 1,
+					totalTokens: threshold + 2,
+					cacheRead: 0,
+					cacheWrite: 0,
+					cost: { input: 0, output: 0, total: 0, cacheRead: 0, cacheWrite: 0 },
+				},
+			};
+			harness.session.agent.state.messages = [assistant];
+			const internals = harness.session as unknown as {
+				_checkCompaction: (message: AssistantMessage) => Promise<boolean>;
+				_runAutoCompaction: (reason: string, retry: boolean) => Promise<boolean>;
+			};
+			const autoCompact = vi.spyOn(internals, "_runAutoCompaction").mockResolvedValue(true);
+			await internals._checkCompaction(assistant);
+			expect(autoCompact).toHaveBeenCalledWith("threshold", false);
+		},
+	);
+
+	it("rejects an incompatible provider result before replacing history", async () => {
+		const harness = await seededHarness();
+		installCompactor(harness, async () => ({ checkpoint: { ...checkpointFor(harness), model: "wrong-model" } }));
+		await expect(harness.session.compact()).rejects.toThrow(/incompatible checkpoint/);
+		expect(harness.sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(false);
+	});
+	it("persists the entire window, resumes it, and continues without duplicating retained history", async () => {
+		const harness = await seededHarness();
+		const checkpoint = checkpointFor(harness);
+		const compact = vi.fn<CompactFunction>().mockResolvedValue({ checkpoint });
+		installCompactor(harness, compact);
+		await harness.session.compact("Keep paths");
+		expect(compact).toHaveBeenCalledOnce();
+		expect(compact.mock.calls[0][1].systemPrompt).toBe(harness.session.agent.state.systemPrompt);
+		expect(
+			compact.mock.calls[0][1].messages.some((message) =>
+				getMessageText(message).includes("original project paths"),
+			),
+		).toBe(true);
+		expect(compact.mock.calls[0][2]).toMatchObject({ customInstructions: "Keep paths" });
+		const marker = harness.session.messages.find((message) => message.role === "compactionSummary");
+		expect(marker).toMatchObject({ providerContext: checkpoint, retainedMessageCount: 0 });
+		expect(
+			harness.session.messages.filter((message) => message.role === "assistant" || message.role === "user"),
+		).toHaveLength(0);
+		const reopened = SessionManager.open(harness.sessionManager.getSessionFile()!);
+		expect(convertToLlm(reopened.buildSessionContext(harness.session.model).messages)[0]).toMatchObject({
+			providerContext: checkpoint,
+		});
+		expect(readFileSync(harness.sessionManager.getSessionFile()!, "utf8")).toContain(
+			"Remember original project paths",
+		);
+		let resumedContext: Context | undefined;
+		harness.setResponses([
+			(context) => {
+				resumedContext = context;
+				return fauxAssistantMessage("Still working");
+			},
+		]);
+		await harness.session.prompt("Continue after compaction");
+		expect(resumedContext?.messages[0]).toMatchObject({ providerContext: checkpoint });
+		expect(
+			resumedContext?.messages.filter((message) => getMessageText(message).includes("Continue after compaction")),
+		).toHaveLength(1);
+		await harness.session.compact();
+		expect(compact.mock.calls[1][1].messages[0]).toMatchObject({ providerContext: checkpoint });
+	});
+
+	it("rebuilds original history for a different model or endpoint and can restore the checkpoint", async () => {
+		const harness = await seededHarness();
+		const checkpoint = checkpointFor(harness);
+		installCompactor(harness, async () => ({ checkpoint }));
+		await harness.session.compact();
+		await harness.session.setModel(harness.getModel("faux-2")!);
+		expect(
+			harness.session.messages.some((message) => getMessageText(message).includes("original project paths")),
+		).toBe(true);
+		expect(
+			convertToLlm(harness.session.messages).some((message) => message.role === "user" && message.providerContext),
+		).toBe(false);
+		await harness.session.setModel(harness.getModel("faux-1")!);
+		expect(convertToLlm(harness.session.messages)[0]).toMatchObject({ providerContext: checkpoint });
+		const changedEndpoint = harness.sessionManager.buildSessionContext({
+			...harness.session.model!,
+			baseUrl: "https://other.example",
+		});
+		expect(
+			changedEndpoint.messages.some((message) => getMessageText(message).includes("original project paths")),
+		).toBe(true);
+	});
+
+	it("ignores unknown checkpoint versions and never uses the display label as a local summary", async () => {
+		const harness = await seededHarness();
+		const firstId = harness.sessionManager.getBranch().find((entry) => entry.type === "message")!.id;
+		harness.sessionManager.appendCompaction("Display label", firstId, 5000, {
+			providerCheckpoint: { ...checkpointFor(harness), version: 2 },
+		});
+		harness.sessionManager.appendMessage({ role: "user", content: "New work", timestamp: Date.now() });
+		const restored = harness.sessionManager.buildSessionContext(harness.session.model);
+		expect(restored.messages.some((message) => getMessageText(message).includes("original project paths"))).toBe(
+			true,
+		);
+		const preparation = prepareCompaction(harness.sessionManager.getBranch(), {
+			enabled: true,
+			reserveTokens: 1000,
+			keepRecentTokens: 1,
+		});
+		expect(preparation?.previousSummary).toBeUndefined();
+	});
+
+	it("falls back to the existing local summarizer when a provider reports unsupported", async () => {
+		const harness = await seededHarness();
+		installCompactor(harness, async () => undefined);
+		harness.setResponses([fauxAssistantMessage("Local history summary"), fauxAssistantMessage("Local turn summary")]);
+		const result = await harness.session.compact();
+		expect(result.summary).toContain("Local history summary");
+		expect(getProviderCheckpoint(result.details)).toBeUndefined();
+	});
+
+	it("retries transient unary failures before committing one checkpoint", async () => {
+		const harness = await seededHarness();
+		const compact = vi
+			.fn<CompactFunction>()
+			.mockRejectedValueOnce(Object.assign(new Error("busy"), { status: 503, retryAfterMs: 1 }))
+			.mockResolvedValue({ checkpoint: checkpointFor(harness) });
+		installCompactor(harness, compact);
+		await harness.session.compact();
+		expect(compact).toHaveBeenCalledTimes(2);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(1);
+	});
+
+	it("preserves the live and saved history when cancelled", async () => {
+		const harness = await seededHarness();
+		const compact = vi.fn<CompactFunction>().mockImplementation(
+			(_model, _context, options) =>
+				new Promise((_resolve, reject) => {
+					options?.signal?.addEventListener("abort", () => reject(new DOMException("Cancelled", "AbortError")), {
+						once: true,
+					});
+				}),
+		);
+		installCompactor(harness, compact);
+		const pending = harness.session.compact();
+		const rejected = expect(pending).rejects.toThrow(/[Cc]ancel/);
+		await vi.waitFor(() => expect(compact).toHaveBeenCalledOnce());
+		harness.session.abortCompaction();
+		await rejected;
+		expect(harness.sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(false);
+		expect(
+			harness.session.messages.some((message) => getMessageText(message).includes("original project paths")),
+		).toBe(true);
+	});
+
+	it("rolls back a checkpoint when its disk append fails", async () => {
+		const harness = await seededHarness();
+		installCompactor(harness, async () => ({ checkpoint: checkpointFor(harness) }));
+		const persist = harness.sessionManager._persist.bind(harness.sessionManager);
+		vi.spyOn(harness.sessionManager, "_persist").mockImplementation((entry) => {
+			if (entry.type === "compaction") throw new Error("disk full");
+			persist(entry);
+		});
+		await expect(harness.session.compact()).rejects.toThrow("disk full");
+		expect(harness.sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(false);
+		expect(
+			SessionManager.open(harness.sessionManager.getSessionFile()!)
+				.getEntries()
+				.some((entry) => entry.type === "compaction"),
+		).toBe(false);
+		expect(
+			harness.session.messages.some((message) => getMessageText(message).includes("original project paths")),
+		).toBe(true);
+	});
+
+	it("summarizes oversized restored transcripts in bounded calls with distinct request identities", async () => {
+		const harness = await createHarness({ models: [{ id: "faux-1", contextWindow: 8000, maxTokens: 1000 }] });
+		harnesses.push(harness);
+		const calls: Context[] = [];
+		harness.setResponses(
+			Array.from({ length: 20 }, () => (context: Context) => {
+				calls.push(context);
+				return fauxAssistantMessage("Accumulated summary");
+			}),
+		);
+		let requestId = 0;
+		const result = await generateSummary(
+			[{ role: "user", content: `START${"x".repeat(100_000)}END`, timestamp: 1 }],
+			harness.getModel(),
+			1000,
+			"faux-key",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			(call) => call({ "x-request-id": String(++requestId) }),
+		);
+		expect(result.summary).toBe("Accumulated summary");
+		expect(calls.length).toBeGreaterThan(1);
+		expect(requestId).toBe(calls.length);
+		expect(getMessageText(calls[0].messages[0])).toContain("START");
+		expect(getMessageText(calls.at(-1)!.messages[0])).toContain("END");
+		for (const call of calls) expect(getMessageText(call.messages[0]).length / 3).toBeLessThan(8000 - 800);
+	});
+
+	it("does not retry permanent failures or excessive Retry-After delays", async () => {
+		for (const failure of [{ status: 401 }, { status: 429, retryAfterMs: 60_001 }]) {
+			const request = vi.fn().mockRejectedValue(Object.assign(new Error("failed"), failure));
+			await expect(requestWithProviderRetry(request)).rejects.toThrow("failed");
+			expect(request).toHaveBeenCalledOnce();
+		}
+	});
+});


### PR DESCRIPTION
Astra sessions now use server compaction and resume from durable encrypted checkpoints. Previously Prime generated only text summaries, could compact API-key sessions after Astra's input ceiling, and silently disabled Astra Fast mode.

- Added Codex's explicit streaming `compaction_trigger` request for ChatGPT login and `/responses/compact` for API-key authentication. Replayed opaque windows without flattening reasoning or duplicating retained history.
- Persisted checkpoints with provider/model/API/endpoint identity. Rebuilt context from the original transcript on incompatible model switches, bounded local fallback summary requests, and preserved history on cancellation, malformed responses, or failed disk writes.
- Applied the 922,000-token API input ceiling and Codex's 90% compaction headroom within the existing 272,000-token ChatGPT window. Enabled Astra priority/Fast mode and added optional `maxInputTokens` model overrides.
- Added documentation and changelog fragments. Daemon schema 28 adds backward-compatible response metadata; compatibility floors and startup capabilities are unchanged. The shared session implementation covers TUI, daemon clients, RPC, and SDK.

Validation completed before submitting:

- `npm run check`: formatting, lint, TypeScript, installer checks, and browser smoke passed, including the pre-commit run.
- 344 focused tests passed; 10 existing tests remained skipped. Coverage includes provider request/replay, compaction continuation, persistence/reopening, model switches, cancellation, disk failures, retry policy, semantic request tracking, Fast mode, and daemon compatibility.
- Built and packaged all four workspaces. The packaged CLI passed `--version`, `--help`, and an isolated TUI launch showing `GPT-6 Astra · medium · fast`.
- Live Astra tests with ChatGPT login returned an encrypted checkpoint and recovered a code present only in an earlier assistant answer. Both SSE and the default transport passed, including JSON checkpoint round-tripping. The API-key adapter was tested with HTTP fixtures; live API-key verification was unavailable.

Ultra, expanded ChatGPT context defaults, and inline automatic `context_management` compaction remain outside this change. Older Prime workers cannot interpret the new encrypted checkpoint metadata in session files; use a supporting version to resume those checkpoints.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `gpt-6-astra` server compaction and Fast mode, fix compaction recovery and thresholds
> - OpenAI Responses and Codex Responses providers now support server compaction for `gpt-6-astra`, returning encrypted provider checkpoints that are persisted and replayed on session resume; unsupported models fall back to bounded local summarization
> - `gpt-6-astra` is now eligible for Fast mode through supported OpenAI providers
> - Compaction thresholds use the selected model's effective input limit (`getModelInputLimit`) with a minimum 10% reserve for the Astra model; `maxInputTokens` can be configured per model definition or override
> - Switching models or endpoints now rebuilds context from the original transcript instead of replaying an incompatible checkpoint; threshold checks ignore stale usage from a previous provider/model and use the active compaction boundary; failed compaction-entry appends roll back in-memory state
> - Local summarization splits oversized transcripts into multiple model calls bounded by input/output limits, using prior results as context for the next call
> - Transient HTTP 408/429/5xx and network errors during compaction requests are retried per `ProviderRetryPolicy`
> - Risk: `transformMessages` now throws if a provider checkpoint does not match the target model (`transform-messages.ts`); daemon schema revision advanced from 27 to 28 in `daemon-protocol.ts` (backward compatible but peers must handle optional `providerContext` and `maxInputTokens`)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c971060.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->