### PR TITLE
preserve literal dollar sequences in prompt arguments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,8 @@ https://github.com/PrimeIntellect-ai/prime-agent/discussions
 ## Context
 
 <!-- Link the accepted Issue or Discussion and explain why this change is needed.
-Prime Agent Linear tickets should normally use the Research team and the Prime Agent: Long-Horizon research project.
+Link a Prime Agent Linear ticket from either Engineering (ENG) or Research (RES).
+Research tickets should use the Prime Agent: Long-Horizon research project.
 If this change has no ticket, add `No-Ticket: <short reason>` below. -->
 
 ## Changes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,9 @@ https://github.com/PrimeIntellect-ai/prime-agent/discussions
 ## Context
 
 <!-- Link the accepted Issue or Discussion and explain why this change is needed.
-Link a Prime Agent Linear ticket from either Engineering (ENG) or Research (RES).
-Research tickets should use the Prime Agent: Long-Horizon research project.
+Link a Prime Agent Linear ticket.
+Engineering issues should use the Engineering (ENG) team and the Prime Agent V1 board.
+Capabilities and research issues should use the Research (RES) team and the Prime Agent: Long-Horizon board.
 If this change has no ticket, add `No-Ticket: <short reason>` below. -->
 
 ## Changes

--- a/.github/workflows/linear-ticket.yml
+++ b/.github/workflows/linear-ticket.yml
@@ -20,7 +20,7 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const text = `${pr.title}\n${pr.body ?? ""}\n${pr.head.ref}`;
-            const ticket = /\bres-\d+\b|linear\.app\/[\w-]+\/issue\/res-\d+/i;
+            const ticket = /\b(?:eng|res)-\d+\b|linear\.app\/[\w-]+\/issue\/(?:eng|res)-\d+/i;
             const optOut = /^\s*No-Ticket:\s*\S.*$/im;
             if (ticket.test(text)) {
               core.info("Linear ticket reference found.");
@@ -34,9 +34,9 @@ jobs:
             core.setFailed(
               [
                 "No Linear ticket is linked in this pull request.",
-                "Prime Agent tickets should normally use the Research team and the Prime Agent: Long-Horizon research project.",
-                "Add the ticket ID (e.g. RES-1234) or a linear.app issue link to the PR title or description,",
-                "or use a branch named after the ticket (e.g. res-1234).",
+                "Prime Agent tickets may use either the Engineering (ENG) or Research (RES) team.",
+                "Add the ticket ID (e.g. ENG-1234 or RES-1234) or a linear.app issue link to the PR title or description,",
+                "or use a branch named after the ticket (e.g. eng-1234 or res-1234).",
                 'If this change genuinely has no ticket, add a line to the PR description: "No-Ticket: <short reason>".',
               ].join(" "),
             );

--- a/.github/workflows/linear-ticket.yml
+++ b/.github/workflows/linear-ticket.yml
@@ -34,7 +34,8 @@ jobs:
             core.setFailed(
               [
                 "No Linear ticket is linked in this pull request.",
-                "Prime Agent tickets may use either the Engineering (ENG) or Research (RES) team.",
+                "Prime Agent tickets may use either the Engineering (ENG) team",
+                "or the Research (RES) team and the Prime Agent: Long-Horizon research project.",
                 "Add the ticket ID (e.g. ENG-1234 or RES-1234) or a linear.app issue link to the PR title or description,",
                 "or use a branch named after the ticket (e.g. eng-1234 or res-1234).",
                 'If this change genuinely has no ticket, add a line to the PR description: "No-Ticket: <short reason>".',

--- a/.github/workflows/linear-ticket.yml
+++ b/.github/workflows/linear-ticket.yml
@@ -34,8 +34,8 @@ jobs:
             core.setFailed(
               [
                 "No Linear ticket is linked in this pull request.",
-                "Prime Agent tickets may use either the Engineering (ENG) team",
-                "or the Research (RES) team and the Prime Agent: Long-Horizon research project.",
+                "Engineering issues should use the Engineering (ENG) team and the Prime Agent V1 board.",
+                "Capabilities and research issues should use the Research (RES) team and the Prime Agent: Long-Horizon board.",
                 "Add the ticket ID (e.g. ENG-1234 or RES-1234) or a linear.app issue link to the PR title or description,",
                 "or use a branch named after the ticket (e.g. eng-1234 or res-1234).",
                 'If this change genuinely has no ticket, add a line to the PR description: "No-Ticket: <short reason>".',

--- a/packages/coding-agent/.changes/eng-6014-literal-prompt-arguments.md
+++ b/packages/coding-agent/.changes/eng-6014-literal-prompt-arguments.md
@@ -1,0 +1,1 @@
+- Fixed prompt templates altering literal dollar sequences and expanding placeholders inside user arguments.

--- a/packages/coding-agent/src/core/prompt-templates.ts
+++ b/packages/coding-agent/src/core/prompt-templates.ts
@@ -71,39 +71,22 @@ export function parseCommandArgs(argsString: string): string[] {
  * containing patterns like $1, $@, or $ARGUMENTS are NOT recursively substituted.
  */
 export function substituteArgs(content: string, args: string[]): string {
-	let result = content;
-
-	// Replace $1, $2, etc. with positional args FIRST (before wildcards)
-	// This prevents wildcard replacement values containing $<digit> patterns from being re-substituted
-	result = result.replace(/\$(\d+)/g, (_, num) => {
-		const index = parseInt(num, 10) - 1;
-		return args[index] ?? "";
-	});
-
-	// Replace ${@:start} or ${@:start:length} with sliced args (bash-style)
-	// Process BEFORE simple $@ to avoid conflicts
-	result = result.replace(/\$\{@:(\d+)(?::(\d+))?\}/g, (_, startStr, lengthStr) => {
-		let start = parseInt(startStr, 10) - 1; // Convert to 0-indexed (user provides 1-indexed)
-		// Treat 0 as 1 (bash convention: args start at 1)
-		if (start < 0) start = 0;
-
-		if (lengthStr) {
-			const length = parseInt(lengthStr, 10);
-			return args.slice(start, start + length).join(" ");
-		}
-		return args.slice(start).join(" ");
-	});
-
-	// Pre-compute all args joined (optimization)
 	const allArgs = args.join(" ");
-
-	// Replace $ARGUMENTS with all args joined (new syntax, aligns with Claude, Codex, OpenCode)
-	result = result.replace(/\$ARGUMENTS/g, allArgs);
-
-	// Replace $@ with all args joined (existing syntax)
-	result = result.replace(/\$@/g, allArgs);
-
-	return result;
+	return content.replace(
+		/\$(?:(\d+)|\{@:(\d+)(?::(\d+))?\}|ARGUMENTS|@)/g,
+		(_, num: string | undefined, startStr: string | undefined, lengthStr: string | undefined) => {
+			if (num !== undefined) {
+				return args[parseInt(num, 10) - 1] ?? "";
+			}
+			if (startStr !== undefined) {
+				// Slices are 1-indexed; zero also starts at the first argument.
+				const start = Math.max(0, parseInt(startStr, 10) - 1);
+				const end = lengthStr !== undefined ? start + parseInt(lengthStr, 10) : undefined;
+				return args.slice(start, end).join(" ");
+			}
+			return allArgs;
+		},
+	);
 }
 
 function loadTemplateFromFile(filePath: string, sourceInfo: SourceInfo): PromptTemplate | null {

--- a/packages/coding-agent/test/suite/regressions/6014-literal-prompt-arguments.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6014-literal-prompt-arguments.test.ts
@@ -1,0 +1,80 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { describe, expect, test } from "vitest";
+import {
+	expandPromptTemplate,
+	loadPromptTemplates,
+	type PromptTemplate,
+	substituteArgs,
+} from "../../../src/core/prompt-templates.js";
+import { createTestResourceLoader } from "../../utilities.js";
+import { createHarness, getMessageText, getUserTexts } from "../harness.js";
+
+describe("ENG-6014 literal prompt arguments", () => {
+	test.each(["$$", "$&", "$`", "$'", "$1", "$10", "$ARGUMENTS", "$@", `\${@:2}`, `\${@:1:2}`])(
+		"preserves %s in every placeholder form",
+		(literal) => {
+			const args = [literal, "tail"];
+			expect(substituteArgs("Before $1 after", args)).toBe(`Before ${literal} after`);
+			expect(substituteArgs("Before $ARGUMENTS after", args)).toBe(`Before ${literal} tail after`);
+			expect(substituteArgs("Before $@ after", args)).toBe(`Before ${literal} tail after`);
+			expect(substituteArgs(`Before \${@:1} after`, args)).toBe(`Before ${literal} tail after`);
+			expect(substituteArgs(`Before \${@:2:1} after`, ["head", literal, "tail"])).toBe(`Before ${literal} after`);
+		},
+	);
+
+	test("does not expand placeholders formed across insertion boundaries", () => {
+		expect(substituteArgs("$1ARGUMENTS|$1@|$1{@:2}", ["$", "tail"])).toBe(`$ARGUMENTS|$@|\${@:2}`);
+	});
+
+	test("expands mixed and repeated template placeholders without expanding inserted arguments", () => {
+		expect(substituteArgs(`$1|$2|\${@:2:1}|$@|$ARGUMENTS|$1`, ["$@", `\${@:1}`, "$ARGUMENTS"])).toBe(
+			`$@|\${@:1}|\${@:1}|$@ \${@:1} $ARGUMENTS|$@ \${@:1} $ARGUMENTS|$@`,
+		);
+	});
+
+	test.each([
+		{ input: "$$", expected: "Explain: $$" },
+		{ input: "$&", expected: "Explain: $&" },
+		{ input: "$@ tail", expected: "Explain: $@ tail" },
+		{ input: '"$`"', expected: "Explain: $`" },
+		{ input: '"$\'"', expected: "Explain: $'" },
+		{ input: "ordinary text", expected: "Explain: ordinary text" },
+	])("preserves $input through a loaded template and the provider context", async ({ input, expected }) => {
+		const prompts: PromptTemplate[] = [];
+		const resourceLoader = createTestResourceLoader();
+		resourceLoader.getPrompts = () => ({ prompts, diagnostics: [] });
+		const harness = await createHarness({ resourceLoader, tools: [] });
+		try {
+			const filePath = join(harness.tempDir, "explain.md");
+			writeFileSync(filePath, "Explain: $ARGUMENTS");
+			prompts.push(
+				...loadPromptTemplates({
+					cwd: harness.tempDir,
+					agentDir: harness.tempDir,
+					promptPaths: [filePath],
+					includeDefaults: false,
+				}),
+			);
+			expect(prompts).toHaveLength(1);
+			const command = `/explain ${input}`;
+			expect(expandPromptTemplate(command, prompts)).toBe(expected);
+			const providerTexts: string[] = [];
+			harness.setResponses([
+				(context) => {
+					providerTexts.push(...context.messages.filter((message) => message.role === "user").map(getMessageText));
+					return fauxAssistantMessage("ok");
+				},
+			]);
+
+			await harness.session.prompt(command);
+
+			expect(getUserTexts(harness)).toEqual([expected]);
+			expect(providerTexts).toEqual([expected]);
+			expect(harness.faux.state.callCount).toBe(1);
+		} finally {
+			harness.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
- fixes literal dollar corruption caused by replacement-string syntax and repeated substitution passes; addresses [eng-6014](https://linear.app/primeintellect/issue/ENG-6014/prompt-template-expansion-changes-literal-dollar-sequences-in-user), with symptom evidence in [discussion #2106](https://github.com/PrimeIntellect-ai/prime-agent/discussions/2106).
- validation: head `849f2a882fc83bbc74934e6a3427c63b4fd15c09` passes 99 focused tests and `npm run check` locally and in prime sandbox, plus 67 installed-package probes; baseline `4ec05a0969825a32261ffed43ab5740071a73ae6` reproduces all three reported failures, with 15 regression failures and 24 installed-package mismatches, while ordinary-text and slice controls pass on both.
- sandbox `g0c05flqi9n0tjbr3tytstxt` was deleted after collecting evidence: `node:24-bookworm`, container, linux x64, node 24.18.0, npm 11.16.0, 2 cpu/4 gb ram/20 gb disk, 60-minute limit; tested fresh tarball installs from both commits and faux-provider session delivery, with no live provider calls or interactive ui coverage; code ci passes.

Linear: [ENG-6014](https://linear.app/primeintellect/issue/ENG-6014/prompt-template-expansion-changes-literal-dollar-sequences-in-user)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `substituteArgs` to preserve literal dollar sequences in prompt arguments
> - Replaces sequential placeholder substitutions in `substituteArgs` with a single regex scan so inserted argument values are not re-processed as template syntax
> - Positional, sliced, all-argument, and at-sign placeholders are all resolved in one pass; slice indexing stays one-based with zero clamped to the first argument and missing positional args still yield empty strings
> - Adds regression and integration tests covering dollar sequences, placeholder-like argument values, insertion boundaries, and loaded-template expansion through the session harness
> - Updates the Linear ticket workflow and PR template to accept both `ENG` and `RES` ticket identifiers
> - Risk: none identified — behavior change is a strict fix; templates relying on argument values being re-expanded as placeholders will now see them preserved literally
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f99272.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Prompt template expansion behavior changes for arguments containing dollar-like syntax; templates that depended on re-expanding inserted argument text may behave differently.
> 
> **Overview**
> Fixes **ENG-6014** by rewriting **`substituteArgs`** in `prompt-templates.ts` to expand placeholders in a **single regex pass** with a replacement callback, so user-supplied argument text (e.g. `$$`, `$&`, literal `$1` / `$@` / `$ARGUMENTS`) is inserted **verbatim** instead of being altered by replacement-string rules or follow-up passes.
> 
> Adds focused regression coverage in **`6014-literal-prompt-arguments.test.ts`** (unit cases plus loaded-template / session delivery) and a small changeset note.
> 
> Separately updates **PR template** and the **Linear ticket** GitHub Action to recognize **ENG** as well as **RES** ticket IDs and to document Engineering vs Research board expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f992728051e593348c894f1211c2d7dbbfd5946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->