### PR TITLE
polish agents view visual hierarchy

### DIFF
--- a/packages/coding-agent/.changes/eng-5999-agents-view-visual-hierarchy.md
+++ b/packages/coding-agent/.changes/eng-5999-agents-view-visual-hierarchy.md
@@ -1,0 +1,2 @@
+- Changed Agents View session statistics to use muted secondary text while preserving the available details ([ENG-6000](https://linear.app/primeintellect/issue/ENG-6000)).
+- Changed Agents View session search to inline editable text without an input background or border ([ENG-6001](https://linear.app/primeintellect/issue/ENG-6001)).

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -2579,7 +2579,7 @@ export class AgentsViewMode implements Component, Focusable {
 			formatTableCell(theme.fg("muted", formatSessionModel(row.summary)), layout.modelWidth),
 		];
 		if (layout.activityWidth > 0) cells.push(formatTableCell(theme.fg("dim", activity), layout.activityWidth));
-		cells.push(details);
+		cells.push(theme.fg("muted", details));
 		return markRow(formatTableCell(cells.join("  "), width));
 	}
 
@@ -2661,7 +2661,14 @@ export class AgentsViewMode implements Component, Focusable {
 	}
 
 	private renderPrompt(width: number): string[] {
-		return this.editor.render(width);
+		const inline = !this.replyTarget && !this.renameTarget;
+		// A transparent surface preserves the editor's padding, scroll hints, and cursor without input chrome.
+		this.editor.backgroundColor = inline ? (text) => text : theme.getEditorBackgroundColor();
+		const lines = this.editor.render(width);
+		if (!inline) return lines;
+		return lines
+			.filter((line, index) => (index > 0 && index < lines.length - 1) || line.trim().length > 0)
+			.map((line) => theme.fg("muted", line));
 	}
 
 	private renderDock(width: number): string[] {


### PR DESCRIPTION
- mute session cost and age values and render search inline, preserving editing and existing statistics.
- validated with `npm run check`, 64 focused tests, and rendered ui checks across all three bundled themes.
- fixes [eng-6000](https://linear.app/primeintellect/issue/ENG-6000) and [eng-6001](https://linear.app/primeintellect/issue/ENG-6001), under [eng-5999](https://linear.app/primeintellect/issue/ENG-5999); related layout: [res-1277](https://linear.app/primeintellect/issue/RES-1277).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mute session details and inline search prompt in `AgentsViewMode`
> - Renders session details cells with the muted foreground style instead of unstyled output.
> - Adds an inline mode for `AgentsViewMode.renderPrompt` that applies a transparent editor surface, removes empty boundary lines, and uses muted text styling when no reply or rename target is active.
> - Reply and rename prompts keep their existing editor background and return the editor's rendered lines unchanged.
> - Risk: none — styling-only change with no impact on prompt input behavior or reply/rename flows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4adf00.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only TUI rendering in Agents View; no session, daemon, or search behavior changes.
> 
> **Overview**
> Improves **Agents View** visual hierarchy so primary session rows read ahead of chrome and metadata.
> 
> **Session list:** The **Cost** and **Age** column (and the same detail cells on each row) now render with **`muted`** foreground, matching model labels and de-emphasizing stats without dropping cost, age, or layout.
> 
> **Session search:** When the prompt is plain search (not reply or rename), the composer drops the **editor panel background** via a transparent `backgroundColor`, trims empty padding lines from the render, and draws the text in **muted** so search reads as inline editable text rather than a bordered input. Reply and rename modes still use the normal editor background and styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4adf00608060b7763b1839170dbf694a7df1e5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->