### PR TITLE
Dismiss resolved extension dialogs in daemon clients

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed terminal extension dialogs remaining visible after daemon cancellation or completion ([#2111](https://github.com/PrimeIntellect-ai/prime-agent/issues/2111)).
 - Fixed fullscreen wheel scrolling in Ghostty while retaining application link clicks; set `terminal.fullscreenMouse` to `false` to use native Cmd-click instead.
 - Changed the agents view to sort idle and inactive sessions by last message time, newest first, while keeping running agents in stable creation order.
 - Fixed `openai-codex` models being invisible to `rlm` subagents and `find_models` because model discovery reported Prime Agent's own version as the Codex client version ([#1375](https://github.com/PrimeIntellect-ai/prime-agent/pull/1375) by [@bilelrais](https://github.com/bilelrais)).

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -305,7 +305,7 @@ export class DaemonAgentConnection implements AgentConnection {
 			capabilities: [
 				"attach_snapshot",
 				"event_sequence",
-				...(supportsExtensionUi ? (["extension_ui"] as const) : []),
+				...(supportsExtensionUi ? (["extension_ui", "extension_ui_dismiss"] as const) : []),
 				"slim_attach",
 				"chunked_snapshot",
 				...(this.options.ownedSession ? (["client_owned_sessions"] as const) : []),
@@ -1156,7 +1156,7 @@ export class DaemonAgentConnection implements AgentConnection {
 				capabilities: [
 					"attach_snapshot",
 					"event_sequence",
-					...(supportsExtensionUi ? (["extension_ui"] as const) : []),
+					...(supportsExtensionUi ? (["extension_ui", "extension_ui_dismiss"] as const) : []),
 					"slim_attach",
 					"chunked_snapshot",
 					...(this.options.ownedSession ? (["client_owned_sessions"] as const) : []),
@@ -1542,6 +1542,10 @@ export class DaemonAgentConnection implements AgentConnection {
 			this.latestSnapshot = latestSnapshot;
 			this.latestSnapshotIsFresh = true;
 			await this.emit({ type: "session_replaced", state: message.state, messages: message.messages });
+			return;
+		}
+		if (message.type === "extension_ui_dismiss") {
+			await this.emit({ type: "extension_ui_dismiss", id: message.id });
 			return;
 		}
 		if (message.type === "extension_ui_request") {

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -624,6 +624,7 @@ export type AgentConnectionEvent =
 	| { type: "session_resynced"; snapshot: AgentConnectionSnapshot }
 	| { type: "session_status"; recap?: string }
 	| { type: "extension_ui_request"; request: AgentConnectionExtensionUiRequest }
+	| { type: "extension_ui_dismiss"; id: string }
 	| { type: "extension_error"; extensionPath: string; event: string; error: string }
 	| { type: "connection_status"; status: "reconnecting" | "connected"; error?: string }
 	| { type: "heartbeats_changed" }

--- a/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
@@ -161,8 +161,12 @@ function createExtensionUIContext(
 				opts?.signal?.removeEventListener("abort", onAbort);
 				state.extensionUiRequests.delete(requestId);
 			};
+			let settled = false;
 			const finish = (value: T) => {
+				if (settled) return;
+				settled = true;
 				cleanup();
+				broadcast(state, { type: "extension_ui_dismiss", activeSessionId: state.activeSessionId, id: requestId });
 				resolveDialog(value);
 			};
 			const onAbort = () => finish(fallback);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -6905,6 +6905,11 @@ function isSequencedSessionOutbound(message: DaemonOutbound): message is Sequenc
 }
 
 export function shouldSendDaemonOutboundToClient(client: DaemonSocketClient, message: DaemonOutbound): boolean {
+	if (message.type === "extension_ui_dismiss") {
+		return (client.capabilitiesByActiveSessionId?.get(message.activeSessionId) ?? client.capabilities).has(
+			"extension_ui_dismiss",
+		);
+	}
 	return (
 		message.type !== "extension_ui_request" ||
 		!isDaemonDialogExtensionUiRequest(message.method) ||

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -60,8 +60,8 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 14 carries the client's monotonic telemetry opt-out on attach and reattach.
 // Revision 15 adds the mutate_queued_message command and queue_message_mutation capability.
 // Revision 16 adds the "stopping" workerState and stops reporting disconnected workers as "ready".
-export const DAEMON_SCHEMA_REVISION = 16;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-16-1bcb9e7f1a49";
+export const DAEMON_SCHEMA_REVISION = 17;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-17-b35b05e0f224";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -77,6 +77,7 @@ export type DaemonClientCapability =
 	| "attach_snapshot"
 	| "event_sequence"
 	| "extension_ui"
+	| "extension_ui_dismiss"
 	| "slim_attach"
 	| "chunked_snapshot"
 	| "client_owned_sessions";
@@ -123,6 +124,7 @@ export const DAEMON_SUPPORTED_CLIENT_CAPABILITIES: readonly DaemonClientCapabili
 	"attach_snapshot",
 	"event_sequence",
 	"extension_ui",
+	"extension_ui_dismiss",
 	"slim_attach",
 	"chunked_snapshot",
 	"client_owned_sessions",
@@ -928,6 +930,7 @@ export type DaemonOutbound =
 			snapshotId: string;
 			error: string;
 	  }
+	| { type: "extension_ui_dismiss"; activeSessionId: string; id: string; meta?: DaemonEventMeta }
 	| { type: "session_detached"; activeSessionId: string }
 	| { type: "session_closed"; activeSessionId: string; reason: DaemonSessionClosedReason; meta?: DaemonEventMeta }
 	| {
@@ -967,6 +970,7 @@ export const DAEMON_OUTBOUND_COMPATIBILITY = {
 	session_detached: LEGACY_DAEMON_COMMAND,
 	session_closed: LEGACY_DAEMON_COMMAND,
 	extension_ui_request: LEGACY_DAEMON_COMMAND,
+	extension_ui_dismiss: { minProtocol: 7, capability: "extension_ui_dismiss" },
 	extension_error: LEGACY_DAEMON_COMMAND,
 } as const satisfies Record<DaemonOutbound["type"], DaemonCommandCompatibility>;
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3906,23 +3906,19 @@ export class InteractiveMode {
 	/**
 	 * Show a multi-line editor for extensions (with Ctrl+G support).
 	 */
-	private showExtensionEditor(title: string, prefill?: string): Promise<string | undefined> {
+	private showExtensionEditor(title: string, prefill?: string, signal?: AbortSignal): Promise<string | undefined> {
+		if (signal?.aborted) return Promise.resolve(undefined);
 		return new Promise((resolve) => {
-			this.extensionEditor = new ExtensionEditorComponent(
-				this.ui,
-				this.keybindings,
-				title,
-				prefill,
-				(value) => {
-					this.hideExtensionEditor();
-					resolve(value);
-				},
-				() => {
-					this.hideExtensionEditor();
-					resolve(undefined);
-				},
+			const finish = (value: string | undefined) => {
+				signal?.removeEventListener("abort", onAbort);
+				this.hideExtensionEditor();
+				resolve(value);
+			};
+			const onAbort = () => finish(undefined);
+			this.extensionEditor = new ExtensionEditorComponent(this.ui, this.keybindings, title, prefill, finish, () =>
+				finish(undefined),
 			);
-
+			signal?.addEventListener("abort", onAbort, { once: true });
 			this.editorContainer.clear();
 			this.editorContainer.addChild(this.extensionEditor);
 			this.ui.setFocus(this.extensionEditor);
@@ -5133,6 +5129,10 @@ export class InteractiveMode {
 					this.renderRecap();
 				} else if (event.type === "side_question_event") {
 					this.handleSideQuestionEvent(event.event);
+				} else if (event.type === "extension_ui_dismiss") {
+					const pending = this.activeConnectionExtensionUiRequests.get(event.id);
+					this.activeConnectionExtensionUiRequests.delete(event.id);
+					pending?.cancelLocal();
 				} else if (event.type === "extension_ui_request") {
 					await this.handleConnectionExtensionUiRequest(event.request);
 				} else if (event.type === "connection_status") {
@@ -5164,10 +5164,17 @@ export class InteractiveMode {
 				const cancelled = new Promise<AgentConnectionExtensionUiResponse>((resolve) => {
 					cancelLocal = resolve;
 				});
+				const controller = new AbortController();
 				this.activeConnectionExtensionUiRequests.set(request.id, {
-					cancelLocal: () => cancelLocal({ cancelled: true }),
+					cancelLocal: () => {
+						controller.abort();
+						cancelLocal({ cancelled: true });
+					},
 				});
-				response = await Promise.race([this.resolveConnectionExtensionUiRequest(request), cancelled]);
+				response = await Promise.race([
+					this.resolveConnectionExtensionUiRequest(request, controller.signal),
+					cancelled,
+				]);
 			} else {
 				response = await this.resolveConnectionExtensionUiRequest(request);
 			}
@@ -5218,6 +5225,7 @@ export class InteractiveMode {
 
 	private async resolveConnectionExtensionUiRequest(
 		request: AgentConnectionExtensionUiRequest,
+		signal?: AbortSignal,
 	): Promise<AgentConnectionExtensionUiResponse | undefined> {
 		const { payload } = request;
 		switch (request.method) {
@@ -5229,6 +5237,7 @@ export class InteractiveMode {
 				}
 				const value = await this.showExtensionSelector(title, options, {
 					timeout: getPayloadNumber(payload, "timeout"),
+					signal,
 				});
 				return value === undefined ? { cancelled: true } : { value };
 			}
@@ -5240,6 +5249,7 @@ export class InteractiveMode {
 				}
 				const confirmed = await this.showExtensionConfirm(title, message, {
 					timeout: getPayloadNumber(payload, "timeout"),
+					signal,
 				});
 				return { confirmed };
 			}
@@ -5250,6 +5260,7 @@ export class InteractiveMode {
 				}
 				const value = await this.showExtensionInput(title, getPayloadString(payload, "placeholder"), {
 					timeout: getPayloadNumber(payload, "timeout"),
+					signal,
 				});
 				return value === undefined ? { cancelled: true } : { value };
 			}

--- a/packages/coding-agent/test/daemon-extension-binding.test.ts
+++ b/packages/coding-agent/test/daemon-extension-binding.test.ts
@@ -112,6 +112,48 @@ describe("daemon extension binding", () => {
 		return runtime;
 	}
 
+	it("dismisses an aborted dialog once without converting it to a choice", async () => {
+		const controller = new AbortController();
+		let choice: string | undefined = "unresolved";
+		const runtime = await createRuntimeForTest((pi) => {
+			pi.registerCommand("consent-test", {
+				description: "synthetic dialog",
+				handler: async (_args, ctx) => {
+					choice = await ctx.ui.select("Synthetic approval", ["Approve", "Deny"], { signal: controller.signal });
+				},
+			});
+		}, []);
+		const outbound: DaemonOutbound[] = [];
+		const state: ActiveSessionState = {
+			activeSessionId: "active-dialog",
+			runtime,
+			clients: new Set([{ supportsExtensionUi: true } as never]),
+			pendingAttaches: 0,
+			extensionUiRequests: new Map(),
+			eventGeneration: "dialog",
+			lastEventSequence: 0,
+		};
+		await bindActiveSessionState(state, {
+			broadcast: (_state, message) => {
+				outbound.push(message);
+				if (message.type === "extension_ui_request") queueMicrotask(() => controller.abort());
+			},
+			shutdown: () => {},
+		});
+		await runtime.session.prompt("/consent-test");
+		expect(choice).toBeUndefined();
+		expect(state.extensionUiRequests.size).toBe(0);
+		const request = outbound.find((message) => message.type === "extension_ui_request");
+		expect(request).toBeDefined();
+		expect(outbound.filter((message) => message.type === "extension_ui_dismiss")).toEqual([
+			{
+				type: "extension_ui_dismiss",
+				activeSessionId: "active-dialog",
+				id: request && "id" in request ? request.id : undefined,
+			},
+		]);
+	});
+
 	it("strips the duplicated partial message from broadcast message_update events", async () => {
 		const runtime = await createRuntimeForTest(() => {}, ["streamed reply"]);
 

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -46,6 +46,16 @@ import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js"
 import { DAEMON_WORKER_SUPERVISOR_SOCKET_ENV } from "../src/modes/daemon/daemon-worker-protocol.js";
 
 describe("daemon mode helpers", () => {
+	it("gates dialog dismissal on the attached session capability", () => {
+		const client = makeClient("client", "active");
+		const event: DaemonOutbound = { type: "extension_ui_dismiss", activeSessionId: "active", id: "dialog" };
+		expect(shouldSendDaemonOutboundToClient(client, event)).toBe(false);
+		client.capabilities.add("extension_ui_dismiss");
+		expect(shouldSendDaemonOutboundToClient(client, event)).toBe(true);
+		client.capabilitiesByActiveSessionId = new Map([["active", new Set()]]);
+		expect(shouldSendDaemonOutboundToClient(client, event)).toBe(false);
+	});
+
 	it("preserves envelope client identity while registering prompt admission", () => {
 		const daemon = new AgentDaemon("/tmp/unused-daemon.sock", {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1634,6 +1634,51 @@ describe("InteractiveMode connection extension UI", () => {
 
 	const prototype = InteractiveMode.prototype as unknown as ConnectionExtensionUiHandlerHarness;
 
+	test("daemon dismissal aborts only its dialog and suppresses a late response", async () => {
+		type DismissEvent = { type: "extension_ui_dismiss"; id: string };
+		let listener: ((event: DismissEvent) => Promise<void> | void) | undefined;
+		let signal: AbortSignal | undefined;
+		let finish!: (response: AgentConnectionExtensionUiResponse) => void;
+		const response = new Promise<AgentConnectionExtensionUiResponse>((resolve) => {
+			finish = resolve;
+		});
+		const otherCancel = vi.fn();
+		const fakeThis = Object.assign(Object.create(InteractiveMode.prototype), {
+			activeConnectionExtensionUiRequests: new Map([["other", { cancelLocal: otherCancel }]]),
+			agentConnection: {
+				subscribe: vi.fn((callback) => {
+					listener = callback;
+					return vi.fn();
+				}),
+				respondToExtensionUiRequest: vi.fn(async () => {}),
+			},
+			sessionEventQueue: Promise.resolve(),
+			sessionEventGeneration: 0,
+			showError: vi.fn(),
+			resolveConnectionExtensionUiRequest: vi.fn((_request, optionsSignal: AbortSignal) => {
+				signal = optionsSignal;
+				return response;
+			}),
+		});
+		(InteractiveMode.prototype as unknown as { subscribeToAgent(this: typeof fakeThis): void }).subscribeToAgent.call(
+			fakeThis,
+		);
+		const handling = prototype.handleConnectionExtensionUiRequest.call(fakeThis, {
+			id: "dialog",
+			method: "select",
+			payload: {},
+		});
+		await listener?.({ type: "extension_ui_dismiss", id: "dialog" });
+		await handling;
+		expect(signal?.aborted).toBe(true);
+		expect(otherCancel).not.toHaveBeenCalled();
+		expect(fakeThis.activeConnectionExtensionUiRequests.has("other")).toBe(true);
+		finish({ value: "Approve" });
+		await Promise.resolve();
+		expect(fakeThis.agentConnection.respondToExtensionUiRequest).not.toHaveBeenCalled();
+		expect(fakeThis.showError).not.toHaveBeenCalled();
+	});
+
 	test("reset cancellation responds to active connection UI requests", async () => {
 		const cancelLocal = vi.fn();
 		const fakeThis = Object.create(InteractiveMode.prototype) as ConnectionExtensionUiCancelHarness;


### PR DESCRIPTION
Fixes #2111.

## Summary
- Add capability-gated `extension_ui_dismiss` and bump schema identity.
- Dismiss a dialog once when the daemon resolves or aborts it.
- Forward dismissal to the terminal, abort only the matching local dialog, and suppress a later local answer.
- Preserve old-client behavior: clients without the capability receive no new event.

## Verification
- `npm run check` passed.
- Focused Vitest: daemon-protocol, daemon-extension-binding, daemon-mode, interactive-mode-status: 363 passed.
- `git diff --check` passed.

## Remaining validation
Draft: independent review and controlled live TUI validation still required. This is only the host prerequisite; persistent dual-channel consent arbitration lives in the extension. No installed runtime changes or production actions.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dismiss resolved extension dialogs in daemon clients via `extension_ui_dismiss`
> - Adds a new `extension_ui_dismiss` daemon protocol message (schema revision 17) so the daemon can tell connected clients to remove a finished extension dialog UI.
> - The `dialogRequest` helper in [daemon-extension-binding.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2112/files#diff-a4bdfdf7adfe6342e35b280f672b6f5826ed0c282decda6fec28b75d499da8a3) now broadcasts one dismissal event whenever a dialog settles (response, abort, or timeout), guarded so cleanup and dismissal run only once.
> - `InteractiveMode` handles `extension_ui_dismiss` events by aborting the matching request's `AbortSignal` and removing it from the active request map; unrelated requests are left untouched.
> - Daemon connection attach/reattach now advertise the `extension_ui_dismiss` capability, and the outbound filter only forwards dismissal messages to clients that support it.
> - Behavioral Change: `showExtensionEditor` dialogs created through `resolveConnectionExtensionUiRequest` do not receive the cancellation signal and will not be dismissed by a later `extension_ui_dismiss` event, unlike select/confirm/input dialogs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bbb4195.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->