### PR TITLE
accept engineering and research tickets in the contribution gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,8 @@ https://github.com/PrimeIntellect-ai/prime-agent/discussions
 ## Context
 
 <!-- Link the accepted Issue or Discussion and explain why this change is needed.
-Prime Agent Linear tickets should normally use the Research team and the Prime Agent: Long-Horizon research project.
+Link a Prime Agent Linear ticket from either Engineering (ENG) or Research (RES).
+Research tickets should use the Prime Agent: Long-Horizon research project.
 If this change has no ticket, add `No-Ticket: <short reason>` below. -->
 
 ## Changes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,9 @@ https://github.com/PrimeIntellect-ai/prime-agent/discussions
 ## Context
 
 <!-- Link the accepted Issue or Discussion and explain why this change is needed.
-Link a Prime Agent Linear ticket from either Engineering (ENG) or Research (RES).
-Research tickets should use the Prime Agent: Long-Horizon research project.
+Link a Prime Agent Linear ticket.
+Engineering issues should use the Engineering (ENG) team and the Prime Agent V1 board.
+Capabilities and research issues should use the Research (RES) team and the Prime Agent: Long-Horizon board.
 If this change has no ticket, add `No-Ticket: <short reason>` below. -->
 
 ## Changes

--- a/.github/workflows/linear-ticket.yml
+++ b/.github/workflows/linear-ticket.yml
@@ -20,7 +20,7 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const text = `${pr.title}\n${pr.body ?? ""}\n${pr.head.ref}`;
-            const ticket = /\bres-\d+\b|linear\.app\/[\w-]+\/issue\/res-\d+/i;
+            const ticket = /\b(?:eng|res)-\d+\b|linear\.app\/[\w-]+\/issue\/(?:eng|res)-\d+/i;
             const optOut = /^\s*No-Ticket:\s*\S.*$/im;
             if (ticket.test(text)) {
               core.info("Linear ticket reference found.");
@@ -34,9 +34,9 @@ jobs:
             core.setFailed(
               [
                 "No Linear ticket is linked in this pull request.",
-                "Prime Agent tickets should normally use the Research team and the Prime Agent: Long-Horizon research project.",
-                "Add the ticket ID (e.g. RES-1234) or a linear.app issue link to the PR title or description,",
-                "or use a branch named after the ticket (e.g. res-1234).",
+                "Prime Agent tickets may use either the Engineering (ENG) or Research (RES) team.",
+                "Add the ticket ID (e.g. ENG-1234 or RES-1234) or a linear.app issue link to the PR title or description,",
+                "or use a branch named after the ticket (e.g. eng-1234 or res-1234).",
                 'If this change genuinely has no ticket, add a line to the PR description: "No-Ticket: <short reason>".',
               ].join(" "),
             );

--- a/.github/workflows/linear-ticket.yml
+++ b/.github/workflows/linear-ticket.yml
@@ -34,7 +34,8 @@ jobs:
             core.setFailed(
               [
                 "No Linear ticket is linked in this pull request.",
-                "Prime Agent tickets may use either the Engineering (ENG) or Research (RES) team.",
+                "Prime Agent tickets may use either the Engineering (ENG) team",
+                "or the Research (RES) team and the Prime Agent: Long-Horizon research project.",
                 "Add the ticket ID (e.g. ENG-1234 or RES-1234) or a linear.app issue link to the PR title or description,",
                 "or use a branch named after the ticket (e.g. eng-1234 or res-1234).",
                 'If this change genuinely has no ticket, add a line to the PR description: "No-Ticket: <short reason>".',

--- a/.github/workflows/linear-ticket.yml
+++ b/.github/workflows/linear-ticket.yml
@@ -34,8 +34,8 @@ jobs:
             core.setFailed(
               [
                 "No Linear ticket is linked in this pull request.",
-                "Prime Agent tickets may use either the Engineering (ENG) team",
-                "or the Research (RES) team and the Prime Agent: Long-Horizon research project.",
+                "Engineering issues should use the Engineering (ENG) team and the Prime Agent V1 board.",
+                "Capabilities and research issues should use the Research (RES) team and the Prime Agent: Long-Horizon board.",
                 "Add the ticket ID (e.g. ENG-1234 or RES-1234) or a linear.app issue link to the PR title or description,",
                 "or use a branch named after the ticket (e.g. eng-1234 or res-1234).",
                 'If this change genuinely has no ticket, add a line to the PR description: "No-Ticket: <short reason>".',


### PR DESCRIPTION
- accept engineering and research linear tickets in pr titles, descriptions, links, and branch names.
- update contributor guidance; validated 31 gate scenarios and passed `npm run check`.

no-ticket: contribution workflow maintenance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only GitHub workflow regex and contributor template text change; no application or security logic is affected.
> 
> **Overview**
> The PR contribution gate now treats **Engineering (`ENG-*`)** tickets the same as **Research (`RES-*`)** when checking PR titles, descriptions, branch names, and `linear.app` issue links.
> 
> The **PR template** Context section is updated so contributors link either an ENG ticket on the **Prime Agent V1** board or a RES ticket on the **Prime Agent: Long-Horizon** board (or use `No-Ticket:` when appropriate). The **linear-ticket** workflow regex and failure text match that split, with examples for both ticket prefixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f8d8d9723a5ade555078f73da64713a7f04494a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept Engineering (`ENG`) tickets in contribution gate alongside Research (`RES`)
> - Expands the [linear-ticket workflow](https://github.com/PrimeIntellect-ai/prime-agent/pull/2124/files#diff-ce6fb4658459ed854d72950d809841bbd48b2cbae4ed1ab56d7e1a6b6be59b52) to recognize Engineering-team ticket identifiers and links, not just Research-team ones
> - Updates the [PR template](https://github.com/PrimeIntellect-ai/prime-agent/pull/2124/files#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35) Context guidance to allow either ENG or RES Prime Agent Linear tickets, keeping the Long-Horizon project requirement for RES tickets
> - Failure messages now name both supported teams with ENG and RES examples for ticket IDs and branch names
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2124 opened
>
> - Updated the failure message in the `linear-ticket.yml` GitHub workflow to clarify that Prime Agent tickets may reference either the Engineering team or the Research team with the Prime Agent: Long-Horizon research project [a41e7cb]
> - Updated Linear ticket reference guidance to specify that Engineering issues should reference the `Engineering (ENG)` team with the `Prime Agent V1` board, and capabilities/research issues should reference the `Research (RES)` team with the `Prime Agent: Long-Horizon` board [8f8d8d9]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a41e7cb. 1 file reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>.github/workflows/linear-ticket.yml — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 23](https://github.com/PrimeIntellect-ai/prime-agent/blob/a41e7cb02a856c06d3f95803c7eae98471f16cdc/.github/workflows/linear-ticket.yml#L23): The Linear URL alternative has no boundary after `\d+`, so a PR body containing a non-ticket string such as `https://linear.app/team/issue/ENG-123not-a-ticket` satisfies the gate. Unlike the bare-ID alternative, this permits a malformed Engineering reference to bypass the required-ticket check. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->