### PR TITLE
identify opencode conversations and application

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,8 @@ https://github.com/PrimeIntellect-ai/prime-agent/discussions
 ## Context
 
 <!-- Link the accepted Issue or Discussion and explain why this change is needed.
-Prime Agent Linear tickets should normally use the Research team and the Prime Agent: Long-Horizon research project.
+Link a Prime Agent Linear ticket from either Engineering (ENG) or Research (RES).
+Research tickets should use the Prime Agent: Long-Horizon research project.
 If this change has no ticket, add `No-Ticket: <short reason>` below. -->
 
 ## Changes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,9 @@ https://github.com/PrimeIntellect-ai/prime-agent/discussions
 ## Context
 
 <!-- Link the accepted Issue or Discussion and explain why this change is needed.
-Link a Prime Agent Linear ticket from either Engineering (ENG) or Research (RES).
-Research tickets should use the Prime Agent: Long-Horizon research project.
+Link a Prime Agent Linear ticket.
+Engineering issues should use the Engineering (ENG) team and the Prime Agent V1 board.
+Capabilities and research issues should use the Research (RES) team and the Prime Agent: Long-Horizon board.
 If this change has no ticket, add `No-Ticket: <short reason>` below. -->
 
 ## Changes

--- a/.github/workflows/linear-ticket.yml
+++ b/.github/workflows/linear-ticket.yml
@@ -20,7 +20,7 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const text = `${pr.title}\n${pr.body ?? ""}\n${pr.head.ref}`;
-            const ticket = /\bres-\d+\b|linear\.app\/[\w-]+\/issue\/res-\d+/i;
+            const ticket = /\b(?:eng|res)-\d+\b|linear\.app\/[\w-]+\/issue\/(?:eng|res)-\d+/i;
             const optOut = /^\s*No-Ticket:\s*\S.*$/im;
             if (ticket.test(text)) {
               core.info("Linear ticket reference found.");
@@ -34,9 +34,9 @@ jobs:
             core.setFailed(
               [
                 "No Linear ticket is linked in this pull request.",
-                "Prime Agent tickets should normally use the Research team and the Prime Agent: Long-Horizon research project.",
-                "Add the ticket ID (e.g. RES-1234) or a linear.app issue link to the PR title or description,",
-                "or use a branch named after the ticket (e.g. res-1234).",
+                "Prime Agent tickets may use either the Engineering (ENG) or Research (RES) team.",
+                "Add the ticket ID (e.g. ENG-1234 or RES-1234) or a linear.app issue link to the PR title or description,",
+                "or use a branch named after the ticket (e.g. eng-1234 or res-1234).",
                 'If this change genuinely has no ticket, add a line to the PR description: "No-Ticket: <short reason>".',
               ].join(" "),
             );

--- a/.github/workflows/linear-ticket.yml
+++ b/.github/workflows/linear-ticket.yml
@@ -34,7 +34,8 @@ jobs:
             core.setFailed(
               [
                 "No Linear ticket is linked in this pull request.",
-                "Prime Agent tickets may use either the Engineering (ENG) or Research (RES) team.",
+                "Prime Agent tickets may use either the Engineering (ENG) team",
+                "or the Research (RES) team and the Prime Agent: Long-Horizon research project.",
                 "Add the ticket ID (e.g. ENG-1234 or RES-1234) or a linear.app issue link to the PR title or description,",
                 "or use a branch named after the ticket (e.g. eng-1234 or res-1234).",
                 'If this change genuinely has no ticket, add a line to the PR description: "No-Ticket: <short reason>".',

--- a/.github/workflows/linear-ticket.yml
+++ b/.github/workflows/linear-ticket.yml
@@ -34,8 +34,8 @@ jobs:
             core.setFailed(
               [
                 "No Linear ticket is linked in this pull request.",
-                "Prime Agent tickets may use either the Engineering (ENG) team",
-                "or the Research (RES) team and the Prime Agent: Long-Horizon research project.",
+                "Engineering issues should use the Engineering (ENG) team and the Prime Agent V1 board.",
+                "Capabilities and research issues should use the Research (RES) team and the Prime Agent: Long-Horizon board.",
                 "Add the ticket ID (e.g. ENG-1234 or RES-1234) or a linear.app issue link to the PR title or description,",
                 "or use a branch named after the ticket (e.g. eng-1234 or res-1234).",
                 'If this change genuinely has no ticket, add a line to the PR description: "No-Ticket: <short reason>".',

--- a/packages/ai/.changes/eng-6009-opencode-identification.md
+++ b/packages/ai/.changes/eng-6009-opencode-identification.md
@@ -1,0 +1,1 @@
+- Fixed OpenCode Zen and Go requests to identify Prime Agent and send the conversation ID across all supported adapters, including when prompt caching is disabled.

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -48,6 +48,7 @@ import {
 
 import { resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
+import { withOpenCodeHeaders } from "./opencode-headers.js";
 import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -507,6 +508,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 					shouldUseFineGrainedToolStreamingBeta(model, context),
 					options?.headers,
 					copilotDynamicHeaders,
+					options?.sessionId,
 				);
 				client = created.client;
 				isOAuth = created.isOAuthToken;
@@ -860,6 +862,7 @@ function createClient(
 	useFineGrainedToolStreamingBeta: boolean,
 	optionsHeaders?: Record<string, string>,
 	dynamicHeaders?: Record<string, string>,
+	sessionId?: string,
 ): { client: Anthropic; isOAuthToken: boolean } {
 	// Adaptive thinking models (Opus 4.6, Sonnet 4.6) have interleaved thinking built-in.
 	// The beta header is deprecated on Opus 4.6 and redundant on Sonnet 4.6, so skip it.
@@ -946,14 +949,18 @@ function createClient(
 		apiKey,
 		baseURL: model.baseUrl,
 		dangerouslyAllowBrowser: true,
-		defaultHeaders: mergeHeaders(
-			{
-				accept: "application/json",
-				"anthropic-dangerous-direct-browser-access": "true",
-				...(betaFeatures.length > 0 ? { "anthropic-beta": betaFeatures.join(",") } : {}),
-			},
-			model.headers,
-			optionsHeaders,
+		defaultHeaders: withOpenCodeHeaders(
+			model.provider,
+			sessionId,
+			mergeHeaders(
+				{
+					accept: "application/json",
+					"anthropic-dangerous-direct-browser-access": "true",
+					...(betaFeatures.length > 0 ? { "anthropic-beta": betaFeatures.join(",") } : {}),
+				},
+				model.headers,
+				optionsHeaders,
+			),
 		),
 	});
 

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -36,6 +36,7 @@ import {
 	mapToolChoice,
 	retainThoughtSignature,
 } from "./google-shared.js";
+import { withOpenCodeHeaders } from "./opencode-headers.js";
 import { buildBaseOptions } from "./simple-options.js";
 
 export interface GoogleOptions extends StreamOptions {
@@ -77,7 +78,7 @@ export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions>
 
 		try {
 			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-			const client = createClient(model, apiKey, options?.headers);
+			const client = createClient(model, apiKey, options?.headers, options?.sessionId);
 			let params = buildParams(model, context, options);
 			const nextParams = await options?.onPayload?.(params, model);
 			if (nextParams !== undefined) {
@@ -324,14 +325,16 @@ function createClient(
 	model: Model<"google-generative-ai">,
 	apiKey?: string,
 	optionsHeaders?: Record<string, string>,
+	sessionId?: string,
 ): GoogleGenAI {
 	const httpOptions: { baseUrl?: string; apiVersion?: string; headers?: Record<string, string> } = {};
 	if (model.baseUrl) {
 		httpOptions.baseUrl = model.baseUrl;
 		httpOptions.apiVersion = ""; // baseUrl already includes version path, don't append
 	}
-	if (model.headers || optionsHeaders) {
-		httpOptions.headers = { ...model.headers, ...optionsHeaders };
+	const headers = withOpenCodeHeaders(model.provider, sessionId, { ...model.headers, ...optionsHeaders });
+	if (Object.keys(headers).length > 0) {
+		httpOptions.headers = headers;
 	}
 
 	return new GoogleGenAI({

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -38,6 +38,7 @@ import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { recordStreamFailure } from "../utils/stream-failure.js";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
+import { withOpenCodeHeaders } from "./opencode-headers.js";
 import { buildBaseOptions } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -173,7 +174,15 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 					? getAnthropicCacheWriteCost(model.cost.input, cacheControl.ttl === "1h" ? "1h" : "5m")
 					: undefined;
 			const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
-			const client = createClient(model, context, apiKey, options?.headers, cacheSessionId, compat);
+			const client = createClient(
+				model,
+				context,
+				apiKey,
+				options?.headers,
+				cacheSessionId,
+				compat,
+				options?.sessionId,
+			);
 			let params = buildParams(model, context, options, compat, cacheRetention, cacheControl);
 			const nextParams = await options?.onPayload?.(params, model);
 			if (nextParams !== undefined) {
@@ -515,8 +524,9 @@ function createClient(
 	context: Context,
 	apiKey?: string,
 	optionsHeaders?: Record<string, string>,
-	sessionId?: string,
+	cacheSessionId?: string,
 	compat: ResolvedOpenAICompletionsCompat = getCompat(model),
+	conversationId?: string,
 ) {
 	if (!apiKey) {
 		if (!process.env.OPENAI_API_KEY) {
@@ -542,10 +552,10 @@ function createClient(
 		if (teamId) headers["X-Prime-Team-ID"] = teamId;
 	}
 
-	if (sessionId && compat.sendSessionAffinityHeaders) {
-		headers.session_id = sessionId;
-		headers["x-client-request-id"] = sessionId;
-		headers["x-session-affinity"] = sessionId;
+	if (cacheSessionId && compat.sendSessionAffinityHeaders) {
+		headers.session_id = cacheSessionId;
+		headers["x-client-request-id"] = cacheSessionId;
+		headers["x-session-affinity"] = cacheSessionId;
 	}
 
 	if (optionsHeaders) {
@@ -565,7 +575,7 @@ function createClient(
 		apiKey,
 		baseURL: isCloudflareProvider(model.provider) ? resolveCloudflareBaseUrl(model) : model.baseUrl,
 		dangerouslyAllowBrowser: true,
-		defaultHeaders,
+		defaultHeaders: withOpenCodeHeaders(model.provider, conversationId, defaultHeaders),
 		maxRetries: 0,
 	});
 }

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -24,6 +24,7 @@ import {
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
+import { withOpenCodeHeaders } from "./opencode-headers.js";
 import { buildBaseOptions } from "./simple-options.js";
 
 const OPENAI_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]);
@@ -92,7 +93,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIRes
 			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
 			const cacheRetention = resolveCacheRetention(options?.cacheRetention);
 			const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
-			const client = createClient(model, context, apiKey, options?.headers, cacheSessionId);
+			const client = createClient(model, context, apiKey, options?.headers, cacheSessionId, options?.sessionId);
 			let params = buildParams(model, context, options);
 			const nextParams = await options?.onPayload?.(params, model);
 			if (nextParams !== undefined) {
@@ -164,7 +165,8 @@ function createClient(
 	context: Context,
 	apiKey?: string,
 	optionsHeaders?: Record<string, string>,
-	sessionId?: string,
+	cacheSessionId?: string,
+	conversationId?: string,
 ) {
 	if (!apiKey) {
 		if (!process.env.OPENAI_API_KEY) {
@@ -186,11 +188,11 @@ function createClient(
 		Object.assign(headers, copilotHeaders);
 	}
 
-	if (sessionId) {
+	if (cacheSessionId) {
 		if (compat.sendSessionIdHeader) {
-			headers.session_id = sessionId;
+			headers.session_id = cacheSessionId;
 		}
-		headers["x-client-request-id"] = sessionId;
+		headers["x-client-request-id"] = cacheSessionId;
 	}
 
 	if (optionsHeaders) {
@@ -210,7 +212,7 @@ function createClient(
 		apiKey,
 		baseURL: isCloudflareProvider(model.provider) ? resolveCloudflareBaseUrl(model) : model.baseUrl,
 		dangerouslyAllowBrowser: true,
-		defaultHeaders,
+		defaultHeaders: withOpenCodeHeaders(model.provider, conversationId, defaultHeaders),
 		maxRetries: 0,
 	});
 }

--- a/packages/ai/src/providers/opencode-headers.ts
+++ b/packages/ai/src/providers/opencode-headers.ts
@@ -1,0 +1,16 @@
+export function withOpenCodeHeaders<T extends string | null>(
+	provider: string,
+	sessionId: string | undefined,
+	headers: Record<string, T>,
+): Record<string, T | string> {
+	if (provider !== "opencode" && provider !== "opencode-go") return headers;
+
+	const merged: Record<string, T | string> = { "User-Agent": "prime-agent" };
+	if (sessionId) merged["x-opencode-session"] = sessionId;
+	for (const [name, value] of Object.entries(headers)) {
+		// Keep the SDK's User-Agent casing so Google's SDK replaces its default.
+		const key = name.toLowerCase();
+		merged[key === "user-agent" ? "User-Agent" : key] = value;
+	}
+	return merged;
+}

--- a/packages/ai/test/opencode-headers.test.ts
+++ b/packages/ai/test/opencode-headers.test.ts
@@ -1,0 +1,211 @@
+import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { getModels } from "../src/models.js";
+import { complete, completeSimple } from "../src/stream.js";
+import type { Api, AssistantMessage, Context, Model, SimpleStreamOptions } from "../src/types.js";
+
+const context: Context = { messages: [{ role: "user", content: "Reply OK", timestamp: 1 }] };
+const models = (["opencode", "opencode-go"] as const).flatMap((provider) => {
+	const catalog = getModels(provider);
+	return [...new Set(catalog.map((model) => model.api))].map((api) => catalog.find((model) => model.api === api)!);
+});
+
+let server: Server;
+let baseUrl: string;
+let requests: { headers: IncomingHttpHeaders; body: Record<string, unknown> }[];
+let enforceContract: boolean;
+
+beforeAll(async () => {
+	server = createServer(async (req, res) => {
+		let raw = "";
+		for await (const chunk of req) raw += chunk.toString();
+		const body = JSON.parse(raw) as Record<string, unknown>;
+		requests.push({ headers: req.headers, body });
+		if (
+			enforceContract &&
+			(!req.headers["x-opencode-session"] || !req.headers["user-agent"]?.startsWith("prime-agent"))
+		) {
+			res.writeHead(400, { "content-type": "application/json" });
+			res.end(JSON.stringify({ error: { type: "invalid_request_error", message: "Missing OpenCode identity" } }));
+			return;
+		}
+
+		res.writeHead(200, { "content-type": "text/event-stream" });
+		const event = (type: string, data: Record<string, unknown>) =>
+			res.write(`event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`);
+		if (req.url?.includes("/messages")) {
+			event("message_start", {
+				message: {
+					id: "fixture-message",
+					type: "message",
+					role: "assistant",
+					model: body.model,
+					content: [],
+					stop_reason: null,
+					stop_sequence: null,
+					usage: { input_tokens: 1, output_tokens: 0 },
+				},
+			});
+			event("content_block_start", { index: 0, content_block: { type: "text", text: "" } });
+			event("content_block_delta", { index: 0, delta: { type: "text_delta", text: "OK" } });
+			event("content_block_stop", { index: 0 });
+			event("message_delta", {
+				delta: { stop_reason: "end_turn", stop_sequence: null },
+				usage: { output_tokens: 1 },
+			});
+			event("message_stop", {});
+		} else if (req.url?.includes("/responses")) {
+			const item = {
+				id: "fixture-output",
+				type: "message",
+				status: "completed",
+				role: "assistant",
+				content: [{ type: "output_text", text: "OK", annotations: [] }],
+			};
+			event("response.created", { response: { id: "fixture-response", status: "in_progress", output: [] } });
+			event("response.output_item.added", {
+				output_index: 0,
+				item: { ...item, status: "in_progress", content: [] },
+			});
+			event("response.content_part.added", {
+				output_index: 0,
+				content_index: 0,
+				part: { type: "output_text", text: "", annotations: [] },
+			});
+			event("response.output_text.delta", { output_index: 0, content_index: 0, delta: "OK" });
+			event("response.output_item.done", { output_index: 0, item });
+			event("response.completed", {
+				response: {
+					id: "fixture-response",
+					status: "completed",
+					output: [item],
+					usage: { input_tokens: 1, output_tokens: 1 },
+				},
+			});
+		} else if (req.url?.includes(":streamGenerateContent")) {
+			res.write(
+				`data: ${JSON.stringify({ candidates: [{ content: { role: "model", parts: [{ text: "OK" }] }, finishReason: "STOP" }] })}\n\n`,
+			);
+		} else {
+			res.write(
+				`data: ${JSON.stringify({ id: "fixture-completion", choices: [{ index: 0, delta: { role: "assistant", content: "OK" }, finish_reason: "stop" }] })}\n\n`,
+			);
+			res.write("data: [DONE]\n\n");
+		}
+		res.end();
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}/v1`;
+});
+
+afterAll(async () => {
+	server.closeAllConnections();
+	await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+});
+
+beforeEach(() => {
+	requests = [];
+	enforceContract = true;
+});
+
+function expectSuccess(result: AssistantMessage) {
+	expect(result.stopReason, result.errorMessage).toBe("stop");
+	expect(
+		result.content
+			.filter((block) => block.type === "text")
+			.map((block) => block.text)
+			.join(""),
+	).toBe("OK");
+}
+
+describe.each(models)("OpenCode identity: $provider/$api", (catalogModel) => {
+	function request(options: SimpleStreamOptions = {}, model: Model<Api> = catalogModel, simple = true) {
+		return (simple ? completeSimple : complete)({ ...model, baseUrl }, context, {
+			apiKey: "fixture-not-a-real-key",
+			sessionId: "conversation-a",
+			maxTokens: 512,
+			transport: "sse",
+			signal: AbortSignal.timeout(5000),
+			...options,
+		});
+	}
+
+	it.each([true, false])("identifies repeated and distinct conversations (simple=%s)", async (simple) => {
+		for (const sessionId of ["conversation-a", "conversation-a", "conversation-b"]) {
+			const result = await request({ sessionId }, catalogModel, simple);
+			const headers = requests.at(-1)?.headers;
+			expect({ session: headers?.["x-opencode-session"], userAgent: headers?.["user-agent"] }).toEqual({
+				session: sessionId,
+				userAgent: expect.stringMatching(/^prime-agent(?:\/|$)/),
+			});
+			expectSuccess(result);
+		}
+	});
+
+	it.each(["none", "short", "long"] as const)(
+		"identifies conversations with cacheRetention=%s",
+		async (cacheRetention) => {
+			const result = await request({ cacheRetention });
+			expect(requests.at(-1)?.headers["x-opencode-session"]).toBe("conversation-a");
+			expectSuccess(result);
+			if (cacheRetention === "none") {
+				expect(requests.at(-1)?.body.prompt_cache_key).toBeUndefined();
+				expect(requests.at(-1)?.headers.session_id).toBeUndefined();
+			}
+		},
+	);
+
+	it("accepts explicit identification headers as a contract control", async () => {
+		const result = await request({
+			headers: { "X-OpenCode-Session": "manual-conversation", "User-Agent": "prime-agent-control/1" },
+		});
+		expectSuccess(result);
+		expect(requests.at(-1)?.headers["x-opencode-session"]).toBe("manual-conversation");
+		expect(requests.at(-1)?.headers["user-agent"]).toBe("prime-agent-control/1");
+	});
+
+	it("preserves model headers and lets request headers override them regardless of casing", async () => {
+		const model = {
+			...catalogModel,
+			headers: {
+				"User-Agent": "prime-agent-model/1",
+				"X-OpenCode-Session": "model-conversation",
+				"X-Fixture": "model",
+			},
+		};
+		expectSuccess(await request({}, model));
+		expect(requests.at(-1)?.headers["user-agent"]).toBe("prime-agent-model/1");
+		expect(requests.at(-1)?.headers["x-opencode-session"]).toBe("model-conversation");
+		expectSuccess(
+			await request(
+				{
+					headers: {
+						"user-agent": "prime-agent-request/1",
+						"x-opencode-session": "request-conversation",
+						"x-fixture": "request",
+					},
+				},
+				model,
+			),
+		);
+		expect(requests.at(-1)?.headers["user-agent"]).toBe("prime-agent-request/1");
+		expect(requests.at(-1)?.headers["x-opencode-session"]).toBe("request-conversation");
+		expect(requests.at(-1)?.headers["x-fixture"]).toBe("request");
+		expect(model.headers["X-Fixture"]).toBe("model");
+	});
+
+	it.each([undefined, ""])("does not invent a conversation when sessionId=%s", async (sessionId) => {
+		enforceContract = false;
+		expectSuccess(await request({ sessionId }));
+		expect(requests.at(-1)?.headers["x-opencode-session"]).toBeUndefined();
+		expect(requests.at(-1)?.headers["user-agent"]).toMatch(/^prime-agent(?:\/|$)/);
+	});
+
+	it("does not add OpenCode identity for unrelated providers", async () => {
+		enforceContract = false;
+		expectSuccess(await request({}, { ...catalogModel, provider: "fixture-provider" }));
+		expect(requests.at(-1)?.headers["x-opencode-session"]).toBeUndefined();
+		expect(requests.at(-1)?.headers["user-agent"]).not.toMatch(/^prime-agent(?:\/|$)/);
+	});
+});


### PR DESCRIPTION
- fixes [eng-6009](https://linear.app/primeintellect/issue/ENG-6009): opencode zen/go adapters dropped conversation identity and used generic sdk user agents, matching [discussion 2072](https://github.com/PrimeIntellect-ai/prime-agent/discussions/2072) and [discussion 2110](https://github.com/PrimeIntellect-ai/prime-agent/discussions/2110).
- sends `x-opencode-session` and `user-agent: prime-agent` across completions, responses, anthropic, and gemini, including with caching disabled; preserves explicit headers and unrelated providers.
- validated head `ec3c052a670096c998f936cb93519e7b659c0178` with 108 local tests and `npm run check`, then compiled, packed, and installed the ai package in prime sandbox `hyqg53f0uckhi4p4rlj9nrl0` (`node:24-bookworm`, linux x64, node 24.18.0, npm 11.16.0, container, 2 cpu/4 gb): baseline `4ec05a0969825a32261ffed43ab5740071a73ae6` failed the default header contract on all seven catalog provider/api combinations and passed all seven explicit-header controls; the installed fix passed 70 regression checks plus 38 existing provider checks, with matching dependency versions; logs were collected and the sandbox deleted; provider rejection was simulated locally, with no authenticated live opencode call.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbound HTTP headers for OpenCode providers across multiple adapters; mis-wiring could break provider contracts, though scope is limited to opencode/opencode-go and is covered by new tests.
> 
> **Overview**
> Restores **OpenCode Zen/Go** request identity in the AI package by sending **`User-Agent: prime-agent`** and **`x-opencode-session`** (from stream `sessionId`) on **`opencode`** and **`opencode-go`** only, via shared **`withOpenCodeHeaders`**, wired through Anthropic, Google, OpenAI Completions, and OpenAI Responses clients.
> 
> OpenAI-style adapters now **split cache affinity from conversation identity**: prompt-cache / `session_id` headers still honor **`cacheRetention === "none"`**, while **`x-opencode-session`** is set whenever a session id is provided—including when caching is off. Model and caller headers can still override identification fields.
> 
> Also updates the **PR template** and **linear-ticket** workflow to require or document **ENG-** tickets (engineering) alongside **RES-** (research), with updated failure messages and examples.
> 
> Adds a changelog note for ENG-6009 and **integration tests** that assert the header contract across OpenCode catalog APIs (including cache retention and non-OpenCode providers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 286e3f5b501b1b245bc2b417a7357c367039ff6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenCode identity headers to Anthropic, Google, and OpenAI providers
> - Adds `withOpenCodeHeaders` utility in [opencode-headers.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2131/files#diff-f8ede3e4ed4f0c1853feb6312cd8098b9f4d76dd1b07673ffa9fe575c010b9f7) to apply Prime Agent `user-agent` and an OpenCode session header for OpenCode and OpenCode Go providers.
> - Updates client factories and streaming handlers for Anthropic, Google, OpenAI Completions, and OpenAI Responses to pass conversation identifiers and apply the shared header policy.
> - Adds a local fixture server and tests in [opencode-headers.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2131/files#diff-da1f6e49e881feab6005fe718fe42095461bc50efac0f2db6d5e2328cfeb8b65) to verify header precedence, cache retention behavior, and provider isolation.
> - Updates [PULL_REQUEST_TEMPLATE.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/2131/files#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35) and [linear-ticket.yml](https://github.com/PrimeIntellect-ai/prime-agent/pull/2131/files#diff-ce6fb4658459ed854d72950d809841bbd48b2cbae4ed1ab56d7e1a6b6be59b52) to require and accept ENG ticket references.
> - Behavioral Change: OpenAI streams now send conversation identity via the session header even when cache retention is disabled; cache-specific headers remain tied to the cache session value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 286e3f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->