### PR TITLE
fix(coding-agent): wait for startup before listing heartbeats

### DIFF
--- a/packages/coding-agent/.changes/fix-heartbeat-list-during-startup.md
+++ b/packages/coding-agent/.changes/fix-heartbeat-list-during-startup.md
@@ -1,0 +1,1 @@
+- Fixed `heartbeats_list` failing with "Cannot list heartbeats while session worker is starting" by awaiting in-flight worker launches before enumerating heartbeats.

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2289,9 +2289,11 @@ export class DaemonSupervisor {
 					const match = await this.findWorkerForClient(client, command.activeSessionId);
 					return this.forwardToWorker(match.worker, command);
 				}
+				const openings = [...this.openingWorkers.values()];
 				const workers = [...this.workers.values()].filter(
 					(worker) => this.isLiveWorker(worker) && worker.descriptor.lifecycle !== "failed",
 				);
+				await Promise.allSettled(openings);
 				const heartbeats = new Map<string, AgentConnectionHeartbeat>();
 				const snapshots: Array<{ heartbeats?: AgentConnectionHeartbeat[]; response?: DaemonResponse }> =
 					await Promise.all(

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2293,7 +2293,9 @@ export class DaemonSupervisor {
 				const workers = [...this.workers.values()].filter(
 					(worker) => this.isLiveWorker(worker) && worker.descriptor.lifecycle !== "failed",
 				);
-				await Promise.allSettled(openings);
+				for (const result of await Promise.allSettled(openings)) {
+					if (result.status === "fulfilled" && !workers.includes(result.value)) workers.push(result.value);
+				}
 				const heartbeats = new Map<string, AgentConnectionHeartbeat>();
 				const snapshots: Array<{ heartbeats?: AgentConnectionHeartbeat[]; response?: DaemonResponse }> =
 					await Promise.all(

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2290,12 +2290,14 @@ export class DaemonSupervisor {
 					return this.forwardToWorker(match.worker, command);
 				}
 				const openings = [...this.openingWorkers.values()];
-				const workers = [...this.workers.values()].filter(
-					(worker) => this.isLiveWorker(worker) && worker.descriptor.lifecycle !== "failed",
-				);
+				const selectedWorkers = new Set(this.workers.values());
 				for (const result of await Promise.allSettled(openings)) {
-					if (result.status === "fulfilled" && !workers.includes(result.value)) workers.push(result.value);
+					if (result.status === "fulfilled") selectedWorkers.add(result.value);
 				}
+				const workers = [...this.workers.values()].filter(
+					(worker) =>
+						selectedWorkers.has(worker) && this.isLiveWorker(worker) && worker.descriptor.lifecycle !== "failed",
+				);
 				const heartbeats = new Map<string, AgentConnectionHeartbeat>();
 				const snapshots: Array<{ heartbeats?: AgentConnectionHeartbeat[]; response?: DaemonResponse }> =
 					await Promise.all(

--- a/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
@@ -8,6 +8,7 @@ import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
 
 interface SupervisorHarness {
 	workers: Map<string, unknown>;
+	openingWorkers: Map<string, Promise<unknown>>;
 	forwardToWorker(worker: unknown, command: DaemonCommand, timeoutMs?: number): Promise<DaemonResponse>;
 	handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<DaemonResponse | undefined>;
 	handleWorkerFrame(worker: unknown, frame: unknown): void;
@@ -30,7 +31,7 @@ function createSupervisorHarness(): SupervisorHarness {
 	}) as unknown as SupervisorHarness;
 }
 
-function worker(lifecycle: "ready" | "recovering" | "failed", connected = true) {
+function worker(lifecycle: "starting" | "ready" | "recovering" | "failed", connected = true) {
 	return {
 		descriptor: { lifecycle },
 		...(connected ? { client: {} } : {}),
@@ -38,6 +39,34 @@ function worker(lifecycle: "ready" | "recovering" | "failed", connected = true) 
 }
 
 describe("daemon supervisor heartbeat aggregation", () => {
+	it.each([true, false])("waits for startup before listing heartbeats (registered: %s)", async (registered) => {
+		const supervisor = createSupervisorHarness();
+		const target = worker("starting");
+		if (registered) supervisor.workers.set("target", target);
+		let finishStartup = () => {};
+		supervisor.openingWorkers.set(
+			"target",
+			new Promise<unknown>((resolve) => {
+				finishStartup = () => resolve(target);
+			}),
+		);
+		supervisor.forwardToWorker = vi.fn(async (_worker, command) =>
+			success(command.id, command.type, { heartbeats: [{ job: { id: "heartbeat-1" } }] }),
+		);
+
+		const pending = supervisor.handleCommand({} as DaemonSocketClient, { type: "heartbeats_list" });
+		expect(supervisor.forwardToWorker).not.toHaveBeenCalled();
+		target.descriptor.lifecycle = "ready";
+		supervisor.workers.set("target", target);
+		finishStartup();
+
+		await expect(pending).resolves.toMatchObject({
+			success: true,
+			data: { heartbeats: [{ job: { id: "heartbeat-1" } }] },
+		});
+		expect(supervisor.forwardToWorker).toHaveBeenCalledOnce();
+	});
+
 	it("uses the last complete worker snapshot during recovery", async () => {
 		const supervisor = createSupervisorHarness();
 		const first = worker("ready");


### PR DESCRIPTION
Fixes [RES-1324](https://linear.app/primeintellect/issue/RES-1324)

## Summary
Wait for existing launch promises before listing heartbeats, including sessions registered during that wait. Reuse the existing startup state.

Small production fix, one short regression test using existing fixtures, and the required changelog fragment.

## Validation
- Startup regression fails without the wait and passes with it.
- The same test covers a launch that registers during the wait; it fails on the earlier two-line patch and passes now.
- All eight heartbeat tests and `npm run check` pass.
- Temporary local regressions reproduce failed-startup and private-session visibility bugs on the earlier patch, and pass with the final filter.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `heartbeats_list` to await in-flight worker openings before aggregating
> When `heartbeats_list` runs without an active session, the handler now snapshots in-flight worker-opening promises, awaits them, and includes fulfilled workers in the selection set. Rejected openings are ignored, and the final aggregation still filters to live, non-failed workers before forwarding. Adds a parameterized test covering both pre-registered and post-startup workers.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2125 opened
>
> - Modified `heartbeats_list` command handling in `DaemonSupervisor` to use bounded waits and exclude client-owned launches from global catalog synchronization [961aebb]
> - Added test coverage for bounded waits and client-owned launch exclusion in `heartbeats_list` command handling [961aebb]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b81f480.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon command timing and worker selection for heartbeat aggregation; bounded timeouts alter failure modes but reduce risk of indefinite hangs during startup or recovery.
> 
> **Overview**
> Fixes **`heartbeats_list`** failing during worker startup and prevents catalog/session listing from hanging past the client’s ~30s request budget.
> 
> For **global** listing (no active session), the supervisor now waits only on **catalog-visible** in-flight launches via a new `catalogOpeningWorkers` map—client-owned private creates stay in `openingWorkers` for dedupe but no longer block the catalog. That wait is capped at **`HEARTBEAT_LIST_LAUNCH_WAIT_MS` (15s)**; after the budget, listing proceeds with registered workers, and workers still in `starting` continue to surface the existing per-worker error instead of being skipped silently.
> 
> For **session-scoped** listing, the worker forward is wrapped in **`Promise.race`** with **`HEARTBEAT_LIST_FORWARD_TIMEOUT_MS` (25s)** so a stuck or long recovery fails daemon-side with a clear timeout instead of a client transport timeout.
> 
> Regression coverage in `daemon-supervisor-heartbeats.test.ts` exercises startup wait, private launch non-blocking, launch-wait budget, still-starting errors, and session forward bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 961aebba3c17ba84be9f0eb1260c1ff2ab1c6c1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->