### PR TITLE
recognize litellm maximum-context rejections

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,8 @@ https://github.com/PrimeIntellect-ai/prime-agent/discussions
 ## Context
 
 <!-- Link the accepted Issue or Discussion and explain why this change is needed.
-Prime Agent Linear tickets should normally use the Research team and the Prime Agent: Long-Horizon research project.
+Link a Prime Agent Linear ticket from either Engineering (ENG) or Research (RES).
+Research tickets should use the Prime Agent: Long-Horizon research project.
 If this change has no ticket, add `No-Ticket: <short reason>` below. -->
 
 ## Changes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,9 @@ https://github.com/PrimeIntellect-ai/prime-agent/discussions
 ## Context
 
 <!-- Link the accepted Issue or Discussion and explain why this change is needed.
-Link a Prime Agent Linear ticket from either Engineering (ENG) or Research (RES).
-Research tickets should use the Prime Agent: Long-Horizon research project.
+Link a Prime Agent Linear ticket.
+Engineering issues should use the Engineering (ENG) team and the Prime Agent V1 board.
+Capabilities and research issues should use the Research (RES) team and the Prime Agent: Long-Horizon board.
 If this change has no ticket, add `No-Ticket: <short reason>` below. -->
 
 ## Changes

--- a/.github/workflows/linear-ticket.yml
+++ b/.github/workflows/linear-ticket.yml
@@ -20,7 +20,7 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const text = `${pr.title}\n${pr.body ?? ""}\n${pr.head.ref}`;
-            const ticket = /\bres-\d+\b|linear\.app\/[\w-]+\/issue\/res-\d+/i;
+            const ticket = /\b(?:eng|res)-\d+\b|linear\.app\/[\w-]+\/issue\/(?:eng|res)-\d+/i;
             const optOut = /^\s*No-Ticket:\s*\S.*$/im;
             if (ticket.test(text)) {
               core.info("Linear ticket reference found.");
@@ -34,9 +34,9 @@ jobs:
             core.setFailed(
               [
                 "No Linear ticket is linked in this pull request.",
-                "Prime Agent tickets should normally use the Research team and the Prime Agent: Long-Horizon research project.",
-                "Add the ticket ID (e.g. RES-1234) or a linear.app issue link to the PR title or description,",
-                "or use a branch named after the ticket (e.g. res-1234).",
+                "Prime Agent tickets may use either the Engineering (ENG) or Research (RES) team.",
+                "Add the ticket ID (e.g. ENG-1234 or RES-1234) or a linear.app issue link to the PR title or description,",
+                "or use a branch named after the ticket (e.g. eng-1234 or res-1234).",
                 'If this change genuinely has no ticket, add a line to the PR description: "No-Ticket: <short reason>".',
               ].join(" "),
             );

--- a/.github/workflows/linear-ticket.yml
+++ b/.github/workflows/linear-ticket.yml
@@ -34,7 +34,8 @@ jobs:
             core.setFailed(
               [
                 "No Linear ticket is linked in this pull request.",
-                "Prime Agent tickets may use either the Engineering (ENG) or Research (RES) team.",
+                "Prime Agent tickets may use either the Engineering (ENG) team",
+                "or the Research (RES) team and the Prime Agent: Long-Horizon research project.",
                 "Add the ticket ID (e.g. ENG-1234 or RES-1234) or a linear.app issue link to the PR title or description,",
                 "or use a branch named after the ticket (e.g. eng-1234 or res-1234).",
                 'If this change genuinely has no ticket, add a line to the PR description: "No-Ticket: <short reason>".',

--- a/.github/workflows/linear-ticket.yml
+++ b/.github/workflows/linear-ticket.yml
@@ -34,8 +34,8 @@ jobs:
             core.setFailed(
               [
                 "No Linear ticket is linked in this pull request.",
-                "Prime Agent tickets may use either the Engineering (ENG) team",
-                "or the Research (RES) team and the Prime Agent: Long-Horizon research project.",
+                "Engineering issues should use the Engineering (ENG) team and the Prime Agent V1 board.",
+                "Capabilities and research issues should use the Research (RES) team and the Prime Agent: Long-Horizon board.",
                 "Add the ticket ID (e.g. ENG-1234 or RES-1234) or a linear.app issue link to the PR title or description,",
                 "or use a branch named after the ticket (e.g. eng-1234 or res-1234).",
                 'If this change genuinely has no ticket, add a line to the PR description: "No-Ticket: <short reason>".',

--- a/packages/ai/.changes/eng-6011-litellm-context-overflow.md
+++ b/packages/ai/.changes/eng-6011-litellm-context-overflow.md
@@ -1,0 +1,1 @@
+- Fixed detection of LiteLLM context-limit errors when input plus requested output exceed the model's context window.

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -15,6 +15,7 @@ import type { AssistantMessage } from "../types.js";
  * - xAI: "This model's maximum prompt length is 131072 but the request contains 537812 tokens"
  * - Groq: "Please reduce the length of the messages or completion"
  * - OpenRouter: "This endpoint's maximum context length is X tokens. However, you requested about Y tokens"
+ * - LiteLLM: "Requested token count exceeds the model's maximum context length of X tokens"
  * - llama.cpp: "the request exceeds the available context size, try increasing it"
  * - LM Studio: "tokens to keep from the initial prompt is greater than the context length"
  * - GitHub Copilot: "prompt token count of X exceeds the limit of Y"
@@ -37,6 +38,7 @@ const OVERFLOW_PATTERNS = [
 	/maximum prompt length is \d+/i, // xAI (Grok)
 	/reduce the length of the messages/i, // Groq
 	/maximum context length is \d+ tokens/i, // OpenRouter (all backends)
+	/exceeds the model's maximum context length/i, // LiteLLM (input + requested output)
 	/exceeds the limit of \d+/i, // GitHub Copilot
 	/exceeds the available context size/i, // llama.cpp server
 	/greater than the context length/i, // LM Studio
@@ -86,6 +88,7 @@ const NON_OVERFLOW_PATTERNS = [
  * - Cerebras: 400/413 status code (no body)
  * - Mistral: "Prompt contains X tokens ... too large for model with Y maximum context length"
  * - OpenRouter (all backends): "maximum context length is X tokens"
+ * - LiteLLM: "exceeds the model's maximum context length of X tokens"
  * - llama.cpp: "exceeds the available context size"
  * - LM Studio: "greater than the context length"
  * - Kimi For Coding: "exceeded model token limit: X (requested: Y)"

--- a/packages/ai/test/overflow.test.ts
+++ b/packages/ai/test/overflow.test.ts
@@ -30,6 +30,33 @@ function createErrorMessage(errorMessage: string): AssistantMessage {
 }
 
 describe("isContextOverflow", () => {
+	const litellmError =
+		"400 litellm.BadRequestError: OpenAIException - Requested token count exceeds the model's maximum context length of 262144 tokens. You requested a total of 270128 tokens: 261936 tokens from the input messages and 8192 tokens for the completion. Please reduce the number of tokens in the input messages or the completion to fit within the limit.. Received Model Group=qwen3.8-27b-nvfp4";
+
+	it.each([262144, undefined])("detects LiteLLM context rejection with contextWindow=%s", (contextWindow) => {
+		expect(isContextOverflow(createErrorMessage(litellmError), contextWindow)).toBe(true);
+	});
+
+	it("detects context rejection without a proxy prefix, regardless of case", () => {
+		const message = createErrorMessage(
+			"REQUESTED TOKEN COUNT EXCEEDS THE MODEL'S MAXIMUM CONTEXT LENGTH OF 262144 TOKENS.",
+		);
+		expect(isContextOverflow(message)).toBe(true);
+	});
+
+	it.each([
+		"429 rate limit: too many tokens",
+		"Requested token count exceeds the per-minute token quota.",
+		"400 litellm.BadRequestError: unsupported parameter: temperature",
+		`429 rate limit: upstream previously returned ${litellmError}`,
+	])("does not classify an unrelated or rate-limited rejection as overflow: %s", (errorMessage) => {
+		expect(isContextOverflow(createErrorMessage(errorMessage), 262144)).toBe(false);
+	});
+
+	it.each(["stop", "aborted"] as const)("ignores context error text with stopReason=%s", (stopReason) => {
+		expect(isContextOverflow({ ...createErrorMessage(litellmError), stopReason }, 262144)).toBe(false);
+	});
+
 	it("detects explicit Ollama prompt-too-long errors", () => {
 		const message = createErrorMessage("400 `prompt too long; exceeded max context length by 100918 tokens`");
 		expect(isContextOverflow(message, 32768)).toBe(true);

--- a/packages/coding-agent/.changes/eng-6011-litellm-context-overflow.md
+++ b/packages/coding-agent/.changes/eng-6011-litellm-context-overflow.md
@@ -1,0 +1,1 @@
+- Fixed automatic compaction and recovery for LiteLLM maximum-context rejections.

--- a/packages/coding-agent/test/suite/regressions/6011-litellm-context-overflow.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6011-litellm-context-overflow.test.ts
@@ -1,0 +1,85 @@
+import { type Context, fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHarness, getMessageText, type Harness } from "../harness.js";
+
+const litellmError =
+	"400 litellm.BadRequestError: OpenAIException - Requested token count exceeds the model's maximum context length of 262144 tokens. You requested a total of 270128 tokens: 261936 tokens from the input messages and 8192 tokens for the completion. Please reduce the number of tokens in the input messages or the completion to fit within the limit.. Received Model Group=qwen3.8-27b-nvfp4";
+
+describe("LiteLLM context overflow recovery", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	async function setup() {
+		const harness = await createHarness({
+			models: [{ id: "litellm-fixture", contextWindow: 262144, maxTokens: 8192 }],
+			settings: {
+				autoRefine: { enabled: false },
+				compaction: { enabled: true, reserveTokens: 8192, keepRecentTokens: 50 },
+				retry: { enabled: true, maxRetries: 1, baseDelayMs: 1 },
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("Earlier findings recorded.")]);
+		await harness.session.prompt("Earlier context. ".repeat(100));
+		return harness;
+	}
+
+	it.each([
+		["LiteLLM rejection", litellmError],
+		["known overflow control", "prompt is too long: 270128 tokens > 262144 maximum"],
+	])("compacts and continues after %s without retrying the unchanged request", async (_name, errorMessage) => {
+		const harness = await setup();
+		const requests: Context[] = [];
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage }),
+			(context) => {
+				requests.push({ systemPrompt: context.systemPrompt, messages: structuredClone(context.messages) });
+				return fauxAssistantMessage("Summary of earlier findings.");
+			},
+			(context) => {
+				requests.push({ systemPrompt: context.systemPrompt, messages: structuredClone(context.messages) });
+				return fauxAssistantMessage("Recovered.");
+			},
+		]);
+
+		await harness.session.prompt("Continue the task using the earlier findings. ".repeat(8));
+
+		expect(harness.eventsOfType("compaction_start").map((event) => event.reason)).toEqual(["overflow"]);
+		expect(harness.eventsOfType("compaction_end")).toEqual([
+			expect.objectContaining({ reason: "overflow", aborted: false, willRetry: true, result: expect.any(Object) }),
+		]);
+		await vi.waitFor(() => {
+			expect(harness.session.messages.at(-1)).toEqual(
+				expect.objectContaining({ content: [{ type: "text", text: "Recovered." }], stopReason: "stop" }),
+			);
+		});
+		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
+		expect(requests).toHaveLength(2);
+		expect(getMessageText(requests[0].messages[0])).toContain("<conversation>");
+		expect(requests[1].messages.map(getMessageText).join("\n")).toContain("Summary of earlier findings.");
+		expect(
+			requests[1].messages.some((message) => message.role === "assistant" && message.stopReason === "error"),
+		).toBe(false);
+		expect(harness.sessionManager.getBranch().filter((entry) => entry.type === "compaction")).toHaveLength(1);
+		expect(harness.faux.state.callCount).toBe(4);
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("retries a token-rate-limit rejection without compacting", async () => {
+		const harness = await setup();
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "429 rate limit: too many tokens" }),
+			fauxAssistantMessage("Recovered after rate limit."),
+		]);
+
+		await harness.session.prompt("Continue the task.");
+
+		expect(harness.eventsOfType("compaction_start")).toEqual([]);
+		expect(harness.eventsOfType("auto_retry_start")).toHaveLength(1);
+		expect(getMessageText(harness.session.messages.at(-1))).toBe("Recovered after rate limit.");
+		expect(harness.faux.state.callCount).toBe(3);
+	});
+});


### PR DESCRIPTION
- recognizes litellm maximum-context rejections so existing overflow compaction runs before retry; addresses [eng-6011](https://linear.app/primeintellect/issue/ENG-6011/litellm-maximum-context-rejection-is-not-classified-as-context), reported in [discussion #2088](https://github.com/PrimeIntellect-ai/prime-agent/discussions/2088).
- validated head `a2131be2773119e7ee1fe6e8cc764a95242e7803` against baseline `4ec05a0969825a32261ffed43ab5740071a73ae6` in prime sandbox `xboin1vp7ctxmzop9sjxksuh` (`node:24-bookworm`, linux x64, node 24.18.0, npm 11.16.0, 2 cpu/4 gb ram/10 gb disk): the compiled, packed, and installed ai package changed the reported classification from false to true, with four controls unchanged; sandbox deleted after collecting logs.
- passed 18 classifier tests, 74 faux-provider compaction/retry tests, and `npm run check` locally and in the sandbox; identical baseline fixtures failed only the new rejection cases, including recovery, while controls passed; no live litellm/vllm or paid inference calls; code ci passed.

Linear: [ENG-6011](https://linear.app/primeintellect/issue/ENG-6011/litellm-maximum-context-rejection-is-not-classified-as-context)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared overflow classification used by agent compaction/retry paths; misclassification could compact on rate limits or skip compaction on overflow, though new negative tests reduce that risk.
> 
> **Overview**
> **LiteLLM context rejections** (when input plus requested completion exceed the model limit) are now treated as context overflow, so the coding agent runs **overflow compaction** and continues instead of treating the failure as a generic error or retrying the same oversized request.
> 
> The `packages/ai` overflow classifier adds a pattern for messages like *"exceeds the model's maximum context length"*, with unit tests for case-insensitive matching and guards so rate limits, token quotas, and unrelated LiteLLM errors are not misclassified. A coding-agent regression test confirms compaction and recovery for the real LiteLLM error string (and still retries rate-limit errors without compacting).
> 
> **Contributor workflow:** the PR template and Linear ticket CI now accept **ENG-** tickets (in addition to **RES-**), with updated guidance for Engineering vs Research boards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a65ce8ed99e0d54ea66c215b83508cd46f93cdcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `isContextOverflow` to recognize LiteLLM maximum-context rejections
> - Adds a case-insensitive pattern in [overflow.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2129/files#diff-30f350598d8206d5cab80b09f21240a7cdb6b646e81506389f7884f7d0013680) that matches LiteLLM messages stating the requested token count exceeds the model's maximum context length.
> - LiteLLM context-limit rejections now trigger automatic overflow compaction and recovery, rather than being missed or retried unchanged.
> - Adds regression tests in [overflow.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2129/files#diff-272681e52108eeedd8e703d382ed7ebef05ebd883e7328f2402c8eb5da361c20) and [6011-litellm-context-overflow.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2129/files#diff-7a0099c70cc0f8ec7d3fce5ec4eb96db7c5f10eea96e555e2d85baa555395090) covering positive detection, negative cases (token rate limits, per-minute quotas, unsupported parameters), compaction-and-recovery flow, and confirmation that token-rate-limit errors stay on the retry path.
> - Risk: if a LiteLLM rejection message format differs from the added pattern, `isContextOverflow` will not detect it; the pattern only matches the documented "maximum context" wording.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a65ce8e. 2 files reviewed, 2 issues evaluated, 2 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>.github/workflows/linear-ticket.yml — 0 comments posted, 2 evaluated, 2 filtered</summary>
>
> - [line 23](https://github.com/PrimeIntellect-ai/prime-agent/blob/a65ce8ed99e0d54ea66c215b83508cd46f93cdcd/.github/workflows/linear-ticket.yml#L23): The Linear-link alternative is not anchored to a host or even a URL boundary. A non-Linear string such as `https://notlinear.app/team/issue/ENG-123` (or a path containing `linear.app/...`) contains the matched substring `linear.app/team/issue/ENG-123`, so it passes the gate despite not linking to Linear. Require an appropriate scheme/host boundary before `linear.app` when recognizing URL references. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 23](https://github.com/PrimeIntellect-ai/prime-agent/blob/a65ce8ed99e0d54ea66c215b83508cd46f93cdcd/.github/workflows/linear-ticket.yml#L23): The URL alternative ends immediately after `\d+`, so it accepts only the numeric prefix of a malformed reference. For example, a PR body containing `https://linear.app/team/issue/ENG-123not-a-ticket` makes `ticket.test(text)` succeed even though the purported issue ID has trailing word characters; the gate is therefore bypassed without a valid ticket or `No-Ticket` opt-out. Add a trailing word boundary (or an equivalent URL/ID terminator) to this alternative. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->