### PR TITLE
drop orphaned tool results after interrupted turns

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,8 @@ https://github.com/PrimeIntellect-ai/prime-agent/discussions
 ## Context
 
 <!-- Link the accepted Issue or Discussion and explain why this change is needed.
-Prime Agent Linear tickets should normally use the Research team and the Prime Agent: Long-Horizon research project.
+Link a Prime Agent Linear ticket from either Engineering (ENG) or Research (RES).
+Research tickets should use the Prime Agent: Long-Horizon research project.
 If this change has no ticket, add `No-Ticket: <short reason>` below. -->
 
 ## Changes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,9 @@ https://github.com/PrimeIntellect-ai/prime-agent/discussions
 ## Context
 
 <!-- Link the accepted Issue or Discussion and explain why this change is needed.
-Link a Prime Agent Linear ticket from either Engineering (ENG) or Research (RES).
-Research tickets should use the Prime Agent: Long-Horizon research project.
+Link a Prime Agent Linear ticket.
+Engineering issues should use the Engineering (ENG) team and the Prime Agent V1 board.
+Capabilities and research issues should use the Research (RES) team and the Prime Agent: Long-Horizon board.
 If this change has no ticket, add `No-Ticket: <short reason>` below. -->
 
 ## Changes

--- a/.github/workflows/linear-ticket.yml
+++ b/.github/workflows/linear-ticket.yml
@@ -20,7 +20,7 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const text = `${pr.title}\n${pr.body ?? ""}\n${pr.head.ref}`;
-            const ticket = /\bres-\d+\b|linear\.app\/[\w-]+\/issue\/res-\d+/i;
+            const ticket = /\b(?:eng|res)-\d+\b|linear\.app\/[\w-]+\/issue\/(?:eng|res)-\d+/i;
             const optOut = /^\s*No-Ticket:\s*\S.*$/im;
             if (ticket.test(text)) {
               core.info("Linear ticket reference found.");
@@ -34,9 +34,9 @@ jobs:
             core.setFailed(
               [
                 "No Linear ticket is linked in this pull request.",
-                "Prime Agent tickets should normally use the Research team and the Prime Agent: Long-Horizon research project.",
-                "Add the ticket ID (e.g. RES-1234) or a linear.app issue link to the PR title or description,",
-                "or use a branch named after the ticket (e.g. res-1234).",
+                "Prime Agent tickets may use either the Engineering (ENG) or Research (RES) team.",
+                "Add the ticket ID (e.g. ENG-1234 or RES-1234) or a linear.app issue link to the PR title or description,",
+                "or use a branch named after the ticket (e.g. eng-1234 or res-1234).",
                 'If this change genuinely has no ticket, add a line to the PR description: "No-Ticket: <short reason>".',
               ].join(" "),
             );

--- a/.github/workflows/linear-ticket.yml
+++ b/.github/workflows/linear-ticket.yml
@@ -34,7 +34,8 @@ jobs:
             core.setFailed(
               [
                 "No Linear ticket is linked in this pull request.",
-                "Prime Agent tickets may use either the Engineering (ENG) or Research (RES) team.",
+                "Prime Agent tickets may use either the Engineering (ENG) team",
+                "or the Research (RES) team and the Prime Agent: Long-Horizon research project.",
                 "Add the ticket ID (e.g. ENG-1234 or RES-1234) or a linear.app issue link to the PR title or description,",
                 "or use a branch named after the ticket (e.g. eng-1234 or res-1234).",
                 'If this change genuinely has no ticket, add a line to the PR description: "No-Ticket: <short reason>".',

--- a/.github/workflows/linear-ticket.yml
+++ b/.github/workflows/linear-ticket.yml
@@ -34,8 +34,8 @@ jobs:
             core.setFailed(
               [
                 "No Linear ticket is linked in this pull request.",
-                "Prime Agent tickets may use either the Engineering (ENG) team",
-                "or the Research (RES) team and the Prime Agent: Long-Horizon research project.",
+                "Engineering issues should use the Engineering (ENG) team and the Prime Agent V1 board.",
+                "Capabilities and research issues should use the Research (RES) team and the Prime Agent: Long-Horizon board.",
                 "Add the ticket ID (e.g. ENG-1234 or RES-1234) or a linear.app issue link to the PR title or description,",
                 "or use a branch named after the ticket (e.g. eng-1234 or res-1234).",
                 'If this change genuinely has no ticket, add a line to the PR description: "No-Ticket: <short reason>".',

--- a/packages/ai/.changes/fix-interrupted-tool-results.md
+++ b/packages/ai/.changes/fix-interrupted-tool-results.md
@@ -1,0 +1,1 @@
+- Fixed orphaned tool results in provider history after aborted or errored assistant turns.

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -194,6 +194,9 @@ export function transformMessages<TApi extends Api>(
 
 			result.push(msg);
 		} else if (msg.role === "toolResult") {
+			if (!pendingToolCalls.some((toolCall) => toolCall.id === msg.toolCallId)) {
+				continue;
+			}
 			existingToolResultIds.add(msg.toolCallId);
 			result.push(msg);
 		} else if (msg.role === "user") {

--- a/packages/ai/test/transform-messages-interrupted-tools.test.ts
+++ b/packages/ai/test/transform-messages-interrupted-tools.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { transformMessages } from "../src/providers/transform-messages.js";
+import type { AssistantMessage, Message, Model, StopReason, ToolResultMessage } from "../src/types.js";
+
+const model: Model<"anthropic-messages"> = {
+	id: "fixture",
+	name: "Fixture",
+	api: "anthropic-messages",
+	provider: "anthropic",
+	baseUrl: "http://localhost",
+	reasoning: false,
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 8192,
+	maxTokens: 1024,
+};
+
+function assistant(stopReason: StopReason, ...ids: string[]): AssistantMessage {
+	return {
+		role: "assistant",
+		content: ids.map((id) => ({ type: "toolCall", id, name: "fixture_tool", arguments: {} })),
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: 0,
+	};
+}
+
+function toolResult(toolCallId: string, text = "completed"): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "fixture_tool",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: 0,
+	};
+}
+
+const user: Message = { role: "user", content: "Run fixture", timestamp: 0 };
+
+describe.each([false, true])("interrupted tool history (cross-provider: %s)", (crossProvider) => {
+	function transform(messages: Message[]): Message[] {
+		const target = crossProvider ? { ...model, provider: "other-provider" } : model;
+		return transformMessages(messages, target, (id) => id.replace(/[^a-zA-Z0-9_-]/g, "_"));
+	}
+
+	it.each(["aborted", "error"] as const)("omits results from an %s assistant message", (reason) => {
+		const messages = [user, assistant(reason, "call|1"), toolResult("call|1")];
+		const original = structuredClone(messages);
+
+		expect(transform(messages)).toEqual([user]);
+		expect(messages).toEqual(original);
+	});
+
+	it("preserves a completed tool exchange", () => {
+		const messages = [user, assistant("toolUse", "call|1"), toolResult("call|1")];
+		const expectedId = crossProvider ? "call_1" : "call|1";
+
+		expect(transform(messages)).toEqual([user, assistant("toolUse", expectedId), toolResult(expectedId)]);
+	});
+
+	it("omits every result from consecutive interrupted turns", () => {
+		const messages = [
+			user,
+			assistant("aborted", "call|1", "call|2"),
+			toolResult("call|2"),
+			assistant("error", "call|3"),
+			toolResult("call|3"),
+			toolResult("call|1"),
+		];
+
+		expect(transform(messages)).toEqual([user]);
+	});
+
+	it.each(["aborted", "error"] as const)("keeps valid exchanges before and after an %s turn", (reason) => {
+		const before = [assistant("toolUse", "before|1"), toolResult("before|1")];
+		const retry = [assistant("toolUse", "call|1"), toolResult("call|1", "retry completed")];
+		const messages = [
+			user,
+			...before,
+			assistant(reason, "call|1", "call|2"),
+			toolResult("call|1", "interrupted result"),
+			user,
+			...retry,
+			toolResult("call|2", "late interrupted result"),
+		];
+
+		expect(transform(messages)).toEqual(transform([user, ...before, user, ...retry]));
+	});
+});
+
+describe("tool-result pairing boundaries", () => {
+	it("fills missing results for surviving calls around an interrupted turn", () => {
+		const messages = [
+			user,
+			assistant("toolUse", "before"),
+			assistant("aborted", "interrupted"),
+			toolResult("interrupted"),
+			assistant("toolUse", "after", "missing"),
+			toolResult("after"),
+		];
+
+		expect(transformMessages(messages, model)).toEqual([
+			user,
+			assistant("toolUse", "before"),
+			{ ...toolResult("before", "No result provided"), isError: true, timestamp: expect.any(Number) },
+			assistant("toolUse", "after", "missing"),
+			toolResult("after"),
+			{ ...toolResult("missing", "No result provided"), isError: true, timestamp: expect.any(Number) },
+		]);
+	});
+
+	it("omits results without a call in the preceding assistant turn", () => {
+		const messages = [
+			user,
+			toolResult("unknown"),
+			assistant("toolUse", "finished"),
+			toolResult("finished"),
+			user,
+			toolResult("finished", "late duplicate"),
+		];
+
+		expect(transformMessages(messages, model)).toEqual([
+			user,
+			assistant("toolUse", "finished"),
+			toolResult("finished"),
+			user,
+		]);
+	});
+});


### PR DESCRIPTION
- interrupted assistant turns were removed while their tool results survived; retain results only when their calls survive in the preceding turn, preserving valid exchanges and missing-result repair; tracks [eng-6012](https://linear.app/primeintellect/issue/ENG-6012/aborted-or-errored-assistant-messages-leave-orphaned-tool-results-in), with symptoms in [discussion 1758](https://github.com/PrimeIntellect-ai/prime-agent/discussions/1758) and [discussion 1534](https://github.com/PrimeIntellect-ai/prime-agent/discussions/1534).
- baseline `4ec05a0969825a32261ffed43ab5740071a73ae6`: 12 regression failures and six passing controls; head `0855bd9ee768863bd0945b09d77dbec38ff3d3a0`: all 18 focused tests pass locally and in the sandbox; local `npm run check` and commit-hook checks pass.
- prime sandbox `o2kha75agyjpffkmizz6q0vw`: `node:24-bookworm`, linux x64, node 24.18.0/npm 11.16.0, 2 cpu/4 gb ram/10 gb disk; compiled each commit with `tsgo`, packed with `npm pack`, and installed each archive separately; installed baseline retained orphan results for both aborted/error turns, including normalized ids, while the installed pr head removed them and preserved completed exchanges, reused ids, and missing-result repair; evidence collected and sandbox deleted; component fixtures only, with no live provider or full agent/retry-loop validation.

Linear: [ENG-6012](https://linear.app/primeintellect/issue/ENG-6012/aborted-or-errored-assistant-messages-leave-orphaned-tool-results-in)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop orphaned tool results after interrupted turns in `transformMessages`
> - Adds a guard in the tool-result processing branch of [transform-messages.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2127/files#diff-48d527355851437ed4f7f9a76cffbb8aace06900f010e02177e16b335579c674) that discards tool results whose call ID is not in the pending assistant tool calls.
> - Matching results are still recorded and returned; existing synthetic-result logic fills in results for any unresolved calls.
> - Adds changeset entry and a parameterized test suite covering aborted/errored turns, cross-provider ID normalization, input immutability, and pairing boundaries.
> - Updates PR template and Linear ticket workflow to accept both ENG and RES ticket references.
> - Risk: providers that previously received orphaned tool results will now see them filtered out; verify no downstream logic in `transformMessages` depends on unmatched results surviving normalization.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d63a350.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what message history is sent to LLM providers during transform; scoped to orphaned tool-result cleanup but affects agent replay semantics.
> 
> **Overview**
> Fixes provider history where **aborted or errored assistant turns were stripped** but their **tool results still remained**, which could confuse replay and provider APIs.
> 
> **`transformMessages`** now **skips a `toolResult`** unless its `toolCallId` matches a tool call on the **current pending assistant turn** (same pairing used for synthetic “missing result” fill). Completed exchanges, cross-provider ID normalization, and missing-result repair behavior stay covered by new Vitest tests; a small **changeset** documents the fix.
> 
> Separately, **PR template** and the **Linear ticket CI check** now treat **`ENG-*` and `RES-*`** as valid ticket references and point engineering vs research work at the right Linear teams/boards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d63a35003dc8362d907729f7cb8395f6fe953469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->