### PR TITLE
default prime inference to glm 5.3

### DIFF
--- a/packages/coding-agent/.changes/prime-inference-glm-5-3-default.md
+++ b/packages/coding-agent/.changes/prime-inference-glm-5-3-default.md
@@ -1,0 +1,1 @@
+- Changed the default Prime Inference model from GLM 5.2 to GLM 5.3.

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -14,7 +14,7 @@ import { isPrivatePrimeInferenceModel } from "./prime-inference-models.js";
 
 const log = getLogger("coding-agent.model-resolver");
 
-export const PRIME_INFERENCE_DEFAULT_MODEL_ID = "z-ai/glm-5.2";
+export const PRIME_INFERENCE_DEFAULT_MODEL_ID = "z-ai/glm-5.3";
 
 /** Default model IDs for each known provider */
 export const defaultModelPerProvider: Record<KnownProvider, string> = {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -8693,7 +8693,7 @@ export class InteractiveMode {
 				);
 			}
 		} else if (!selectedModel) {
-			this.showError("Prime Inference login succeeded, but the default GLM 5.2 model is unavailable.");
+			this.showError("Prime Inference login succeeded, but the default GLM 5.3 model is unavailable.");
 		}
 
 		return true;

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -4120,8 +4120,8 @@ describe("InteractiveMode post-login model preparation", () => {
 		maxTokens: 128000,
 	} as AgentConnectionModel;
 
-	test("persists GLM 5.2 before model selection after Prime Inference login", async () => {
-		const fallbackModel = { ...loginPrimeModel, id: "z-ai/glm-5.2", name: "GLM 5.2" };
+	test("persists GLM 5.3 before model selection after Prime Inference login", async () => {
+		const fallbackModel = { ...loginPrimeModel, id: "z-ai/glm-5.3", name: "GLM 5.3" };
 		const flushSettings = vi.fn(async () => {});
 		const fakeThis = Object.create(InteractiveMode.prototype) as LoginHarness;
 		fakeThis.invalidateConnectionModels = vi.fn();

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -300,7 +300,7 @@ describe("default model selection", () => {
 	test("openai defaults track current models", () => {
 		expect(defaultModelPerProvider.openai).toBe("gpt-5.4");
 		expect(defaultModelPerProvider["openai-codex"]).toBe("gpt-5.5");
-		expect(defaultModelPerProvider["prime-inference"]).toBe("z-ai/glm-5.2");
+		expect(defaultModelPerProvider["prime-inference"]).toBe("z-ai/glm-5.3");
 	});
 
 	test("every per-provider default exists in the model catalog", () => {
@@ -358,15 +358,15 @@ describe("default model selection", () => {
 		expect(result.thinkingLevel).toBe("medium");
 	});
 
-	test("findInitialModel prefers GLM 5.2 when Prime Inference is configured", async () => {
+	test("findInitialModel prefers GLM 5.3 when Prime Inference is configured", async () => {
 		const anthropicModel: Model<"anthropic-messages"> = {
 			...mockModels[0],
 			id: "claude-opus-4-7",
 			name: "Claude Opus 4.7",
 		};
 		const primeModel: Model<"anthropic-messages"> = {
-			id: "z-ai/glm-5.2",
-			name: "GLM 5.2",
+			id: "z-ai/glm-5.3",
+			name: "GLM 5.3",
 			api: "anthropic-messages",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -377,7 +377,11 @@ describe("default model selection", () => {
 			maxTokens: 101376,
 		};
 		const registry = {
-			refreshAvailableModels: async () => [anthropicModel, primeModel],
+			refreshAvailableModels: async () => [
+				anthropicModel,
+				{ ...primeModel, id: "z-ai/glm-5.2", name: "GLM 5.2" },
+				primeModel,
+			],
 		} as unknown as Parameters<typeof findInitialModel>[0]["modelRegistry"];
 
 		const result = await findInitialModel({

--- a/packages/coding-agent/test/prime-inference-model-selection.test.ts
+++ b/packages/coding-agent/test/prime-inference-model-selection.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, test } from "vitest";
 import { resolvePrimeInferencePostLoginModelAction } from "../src/core/prime-inference-model-selection.js";
 
 const glmModel: Model<"openai-completions"> = {
-	id: "z-ai/glm-5.2",
-	name: "GLM 5.2",
+	id: "z-ai/glm-5.3",
+	name: "GLM 5.3",
 	api: "openai-completions",
 	provider: "prime-inference",
 	baseUrl: "https://api.pinference.ai/api/v1",
@@ -21,7 +21,7 @@ const registry = {
 };
 
 describe("Prime Inference post-login model selection", () => {
-	test("selects GLM 5.2 as a fallback and opens the model picker", () => {
+	test("selects GLM 5.3 as a fallback and opens the model picker", () => {
 		const action = resolvePrimeInferencePostLoginModelAction(
 			{
 				status: "success",

--- a/packages/coding-agent/test/suite/regressions/4573-prime-inference-login-default.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4573-prime-inference-login-default.test.ts
@@ -36,10 +36,10 @@ describe("ENG-4573 Prime Inference login default", () => {
 		}
 	});
 
-	test("persists GLM 5.2 so the next process starts with a valid model", async () => {
+	test("persists GLM 5.3 so the next process starts with a valid model", async () => {
 		const harness = await createHarness({
 			provider: PRIME_INFERENCE_PROVIDER_ID,
-			models: [{ id: PRIME_INFERENCE_DEFAULT_MODEL_ID, name: "GLM 5.2" }],
+			models: [{ id: PRIME_INFERENCE_DEFAULT_MODEL_ID, name: "GLM 5.3" }],
 		});
 		harnesses.push(harness);
 		const agentDir = join(harness.tempDir, "agent");
@@ -64,10 +64,10 @@ describe("ENG-4573 Prime Inference login default", () => {
 		expect(initial.model?.id).toBe(PRIME_INFERENCE_DEFAULT_MODEL_ID);
 	});
 
-	test("refreshes authenticated models before selecting and persisting GLM 5.2", async () => {
+	test("refreshes authenticated models before selecting and persisting GLM 5.3", async () => {
 		const fallbackModel: AgentConnectionModel = {
 			id: PRIME_INFERENCE_DEFAULT_MODEL_ID,
-			name: "GLM 5.2",
+			name: "GLM 5.3",
 			api: "openai-completions",
 			provider: PRIME_INFERENCE_PROVIDER_ID,
 			baseUrl: "https://api.pinference.ai/api/v1",


### PR DESCRIPTION
- use `z-ai/glm-5.3` as the prime inference default for startup, fallback, and first-time login.
- update login messaging, selection coverage, and the changelog.
- validated with `npm run check` and 199 passing tests across four updated test files.

fixes [res-1322](https://linear.app/primeintellect/issue/RES-1322/default-prime-inference-to-glm-53).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration and messaging only; behavior is the same except for the default model id.
> 
> **Overview**
> Bumps the **Prime Inference** default from **GLM 5.2** (`z-ai/glm-5.2`) to **GLM 5.3** (`z-ai/glm-5.3`) via `PRIME_INFERENCE_DEFAULT_MODEL_ID`, which drives provider defaults, startup preference when Prime is available, and post-login fallback selection.
> 
> The interactive login error text now refers to GLM 5.3 when that default cannot be applied. Tests and a changelog entry were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdc047b9fe5fd183d360a022ec98d61570ae8349. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set Prime Inference default model to GLM 5.3
> Updates `PRIME_INFERENCE_DEFAULT_MODEL_ID` in [model-resolver.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2123/files#diff-22e2eb9b044dcbda43aec220ab0d91127a4f6ed0cc7e2757843bd6bc6aeaa144) from GLM 5.2 to GLM 5.3. The post-login error message in `InteractiveMode.prepareForModelSelectionAfterLogin` now references GLM 5.3. All related tests and fixtures are updated to expect GLM 5.3 as the default.
> - Risk: existing users with persisted model preferences are unaffected, but new Prime Inference users will now default to GLM 5.3.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fdc047b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
