### PR TITLE
respect trace sharing consent and retry in the background

### DIFF
--- a/packages/coding-agent/.changes/trace-sharing-reliability.md
+++ b/packages/coding-agent/.changes/trace-sharing-reliability.md
@@ -1,0 +1,3 @@
+- Fixed automatic trace sharing to respect global and per-project consent across queued work, retries, and active requests.
+- Changed trace uploads to acknowledge background queueing, with durable retries, shared request pacing, cancellation, and one-shot snapshots.
+- Added shared delivery counts, current-session progress, recent outcomes, and actionable retry and pause details to `/traces status`.

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -154,7 +154,7 @@ Type `/` in the editor to trigger commands. [Extensions](#extensions) can regist
 | `/new`, `/clear` | Start a new session |
 | `/name <name>` | Set session display name |
 | `/session` | Show session info (file, ID, messages) |
-| `/traces [status\|on\|off\|preview\|upload-current\|upload-all\|login]` | Preview traces, run one-shot current/all uploads, and manage automatic sharing (`upload` aliases `upload-current`) |
+| `/traces [status\|on\|off\|preview\|upload-current\|upload-all\|cancel\|cancel-all\|login]` | Preview traces, queue or cancel one-shot uploads, inspect delivery status, and manage automatic sharing ([details](docs/trace-sharing.md); `upload` aliases `upload-current`) |
 | `/usage` | Show token, cost, and context usage |
 | `/tree` | Jump to any point in the session and continue from there |
 | `/fork` | Create a new session from a previous user message |

--- a/packages/coding-agent/docs/trace-sharing.md
+++ b/packages/coding-agent/docs/trace-sharing.md
@@ -1,0 +1,25 @@
+# Trace sharing
+
+Automatic trace sharing defaults to off. `/traces on` enables the global `agentTraces.enabled` setting and queues the current persisted session when its project permits sharing. `/traces off` disables automatic sharing globally. A project's `.prime/agent/settings.json` can further disable sharing with `{"agentTraces":{"enabled":false}}`; a project cannot override a global opt-out. Each queued session uses the project recorded in its own header.
+
+| Command | Behavior |
+| --- | --- |
+| `/traces status` | Read effective consent, configuration, queue counts, current-session delivery state, recent outcomes, and retry/pause information. |
+| `/traces preview` | Preview the current raw JSONL without uploading. |
+| `/traces upload-current` (or `/traces upload`) | Queue a one-shot upload of the current file version, even when automatic sharing is off. |
+| `/traces upload-all` | Queue discovery and one-shot uploads of existing sessions and child-session artifacts. |
+| `/traces cancel` | Cancel the bulk request started in this interactive task. |
+| `/traces cancel-all` | Cancel all pending one-shot requests in the shared agent directory, including requests from another task or a previous process. |
+| `/traces login` | Configure a Prime credential with trace write permission. |
+
+Upload commands acknowledge queueing, not successful delivery. Discovery, payload preparation, credential commands, and requests run in the background. Task startup, ongoing work, deletion, and shutdown do not drain the delivery queue. Status reads do not contact the trace server, run credential commands, or start uploads.
+
+One-shot permission applies only to the requested file version. If the file is appended to or replaced before a snapshot can be captured, that request fails with guidance to authorize the current content again. Bulk discovery excludes files created or changed after the request. Once captured, retries reuse the snapshot even if the source changes. An older snapshot is superseded when a newer version has already been delivered. A one-shot request never enables automatic sharing or authorizes later appended content.
+
+Automatic consent is checked before preparation and dispatch and during active requests. Disabling sharing pauses automatic work and attempts to abort active requests. One-shot requests remain independently authorized until cancelled. Cancellation is durable across worker changes; bytes already sent cannot be recalled. Snapshot copies are removed after delivery, cancellation, supersession, or permanent failure.
+
+The existing local outbox stores delivery state and retry deadlines. Workers sharing an agent directory use one delivery lease and a shared request interval of at least 12.1 seconds, with at least 60 seconds between automatic attempts for a session. Network errors, timeouts, rate limits, and transient server failures retry with exponential jitter capped at five minutes; a longer `Retry-After` is respected. A crashed worker's lease can be reclaimed after 30 seconds. Pending work resumes while a worker is running or when one next starts.
+
+Missing or rejected credentials pause delivery; setting a usable credential resumes it. Permanent request/file failures remain visible in status. Automatic file failures can resume after the file changes, and automatic endpoint failures after the endpoint changes. For a failed one-shot request, correct the problem and issue a new upload command. Repeated identical failures do not flood logs, and arbitrary server error bodies and credential values are excluded from status and logs.
+
+The upload remains the existing raw JSONL `PUT` to `/api/v1/agent-traces/sessions/:sessionId`, with the existing parent/root and active-branch git headers and 20 MiB limit. Semantic-edge ledger entries remain separate, retain their cursors, and are excluded from JSONL delivery counts.

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -224,6 +224,7 @@ export async function createAgentSessionFromServices(
 	options: CreateAgentSessionFromServicesOptions,
 ): Promise<CreateAgentSessionResult> {
 	installAgentTraceUpload(options.sessionManager, {
+		agentDir: options.services.agentDir,
 		authStorage: options.services.authStorage,
 		settingsManager: options.services.settingsManager,
 		semanticEdgesLedgerPath: semanticEdgeLedgerPath({

--- a/packages/coding-agent/src/core/agent-trace-payload.ts
+++ b/packages/coding-agent/src/core/agent-trace-payload.ts
@@ -31,7 +31,9 @@ const signature = stats => ({ size: stats.size, mtimeMs: stats.mtimeMs, ino: sta
 const equal = (a, b) => a.size === b.size && a.mtimeMs === b.mtimeMs && a.ino === b.ino && a.dev === b.dev;
 const header = body => {
   let parsed;
-  try { parsed = JSON.parse(body.subarray(0, body.indexOf(10) < 0 ? body.length : body.indexOf(10)).toString("utf8")); } catch {}
+  try { parsed = JSON.parse(body.subarray(0, body.indexOf(10) < 0 ? body.length : body.indexOf(10)).toString("utf8")); } catch {
+    // Invalid JSON is rejected by the shared header validation below.
+  }
   if (!record(parsed) || parsed.type !== "session" || typeof parsed.id !== "string" || typeof parsed.cwd !== "string" || typeof parsed.timestamp !== "string") throw new Error("invalid_session");
   return parsed;
 };
@@ -166,7 +168,9 @@ try {
  let value;
  if (process.platform === "win32") {
   let shell = [process.env.ProgramFiles, process.env["ProgramFiles(x86)"]].filter(Boolean).map(root => root + "\\Git\\bin\\bash.exe").find(existsSync);
-  if (!shell) { try { shell = execFileSync("where", ["bash.exe"], options).trim().split(/\r?\n/).find(existsSync); } catch {} }
+  if (!shell) { try { shell = execFileSync("where", ["bash.exe"], options).trim().split(/\r?\n/).find(existsSync); } catch {
+    // Missing Git Bash falls back to the default shell below.
+  } }
   if (shell) value = execFileSync(shell, ["-c", command], options);
  }
  if (value === undefined) value = execSync(command, options);

--- a/packages/coding-agent/src/core/agent-trace-payload.ts
+++ b/packages/coding-agent/src/core/agent-trace-payload.ts
@@ -1,0 +1,181 @@
+import { Worker } from "node:worker_threads";
+
+export const MAX_TRACE_BYTES = 20 * 1024 * 1024;
+
+export interface TraceFileSignature {
+	size: number;
+	mtimeMs: number;
+	ino: number;
+	dev: number;
+}
+
+export interface TracePayload {
+	body: ArrayBuffer;
+	sessionId: string;
+	traceId: string;
+	parentSessionId?: string;
+	cwd: string;
+	gitRepo?: string;
+	gitCommit?: string;
+	signature: TraceFileSignature;
+}
+
+// A data URL keeps the worker available in both the bundled CLI and the source distribution.
+// All transcript parsing, copying, and snapshot I/O stays off the agent's event loop.
+const PAYLOAD_WORKER = String.raw`
+import { parentPort, workerData } from "node:worker_threads";
+import { open, readFile, writeFile, rename } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+const record = value => value !== null && typeof value === "object" && !Array.isArray(value);
+const signature = stats => ({ size: stats.size, mtimeMs: stats.mtimeMs, ino: stats.ino, dev: stats.dev });
+const equal = (a, b) => a.size === b.size && a.mtimeMs === b.mtimeMs && a.ino === b.ino && a.dev === b.dev;
+const header = body => {
+  let parsed;
+  try { parsed = JSON.parse(body.subarray(0, body.indexOf(10) < 0 ? body.length : body.indexOf(10)).toString("utf8")); } catch {}
+  if (!record(parsed) || parsed.type !== "session" || typeof parsed.id !== "string" || typeof parsed.cwd !== "string" || typeof parsed.timestamp !== "string") throw new Error("invalid_session");
+  return parsed;
+};
+const firstHeader = async path => {
+  const file = await open(path, "r");
+  try {
+    const buffer = Buffer.alloc(65536);
+    const { bytesRead } = await file.read(buffer, 0, buffer.length, 0);
+    return header(buffer.subarray(0, bytesRead));
+  } finally { await file.close(); }
+};
+try {
+  const { sessionFile, expected, snapshotPath, snapshotReady, maxBytes } = workerData;
+  let body, sourceSignature;
+  if (snapshotReady) {
+    body = await readFile(snapshotPath);
+    if (body.length !== expected.size) throw new Error("snapshot_changed");
+    sourceSignature = expected;
+  } else {
+    const file = await open(sessionFile, "r");
+    try {
+      const before = signature(await file.stat());
+      if (before.size > maxBytes) throw new Error("too_large");
+      if (before.size === 0) throw new Error("empty_session");
+      if (expected && !equal(expected, before)) throw new Error("snapshot_changed");
+      body = Buffer.alloc(before.size);
+      let offset = 0;
+      while (offset < body.length) {
+        const { bytesRead } = await file.read(body, offset, body.length - offset, offset);
+        if (!bytesRead) throw new Error("snapshot_changed");
+        offset += bytesRead;
+      }
+      if (!equal(before, signature(await file.stat()))) throw new Error("snapshot_changed");
+      sourceSignature = before;
+    } finally { await file.close(); }
+  }
+  if (body.length > maxBytes) throw new Error("too_large");
+  const currentHeader = header(body);
+  let traceId = currentHeader.id, parentSessionId, currentFile = sessionFile, current = currentHeader;
+  for (let depth = 0; depth < 32 && typeof current.parentSession === "string"; depth++) {
+    const parentPath = resolve(dirname(currentFile), current.parentSession);
+    let parent;
+    try { parent = await firstHeader(parentPath); } catch { break; }
+    if (depth === 0) parentSessionId = parent.id;
+    traceId = parent.id;
+    currentFile = parentPath;
+    current = parent;
+  }
+  const byId = new Map();
+  let leaf;
+  for (const line of body.toString("utf8").split("\n")) {
+    let entry;
+    try { entry = JSON.parse(line); } catch { continue; }
+    if (!record(entry) || entry.type === "session" || typeof entry.id !== "string") continue;
+    byId.set(entry.id, { parentId: entry.parentId, type: entry.type, git: entry.git });
+    leaf = entry.id;
+  }
+  let git = currentHeader.git;
+  current = byId.get(leaf);
+  for (let depth = 0; current && depth <= byId.size; depth++) {
+    if (current.type === "git_state" && record(current.git)) { git = current.git; break; }
+    current = byId.get(current.parentId);
+  }
+  if (snapshotPath && !snapshotReady) {
+    const temp = snapshotPath + ".tmp";
+    await writeFile(temp, body, { mode: 0o600 });
+    await rename(temp, snapshotPath);
+  }
+  const bytes = Uint8Array.from(body);
+  parentPort.postMessage({ payload: {
+    body: bytes.buffer, sessionId: currentHeader.id, cwd: currentHeader.cwd, traceId, parentSessionId,
+    gitRepo: typeof git?.repoUrl === "string" ? git.repoUrl : undefined,
+    gitCommit: typeof git?.commit === "string" ? git.commit : undefined,
+    signature: sourceSignature,
+  } }, [bytes.buffer]);
+} catch (error) {
+  parentPort.postMessage({ error: error.code === "ENOENT" ? "no_session_file" : error.message });
+}
+`;
+
+export function prepareTracePayload(options: {
+	sessionFile: string;
+	expected?: TraceFileSignature;
+	snapshotPath?: string;
+	snapshotReady?: boolean;
+	signal: AbortSignal;
+}): Promise<TracePayload> {
+	return runTraceWorker<TracePayload>(
+		PAYLOAD_WORKER,
+		{ ...options, signal: undefined, maxBytes: MAX_TRACE_BYTES },
+		options.signal,
+	);
+}
+
+function runTraceWorker<T>(source: string, data: unknown, signal: AbortSignal): Promise<T> {
+	return new Promise((resolve, reject) => {
+		if (signal.aborted) {
+			reject(signal.reason);
+			return;
+		}
+		const worker = new Worker(new URL(`data:text/javascript,${encodeURIComponent(source)}`), { workerData: data });
+		const finish = () => {
+			signal.removeEventListener("abort", abort);
+			void worker.terminate();
+		};
+		const abort = () => {
+			finish();
+			reject(signal.reason);
+		};
+		signal.addEventListener("abort", abort, { once: true });
+		worker.once("message", (message: { payload?: T; error?: string }) => {
+			finish();
+			if ("payload" in message) resolve(message.payload as T);
+			else reject(new Error(message.error ?? "preparation_failed"));
+		});
+		worker.once("error", (error) => {
+			finish();
+			reject(error);
+		});
+		worker.once("exit", () => reject(new Error("preparation_failed")));
+		worker.unref();
+	});
+}
+
+const KEY_WORKER = String.raw`
+import { parentPort, workerData } from "node:worker_threads";
+import { execFileSync, execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+try {
+ const command = workerData.slice(1);
+ const options = { encoding: "utf8", timeout: 10000, stdio: ["ignore", "pipe", "ignore"], windowsHide: true };
+ let value;
+ if (process.platform === "win32") {
+  let shell = [process.env.ProgramFiles, process.env["ProgramFiles(x86)"]].filter(Boolean).map(root => root + "\\Git\\bin\\bash.exe").find(existsSync);
+  if (!shell) { try { shell = execFileSync("where", ["bash.exe"], options).trim().split(/\r?\n/).find(existsSync); } catch {} }
+  if (shell) value = execFileSync(shell, ["-c", command], options);
+ }
+ if (value === undefined) value = execSync(command, options);
+ parentPort.postMessage({ payload: value.trim() || undefined });
+} catch { parentPort.postMessage({ payload: undefined }); }
+`;
+
+export async function resolveTraceKey(config: string | undefined, signal: AbortSignal): Promise<string | undefined> {
+	if (!config) return undefined;
+	if (!config.startsWith("!")) return (process.env[config] ?? config) || undefined;
+	return runTraceWorker<string | undefined>(KEY_WORKER, config, signal);
+}

--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -1,39 +1,36 @@
-import { Buffer } from "node:buffer";
 import { createHash, randomUUID } from "node:crypto";
-import { type Dirent, existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
-import { mkdir, readdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
-import { dirname, isAbsolute, join, resolve } from "node:path";
-import { appendRotatingLog, getAgentDir, getAgentTracesLogPath, getSessionsDir, VERSION } from "../config.js";
+import { type Dirent, existsSync, linkSync, mkdirSync, type Stats, unlinkSync, writeFileSync } from "node:fs";
+import { mkdir, open, readdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import lockfile from "proper-lockfile";
+import { appendRotatingLog, getAgentDir, getSessionsDir, VERSION } from "../config.js";
 import { readFirstLineSync } from "../utils/file-lines.js";
+import {
+	MAX_TRACE_BYTES,
+	prepareTracePayload,
+	resolveTraceKey,
+	type TraceFileSignature,
+	type TracePayload,
+} from "./agent-trace-payload.js";
 import type { AuthStorage } from "./auth-storage.js";
 import {
-	loadPrimeCliConfig,
+	getPrimeCliConfigPath,
 	PRIME_AGENT_TRACES_PROVIDER_ID,
 	PRIME_INFERENCE_PROVIDER_ID,
 	resolvePrimeAgentTracesBaseUrl,
 } from "./prime-inference-auth.js";
 import { getSessionArtifactsRoot, type SessionHeader, type SessionManager } from "./session-manager.js";
-import type { SettingsManager } from "./settings-manager.js";
+import type { AgentTraceConsent, SettingsManager } from "./settings-manager.js";
 
-const MAX_TRACE_BYTES = 20 * 1024 * 1024;
-const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
-const TRACE_UPLOAD_DEBOUNCE_MS = 1_000;
-const TRACE_UPLOAD_MIN_INTERVAL_MS = 60_000;
-const TRACE_UPLOAD_RETRY_BASE_DELAY_MS = 500;
-const TRACE_UPLOAD_RETRY_MAX_DELAY_MS = 10_000;
-const TRACE_UPLOAD_MAX_RETRIES = 3;
-const TRACE_UPLOAD_RETRY_JITTER = 0.2;
 const TRACE_PREVIEW_MAX_CHARS = 8_000;
-const TRACE_UPLOAD_ALL_CONCURRENCY = 4;
-const TRACE_UPLOAD_RATE_LIMIT_REQUESTS = 5;
-const TRACE_UPLOAD_RATE_LIMIT_WINDOW_MS = 60_000;
-const TRACE_UPLOAD_RATE_LIMIT_SAFETY_MS = 100;
-const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
-const TRACE_UPLOAD_ALL_MIN_REQUEST_INTERVAL_MS =
-	Math.ceil(TRACE_UPLOAD_RATE_LIMIT_WINDOW_MS / TRACE_UPLOAD_RATE_LIMIT_REQUESTS) + TRACE_UPLOAD_RATE_LIMIT_SAFETY_MS;
+const REQUEST_INTERVAL_MS = 12_100;
+const SESSION_INTERVAL_MS = 60_000;
+const LEASE_STALE_MS = 30_000;
+const RETRY_MAX_MS = 300_000;
+const RETRIABLE_HTTP_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+export const SEMANTIC_EDGES_OUTBOX_KIND = "semantic-edges";
 
 export type AgentTraceCredentialSource = "environment" | "stored" | "prime-inference" | "prime-cli";
-
 export interface AgentTraceCredential {
 	apiKey: string;
 	source: AgentTraceCredentialSource;
@@ -41,51 +38,43 @@ export interface AgentTraceCredential {
 }
 
 export type AgentTraceUploadResult =
-	| {
-			status: "uploaded";
-			sessionId: string;
-			traceId: string;
-			bytesStored: number;
-			key?: string;
-	  }
-	| { status: "disabled" }
-	| { status: "unchanged" }
-	| { status: "missing_credentials" }
-	| { status: "no_session_file" }
-	| { status: "empty_session" }
-	| { status: "invalid_session"; message: string }
-	| { status: "too_large"; size: number; maxBytes: number }
-	| { status: "failed"; statusCode?: number; message: string; retryAfterMs?: number };
-
-export interface AgentTraceUploadOptions {
-	sessionFile: string | undefined;
-	authStorage: AuthStorage;
-	settingsManager: SettingsManager;
-	/** Require the global automatic-sharing opt-in. Set false only for an explicit one-shot upload command. */
-	requireEnabled?: boolean;
-	baseUrl?: string;
-	configPath?: string;
-	fetchFn?: typeof fetch;
-	reloadConfig?: boolean;
-	requestTimeoutMs?: number;
-	signal?: AbortSignal;
-}
-
-export interface AgentTraceSessionUploadOptions extends Omit<AgentTraceUploadOptions, "sessionFile"> {
-	sessionManager: SessionManager;
-}
+	| { status: "queued"; requestId: string }
+	| { status: "disabled" | "no_session_file" | "empty_session" }
+	| { status: "failed"; message: string };
+export type AgentTraceUploadAllResult = AgentTraceUploadResult;
 
 export interface AgentTraceUploadInstallOptions {
 	authStorage: AuthStorage;
 	settingsManager: SettingsManager;
+	agentDir?: string;
 	baseUrl?: string;
 	configPath?: string;
 	fetchFn?: typeof fetch;
 	requestTimeoutMs?: number;
-	/** The session's semantic-edge ledger; registered with the outbox as its own delivery kind. */
 	semanticEdgesLedgerPath?: string;
 }
+export interface AgentTraceUploadOptions extends AgentTraceUploadInstallOptions {
+	sessionFile: string | undefined;
+	/** False is reserved for explicit one-shot requests, bound to the accepted file version. */
+	requireEnabled?: boolean;
+	signal?: AbortSignal;
+}
+export interface AgentTraceSessionUploadOptions extends Omit<AgentTraceUploadOptions, "sessionFile"> {
+	sessionManager: SessionManager;
+}
+export interface AgentTraceUploadAllOptions extends Omit<AgentTraceUploadOptions, "sessionFile"> {
+	sessionDir?: string;
+}
 
+function stringEnv(name: string): string | undefined {
+	return process.env[name]?.trim() || undefined;
+}
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function describeError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
 export type AgentTracePreviewResult =
 	| {
 			status: "ready";
@@ -112,97 +101,6 @@ export interface AgentTracePreviewOptions {
 	sessionFile: string | undefined;
 	baseUrl?: string;
 	maxContentChars?: number;
-}
-
-export interface AgentTraceUploadAllProgress {
-	completed: number;
-	total: number;
-	sessionFile?: string;
-	result?: AgentTraceUploadResult;
-}
-
-export interface AgentTraceUploadAllOptions extends Omit<AgentTraceUploadOptions, "sessionFile"> {
-	sessionDir?: string;
-	concurrency?: number;
-	onProgress?: (progress: AgentTraceUploadAllProgress) => void;
-}
-
-export interface AgentTraceUploadAllResult {
-	total: number;
-	uploaded: number;
-	failed: number;
-	skipped: number;
-	bytesStored: number;
-	results: Array<{ sessionFile: string; result: AgentTraceUploadResult }>;
-}
-
-function stringEnv(name: string): string | undefined {
-	const value = process.env[name];
-	return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function describeError(error: unknown): string {
-	if (!(error instanceof Error)) {
-		return String(error);
-	}
-	const cause = (error as { cause?: unknown }).cause;
-	if (isRecord(cause)) {
-		const code = typeof cause.code === "string" ? cause.code : undefined;
-		const causeMessage = typeof cause.message === "string" ? cause.message : undefined;
-		const detail = code ?? causeMessage;
-		if (detail && detail !== error.message) {
-			return `${error.message} (${detail})`;
-		}
-	}
-	return error.message;
-}
-
-class TraceUploadTimeoutError extends Error {
-	constructor(timeoutMs: number) {
-		super(`Trace upload timed out after ${timeoutMs}ms`);
-		this.name = "TraceUploadTimeoutError";
-	}
-}
-
-const RETRIABLE_NETWORK_CODES = new Set([
-	"ECONNRESET",
-	"ECONNREFUSED",
-	"ECONNABORTED",
-	"EPIPE",
-	"ETIMEDOUT",
-	"ENETUNREACH",
-	"ENETDOWN",
-	"EAI_AGAIN",
-	"UND_ERR_SOCKET",
-	"UND_ERR_CONNECT_TIMEOUT",
-]);
-
-// 429 is deliberately absent: a rate-limited upload is rescheduled by its caller instead of sleeping in-request.
-const RETRIABLE_HTTP_STATUSES = new Set([408, 425, 500, 502, 503, 504]);
-
-function isRetriableNetworkError(error: unknown): boolean {
-	if (error instanceof TraceUploadTimeoutError) {
-		return true;
-	}
-	if (!(error instanceof Error) || error.name === "AbortError") {
-		return false;
-	}
-	const cause = (error as { cause?: unknown }).cause;
-	return isRecord(cause) && typeof cause.code === "string" && RETRIABLE_NETWORK_CODES.has(cause.code);
-}
-
-function stringField(data: Record<string, unknown>, key: string): string | undefined {
-	const value = data[key];
-	return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function numberField(data: Record<string, unknown>, key: string): number | undefined {
-	const value = data[key];
-	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function isSessionHeader(value: unknown): value is SessionHeader {
@@ -299,156 +197,6 @@ function resolveTraceContext(
 	return { traceId, parentSessionId };
 }
 
-function parseResponseObject(text: string): Record<string, unknown> | undefined {
-	if (!text.trim()) {
-		return undefined;
-	}
-	try {
-		const parsed = JSON.parse(text) as unknown;
-		return isRecord(parsed) ? parsed : undefined;
-	} catch {
-		return undefined;
-	}
-}
-
-async function readResponseMessage(response: Response): Promise<string> {
-	const text = await response.text().catch(() => "");
-	if (!text.trim()) {
-		return response.statusText || "Unknown error";
-	}
-
-	const parsed = parseResponseObject(text);
-	if (parsed) {
-		const error = parsed.error;
-		if (isRecord(error)) {
-			const message = stringField(error, "message");
-			if (message) return message;
-		}
-		const detail = stringField(parsed, "detail");
-		if (detail) return detail;
-		const message = stringField(parsed, "message");
-		if (message) return message;
-	}
-
-	return text.trim();
-}
-
-async function fetchWithTimeout(
-	fetchFn: typeof fetch,
-	url: string,
-	init: RequestInit,
-	timeoutMs: number,
-	signal?: AbortSignal,
-): Promise<Response> {
-	const controller = new AbortController();
-	const timeoutError = new TraceUploadTimeoutError(timeoutMs);
-	let timedOut = false;
-	const timeout = setTimeout(() => {
-		timedOut = true;
-		controller.abort(timeoutError);
-	}, timeoutMs);
-	timeout.unref();
-	const onAbort = () => controller.abort(signal?.reason);
-	if (signal?.aborted) {
-		onAbort();
-	} else {
-		signal?.addEventListener("abort", onAbort, { once: true });
-	}
-
-	try {
-		return await fetchFn(url, { ...init, signal: controller.signal });
-	} catch (error) {
-		if (timedOut) {
-			throw timeoutError;
-		}
-		throw error;
-	} finally {
-		clearTimeout(timeout);
-		signal?.removeEventListener("abort", onAbort);
-	}
-}
-
-function delay(ms: number, signal?: AbortSignal): Promise<void> {
-	return new Promise((resolve) => {
-		if (signal?.aborted) {
-			resolve();
-			return;
-		}
-		const timeout = setTimeout(finish, ms);
-		timeout.unref();
-		const onAbort = () => finish();
-		function finish() {
-			clearTimeout(timeout);
-			signal?.removeEventListener("abort", onAbort);
-			resolve();
-		}
-		signal?.addEventListener("abort", onAbort, { once: true });
-	});
-}
-
-function traceUploadRetryDelay(retryIndex: number): number {
-	const exponentialDelay = Math.min(
-		TRACE_UPLOAD_RETRY_MAX_DELAY_MS,
-		TRACE_UPLOAD_RETRY_BASE_DELAY_MS * 2 ** retryIndex,
-	);
-	const jitterMultiplier = 1 - TRACE_UPLOAD_RETRY_JITTER + Math.random() * TRACE_UPLOAD_RETRY_JITTER * 2;
-	return Math.max(0, Math.round(exponentialDelay * jitterMultiplier));
-}
-
-function retryAfterDelay(response: Response, capMs: number = TRACE_UPLOAD_RATE_LIMIT_WINDOW_MS): number | undefined {
-	const value = response.headers.get("retry-after")?.trim();
-	if (!value) {
-		return undefined;
-	}
-	const seconds = Number(value);
-	if (Number.isFinite(seconds) && seconds >= 0) {
-		return Math.min(Math.ceil(seconds * 1_000), capMs);
-	}
-	const retryAt = Date.parse(value);
-	return Number.isFinite(retryAt) ? Math.min(Math.max(0, retryAt - Date.now()), capMs) : undefined;
-}
-
-type BeforeTraceUploadRequest = () => Promise<void>;
-
-async function fetchWithRetry(
-	fetchFn: typeof fetch,
-	url: string,
-	init: RequestInit,
-	timeoutMs: number,
-	signal?: AbortSignal,
-	beforeRequest?: BeforeTraceUploadRequest,
-): Promise<Response> {
-	for (let attempt = 0; ; attempt += 1) {
-		let retryDelayMs: number | undefined;
-		try {
-			await beforeRequest?.();
-			if (signal?.aborted) {
-				throw signal.reason ?? new Error("Trace upload cancelled");
-			}
-			const response = await fetchWithTimeout(fetchFn, url, init, timeoutMs, signal);
-			if (attempt >= TRACE_UPLOAD_MAX_RETRIES || !RETRIABLE_HTTP_STATUSES.has(response.status)) {
-				return response;
-			}
-			if (response.status === 503) {
-				retryDelayMs = retryAfterDelay(response);
-			}
-			await response.body?.cancel().catch(() => undefined);
-		} catch (error) {
-			if (signal?.aborted) {
-				throw signal.reason ?? error;
-			}
-			if (attempt >= TRACE_UPLOAD_MAX_RETRIES || !isRetriableNetworkError(error)) {
-				throw error;
-			}
-		}
-
-		await delay(retryDelayMs ?? traceUploadRetryDelay(attempt), signal);
-		if (signal?.aborted) {
-			throw signal.reason ?? new Error("Trace upload cancelled");
-		}
-	}
-}
-
 function traceContentPreview(body: string, maxChars: number): { content: string; truncated: boolean } {
 	if (body.length <= maxChars) {
 		return { content: body.trimEnd(), truncated: false };
@@ -537,7 +285,7 @@ async function findSessionFilesUnder(root: string, files: Set<string>): Promise<
 			await findSessionFilesUnder(entryPath, files);
 			continue;
 		}
-		if (entry.isFile() && entry.name.endsWith(".jsonl") && readSessionHeader(entryPath)) {
+		if (entry.isFile() && entry.name.endsWith(".jsonl") && (await readSessionHeaderAsync(entryPath))) {
 			files.add(entryPath);
 		}
 	}
@@ -550,621 +298,1035 @@ export async function findAgentTraceFiles(sessionDir: string = getSessionsDir())
 	return [...files].sort();
 }
 
-function createTraceUploadAllRequestGate(signal?: AbortSignal): BeforeTraceUploadRequest {
-	let nextRequestAt = 0;
-	let queue = Promise.resolve();
-	return () => {
-		const slot = queue.then(async () => {
-			const waitMs = Math.max(0, nextRequestAt - Date.now());
-			if (waitMs > 0) {
-				await delay(waitMs, signal);
-			}
-			if (!signal?.aborted) {
-				nextRequestAt = Date.now() + TRACE_UPLOAD_ALL_MIN_REQUEST_INTERVAL_MS;
-			}
-		});
-		queue = slot.catch(() => undefined);
-		return slot;
-	};
-}
-
-export async function uploadAllAgentTraces(options: AgentTraceUploadAllOptions): Promise<AgentTraceUploadAllResult> {
-	const { sessionDir, concurrency, onProgress, ...uploadOptions } = options;
-	const sessionFiles = await findAgentTraceFiles(sessionDir);
-	type UploadResultItem = AgentTraceUploadAllResult["results"][number];
-	const results: Array<UploadResultItem | undefined> = new Array(sessionFiles.length);
-	let cursor = 0;
-	let completed = 0;
-	const beforeRequest = createTraceUploadAllRequestGate(uploadOptions.signal);
-	onProgress?.({ completed, total: sessionFiles.length });
-
-	const worker = async () => {
-		while (true) {
-			if (uploadOptions.signal?.aborted) {
-				return;
-			}
-			const index = cursor;
-			cursor += 1;
-			const sessionFile = sessionFiles[index];
-			if (!sessionFile) {
-				return;
-			}
-			const result = await uploadAgentTraceFileWithRequestGate(
-				{
-					...uploadOptions,
-					sessionFile,
-					reloadConfig: false,
-				},
-				beforeRequest,
-			);
-			if (uploadOptions.signal?.aborted && result.status === "failed") {
-				return;
-			}
-			results[index] = { sessionFile, result };
-			completed += 1;
-			onProgress?.({ completed, total: sessionFiles.length, sessionFile, result });
-		}
-	};
-
-	const requestedConcurrency = concurrency ?? TRACE_UPLOAD_ALL_CONCURRENCY;
-	const normalizedConcurrency =
-		Number.isFinite(requestedConcurrency) && requestedConcurrency > 0
-			? Math.max(1, Math.floor(requestedConcurrency))
-			: TRACE_UPLOAD_ALL_CONCURRENCY;
-	const workerCount = Math.min(sessionFiles.length, normalizedConcurrency);
-	await Promise.all(Array.from({ length: workerCount }, worker));
-
-	const completedResults = results.filter((item): item is UploadResultItem => item !== undefined);
-	let uploaded = 0;
-	let failed = 0;
-	let bytesStored = 0;
-	for (const item of completedResults) {
-		if (item.result.status === "uploaded") {
-			uploaded += 1;
-			bytesStored += item.result.bytesStored;
-		} else if (item.result.status === "failed") {
-			failed += 1;
-		}
-	}
-	return {
-		total: sessionFiles.length,
-		uploaded,
-		failed,
-		skipped: sessionFiles.length - uploaded - failed,
-		bytesStored,
-		results: completedResults,
-	};
-}
-
-interface AgentTraceUploadedSignature {
-	size: number;
-	mtimeMs: number;
-}
-
-export const SEMANTIC_EDGES_OUTBOX_KIND = "semantic-edges";
-
-export interface AgentTraceCatchUpResult {
-	pruned: number;
-	/** Registered semantic-edge ledgers with bytes beyond their cursor; no delivery endpoint exists yet. */
-	semanticEdgeLedgersPending: number;
-	results: Array<{ sessionFile: string; result: AgentTraceUploadResult }>;
-}
-
-function getAgentTraceOutboxDir(): string {
-	return join(getAgentDir(), "agent-traces-outbox");
-}
-
-// One entry file per session file (keyed by path hash): concurrent writers cannot lose each other's cursors, and a bad read costs only its own entry.
-function agentTraceOutboxEntryPath(sessionFile: string): string {
-	const key = createHash("sha256").update(sessionFile).digest("hex").slice(0, 32);
-	return join(getAgentTraceOutboxDir(), `${key}.json`);
-}
-
-function parseOutboxEntry(raw: string):
-	| {
-			sessionFile: string;
-			kind?: string;
-			uploaded: AgentTraceUploadedSignature | null;
-			uploadedBytes?: number;
-	  }
-	| undefined {
-	const parsed = parseResponseObject(raw);
-	if (!parsed || typeof parsed.sessionFile !== "string") {
-		return undefined;
-	}
-	const uploaded =
-		typeof parsed.size === "number" && typeof parsed.mtimeMs === "number"
-			? { size: parsed.size, mtimeMs: parsed.mtimeMs }
-			: null;
-	return {
-		sessionFile: parsed.sessionFile,
-		kind: typeof parsed.kind === "string" ? parsed.kind : undefined,
-		uploaded,
-		uploadedBytes: typeof parsed.uploadedBytes === "number" ? parsed.uploadedBytes : undefined,
-	};
-}
-
-/** `undefined` = no usable cursor; `null` = scheduled but never uploaded. */
-async function readAgentTraceOutboxEntry(sessionFile: string): Promise<AgentTraceUploadedSignature | null | undefined> {
-	let raw: string;
-	try {
-		raw = await readFile(agentTraceOutboxEntryPath(sessionFile), "utf8");
-	} catch {
-		return undefined;
-	}
-	const entry = parseOutboxEntry(raw);
-	return entry && entry.sessionFile === sessionFile ? entry.uploaded : undefined;
-}
-
-function signatureEquals(a: AgentTraceUploadedSignature | null | undefined, b: AgentTraceUploadedSignature): boolean {
-	return a != null && a.size === b.size && a.mtimeMs === b.mtimeMs;
-}
-
-/** Session files with a live upload controller in this process; catch-up leaves them to their controller. */
-const locallyManagedSessionFiles = new Set<string>();
-
-/** Best-effort and synchronous: upload intent must be on disk the moment the transcript persist returns. */
-function markAgentTraceOutboxPendingSync(sessionFile: string, kind?: string): boolean {
-	try {
-		const entryPath = agentTraceOutboxEntryPath(sessionFile);
-		if (existsSync(entryPath)) {
-			return true;
-		}
-		mkdirSync(getAgentTraceOutboxDir(), { recursive: true });
-		const tempPath = `${entryPath}.${process.pid}.${randomUUID()}.tmp`;
-		writeFileSync(
-			tempPath,
-			`${JSON.stringify(kind === undefined ? { sessionFile } : { sessionFile, kind })}\n`,
-			"utf8",
-		);
-		renameSync(tempPath, entryPath);
-		return true;
-	} catch {
-		// A broken agent dir must not break session persists.
-		return false;
-	}
-}
-
-async function recordAgentTraceOutboxUpload(
-	sessionFile: string,
-	signature: AgentTraceUploadedSignature,
-): Promise<void> {
-	const entryPath = agentTraceOutboxEntryPath(sessionFile);
-	await mkdir(getAgentTraceOutboxDir(), { recursive: true });
-	const tempPath = `${entryPath}.${process.pid}.${randomUUID()}.tmp`;
-	await writeFile(tempPath, `${JSON.stringify({ sessionFile, ...signature })}\n`, "utf8");
-	await rename(tempPath, entryPath);
-}
-
-/**
- * Startup catch-up: upload every outbox entry whose file content is ahead of its
- * cursor, and prune entries whose file no longer exists. Runs once per process,
- * in whichever process hosts sessions (the only place trace upload is installed).
- */
-export async function catchUpAgentTraceUploads(
-	options: Omit<AgentTraceUploadOptions, "sessionFile">,
-): Promise<AgentTraceCatchUpResult> {
-	const catchUp: AgentTraceCatchUpResult = { pruned: 0, semanticEdgeLedgersPending: 0, results: [] };
-	if (options.requireEnabled !== false && !(await getAgentTracesEnabled(options))) {
-		return catchUp;
-	}
-	let entryNames: string[];
-	try {
-		entryNames = await readdir(getAgentTraceOutboxDir());
-	} catch {
-		return catchUp;
-	}
-	const beforeRequest = createTraceUploadAllRequestGate(options.signal);
-	for (const entryName of entryNames) {
-		if (options.signal?.aborted) {
-			break;
-		}
-		if (!entryName.endsWith(".json")) {
-			continue;
-		}
-		const entryPath = join(getAgentTraceOutboxDir(), entryName);
-		let raw: string;
-		try {
-			raw = await readFile(entryPath, "utf8");
-		} catch {
-			// Transient read error: keep the entry and retry at the next startup.
-			continue;
-		}
-		const entry = parseOutboxEntry(raw);
-		if (!entry) {
-			await unlink(entryPath).catch(() => undefined);
-			catchUp.pruned += 1;
-			continue;
-		}
-		if (entry.kind === SEMANTIC_EDGES_OUTBOX_KIND) {
-			let ledgerStats: Awaited<ReturnType<typeof stat>>;
-			try {
-				ledgerStats = await stat(entry.sessionFile);
-			} catch (error) {
-				if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-					await unlink(entryPath).catch(() => undefined);
-					catchUp.pruned += 1;
-				}
-				continue;
-			}
-			if (!ledgerStats.isFile()) {
-				await unlink(entryPath).catch(() => undefined);
-				catchUp.pruned += 1;
-				continue;
-			}
-			// Append-only byte cursor: a ledger whose size equals its delivered offset has nothing new.
-			if (ledgerStats.size === entry.uploadedBytes) {
-				continue;
-			}
-			// No delivery endpoint exists yet (verifiers#2449 consumes edges in-band over ACP
-			// metadata; the trace server has no semantic-edges route). The delta and cursor stay
-			// untouched so the first real sender delivers the whole backlog.
-			catchUp.semanticEdgeLedgersPending += 1;
-			continue;
-		}
-		if (entry.kind !== undefined) {
-			// A newer build may register kinds this one cannot deliver; leave their cursors alone.
-			continue;
-		}
-		if (locallyManagedSessionFiles.has(entry.sessionFile)) {
-			continue;
-		}
-		let stats: Awaited<ReturnType<typeof stat>>;
-		try {
-			stats = await stat(entry.sessionFile);
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-				await unlink(entryPath).catch(() => undefined);
-				catchUp.pruned += 1;
-			}
-			continue;
-		}
-		if (!stats.isFile()) {
-			await unlink(entryPath).catch(() => undefined);
-			catchUp.pruned += 1;
-			continue;
-		}
-		if (signatureEquals(entry.uploaded, { size: stats.size, mtimeMs: stats.mtimeMs })) {
-			continue;
-		}
-		const result = await uploadAgentTraceFileWithRequestGate(
-			{ ...options, sessionFile: entry.sessionFile, reloadConfig: false },
-			beforeRequest,
-		);
-		catchUp.results.push({ sessionFile: entry.sessionFile, result });
-	}
-	return catchUp;
-}
-
 export async function getPrimeAgentTraceCredential(
 	authStorage: AuthStorage,
-	options: { reloadAuth?: boolean; configPath?: string } = {},
+	options: { configPath?: string; signal?: AbortSignal } = {},
 ): Promise<AgentTraceCredential | undefined> {
-	const traceEnvKey = stringEnv("PRIME_AGENT_TRACES_API_KEY");
-	if (traceEnvKey) {
-		return { apiKey: traceEnvKey, source: "environment", label: "PRIME_AGENT_TRACES_API_KEY" };
-	}
-
-	if (options.reloadAuth !== false) {
-		authStorage.reload();
-	}
-
-	const traceKey = await authStorage.getApiKey(PRIME_AGENT_TRACES_PROVIDER_ID, { includeFallback: false });
-	if (traceKey) {
-		return { apiKey: traceKey, source: "stored", label: "Prime Agent Traces credential" };
-	}
-
-	const primeEnvKey = stringEnv("PRIME_API_KEY");
-	if (primeEnvKey) {
-		return { apiKey: primeEnvKey, source: "environment", label: "PRIME_API_KEY" };
-	}
-
-	const primeCredential = authStorage.get(PRIME_INFERENCE_PROVIDER_ID);
-	if (primeCredential) {
-		const primeKey = await authStorage.getApiKey(PRIME_INFERENCE_PROVIDER_ID, { includeFallback: false });
-		if (primeKey) {
-			return { apiKey: primeKey, source: "prime-inference", label: "Prime Inference credential" };
-		}
-	}
-
-	const primeCliKey = loadPrimeCliConfig(options.configPath).apiKey;
-	if (primeCliKey) {
-		return { apiKey: primeCliKey, source: "prime-cli", label: "Prime CLI credential" };
-	}
-
+	const signal = options.signal ?? new AbortController().signal;
+	const traceEnv = stringEnv("PRIME_AGENT_TRACES_API_KEY");
+	if (traceEnv) return { apiKey: traceEnv, source: "environment", label: "PRIME_AGENT_TRACES_API_KEY" };
+	const traceKey = await resolveTraceKey(await authStorage.readApiKeyConfig(PRIME_AGENT_TRACES_PROVIDER_ID), signal);
+	if (traceKey) return { apiKey: traceKey, source: "stored", label: "Prime Agent Traces credential" };
+	const primeEnv = stringEnv("PRIME_API_KEY");
+	if (primeEnv) return { apiKey: primeEnv, source: "environment", label: "PRIME_API_KEY" };
+	const primeKey = await resolveTraceKey(await authStorage.readApiKeyConfig(PRIME_INFERENCE_PROVIDER_ID), signal);
+	if (primeKey) return { apiKey: primeKey, source: "prime-inference", label: "Prime Inference credential" };
+	const config = await readJson<{ api_key?: string }>(
+		getPrimeCliConfigPath(options.configPath ?? authStorage.getPrimeCliConfigPath()),
+	);
+	if (typeof config?.api_key === "string" && config.api_key.trim())
+		return { apiKey: config.api_key.trim(), source: "prime-cli", label: "Prime CLI credential" };
 	return undefined;
 }
 
-async function getAgentTracesEnabled(
-	options: Pick<AgentTraceUploadOptions, "reloadConfig" | "settingsManager">,
-): Promise<boolean> {
-	if (options.reloadConfig !== false) {
-		await options.settingsManager.reload().catch(() => undefined);
-	}
-	return options.settingsManager.getAgentTracesEnabled();
+type DeliveryState =
+	| "queued"
+	| "uploading"
+	| "retrying"
+	| "paused"
+	| "failed"
+	| "delivered"
+	| "cancelled"
+	| "superseded";
+export type TraceFailure =
+	| "network"
+	| "timeout"
+	| "credentials"
+	| "missing_credentials"
+	| "http"
+	| "snapshot_changed"
+	| "invalid_session"
+	| "too_large"
+	| "empty_session"
+	| "no_session_file"
+	| "preparation_failed"
+	| "settings_unavailable"
+	| "invalid_endpoint";
+interface DeliveryFailure {
+	reason: TraceFailure;
+	at: number;
+	statusCode?: number;
+}
+interface TraceJob {
+	sessionFile: string;
+	kind?: string;
+	// The original flat size/mtime cursor remains readable for existing outboxes.
+	size?: number;
+	mtimeMs?: number;
+	state?: DeliveryState;
+	requestedAt?: number;
+	manual?: { requestId: string; expected: TraceFileSignature; snapshotReady?: boolean };
+	uploaded?: TraceFileSignature;
+	attempted?: TraceFileSignature;
+	attempts?: number;
+	nextAttemptAt?: number;
+	lastAttemptAt?: number;
+	lastSuccessAt?: number;
+	failure?: DeliveryFailure;
+	lastFailure?: DeliveryFailure;
+	pauseReason?: AgentTraceConsent["reason"] | "missing_credentials" | "credentials";
+	endpointFingerprint?: string;
+	credentialFingerprint?: string;
+}
+interface TraceBatch {
+	kind: "trace-batch";
+	requestId: string;
+	sessionDir: string;
+	requestedAt: number;
+	manual: boolean;
+	state: "queued" | "delivered" | "cancelled";
+}
+interface DeliveryCoordinator {
+	activeJob?: string;
+	nextRequestAt?: number;
+	invalidCredential?: string;
+	endpointFingerprint?: string;
+}
+interface DeliveryReceipt {
+	signature: TraceFileSignature;
+	requestedAt: number;
+	deliveredAt: number;
 }
 
-async function uploadAgentTraceFileWithRequestGate(
-	options: AgentTraceUploadOptions,
-	beforeRequest?: BeforeTraceUploadRequest,
-): Promise<AgentTraceUploadResult> {
-	const result = await performAgentTraceUpload(options, beforeRequest);
-	logAgentTraceOutcome(options.sessionFile, result);
-	return result;
+function validSignature(value: unknown): value is TraceFileSignature {
+	return (
+		isRecord(value) &&
+		["size", "mtimeMs", "ino", "dev"].every(
+			(key) => typeof value[key] === "number" && Number.isFinite(value[key]) && value[key] >= 0,
+		)
+	);
 }
-
-export function uploadAgentTraceFile(options: AgentTraceUploadOptions): Promise<AgentTraceUploadResult> {
-	return uploadAgentTraceFileWithRequestGate(options);
-}
-
-function logAgentTraceOutcome(sessionFile: string | undefined, result: AgentTraceUploadResult): void {
-	let line: string | undefined;
-	switch (result.status) {
-		case "uploaded":
-			line = `uploaded session ${result.sessionId} (${result.bytesStored} bytes)`;
-			break;
-		case "failed":
-			line = `upload failed${result.statusCode ? ` (HTTP ${result.statusCode})` : ""}: ${result.message}`;
-			break;
-		case "too_large":
-			line = `upload skipped: session is ${result.size} bytes (limit ${result.maxBytes})`;
-			break;
-		case "invalid_session":
-			line = `upload skipped: ${result.message}`;
-			break;
-		case "missing_credentials":
-			line = "upload skipped: no Prime credential configured (run /traces login)";
-			break;
-		default:
-			return;
-	}
-	const suffix = sessionFile ? ` [${sessionFile}]` : "";
-	appendRotatingLog(getAgentTracesLogPath(), `[${new Date().toISOString()}] ${line}${suffix}`);
-}
-
-async function performAgentTraceUpload(
-	options: AgentTraceUploadOptions,
-	beforeRequest?: BeforeTraceUploadRequest,
-): Promise<AgentTraceUploadResult> {
-	const requireEnabled = options.requireEnabled !== false;
-	if (requireEnabled && !(await getAgentTracesEnabled(options))) {
-		return { status: "disabled" };
-	}
-	if (!options.sessionFile) {
-		return { status: "no_session_file" };
-	}
-
-	let signature: AgentTraceUploadedSignature;
-	try {
-		const stats = await stat(options.sessionFile);
-		if (!stats.isFile()) {
-			return { status: "no_session_file" };
-		}
-		signature = { size: stats.size, mtimeMs: stats.mtimeMs };
-	} catch {
-		return { status: "no_session_file" };
-	}
-	const fileSize = signature.size;
-	if (fileSize === 0) {
-		return { status: "empty_session" };
-	}
-	if (fileSize > MAX_TRACE_BYTES) {
-		return { status: "too_large", size: fileSize, maxBytes: MAX_TRACE_BYTES };
-	}
-	// Cursor invariant: an automatic upload never re-sends a file whose content already matches its uploaded cursor.
-	if (requireEnabled && signatureEquals(await readAgentTraceOutboxEntry(options.sessionFile), signature)) {
-		return { status: "unchanged" };
-	}
-
-	const header = readSessionHeader(options.sessionFile);
-	if (!header) {
-		return { status: "invalid_session", message: "Session file is missing a valid session header" };
-	}
-
-	const credential = await getPrimeAgentTraceCredential(options.authStorage, {
-		configPath: options.configPath,
-		reloadAuth: options.reloadConfig !== false,
-	});
-	if (!credential) {
-		return { status: "missing_credentials" };
-	}
-
-	if (requireEnabled && !(await getAgentTracesEnabled(options))) {
-		return { status: "disabled" };
-	}
-
-	let body: string;
-	try {
-		body = await readFile(options.sessionFile, "utf8");
-	} catch (error) {
-		return { status: "failed", message: describeError(error) };
-	}
-	if (!body.trim()) {
-		return { status: "empty_session" };
-	}
-
-	const traceContext = resolveTraceContext(options.sessionFile, header);
-	const bodyBytes = Buffer.byteLength(body, "utf8");
-	const headers: Record<string, string> = {
-		Authorization: `Bearer ${credential.apiKey}`,
-		"Content-Type": "application/x-ndjson",
-		Accept: "application/json",
-		"X-Trace-Id": traceContext.traceId,
-		"X-Cwd": header.cwd,
-		"X-Agent-Version": VERSION,
-	};
-	if (traceContext.parentSessionId) {
-		headers["X-Parent-Session"] = traceContext.parentSessionId;
-	}
-	const git = activeGitContext(body, header);
-	if (git?.repoUrl) {
-		headers["X-Git-Repo"] = git.repoUrl;
-	}
-	if (git?.commit) {
-		headers["X-Git-Commit"] = git.commit;
-	}
-
-	if (requireEnabled && !(await getAgentTracesEnabled(options))) {
-		return { status: "disabled" };
-	}
-
-	const baseUrl = resolvePrimeAgentTracesBaseUrl(options.baseUrl);
-	const url = `${baseUrl}/api/v1/agent-traces/sessions/${encodeURIComponent(header.id)}`;
-	const fetchFn = options.fetchFn ?? fetch;
-
-	let response: Response;
-	try {
-		response = await fetchWithRetry(
-			fetchFn,
-			url,
-			{
-				method: "PUT",
-				headers,
-				body,
-			},
-			options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
-			options.signal,
-			beforeRequest,
+function validEntry(value: TraceJob | TraceBatch): boolean {
+	if (value.kind === "trace-batch") {
+		const batch = value as TraceBatch;
+		return (
+			typeof batch.requestId === "string" &&
+			!!batch.requestId &&
+			typeof batch.sessionDir === "string" &&
+			typeof batch.requestedAt === "number" &&
+			Number.isFinite(batch.requestedAt) &&
+			typeof batch.manual === "boolean"
 		);
-	} catch (error) {
-		return { status: "failed", message: describeError(error) };
 	}
-
-	if (!response.ok) {
-		return {
-			status: "failed",
-			statusCode: response.status,
-			message: await readResponseMessage(response),
-			retryAfterMs: retryAfterDelay(response, MAX_TIMER_DELAY_MS),
-		};
+	if (value.kind !== undefined) return true;
+	const job = value as TraceJob;
+	if (typeof job.sessionFile !== "string" || !job.sessionFile) return false;
+	if (
+		job.manual !== undefined &&
+		(!isRecord(job.manual) ||
+			typeof job.manual.requestId !== "string" ||
+			!job.manual.requestId ||
+			!validSignature(job.manual.expected) ||
+			typeof job.requestedAt !== "number" ||
+			!Number.isFinite(job.requestedAt) ||
+			(job.manual.snapshotReady !== undefined && typeof job.manual.snapshotReady !== "boolean"))
+	)
+		return false;
+	if (job.uploaded !== undefined && !validSignature(job.uploaded)) return false;
+	if (
+		job.state !== undefined &&
+		!["queued", "uploading", "retrying", "paused", "failed", "delivered", "cancelled", "superseded"].includes(
+			job.state,
+		)
+	)
+		return false;
+	for (const failure of [job.failure, job.lastFailure]) {
+		if (
+			failure !== undefined &&
+			(!isRecord(failure) ||
+				typeof failure.reason !== "string" ||
+				!Object.hasOwn(FAILURE_MESSAGES, failure.reason) ||
+				typeof failure.at !== "number" ||
+				!Number.isFinite(failure.at) ||
+				Math.abs(failure.at) > 8.64e15 ||
+				(failure.statusCode !== undefined &&
+					(typeof failure.statusCode !== "number" || !Number.isInteger(failure.statusCode))))
+		)
+			return false;
 	}
+	return [job.nextAttemptAt, job.lastAttemptAt, job.lastSuccessAt, job.requestedAt, job.attempts].every(
+		(value) =>
+			value === undefined || (typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 8.64e15),
+	);
+}
 
-	const responseText = await response.text().catch(() => "");
-	const responseData = parseResponseObject(responseText);
+function digest(value: string): string {
+	return createHash("sha256").update(value).digest("hex");
+}
+function outboxDir(agentDir = getAgentDir()): string {
+	return join(agentDir, "agent-traces-outbox");
+}
+function jobPath(dir: string, sessionFile: string): string {
+	return join(dir, `${digest(sessionFile).slice(0, 32)}.json`);
+}
+function receiptPath(dir: string, sessionFile: string): string {
+	return join(dir, `.delivered-${digest(sessionFile).slice(0, 32)}`);
+}
+function cancelPath(dir: string, requestId: string): string {
+	return join(dir, `.cancel-${digest(requestId)}`);
+}
+function signature(stats: Stats): TraceFileSignature {
+	return { size: stats.size, mtimeMs: stats.mtimeMs, ino: stats.ino, dev: stats.dev };
+}
+function sameSignature(a: TraceFileSignature | undefined, b: TraceFileSignature): boolean {
+	return !!a && a.size === b.size && a.mtimeMs === b.mtimeMs && a.ino === b.ino && a.dev === b.dev;
+}
+async function readJson<T>(path: string): Promise<T | undefined> {
 	try {
-		await recordAgentTraceOutboxUpload(options.sessionFile, signature);
+		const value: unknown = JSON.parse(await readFile(path, "utf8"));
+		return isRecord(value) ? (value as T) : undefined;
 	} catch (error) {
-		return { status: "failed", message: `stored, but recording the upload cursor failed: ${describeError(error)}` };
+		if ((error as NodeJS.ErrnoException).code === "ENOENT" || error instanceof SyntaxError) return undefined;
+		throw error;
 	}
-	return {
-		status: "uploaded",
-		sessionId: responseData ? (stringField(responseData, "session_id") ?? header.id) : header.id,
-		traceId: responseData ? (stringField(responseData, "trace_id") ?? traceContext.traceId) : traceContext.traceId,
-		bytesStored: responseData ? (numberField(responseData, "bytes_stored") ?? bodyBytes) : bodyBytes,
-		key: responseData ? stringField(responseData, "key") : undefined,
+}
+function ownershipLost(signal?: AbortSignal): boolean {
+	return signal?.reason instanceof Error && signal.reason.message === "ownership_lost";
+}
+async function writeJson(path: string, value: unknown, signal?: AbortSignal): Promise<void> {
+	const temp = `${path}.${process.pid}.${randomUUID()}.tmp`;
+	try {
+		if (ownershipLost(signal)) throw signal?.reason;
+		await writeFile(temp, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+		if (ownershipLost(signal)) throw signal?.reason;
+		await rename(temp, path);
+	} finally {
+		await unlink(temp).catch(() => undefined);
+	}
+}
+
+/** Only the tiny registration is synchronous, so a successful transcript persist has durable intent. */
+function registerTrace(dir: string, sessionFile: string, kind?: string): boolean {
+	const path = jobPath(dir, sessionFile);
+	if (existsSync(path)) return true;
+	const temp = `${path}.${process.pid}.${randomUUID()}.tmp`;
+	try {
+		mkdirSync(dir, { recursive: true, mode: 0o700 });
+		writeFileSync(temp, JSON.stringify({ sessionFile, kind, requestedAt: Date.now(), state: "queued" }), {
+			mode: 0o600,
+		});
+		// An exclusive link cannot overwrite a cursor written by another process.
+		try {
+			linkSync(temp, path);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+		}
+		return true;
+	} catch {
+		return false;
+	} finally {
+		try {
+			unlinkSync(temp);
+		} catch {
+			/* Best effort registration must not interrupt a session. */
+		}
+	}
+}
+
+function registerCancellation(dir: string, requestId: string, signal?: AbortSignal): void {
+	const cancel = () => {
+		try {
+			writeFileSync(cancelPath(dir, requestId), "cancelled\n", { mode: 0o600 });
+		} catch {
+			appendRotatingLog(
+				join(dirname(dir), "logs", "agent-traces.log"),
+				"Trace cancellation could not be recorded. Check agent directory access and retry /traces cancel-all.",
+			);
+		}
 	};
+	if (signal?.aborted) cancel();
+	else signal?.addEventListener("abort", cancel, { once: true });
+}
+
+/** Cancellation is separate from job updates, so an owner cannot overwrite another process's cancellation. */
+export async function cancelAgentTraceRequest(requestId: string, agentDir = getAgentDir()): Promise<void> {
+	const dir = outboxDir(agentDir);
+	await mkdir(dir, { recursive: true, mode: 0o700 });
+	await writeFile(cancelPath(dir, requestId), "cancelled\n", { mode: 0o600 });
+}
+
+/** Explicitly cancel every pending one-shot request in this shared agent directory. */
+export async function cancelPendingAgentTraceRequests(
+	agentDir = getAgentDir(),
+): Promise<{ cancelled: number; failed: number }> {
+	const dir = outboxDir(agentDir);
+	const ids = new Set<string>();
+	for (const name of await readdir(dir).catch(() => [] as string[])) {
+		if (!name.endsWith(".json")) continue;
+		const raw = await readJson<TraceJob | TraceBatch>(join(dir, name)).catch(() => undefined);
+		if (!raw || !validEntry(raw)) continue;
+		if (raw.kind === "trace-batch") {
+			const batch = raw as TraceBatch;
+			if (batch.state === "queued") ids.add(batch.requestId);
+		} else if (raw.kind === undefined) {
+			const job = raw as TraceJob;
+			if (job.manual && !["delivered", "cancelled", "superseded", "failed"].includes(job.state ?? ""))
+				ids.add(job.manual.requestId);
+		}
+	}
+	let cancelled = 0,
+		failed = 0;
+	for (const id of ids) {
+		try {
+			await cancelAgentTraceRequest(id, agentDir);
+			cancelled++;
+		} catch {
+			failed++;
+		}
+	}
+	return { cancelled, failed };
+}
+
+export async function uploadAgentTraceFile(options: AgentTraceUploadOptions): Promise<AgentTraceUploadResult> {
+	if (!options.sessionFile) return { status: "no_session_file" };
+	const dir = outboxDir(options.agentDir);
+	try {
+		const sessionFile = resolve(options.sessionFile);
+		const stats = await stat(sessionFile);
+		if (!stats.isFile()) return { status: "no_session_file" };
+		if (!stats.size) return { status: "empty_session" };
+		const manual = options.requireEnabled === false;
+		if (!manual) {
+			const header = await readSessionHeaderAsync(sessionFile);
+			if (!header || !(await options.settingsManager.readAgentTracesConsent(header.cwd)).enabled)
+				return { status: "disabled" };
+			if (!registerTrace(dir, sessionFile)) throw new Error("queue_unavailable");
+		}
+		const requestId = randomUUID();
+		if (manual) {
+			await mkdir(dir, { recursive: true, mode: 0o700 });
+			registerCancellation(dir, requestId, options.signal);
+			await writeJson(join(dir, `manual-${requestId}.json`), {
+				sessionFile,
+				state: "queued",
+				requestedAt: Date.now(),
+				manual: { requestId, expected: signature(stats) },
+			} satisfies TraceJob);
+		}
+		getDeliveryQueue(options).start();
+		return { status: "queued", requestId };
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return { status: "no_session_file" };
+		return { status: "failed", message: "Could not save the trace request. Check access to the agent directory." };
+	}
 }
 
 export function uploadAgentTraceSession(options: AgentTraceSessionUploadOptions): Promise<AgentTraceUploadResult> {
-	return uploadAgentTraceFile({
-		...options,
-		sessionFile: options.sessionManager.getSessionFile(),
-	});
+	return uploadAgentTraceFile({ ...options, sessionFile: options.sessionManager.getSessionFile() });
 }
 
-class AgentTraceUploadController {
-	private timeout: NodeJS.Timeout | undefined;
-	private pending = false;
-	private inFlight: Promise<void> | undefined;
-	private lastUploadStartedAt: number | undefined;
-	private notBeforeAt = 0;
+/** Persist the request before discovery; neither scanning nor delivery runs on the command's critical path. */
+export async function uploadAllAgentTraces(options: AgentTraceUploadAllOptions): Promise<AgentTraceUploadAllResult> {
+	const dir = outboxDir(options.agentDir);
+	const requestId = randomUUID();
+	try {
+		await mkdir(dir, { recursive: true, mode: 0o700 });
+		registerCancellation(dir, requestId, options.signal);
+		await writeJson(join(dir, `batch-${requestId}.json`), {
+			kind: "trace-batch",
+			requestId,
+			sessionDir: resolve(options.sessionDir ?? getSessionsDir()),
+			requestedAt: Date.now(),
+			manual: options.requireEnabled === false,
+			state: "queued",
+		} satisfies TraceBatch);
+		getDeliveryQueue(options).start();
+		return { status: "queued", requestId };
+	} catch {
+		return { status: "failed", message: "Could not save the trace request. Check access to the agent directory." };
+	}
+}
 
-	constructor(
-		private readonly sessionManager: SessionManager,
-		private options: AgentTraceUploadInstallOptions,
-	) {}
+async function readSessionHeaderAsync(path: string): Promise<SessionHeader | undefined> {
+	try {
+		const file = await open(path, "r");
+		try {
+			const bytes = Buffer.alloc(65_536);
+			const { bytesRead } = await file.read(bytes, 0, bytes.length, 0);
+			const firstLine = bytes.subarray(0, bytesRead).toString("utf8").split("\n", 1)[0];
+			const parsed: unknown = JSON.parse(firstLine ?? "");
+			return isSessionHeader(parsed) ? parsed : undefined;
+		} finally {
+			await file.close();
+		}
+	} catch {
+		return undefined;
+	}
+}
 
+function retryAt(attempt: number, response?: Response): number {
+	const exponential = Math.min(RETRY_MAX_MS, 1_000 * 2 ** Math.min(attempt - 1, 20));
+	const backoff = Math.min(RETRY_MAX_MS, Math.round(exponential * (0.8 + Math.random() * 0.4)));
+	const value = response?.headers.get("retry-after");
+	const seconds = value?.trim() ? Number(value) : Number.NaN;
+	const serverAt = Number.isFinite(seconds) && seconds >= 0 ? Date.now() + seconds * 1_000 : Date.parse(value ?? "");
+	return Math.min(8.64e15, Math.max(Date.now() + backoff, Number.isFinite(serverAt) ? serverAt : 0));
+}
+
+function logFailure(job: TraceJob, previous: DeliveryFailure | undefined, agentDir: string): void {
+	if (!job.failure || (previous?.reason === job.failure.reason && previous?.statusCode === job.failure.statusCode))
+		return;
+	// Do not persist arbitrary server/exception messages: either can contain credentials or payload fragments.
+	appendRotatingLog(
+		join(agentDir, "logs", "agent-traces.log"),
+		`[${new Date().toISOString()}] Trace delivery: ${job.failure.reason}${job.failure.statusCode ? ` (HTTP ${job.failure.statusCode})` : ""}. Run /traces status.\n`,
+	);
+}
+
+export class AgentTraceDeliveryQueue {
+	private timer?: NodeJS.Timeout;
+	private running?: Promise<void>;
+	private controller?: AbortController;
+	private stopped = false;
+	readonly agentDir: string;
+	private readonly dir: string;
+	constructor(private options: AgentTraceUploadInstallOptions) {
+		this.agentDir = resolve(options.agentDir ?? getAgentDir());
+		this.dir = outboxDir(this.agentDir);
+	}
+	private writeJson(path: string, value: unknown): Promise<void> {
+		return writeJson(path, value, this.controller?.signal);
+	}
 	update(options: AgentTraceUploadInstallOptions): void {
 		this.options = options;
 	}
-
-	schedule = (): void => {
-		this.pending = true;
-		// Intent is consent-gated at persist time: an entry created while sharing
-		// is off would turn a later enable into retroactive collection of
-		// opted-out sessions. Marking re-runs every persist (existsSync-cheap),
-		// so an entry pruned by a racing catch-up is re-registered.
-		if (this.options.settingsManager.getAgentTracesEnabled()) {
-			const sessionFile = this.sessionManager.getSessionFile();
-			if (
-				sessionFile &&
-				!locallyManagedSessionFiles.has(sessionFile) &&
-				markAgentTraceOutboxPendingSync(sessionFile)
-			) {
-				locallyManagedSessionFiles.add(sessionFile);
-			}
-			const ledgerPath = this.options.semanticEdgesLedgerPath;
-			if (ledgerPath) {
-				markAgentTraceOutboxPendingSync(ledgerPath, SEMANTIC_EDGES_OUTBOX_KIND);
-			}
-		}
-		this.arm();
-	};
-
-	private arm(): void {
-		if (this.timeout) {
-			clearTimeout(this.timeout);
-		}
-		const elapsed = this.lastUploadStartedAt === undefined ? undefined : Date.now() - this.lastUploadStartedAt;
-		const throttleDelay = elapsed === undefined ? 0 : Math.max(0, TRACE_UPLOAD_MIN_INTERVAL_MS - elapsed);
-		const notBeforeDelay = Math.max(0, this.notBeforeAt - Date.now());
-		this.timeout = setTimeout(
-			() => {
-				this.timeout = undefined;
-				void this.runScheduledUpload();
-			},
-			Math.max(TRACE_UPLOAD_DEBOUNCE_MS, throttleDelay, notBeforeDelay),
-		);
-		this.timeout.unref();
+	start(): void {
+		if (this.timer || this.running) return;
+		this.stopped = false;
+		this.timer = setTimeout(() => {
+			this.timer = undefined;
+			void this.runOnce()
+				.catch(() => undefined)
+				.finally(() => {
+					if (!this.stopped) this.start();
+				});
+		}, 1_000);
+		this.timer.unref();
 	}
-
-	private async runScheduledUpload(): Promise<void> {
-		if (this.inFlight) {
+	stop(): void {
+		this.stopped = true;
+		clearTimeout(this.timer);
+		this.timer = undefined;
+		this.controller?.abort(new Error("stopped"));
+	}
+	runOnce(): Promise<void> {
+		if (this.running) return this.running;
+		this.running = this.drainOne().finally(() => {
+			this.running = undefined;
+		});
+		return this.running;
+	}
+	private async drainOne(): Promise<void> {
+		await mkdir(this.dir, { recursive: true, mode: 0o700 });
+		const controller = new AbortController();
+		this.controller = controller;
+		let release: () => Promise<void>;
+		try {
+			release = await lockfile.lock(join(this.dir, ".delivery"), {
+				realpath: false,
+				retries: 0,
+				stale: LEASE_STALE_MS,
+				update: 5_000,
+				onCompromised: () => controller.abort(new Error("ownership_lost")),
+			});
+		} catch {
 			return;
 		}
-		this.pending = false;
-		this.lastUploadStartedAt = Date.now();
-		this.inFlight = uploadAgentTraceSession({
-			...this.options,
-			sessionManager: this.sessionManager,
-		}).then(
-			(result) => {
-				if (result.status === "failed" && isRescheduledUploadFailure(result.statusCode)) {
-					this.pending = true;
-					if (result.retryAfterMs !== undefined) {
-						this.notBeforeAt = Date.now() + result.retryAfterMs;
-					}
+		try {
+			const coordinatorPath = join(this.dir, ".delivery-state");
+			const coordinator = (await readJson<DeliveryCoordinator>(coordinatorPath)) ?? {};
+			const entries: { path: string; raw: TraceJob | TraceBatch }[] = [];
+			for (const name of await readdir(this.dir)) {
+				if (!name.endsWith(".json")) continue;
+				const path = join(this.dir, name);
+				try {
+					const raw = await readJson<TraceJob | TraceBatch>(path);
+					if (raw && validEntry(raw)) entries.push({ path, raw });
+					else await unlink(path).catch(() => undefined);
+				} catch {
+					/* A broken entry does not block the rest of the queue. */
 				}
-			},
-			() => undefined,
-		);
-		await this.inFlight;
-		this.inFlight = undefined;
-		if (this.pending) {
-			this.arm();
+			}
+			const age = (raw: TraceJob | TraceBatch) =>
+				("lastAttemptAt" in raw ? raw.lastAttemptAt : undefined) ?? raw.requestedAt ?? 0;
+			entries.sort(
+				(a, b) => age(a.raw) - age(b.raw) || Number("lastAttemptAt" in a.raw) - Number("lastAttemptAt" in b.raw),
+			);
+			for (const { path, raw } of entries) {
+				if (controller.signal.aborted) return;
+				if (raw.kind === "trace-batch") {
+					try {
+						await this.expandBatch(path, raw as TraceBatch, controller.signal);
+					} catch {
+						/* Retry this batch without blocking other entries. */
+					}
+					continue;
+				}
+				const job = raw as TraceJob;
+				if (typeof job.sessionFile !== "string") continue;
+				if (job.kind !== undefined) {
+					// Semantic-edge and future delivery kinds have separate protocols; preserve their data and cursors.
+					if (job.kind === SEMANTIC_EDGES_OUTBOX_KIND) {
+						try {
+							if (!(await stat(job.sessionFile)).isFile()) await unlink(path);
+						} catch (error) {
+							if ((error as NodeJS.ErrnoException).code === "ENOENT") await unlink(path).catch(() => undefined);
+						}
+					}
+					continue;
+				}
+				try {
+					if (await this.deliver(path, job, coordinator, controller)) {
+						coordinator.activeJob = undefined;
+						await this.writeJson(coordinatorPath, coordinator);
+						return;
+					}
+				} catch {
+					/* A corrupt/unwritable entry must not starve healthy sessions. */
+				}
+			}
+		} finally {
+			this.controller = undefined;
+			await release().catch(() => undefined);
 		}
 	}
-}
-
-function isRescheduledUploadFailure(statusCode: number | undefined): boolean {
-	return statusCode === undefined || statusCode === 429 || RETRIABLE_HTTP_STATUSES.has(statusCode);
-}
-
-const traceUploadControllers = new WeakMap<SessionManager, AgentTraceUploadController>();
-let catchUpTriggered = false;
-
-export function installAgentTraceUpload(sessionManager: SessionManager, options: AgentTraceUploadInstallOptions): void {
-	if (!catchUpTriggered) {
-		catchUpTriggered = true;
-		void catchUpAgentTraceUploads(options).catch(() => undefined);
+	private async expandBatch(path: string, batch: TraceBatch, signal: AbortSignal): Promise<void> {
+		if (batch.state !== "queued") return;
+		if (existsSync(cancelPath(this.dir, batch.requestId))) {
+			batch.state = "cancelled";
+			await this.writeJson(path, batch);
+			return;
+		}
+		const files = await findAgentTraceFiles(batch.sessionDir);
+		for (const sessionFile of files) {
+			if (signal.aborted || existsSync(cancelPath(this.dir, batch.requestId))) return;
+			const stats = await stat(sessionFile).catch(() => undefined);
+			// A bulk request authorizes only files/versions already present when requested, including after restart.
+			if (!stats || Math.max(stats.mtimeMs, stats.ctimeMs, stats.birthtimeMs) > batch.requestedAt) continue;
+			if (!batch.manual) {
+				const header = await readSessionHeaderAsync(sessionFile);
+				if (header && (await this.options.settingsManager.readAgentTracesConsent(header.cwd)).enabled)
+					registerTrace(this.dir, sessionFile);
+				continue;
+			}
+			const childPath = join(this.dir, `manual-${batch.requestId}-${digest(sessionFile).slice(0, 32)}.json`);
+			if (existsSync(childPath)) continue;
+			await this.writeJson(childPath, {
+				sessionFile,
+				state: "queued",
+				requestedAt: batch.requestedAt,
+				manual: { requestId: batch.requestId, expected: signature(stats) },
+			} satisfies TraceJob);
+		}
+		batch.state = "delivered"; // Discovery complete; child entries retain their individual delivery states.
+		await this.writeJson(path, batch);
 	}
-	let controller = traceUploadControllers.get(sessionManager);
-	if (controller) {
-		controller.update(options);
+	private async deliver(
+		path: string,
+		job: TraceJob,
+		coordinator: DeliveryCoordinator,
+		controller: AbortController,
+	): Promise<boolean> {
+		if (job.manual && ["delivered", "cancelled", "superseded", "failed"].includes(job.state ?? "")) return false;
+		if (job.manual && existsSync(cancelPath(this.dir, job.manual.requestId))) {
+			job.state = "cancelled";
+			await this.writeJson(path, job);
+			await unlink(`${path}.payload`).catch(() => undefined);
+			return false;
+		}
+		let current: TraceFileSignature;
+		if (job.manual?.snapshotReady) current = job.manual.expected;
+		else {
+			const stats = await stat(job.sessionFile).catch(() => undefined);
+			if (!stats?.isFile()) {
+				if (!job.manual) {
+					await unlink(path).catch(() => undefined);
+					return false;
+				}
+				job.state = "failed";
+				job.failure = { reason: "no_session_file", at: Date.now() };
+				await this.writeJson(path, job);
+				return false;
+			}
+			current = signature(stats);
+		}
+		if (
+			!job.manual &&
+			(job.uploaded
+				? sameSignature(job.uploaded, current)
+				: job.size === current.size && job.mtimeMs === current.mtimeMs)
+		)
+			return false;
+		if (!job.manual && job.attempted && !sameSignature(job.attempted, current) && job.state === "failed") {
+			job.state = "queued";
+			job.attempts = 0;
+			job.nextAttemptAt = undefined;
+		}
+		const header = job.manual?.snapshotReady ? undefined : await readSessionHeaderAsync(job.sessionFile);
+		if (!job.manual) {
+			const consent = header ? await this.options.settingsManager.readAgentTracesConsent(header.cwd) : undefined;
+			if (!consent?.enabled) {
+				const reason = consent?.reason ?? "settings_unavailable";
+				if (job.state !== "paused" || job.pauseReason !== reason) {
+					job.state = "paused";
+					job.pauseReason = reason;
+					await this.writeJson(path, job);
+				}
+				return false;
+			}
+		}
+		if ((job.nextAttemptAt ?? 0) > Date.now() || (coordinator.nextRequestAt ?? 0) > Date.now()) return false;
+		if (!job.manual && (job.lastAttemptAt ?? 0) + SESSION_INTERVAL_MS > Date.now()) return false;
+		const endpoint = resolvePrimeAgentTracesBaseUrl(this.options.baseUrl);
+		const endpointFingerprint = digest(endpoint);
+		try {
+			const url = new URL(endpoint);
+			if (!["http:", "https:"].includes(url.protocol) || url.username || url.password)
+				throw new Error("invalid_endpoint");
+		} catch {
+			if (job.failure?.reason !== "invalid_endpoint" || job.endpointFingerprint !== endpointFingerprint) {
+				job.state = "failed";
+				job.endpointFingerprint = endpointFingerprint;
+				job.failure = { reason: "invalid_endpoint", at: Date.now() };
+				await this.writeJson(path, job);
+			}
+			return false;
+		}
+		if (job.state === "failed" && job.endpointFingerprint === endpointFingerprint) return false;
+		job.attempted = current;
+		const previousFailure = job.failure;
+		const credential = await getPrimeAgentTraceCredential(this.options.authStorage, {
+			configPath: this.options.configPath,
+			signal: controller.signal,
+		}).catch(() => undefined);
+		if (controller.signal.aborted) return false;
+		const fingerprint = credential ? digest(credential.apiKey) : undefined;
+		if (
+			!credential ||
+			(coordinator.invalidCredential === fingerprint && coordinator.endpointFingerprint === endpointFingerprint)
+		) {
+			const reason = credential ? "credentials" : "missing_credentials";
+			if (job.state !== "paused" || job.pauseReason !== reason) {
+				job.state = "paused";
+				job.pauseReason = reason;
+				job.failure = { reason, at: Date.now() };
+				await this.writeJson(path, job);
+				logFailure(job, previousFailure, this.agentDir);
+			}
+			return false;
+		}
+		job.endpointFingerprint = endpointFingerprint;
+		job.credentialFingerprint = fingerprint;
+		let authorizationCwd = header?.cwd;
+		let revoked = false;
+		let cancelled = false;
+		const checkAuthorization = async () => {
+			if (job.manual) {
+				cancelled = existsSync(cancelPath(this.dir, job.manual.requestId));
+				if (cancelled) controller.abort(new Error("cancelled"));
+			} else {
+				const consent = authorizationCwd
+					? await this.options.settingsManager.readAgentTracesConsent(authorizationCwd)
+					: undefined;
+				if (!consent?.enabled) {
+					revoked = true;
+					job.pauseReason = consent?.reason ?? "settings_unavailable";
+					controller.abort(new Error("revoked"));
+				}
+			}
+		};
+		await checkAuthorization();
+		if (controller.signal.aborted) return false;
+		let checking = false;
+		const monitor = setInterval(() => {
+			if (checking) return;
+			checking = true;
+			void checkAuthorization()
+				.catch(() => {
+					revoked = true;
+					controller.abort(new Error("consent_unavailable"));
+				})
+				.finally(() => {
+					checking = false;
+				});
+		}, 250);
+		monitor.unref();
+		let timeout: NodeJS.Timeout | undefined;
+		let timedOut = false;
+		let sent = false;
+		try {
+			job.attempts = (job.attempts ?? 0) + 1;
+			job.lastAttemptAt = Date.now();
+			await this.writeJson(path, job);
+			const payload = await prepareTracePayload({
+				sessionFile: job.sessionFile,
+				expected: job.manual?.expected,
+				snapshotPath: job.manual ? `${path}.payload` : undefined,
+				snapshotReady: job.manual?.snapshotReady,
+				signal: controller.signal,
+			});
+			if (job.manual) job.manual.snapshotReady = true;
+			job.attempted = payload.signature;
+			const receipt = await readJson<DeliveryReceipt>(receiptPath(this.dir, job.sessionFile));
+			if (
+				job.manual &&
+				receipt &&
+				receipt.requestedAt >= (job.requestedAt ?? 0) &&
+				!sameSignature(receipt.signature, payload.signature)
+			) {
+				job.state = "superseded";
+				await this.writeJson(path, job);
+				await unlink(`${path}.payload`).catch(() => undefined);
+				return false;
+			}
+			// Use the prepared project's consent for all later checks, including the in-flight monitor.
+			authorizationCwd = payload.cwd;
+			await checkAuthorization();
+			controller.signal.throwIfAborted();
+			job.state = "uploading";
+			job.pauseReason = undefined;
+			coordinator.nextRequestAt = Date.now() + REQUEST_INTERVAL_MS;
+			coordinator.activeJob = basename(path);
+			// Reserve the shared rate slot durably before dispatch, including when the process crashes.
+			await this.writeJson(join(this.dir, ".delivery-state"), coordinator);
+			await this.writeJson(path, job);
+			await checkAuthorization();
+			controller.signal.throwIfAborted();
+			timeout = setTimeout(() => {
+				timedOut = true;
+				controller.abort(new Error("timeout"));
+			}, this.options.requestTimeoutMs ?? 15_000);
+			timeout.unref();
+			sent = true;
+			const response = await (this.options.fetchFn ?? fetch)(
+				`${endpoint}/api/v1/agent-traces/sessions/${encodeURIComponent(payload.sessionId)}`,
+				{
+					method: "PUT",
+					headers: payloadHeaders(payload, credential.apiKey),
+					body: payload.body,
+					signal: controller.signal,
+				},
+			);
+			controller.signal.throwIfAborted();
+			// Delivery requires a successful response, not arbitrary server response content. Never log its body.
+			void response.body?.cancel().catch(() => undefined);
+			if (response.ok) {
+				const deliveredAt = Date.now();
+				await this.writeJson(receiptPath(this.dir, job.sessionFile), {
+					signature: payload.signature,
+					requestedAt: job.manual ? (job.requestedAt ?? deliveredAt) : deliveredAt,
+					deliveredAt,
+				} satisfies DeliveryReceipt);
+				job.uploaded = payload.signature;
+				job.size = payload.signature.size;
+				job.mtimeMs = payload.signature.mtimeMs;
+				job.state = "delivered";
+				job.lastSuccessAt = deliveredAt;
+				job.failure = undefined;
+				job.attempts = 0;
+				job.nextAttemptAt = undefined;
+				coordinator.invalidCredential = undefined;
+			} else {
+				const invalid = response.status === 401 || response.status === 403;
+				job.failure = { reason: invalid ? "credentials" : "http", at: Date.now(), statusCode: response.status };
+				if (invalid) {
+					coordinator.invalidCredential = fingerprint;
+					coordinator.endpointFingerprint = endpointFingerprint;
+					job.state = "paused";
+					job.pauseReason = "credentials";
+				} else if (RETRIABLE_HTTP_STATUSES.has(response.status)) {
+					job.state = "retrying";
+					job.nextAttemptAt = retryAt(job.attempts, response);
+					// Server-wide overload/rate limits apply to every producer, not just this session.
+					coordinator.nextRequestAt = Math.max(coordinator.nextRequestAt ?? 0, job.nextAttemptAt);
+				} else {
+					job.state = "failed";
+				}
+			}
+		} catch (error) {
+			if (cancelled) job.state = "cancelled";
+			else if (revoked) job.state = "paused";
+			else if (controller.signal.aborted && !timedOut) job.state = "queued";
+			else {
+				const code = error instanceof Error ? error.message : "preparation_failed";
+				const permanent = [
+					"snapshot_changed",
+					"invalid_session",
+					"too_large",
+					"empty_session",
+					"no_session_file",
+				].includes(code);
+				job.failure = {
+					reason: timedOut
+						? "timeout"
+						: sent
+							? "network"
+							: permanent
+								? (code as TraceFailure)
+								: "preparation_failed",
+					at: Date.now(),
+				};
+				job.state =
+					permanent && job.manual ? "failed" : permanent && code !== "snapshot_changed" ? "failed" : "retrying";
+				job.nextAttemptAt = retryAt(Math.max(1, job.attempts ?? 1));
+			}
+		} finally {
+			clearInterval(monitor);
+			clearTimeout(timeout);
+		}
+		// A compromised owner must not clobber the replacement owner's progress.
+		if (controller.signal.reason instanceof Error && controller.signal.reason.message === "ownership_lost")
+			return false;
+		if (job.failure) job.lastFailure = job.failure;
+		await this.writeJson(path, job);
+		logFailure(job, previousFailure, this.agentDir);
+		if (job.manual && ["delivered", "cancelled", "superseded", "failed"].includes(job.state ?? ""))
+			await unlink(`${path}.payload`).catch(() => undefined);
+		return sent;
+	}
+}
+
+function payloadHeaders(payload: TracePayload, apiKey: string): Record<string, string> {
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${apiKey}`,
+		"Content-Type": "application/x-ndjson",
+		Accept: "application/json",
+		"X-Trace-Id": payload.traceId,
+		"X-Cwd": payload.cwd,
+		"X-Agent-Version": VERSION,
+	};
+	if (payload.parentSessionId) headers["X-Parent-Session"] = payload.parentSessionId;
+	if (payload.gitRepo) headers["X-Git-Repo"] = payload.gitRepo;
+	if (payload.gitCommit) headers["X-Git-Commit"] = payload.gitCommit;
+	return headers;
+}
+
+const deliveryQueues = new Map<string, AgentTraceDeliveryQueue>();
+function getDeliveryQueue(options: AgentTraceUploadInstallOptions): AgentTraceDeliveryQueue {
+	const key = resolve(options.agentDir ?? getAgentDir());
+	let queue = deliveryQueues.get(key);
+	if (!queue) {
+		queue = new AgentTraceDeliveryQueue(options);
+		deliveryQueues.set(key, queue);
+	} else queue.update(options);
+	return queue;
+}
+
+/** Stops local timers and requests immediately; pending work remains durable for another process. */
+export function stopAgentTraceUploads(agentDir = getAgentDir()): void {
+	const key = resolve(agentDir);
+	deliveryQueues.get(key)?.stop();
+	deliveryQueues.delete(key);
+}
+
+export function catchUpAgentTraceUploads(options: AgentTraceUploadInstallOptions): void {
+	getDeliveryQueue(options).start();
+}
+const controllers = new WeakMap<SessionManager, { options: AgentTraceUploadInstallOptions }>();
+export function installAgentTraceUpload(sessionManager: SessionManager, options: AgentTraceUploadInstallOptions): void {
+	catchUpAgentTraceUploads(options);
+	const existing = controllers.get(sessionManager);
+	if (existing) {
+		existing.options = options;
 		return;
 	}
+	const controller = { options };
+	controllers.set(sessionManager, controller);
+	sessionManager.onPersist(() => {
+		const current = controller.options;
+		if (!current.settingsManager.readAgentTracesConsentSync(sessionManager.getCwd()).enabled) return;
+		const sessionFile = sessionManager.getSessionFile();
+		if (!sessionFile) return;
+		const dir = outboxDir(current.agentDir);
+		registerTrace(dir, sessionFile);
+		if (current.semanticEdgesLedgerPath)
+			registerTrace(dir, current.semanticEdgesLedgerPath, SEMANTIC_EDGES_OUTBOX_KIND);
+		getDeliveryQueue(current).start();
+	});
+}
 
-	controller = new AgentTraceUploadController(sessionManager, options);
-	traceUploadControllers.set(sessionManager, controller);
-	sessionManager.onPersist(controller.schedule);
+export interface AgentTraceStatus {
+	sessionFile: string;
+	credentialSource: string;
+	consent: AgentTraceConsent;
+	endpoint: string;
+	pending: number;
+	inProgress: number;
+	paused: number;
+	failed: number;
+	discovering: number;
+	currentSession: string;
+	lastSuccessAt?: number;
+	lastFailure?: DeliveryFailure;
+	nextAttemptAt?: number;
+	pauseReasons: string[];
+}
+
+function safeEndpoint(baseUrl?: string): string {
+	try {
+		const url = new URL(resolvePrimeAgentTracesBaseUrl(baseUrl));
+		return `${url.origin}${url.pathname === "/" ? "" : url.pathname}`;
+	} catch {
+		return "Invalid endpoint; check PRIME_AGENT_TRACES_BASE_URL";
+	}
+}
+
+async function inspectTraceCredential(authStorage: AuthStorage | undefined, configPath?: string): Promise<string> {
+	if (stringEnv("PRIME_AGENT_TRACES_API_KEY")) return "PRIME_AGENT_TRACES_API_KEY";
+	if (authStorage && (await authStorage.readApiKeyConfig(PRIME_AGENT_TRACES_PROVIDER_ID)))
+		return "Prime Agent Traces credential";
+	if (stringEnv("PRIME_API_KEY")) return "PRIME_API_KEY";
+	if (authStorage && (await authStorage.readApiKeyConfig(PRIME_INFERENCE_PROVIDER_ID)))
+		return "Prime Inference credential";
+	const config = await readJson<{ api_key?: string }>(
+		getPrimeCliConfigPath(configPath ?? authStorage?.getPrimeCliConfigPath()),
+	);
+	return typeof config?.api_key === "string" && config.api_key.trim() ? "Prime CLI credential" : "Not configured";
+}
+
+/** Read-only: never starts delivery, takes a write lock, resolves a credential, or makes a request. */
+export async function readAgentTraceStatus(options: {
+	settingsManager: SettingsManager;
+	authStorage?: AuthStorage;
+	configPath?: string;
+	sessionFile?: string;
+	cwd?: string;
+	agentDir?: string;
+	baseUrl?: string;
+}): Promise<AgentTraceStatus> {
+	const dir = outboxDir(options.agentDir);
+	const header = options.sessionFile ? await readSessionHeaderAsync(options.sessionFile) : undefined;
+	const consent = await options.settingsManager.readAgentTracesConsent(header?.cwd ?? options.cwd ?? process.cwd());
+	const result: AgentTraceStatus = {
+		sessionFile: options.sessionFile ?? "In-memory",
+		credentialSource: await inspectTraceCredential(options.authStorage, options.configPath).catch(
+			() => "Unavailable",
+		),
+		consent,
+		endpoint: safeEndpoint(options.baseUrl),
+		pending: 0,
+		inProgress: 0,
+		paused: 0,
+		failed: 0,
+		discovering: 0,
+		currentSession: options.sessionFile ? "Not queued" : "No persisted trace",
+		pauseReasons: [],
+	};
+	const names = await readdir(dir).catch(() => [] as string[]);
+	const coordinator = await readJson<DeliveryCoordinator>(join(dir, ".delivery-state")).catch(() => undefined);
+	const owned = await lockfile
+		.check(join(dir, ".delivery"), { realpath: false, stale: LEASE_STALE_MS })
+		.catch(() => false);
+	const currentStates: string[] = [];
+	for (const name of names) {
+		if (!name.endsWith(".json")) continue;
+		const path = join(dir, name);
+		const raw = await readJson<TraceJob | TraceBatch>(path).catch(() => undefined);
+		if (!raw || !validEntry(raw)) continue;
+		if (raw.kind === "trace-batch") {
+			if (raw.state === "queued") result.discovering += 1;
+			continue;
+		}
+		const job = raw as TraceJob;
+		if (job.kind !== undefined || typeof job.sessionFile !== "string") continue;
+		const stats = await stat(job.sessionFile).catch(() => undefined);
+		if (!stats && !job.manual) continue;
+		let state = job.state ?? "queued";
+		if (job.manual && existsSync(cancelPath(dir, job.manual.requestId)) && state !== "delivered") state = "cancelled";
+		if (!job.manual && stats) {
+			if (
+				job.uploaded
+					? sameSignature(job.uploaded, signature(stats))
+					: job.size === stats.size && job.mtimeMs === stats.mtimeMs
+			)
+				state = "delivered";
+			else {
+				const ownHeader = await readSessionHeaderAsync(job.sessionFile);
+				const ownConsent = ownHeader
+					? await options.settingsManager.readAgentTracesConsent(ownHeader.cwd)
+					: undefined;
+				if (!ownConsent?.enabled) {
+					state = "paused";
+					job.pauseReason = ownConsent?.reason ?? "settings_unavailable";
+				} else if (state === "delivered") state = "queued";
+				else if (
+					state === "paused" &&
+					job.pauseReason &&
+					!["credentials", "missing_credentials"].includes(job.pauseReason)
+				)
+					state = "queued";
+			}
+		}
+		if (state === "uploading" && (!owned || coordinator?.activeJob !== name)) state = "queued";
+		if (state === "uploading") result.inProgress += 1;
+		if (state === "queued" || state === "retrying") result.pending += 1;
+		if (state === "paused") result.paused += 1;
+		if (state === "failed") result.failed += 1;
+		if (state === "paused" && job.pauseReason && !result.pauseReasons.includes(job.pauseReason))
+			result.pauseReasons.push(job.pauseReason);
+		if (job.lastSuccessAt && job.lastSuccessAt > (result.lastSuccessAt ?? 0))
+			result.lastSuccessAt = job.lastSuccessAt;
+		const failure = job.failure ?? job.lastFailure;
+		if (failure && failure.at > (result.lastFailure?.at ?? 0)) result.lastFailure = failure;
+		if (state === "queued" || state === "retrying") {
+			const next = Math.max(
+				job.nextAttemptAt ?? 0,
+				coordinator?.nextRequestAt ?? 0,
+				job.manual ? 0 : (job.lastAttemptAt ?? 0) + SESSION_INTERVAL_MS,
+			);
+			if (next > Date.now()) result.nextAttemptAt = Math.min(result.nextAttemptAt ?? Number.POSITIVE_INFINITY, next);
+		}
+		if (options.sessionFile && resolve(job.sessionFile) === resolve(options.sessionFile)) {
+			const newer = job.manual && stats && !sameSignature(job.manual.expected, signature(stats));
+			currentStates.push(
+				`${state}${job.manual ? ` (one-shot${newer ? "; current file has newer or changed content" : ""})` : ""}`,
+			);
+		}
+	}
+	if (currentStates.length) result.currentSession = [...new Set(currentStates)].join(", ");
+	return result;
+}
+
+const CONSENT_MESSAGES: Record<AgentTraceConsent["reason"], string> = {
+	enabled: "Enabled",
+	global_off: "Disabled by global setting (default off)",
+	project_off: "Disabled by this project's setting",
+	runtime_off: "Disabled by the runtime setting",
+	settings_unavailable: "Paused: settings unavailable or invalid",
+};
+const FAILURE_MESSAGES: Record<TraceFailure, string> = {
+	invalid_endpoint: "Invalid endpoint; check PRIME_AGENT_TRACES_BASE_URL",
+	network: "Network request failed",
+	timeout: "Request timed out",
+	credentials: "Credential rejected; run /traces login",
+	missing_credentials: "No credential configured; run /traces login",
+	http: "Server rejected the request; check endpoint and permissions",
+	snapshot_changed:
+		"Requested file changed before capture; run /traces upload-current again to authorize its current content",
+	invalid_session: "Invalid session header",
+	too_large: "Trace exceeds the 20 MiB limit",
+	empty_session: "Empty trace",
+	no_session_file: "Requested file is no longer available",
+	preparation_failed: "Could not prepare trace",
+	settings_unavailable: "Settings unavailable; delivery paused",
+};
+export function formatAgentTraceStatus(status: AgentTraceStatus): string {
+	const date = (value?: number) => (value === undefined ? "None" : new Date(value).toISOString());
+	return [
+		"Trace Sharing",
+		"",
+		`Automatic uploads: ${CONSENT_MESSAGES[status.consent.reason]}`,
+		`Queue: ${status.pending} pending, ${status.inProgress} in progress, ${status.paused} paused, ${status.failed} failed`,
+		`Bulk requests awaiting discovery: ${status.discovering}`,
+		`Current session: ${status.currentSession}`,
+		`Last successful delivery: ${date(status.lastSuccessAt)}`,
+		`Last failure: ${status.lastFailure ? `${FAILURE_MESSAGES[status.lastFailure.reason] ?? "Delivery failed"}${status.lastFailure.statusCode ? ` (HTTP ${status.lastFailure.statusCode})` : ""} at ${date(status.lastFailure.at)}` : "None"}`,
+		`Next eligible retry: ${date(status.nextAttemptAt)}`,
+		`Paused: ${status.pauseReasons.map((reason) => CONSENT_MESSAGES[reason as AgentTraceConsent["reason"]] ?? FAILURE_MESSAGES[reason as TraceFailure] ?? "Delivery paused").join("; ") || "No"}`,
+		`Credential: ${status.credentialSource}`,
+		`Endpoint: ${status.endpoint}`,
+		`Session file: ${status.sessionFile}`,
+		"",
+		"Commands: /traces on, /traces off, /traces preview, /traces upload-current, /traces upload-all, /traces cancel, /traces cancel-all, /traces login",
+	].join("\n");
 }

--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -912,7 +912,10 @@ export class AgentTraceDeliveryQueue {
 		let fingerprint: string | undefined;
 		if (credential) {
 			// Persist the salt with the shared rate state so replacement owners recognize rejected keys.
-			coordinator.credentialSalt ??= randomBytes(32).toString("hex");
+			if (typeof coordinator.credentialSalt !== "string" || !/^[a-f0-9]{64}$/.test(coordinator.credentialSalt)) {
+				coordinator.credentialSalt = randomBytes(32).toString("hex");
+				coordinator.invalidCredential = undefined;
+			}
 			fingerprint = await fingerprintCredential(credential.apiKey, coordinator.credentialSalt);
 		}
 		if (controller.signal.aborted) return false;

--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "node:crypto";
+import { createHash, randomBytes, randomUUID, scrypt } from "node:crypto";
 import { type Dirent, existsSync, linkSync, mkdirSync, type Stats, unlinkSync, writeFileSync } from "node:fs";
 import { mkdir, open, readdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
@@ -379,6 +379,7 @@ interface TraceBatch {
 interface DeliveryCoordinator {
 	activeJob?: string;
 	nextRequestAt?: number;
+	credentialSalt?: string;
 	invalidCredential?: string;
 	endpointFingerprint?: string;
 }
@@ -452,6 +453,14 @@ function validEntry(value: TraceJob | TraceBatch): boolean {
 
 function digest(value: string): string {
 	return createHash("sha256").update(value).digest("hex");
+}
+function fingerprintCredential(apiKey: string, salt: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		scrypt(apiKey, salt, 32, (error, key) => {
+			if (error) reject(error);
+			else resolve(key.toString("hex"));
+		});
+	});
 }
 function outboxDir(agentDir = getAgentDir()): string {
 	return join(agentDir, "agent-traces-outbox");
@@ -900,7 +909,13 @@ export class AgentTraceDeliveryQueue {
 			signal: controller.signal,
 		}).catch(() => undefined);
 		if (controller.signal.aborted) return false;
-		const fingerprint = credential ? digest(credential.apiKey) : undefined;
+		let fingerprint: string | undefined;
+		if (credential) {
+			// Persist the salt with the shared rate state so replacement owners recognize rejected keys.
+			coordinator.credentialSalt ??= randomBytes(32).toString("hex");
+			fingerprint = await fingerprintCredential(credential.apiKey, coordinator.credentialSalt);
+		}
+		if (controller.signal.aborted) return false;
 		if (
 			!credential ||
 			(coordinator.invalidCredential === fingerprint && coordinator.endpointFingerprint === endpointFingerprint)

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -7,6 +7,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import {
 	findEnvKeys,
 	getEnvApiKey,
@@ -108,6 +109,15 @@ export interface AuthStorageBackend {
 
 export class FileAuthStorageBackend implements AuthStorageBackend {
 	constructor(private authPath: string = join(getAgentDir(), "auth.json")) {}
+
+	async read(): Promise<string | undefined> {
+		try {
+			return await readFile(this.authPath, "utf8");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+			throw error;
+		}
+	}
 
 	private ensureParentDir(): void {
 		const dir = dirname(this.authPath);
@@ -692,9 +702,19 @@ export class AuthStorage {
 		}
 	}
 
-	/**
-	 * Get credential for a provider.
-	 */
+	/** Read a raw API-key configuration without credential commands, refreshes, or synchronous file locks. */
+	async readApiKeyConfig(provider: string): Promise<string | undefined> {
+		const runtime = this.runtimeOverrides.get(provider);
+		if (runtime) return runtime;
+		const data =
+			this.storage instanceof FileAuthStorageBackend
+				? this.parseStorageData(await this.storage.read())
+				: await this.storage.withLockAsync(async (content) => ({ result: this.parseStorageData(content) }));
+		const credential = data[provider];
+		return credential?.type === "api_key" && typeof credential.key === "string" ? credential.key : undefined;
+	}
+
+	/** Get the cached credential for a provider. */
 	get(provider: string): AuthCredential | undefined {
 		return this.data[provider] ?? undefined;
 	}

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import type { ServiceTier, Transport } from "@earendil-works/pi-ai";
 import { existsSync, mkdirSync, readFileSync } from "fs";
 import { homedir } from "os";
@@ -179,6 +180,30 @@ export interface AgentTracesSettings {
 	enabled?: boolean;
 }
 
+export interface AgentTraceConsent {
+	enabled: boolean;
+	reason: "enabled" | "global_off" | "project_off" | "runtime_off" | "settings_unavailable";
+}
+
+function traceConsent(global: Settings, project: Settings, runtime: Settings = {}): AgentTraceConsent {
+	for (const settings of [global, project, runtime]) {
+		const value = settings.agentTraces;
+		if (
+			value !== undefined &&
+			(value === null ||
+				typeof value !== "object" ||
+				Array.isArray(value) ||
+				(value.enabled !== undefined && typeof value.enabled !== "boolean"))
+		) {
+			return { enabled: false, reason: "settings_unavailable" };
+		}
+	}
+	if (global.agentTraces?.enabled !== true) return { enabled: false, reason: "global_off" };
+	if (project.agentTraces?.enabled === false) return { enabled: false, reason: "project_off" };
+	if (runtime.agentTraces?.enabled === false) return { enabled: false, reason: "runtime_off" };
+	return { enabled: true, reason: "enabled" };
+}
+
 export interface TelemetrySettings {
 	enabled?: boolean;
 	noticeShown?: boolean;
@@ -230,6 +255,49 @@ export class FileSettingsStorage implements SettingsStorage {
 	constructor(cwd: string, agentDir: string) {
 		this.globalSettingsPath = join(agentDir, "settings.json");
 		this.projectSettingsPath = join(cwd, CONFIG_DIR_NAME, "settings.json");
+	}
+
+	/** Small, lock-free consent reads let transcript persistence register durable intent across processes. */
+	readTraceConsentSync(cwd: string): AgentTraceConsent {
+		const read = (path: string): Settings => {
+			try {
+				const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+				if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed))
+					throw new Error("Invalid settings");
+				return parsed as Settings;
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
+				throw error;
+			}
+		};
+		try {
+			return traceConsent(read(this.globalSettingsPath), read(join(cwd, CONFIG_DIR_NAME, "settings.json")));
+		} catch {
+			return { enabled: false, reason: "settings_unavailable" };
+		}
+	}
+
+	async readTraceConsent(cwd: string): Promise<AgentTraceConsent> {
+		const read = async (path: string): Promise<Settings> => {
+			try {
+				const parsed: unknown = JSON.parse(await readFile(path, "utf8"));
+				if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed))
+					throw new Error("Invalid settings");
+				return parsed as Settings;
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
+				throw error;
+			}
+		};
+		try {
+			const [global, project] = await Promise.all([
+				read(this.globalSettingsPath),
+				read(join(cwd, CONFIG_DIR_NAME, "settings.json")),
+			]);
+			return traceConsent(global, project);
+		} catch {
+			return { enabled: false, reason: "settings_unavailable" };
+		}
 	}
 
 	private acquireLockSyncWithRetry(path: string): () => void {
@@ -839,7 +907,32 @@ export class SettingsManager {
 	}
 
 	getAgentTracesEnabled(): boolean {
-		return this.settings.agentTraces?.enabled ?? false;
+		return this.getAgentTracesConsent().enabled;
+	}
+
+	getAgentTracesConsent(): AgentTraceConsent {
+		if (this.globalSettingsLoadError || this.projectSettingsLoadError) {
+			return { enabled: false, reason: "settings_unavailable" };
+		}
+		return traceConsent(this.globalSettings, this.projectSettings, this.runtimeOverrides);
+	}
+
+	readAgentTracesConsentSync(cwd: string): AgentTraceConsent {
+		if (!(this.storage instanceof FileSettingsStorage)) return this.getAgentTracesConsent();
+		const consent = this.storage.readTraceConsentSync(cwd);
+		return consent.enabled && this.runtimeOverrides.agentTraces?.enabled === false
+			? { enabled: false, reason: "runtime_off" }
+			: consent;
+	}
+
+	/** Read consent for the transcript's project without settings locks or credential resolution. */
+	async readAgentTracesConsent(cwd: string): Promise<AgentTraceConsent> {
+		await this.writeQueue;
+		if (!(this.storage instanceof FileSettingsStorage)) return this.getAgentTracesConsent();
+		const consent = await this.storage.readTraceConsent(cwd);
+		return consent.enabled && this.runtimeOverrides.agentTraces?.enabled === false
+			? { enabled: false, reason: "runtime_off" }
+			: consent;
 	}
 
 	setAgentTracesEnabled(enabled: boolean): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -53,7 +53,6 @@ import {
 	APP_NAME,
 	APP_TITLE,
 	getAgentDir,
-	getAgentTracesLogPath,
 	getDebugLogPath,
 	getLogsDir,
 	getShareViewerUrl,
@@ -70,8 +69,11 @@ import {
 	type AgentTracePreviewResult,
 	type AgentTraceUploadAllResult,
 	type AgentTraceUploadResult,
-	getPrimeAgentTraceCredential,
+	cancelAgentTraceRequest,
+	cancelPendingAgentTraceRequests,
+	formatAgentTraceStatus,
 	previewAgentTraceFile,
+	readAgentTraceStatus,
 	uploadAgentTraceFile,
 	uploadAllAgentTraces,
 } from "../../core/agent-traces.js";
@@ -115,7 +117,6 @@ import {
 } from "../../core/messages.js";
 import { findExactModelReferenceMatch, resolveModelScopeFromModels } from "../../core/model-resolver.js";
 import { parseNewSessionCommand } from "../../core/new-session-command.js";
-import { resolvePrimeAgentTracesBaseUrl } from "../../core/prime-inference-auth.js";
 import { resolvePrimeInferencePostLoginModelAction } from "../../core/prime-inference-model-selection.js";
 import { parseCommandArgs } from "../../core/prompt-templates.js";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.js";
@@ -1079,6 +1080,7 @@ export class InteractiveMode {
 
 	private retryLoader: Loader | undefined = undefined;
 	private retryCountdown: CountdownTimer | undefined = undefined;
+	private traceUploadAllRequestId: string | undefined;
 	private traceUploadAllAbortController: AbortController | undefined = undefined;
 
 	private readonly queueSelection = new QueueSelection();
@@ -6784,6 +6786,7 @@ export class InteractiveMode {
 
 	private interruptOrClearInput(): void {
 		this.traceUploadAllAbortController?.abort(new Error("Trace upload cancelled"));
+		this.traceUploadAllAbortController = undefined;
 		if (this.sideQuestionEvent?.status === "running") {
 			this.abortSideQuestion(this.sideQuestionEvent.id, true);
 		}
@@ -9343,38 +9346,25 @@ export class InteractiveMode {
 
 	private formatTraceUploadResult(result: AgentTraceUploadResult): string {
 		switch (result.status) {
-			case "uploaded":
-				return `Trace uploaded (${result.bytesStored.toLocaleString()} bytes).`;
+			case "queued":
+				return "Trace queued for background delivery. Run /traces status for progress.";
 			case "disabled":
-				return "Trace sharing is disabled.";
-			case "unchanged":
-				return "Trace is already uploaded; no new content since the last upload.";
-			case "missing_credentials":
-				return "Trace sharing needs a Prime API key. Run /traces login.";
+				return "Automatic sharing is disabled by global or project settings.";
 			case "no_session_file":
-				return "Current session has no persisted trace yet.";
 			case "empty_session":
-				return "Current session trace is empty.";
-			case "invalid_session":
-				return `Trace upload skipped: ${result.message}.`;
-			case "too_large":
-				return `Trace upload skipped: session file is ${result.size.toLocaleString()} bytes; limit is ${result.maxBytes.toLocaleString()} bytes.`;
+				return "Current session has no persisted trace yet.";
 			case "failed":
-				if (result.statusCode === 404) {
-					return "Trace upload endpoint was not found. The platform API may not be deployed yet, or PRIME_AGENT_TRACES_BASE_URL points at the wrong API.";
-				}
-				return `Trace upload failed: ${result.statusCode ? `HTTP ${result.statusCode}: ` : ""}${result.message}. See ${getAgentTracesLogPath()} for details.`;
+				return result.message;
 		}
 	}
 
-	private async uploadCurrentTraceOnce(): Promise<AgentTraceUploadResult> {
+	private async uploadCurrentTraceOnce(requireEnabled = false): Promise<AgentTraceUploadResult> {
 		const state = await this.agentConnection.getState();
 		return uploadAgentTraceFile({
 			sessionFile: state.sessionFile,
 			authStorage: this.modelRegistry.authStorage,
 			settingsManager: this.settingsManager,
-			requireEnabled: false,
-			reloadConfig: false,
+			requireEnabled,
 		});
 	}
 
@@ -9441,15 +9431,7 @@ export class InteractiveMode {
 			settingsManager: this.settingsManager,
 			sessionDir,
 			requireEnabled: false,
-			reloadConfig: false,
 			signal,
-			onProgress: ({ completed, total }) => {
-				if (total > 0 && (completed === 0 || completed === total || completed % 10 === 0)) {
-					this.showStatus(
-						`Uploading traces: ${completed.toLocaleString()}/${total.toLocaleString()} (${keyText("app.clear")} to cancel)`,
-					);
-				}
-			},
 		});
 	}
 
@@ -9459,134 +9441,102 @@ export class InteractiveMode {
 				.replace(/^\/traces\b/, "")
 				.trim()
 				.toLowerCase() || "status";
-
 		if (command === "status") {
-			await this.settingsManager.reload().catch(() => undefined);
-			const credential = await getPrimeAgentTraceCredential(this.modelRegistry.authStorage);
 			const state = await this.agentConnection.getState();
-			const info = [
-				theme.bold("Trace Sharing"),
-				"",
-				`${theme.fg("dim", "Automatic uploads:")} ${this.settingsManager.getAgentTracesEnabled() ? "Enabled" : "Disabled"}`,
-				`${theme.fg("dim", "Credential:")} ${credential?.label ?? "Not configured"}`,
-				`${theme.fg("dim", "Endpoint:")} ${resolvePrimeAgentTracesBaseUrl()}`,
-				`${theme.fg("dim", "Session file:")} ${state.sessionFile ?? "In-memory"}`,
-				"",
-				theme.fg(
-					"dim",
-					"Commands: /traces on, /traces off, /traces preview, /traces upload-current, /traces upload-all, /traces login",
-				),
-			].join("\n");
+			const status = await readAgentTraceStatus({
+				settingsManager: this.settingsManager,
+				authStorage: this.modelRegistry.authStorage,
+				sessionFile: state.sessionFile,
+			});
 			this.chatContainer.addChild(new Spacer(1));
-			this.chatContainer.addChild(new Text(info, 1, 0));
+			this.chatContainer.addChild(new Text(formatAgentTraceStatus(status), 1, 0));
 			this.ui.requestRender();
 			return;
 		}
-
 		if (command === "off" || command === "disable") {
 			this.settingsManager.setAgentTracesEnabled(false);
 			await this.settingsManager.flush();
-			this.showStatus("Trace sharing disabled.");
+			this.showStatus("Automatic trace sharing disabled. Pending automatic deliveries will pause.");
 			return;
 		}
-
 		if (command === "login") {
 			await this.createAuthFlows().runPrimeAgentTracesLogin();
 			return;
 		}
-
 		if (command === "preview") {
 			await this.previewCurrentTrace();
 			return;
 		}
-
 		if (command === "on" || command === "enable") {
-			let credential = await getPrimeAgentTraceCredential(this.modelRegistry.authStorage);
-			if (!credential) {
-				const authResult = await this.createAuthFlows().runPrimeAgentTracesLogin();
-				if (authResult.status !== "success") {
-					return;
-				}
-				credential = await getPrimeAgentTraceCredential(this.modelRegistry.authStorage);
-			}
-			if (!credential) {
-				this.showError("Trace sharing needs a Prime API key.");
-				return;
-			}
-
 			this.settingsManager.setAgentTracesEnabled(true);
 			await this.settingsManager.flush();
-			const uploadResult = await this.uploadCurrentTraceOnce();
-			const uploadMessage =
-				uploadResult.status === "no_session_file" || uploadResult.status === "empty_session"
-					? "Current session will upload after the first assistant response."
-					: this.formatTraceUploadResult(uploadResult);
-			this.showStatus(`Trace sharing enabled. ${uploadMessage}`);
+			const result = await this.uploadCurrentTraceOnce(true);
+			const message =
+				result.status === "no_session_file" || result.status === "empty_session"
+					? "Current session will queue after the first assistant response."
+					: this.formatTraceUploadResult(result);
+			this.showStatus(`Global automatic trace sharing enabled. ${message}`);
 			return;
 		}
-
 		if (command === "upload" || command === "upload-current") {
-			const credential = await getPrimeAgentTraceCredential(this.modelRegistry.authStorage);
-			if (!credential) {
-				this.showError("Trace sharing needs a Prime API key. Run /traces login.");
-				return;
-			}
-			const uploadResult = await this.uploadCurrentTraceOnce();
-			const message = this.formatTraceUploadResult(uploadResult);
-			if (uploadResult.status === "failed") {
-				this.showError(message);
-			} else {
-				this.showStatus(message);
-			}
+			const result = await this.uploadCurrentTraceOnce();
+			if (result.status === "failed") this.showError(this.formatTraceUploadResult(result));
+			else this.showStatus(this.formatTraceUploadResult(result));
 			return;
 		}
-
-		if (command === "upload-all") {
-			const credential = await getPrimeAgentTraceCredential(this.modelRegistry.authStorage);
-			if (!credential) {
-				this.showError("Trace sharing needs a Prime API key. Run /traces login.");
+		if (command === "cancel") {
+			if (!this.traceUploadAllRequestId) {
+				this.showStatus(
+					"This task has no bulk trace request to cancel. Use /traces cancel-all to cancel pending one-shot requests across tasks.",
+				);
 				return;
 			}
-			if (this.traceUploadAllAbortController) {
-				this.showWarning("A trace upload is already running. Cancel it before starting another.");
-				return;
-			}
-			const state = await this.agentConnection.getState();
-			const abortController = new AbortController();
-			this.traceUploadAllAbortController = abortController;
-			let result: AgentTraceUploadAllResult;
 			try {
-				result = await this.uploadAllTraces(state.sessionDir, abortController.signal);
-			} finally {
-				if (this.traceUploadAllAbortController === abortController) {
-					this.traceUploadAllAbortController = undefined;
-				}
-			}
-			if (abortController.signal.aborted) {
-				this.showStatus("Trace upload cancelled.");
-				return;
-			}
-			if (result.total === 0) {
-				this.showStatus("No persisted traces were found.");
-				return;
-			}
-			const summary = [
-				`Uploaded ${result.uploaded.toLocaleString()} of ${result.total.toLocaleString()} traces`,
-				result.skipped > 0 ? `${result.skipped.toLocaleString()} skipped` : undefined,
-				result.failed > 0 ? `${result.failed.toLocaleString()} failed` : undefined,
-				`${result.bytesStored.toLocaleString()} bytes stored`,
-			]
-				.filter((part): part is string => part !== undefined)
-				.join("; ");
-			if (result.failed > 0) {
-				this.showWarning(`${summary}. See ${getAgentTracesLogPath()} for details.`);
-			} else {
-				this.showStatus(`${summary}.`);
+				await cancelAgentTraceRequest(this.traceUploadAllRequestId);
+				this.traceUploadAllAbortController?.abort();
+				this.traceUploadAllAbortController = undefined;
+				this.traceUploadAllRequestId = undefined;
+				this.showStatus(
+					"Cancellation recorded for this task's bulk trace request. Sent requests cannot be recalled.",
+				);
+			} catch {
+				this.showError("Could not record trace cancellation. Check access to the agent directory and retry.");
 			}
 			return;
 		}
-
-		this.showWarning("Usage: /traces [status|on|off|preview|upload|upload-current|upload-all|login]");
+		if (command === "cancel-all") {
+			const result = await cancelPendingAgentTraceRequests();
+			if (result.failed)
+				this.showError(
+					`Cancelled ${result.cancelled} one-shot requests; could not record ${result.failed} cancellations. Check access to the agent directory and retry.`,
+				);
+			else
+				this.showStatus(
+					`Cancellation recorded for ${result.cancelled} pending one-shot requests across tasks. Sent requests cannot be recalled.`,
+				);
+			return;
+		}
+		if (command === "upload-all") {
+			// Cancel a previous bulk request before replacing its cancellation handle.
+			this.traceUploadAllAbortController?.abort();
+			const state = await this.agentConnection.getState();
+			const controller = new AbortController();
+			this.traceUploadAllAbortController = controller;
+			const result = await this.uploadAllTraces(state.sessionDir, controller.signal);
+			if (result.status === "failed") {
+				this.traceUploadAllAbortController = undefined;
+				this.showError(result.message);
+			} else {
+				if (result.status === "queued") this.traceUploadAllRequestId = result.requestId;
+				this.showStatus(
+					`Bulk trace request queued for background delivery. Run /traces status for progress; /traces cancel or ${keyText("app.clear")} cancels it.`,
+				);
+			}
+			return;
+		}
+		this.showWarning(
+			"Usage: /traces [status|on|off|preview|upload|upload-current|upload-all|cancel|cancel-all|login]",
+		);
 	}
 
 	private async handleContextCommand(): Promise<void> {

--- a/packages/coding-agent/test/agent-traces-process.test.ts
+++ b/packages/coding-agent/test/agent-traces-process.test.ts
@@ -1,0 +1,134 @@
+import { type ChildProcess, fork } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { build } from "esbuild";
+import { expect, it, vi } from "vitest";
+import { AgentTraceDeliveryQueue, stopAgentTraceUploads, uploadAgentTraceFile } from "../src/core/agent-traces.js";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+
+it("runs bundled workers and shares ownership, pacing and crash recovery across processes", async () => {
+	const root = await mkdtemp(join(tmpdir(), "trace-process-"));
+	const agentDir = join(root, "agent"),
+		sends = join(root, "sends.jsonl");
+	const children: ChildProcess[] = [];
+	const noStart = vi.spyOn(AgentTraceDeliveryQueue.prototype, "start").mockImplementation(() => {});
+	try {
+		mkdirSync(agentDir);
+		writeFileSync(join(root, "package.json"), readFileSync(resolve("package.json")));
+		const bundle = join(root, "worker.mjs"),
+			entry = join(root, "worker.ts");
+		writeFileSync(
+			entry,
+			`
+import { appendFileSync } from "node:fs";
+import { AgentTraceDeliveryQueue } from ${JSON.stringify(resolve("src/core/agent-traces.ts"))};
+import { AuthStorage } from ${JSON.stringify(resolve("src/core/auth-storage.ts"))};
+import { SettingsManager } from ${JSON.stringify(resolve("src/core/settings-manager.ts"))};
+Date.now = () => Number(process.env.TRACE_TEST_NOW);
+process.on("message", () => {});
+const queue = new AgentTraceDeliveryQueue({
+ agentDir: ${JSON.stringify(agentDir)}, configPath: ${JSON.stringify(join(root, "absent-config.json"))},
+ authStorage: AuthStorage.inMemory({ "prime-agent-traces": { type: "api_key", key: "synthetic-process-key" } }),
+ settingsManager: SettingsManager.inMemory(),
+ fetchFn: async (url, init) => {
+  appendFileSync(${JSON.stringify(sends)}, JSON.stringify({ url, bytes: init.body.byteLength, at: Date.now(), pid: process.pid }) + "\\n");
+  process.send("request");
+  return new Promise(resolve => process.once("message", () => resolve(new Response("", { status: 200 }))));
+ },
+});
+await queue.runOnce();
+process.send("done", () => process.disconnect());
+`,
+		);
+		await build({
+			entryPoints: [entry],
+			outfile: bundle,
+			bundle: true,
+			platform: "node",
+			format: "esm",
+			target: "node22",
+			tsconfig: resolve("../../tsconfig.json"),
+			logLevel: "silent",
+			banner: { js: 'import { createRequire } from "node:module"; const require = createRequire(import.meta.url);' },
+		});
+		for (const name of ["one", "two"]) {
+			const sessionFile = join(root, `${name}.jsonl`);
+			writeFileSync(
+				sessionFile,
+				`${JSON.stringify({ type: "session", id: name, cwd: root, timestamp: "2026-09-08T00:00:00Z" })}\n`,
+			);
+			expect(
+				await uploadAgentTraceFile({
+					sessionFile,
+					agentDir,
+					authStorage: AuthStorage.inMemory(),
+					settingsManager: SettingsManager.inMemory(),
+					requireEnabled: false,
+				}),
+			).toMatchObject({ status: "queued" });
+		}
+		const launch = (when: number) => {
+			const child = fork(bundle, [], {
+				execArgv: [],
+				cwd: root,
+				stdio: ["ignore", "pipe", "pipe", "ipc"],
+				env: {
+					...process.env,
+					TRACE_TEST_NOW: String(when),
+					PRIME_AGENT_TRACES_API_KEY: "",
+					PRIME_API_KEY: "",
+					PRIME_AGENT_TRACES_BASE_URL: "https://synthetic.invalid",
+				},
+			});
+			children.push(child);
+			const messages: unknown[] = [];
+			let errors = "";
+			child.on("message", (message) => messages.push(message));
+			child.stderr?.on("data", (chunk) => {
+				errors += String(chunk);
+			});
+			const exited = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolveExit) =>
+				child.once("exit", (code, signal) => resolveExit({ code, signal })),
+			);
+			return { child, messages, exited, errors: () => errors };
+		};
+		const now = Date.now(),
+			owner = launch(now);
+		await vi.waitFor(() => expect(owner.messages, owner.errors()).toContain("request"), { timeout: 5000 });
+		const competitor = launch(now);
+		expect(await competitor.exited, competitor.errors()).toEqual({ code: 0, signal: null });
+		expect(competitor.messages).not.toContain("request");
+		owner.child.send("release");
+		expect(await owner.exited, owner.errors()).toEqual({ code: 0, signal: null });
+		const limited = launch(now);
+		expect(await limited.exited, limited.errors()).toEqual({ code: 0, signal: null });
+		expect(limited.messages).not.toContain("request");
+		const crashed = launch(now + 12_100);
+		await vi.waitFor(() => expect(crashed.messages, crashed.errors()).toContain("request"), { timeout: 5000 });
+		crashed.child.kill("SIGKILL");
+		expect((await crashed.exited).signal).toBe("SIGKILL");
+		expect(existsSync(join(agentDir, "agent-traces-outbox", ".delivery.lock"))).toBe(true);
+		const replacement = launch(now + 60_000);
+		await vi.waitFor(() => expect(replacement.messages, replacement.errors()).toContain("request"), {
+			timeout: 5000,
+		});
+		replacement.child.send("release");
+		expect(await replacement.exited, replacement.errors()).toEqual({ code: 0, signal: null });
+		const requests = readFileSync(sends, "utf8")
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line) as { at: number; url: string; bytes: number });
+		expect(requests).toHaveLength(3);
+		expect(requests.map((request) => request.at)).toEqual([now, now + 12_100, now + 60_000]);
+		expect(requests[1]!.url).toBe(requests[2]!.url);
+		expect(requests.every((request) => request.bytes > 0)).toBe(true);
+	} finally {
+		for (const child of children) if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+		noStart.mockRestore();
+		stopAgentTraceUploads(agentDir);
+		rmSync(root, { recursive: true, force: true });
+	}
+}, 20_000);

--- a/packages/coding-agent/test/agent-traces-process.test.ts
+++ b/packages/coding-agent/test/agent-traces-process.test.ts
@@ -9,7 +9,7 @@ import { AgentTraceDeliveryQueue, stopAgentTraceUploads, uploadAgentTraceFile } 
 import { AuthStorage } from "../src/core/auth-storage.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
 
-it("runs bundled workers and shares ownership, pacing and crash recovery across processes", async () => {
+it("runs bundled workers and shares ownership, pacing, crash recovery and rejected-key recovery across processes", async () => {
 	const root = await mkdtemp(join(tmpdir(), "trace-process-"));
 	const agentDir = join(root, "agent"),
 		sends = join(root, "sends.jsonl");
@@ -31,12 +31,12 @@ Date.now = () => Number(process.env.TRACE_TEST_NOW);
 process.on("message", () => {});
 const queue = new AgentTraceDeliveryQueue({
  agentDir: ${JSON.stringify(agentDir)}, configPath: ${JSON.stringify(join(root, "absent-config.json"))},
- authStorage: AuthStorage.inMemory({ "prime-agent-traces": { type: "api_key", key: "synthetic-process-key" } }),
+ authStorage: AuthStorage.inMemory({ "prime-agent-traces": { type: "api_key", key: process.env.TRACE_TEST_KEY } }),
  settingsManager: SettingsManager.inMemory(),
  fetchFn: async (url, init) => {
   appendFileSync(${JSON.stringify(sends)}, JSON.stringify({ url, bytes: init.body.byteLength, at: Date.now(), pid: process.pid }) + "\\n");
   process.send("request");
-  return new Promise(resolve => process.once("message", () => resolve(new Response("", { status: 200 }))));
+  return new Promise(resolve => process.once("message", () => resolve(new Response("", { status: Number(process.env.TRACE_TEST_STATUS) }))));
  },
 });
 await queue.runOnce();
@@ -54,7 +54,7 @@ process.send("done", () => process.disconnect());
 			logLevel: "silent",
 			banner: { js: 'import { createRequire } from "node:module"; const require = createRequire(import.meta.url);' },
 		});
-		for (const name of ["one", "two"]) {
+		const enqueue = async (name: string) => {
 			const sessionFile = join(root, `${name}.jsonl`);
 			writeFileSync(
 				sessionFile,
@@ -69,8 +69,9 @@ process.send("done", () => process.disconnect());
 					requireEnabled: false,
 				}),
 			).toMatchObject({ status: "queued" });
-		}
-		const launch = (when: number) => {
+		};
+		for (const name of ["one", "two"]) await enqueue(name);
+		const launch = (when: number, key = "synthetic-process-key", status = 200) => {
 			const child = fork(bundle, [], {
 				execArgv: [],
 				cwd: root,
@@ -78,6 +79,8 @@ process.send("done", () => process.disconnect());
 				env: {
 					...process.env,
 					TRACE_TEST_NOW: String(when),
+					TRACE_TEST_KEY: key,
+					TRACE_TEST_STATUS: String(status),
 					PRIME_AGENT_TRACES_API_KEY: "",
 					PRIME_API_KEY: "",
 					PRIME_AGENT_TRACES_BASE_URL: "https://synthetic.invalid",
@@ -117,13 +120,32 @@ process.send("done", () => process.disconnect());
 		});
 		replacement.child.send("release");
 		expect(await replacement.exited, replacement.errors()).toEqual({ code: 0, signal: null });
+		await enqueue("three");
+		const rejected = launch(now + 120_000, "synthetic-process-key", 401);
+		await vi.waitFor(() => expect(rejected.messages, rejected.errors()).toContain("request"), { timeout: 5000 });
+		rejected.child.send("release");
+		expect(await rejected.exited, rejected.errors()).toEqual({ code: 0, signal: null });
+		const paused = launch(now + 180_000);
+		expect(await paused.exited, paused.errors()).toEqual({ code: 0, signal: null });
+		expect(paused.messages).not.toContain("request");
+		const rotated = launch(now + 180_000, "replacement-process-key");
+		await vi.waitFor(() => expect(rotated.messages, rotated.errors()).toContain("request"), { timeout: 5000 });
+		rotated.child.send("release");
+		expect(await rotated.exited, rotated.errors()).toEqual({ code: 0, signal: null });
 		const requests = readFileSync(sends, "utf8")
 			.trim()
 			.split("\n")
 			.map((line) => JSON.parse(line) as { at: number; url: string; bytes: number });
-		expect(requests).toHaveLength(3);
-		expect(requests.map((request) => request.at)).toEqual([now, now + 12_100, now + 60_000]);
+		expect(requests).toHaveLength(5);
+		expect(requests.map((request) => request.at)).toEqual([
+			now,
+			now + 12_100,
+			now + 60_000,
+			now + 120_000,
+			now + 180_000,
+		]);
 		expect(requests[1]!.url).toBe(requests[2]!.url);
+		expect(requests[3]!.url).toBe(requests[4]!.url);
 		expect(requests.every((request) => request.bytes > 0)).toBe(true);
 	} finally {
 		for (const child of children) if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");

--- a/packages/coding-agent/test/agent-traces.test.ts
+++ b/packages/coding-agent/test/agent-traces.test.ts
@@ -425,6 +425,31 @@ describe("durable background trace delivery", () => {
 		await run();
 		expect(job(path).state).toBe("delivered");
 	});
+	it("stores distinct salted credential fingerprints for independent agent directories", async () => {
+		const path = file();
+		const fingerprints: string[] = [];
+		const salts: string[] = [];
+		fetchFn.mockImplementation(async () => new Response("", { status: 401 }));
+		for (const scopedAgentDir of [agentDir, join(root, "other-agent")]) {
+			const scopedOptions = { ...options, agentDir: scopedAgentDir };
+			try {
+				await uploadAgentTraceFile({ ...scopedOptions, sessionFile: path, requireEnabled: false });
+				await new AgentTraceDeliveryQueue(scopedOptions).runOnce();
+				const saved = readFileSync(join(scopedAgentDir, "agent-traces-outbox", ".delivery-state"), "utf8");
+				const state = JSON.parse(saved) as { credentialSalt: string; invalidCredential: string };
+				expect(state.credentialSalt).toMatch(/^[a-f0-9]{64}$/);
+				expect(state.invalidCredential).toMatch(/^[a-f0-9]{64}$/);
+				expect(saved).not.toContain("synthetic-key");
+				salts.push(state.credentialSalt);
+				fingerprints.push(state.invalidCredential);
+			} finally {
+				stopAgentTraceUploads(scopedAgentDir);
+			}
+		}
+		expect(salts[0]).not.toBe(salts[1]);
+		expect(fingerprints[0]).not.toBe(fingerprints[1]);
+		expect(fetchFn).toHaveBeenCalledTimes(2);
+	});
 	it("pauses permanent HTTP failures until the automatic file or endpoint changes", async () => {
 		const path = file();
 		await queue(path);

--- a/packages/coding-agent/test/agent-traces.test.ts
+++ b/packages/coding-agent/test/agent-traces.test.ts
@@ -1,17 +1,36 @@
-import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { stat } from "node:fs/promises";
+import {
+	appendFileSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { AssistantMessage } from "@earendil-works/pi-ai";
+import lockfile from "proper-lockfile";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ENV_AGENT_DIR, getAgentTracesLogPath } from "../src/config.js";
+import { CONFIG_DIR_NAME, ENV_AGENT_DIR } from "../src/config.js";
+import * as payloadWorker from "../src/core/agent-trace-payload.js";
 import {
+	AgentTraceDeliveryQueue,
+	type AgentTraceUploadInstallOptions,
+	cancelAgentTraceRequest,
+	cancelPendingAgentTraceRequests,
 	catchUpAgentTraceUploads,
 	findAgentTraceFiles,
+	formatAgentTraceStatus,
+	getPrimeAgentTraceCredential,
 	installAgentTraceUpload,
 	previewAgentTraceFile,
+	readAgentTraceStatus,
+	SEMANTIC_EDGES_OUTBOX_KIND,
+	stopAgentTraceUploads,
 	uploadAgentTraceFile,
 	uploadAllAgentTraces,
 } from "../src/core/agent-traces.js";
@@ -20,1550 +39,755 @@ import { PRIME_AGENT_TRACES_PROVIDER_ID, PRIME_INFERENCE_PROVIDER_ID } from "../
 import { SessionManager } from "../src/core/session-manager.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
 
-interface FetchCall {
-	url: string;
-	init: RequestInit;
+interface Job {
+	sessionFile: string;
+	state?: string;
+	nextAttemptAt?: number;
+	attempts?: number;
+	lastAttemptAt?: number;
+	failure?: { reason: string; at: number };
+	manual?: { snapshotReady?: boolean };
+	size?: number;
+	mtimeMs?: number;
 }
-
-function createAssistantMessage(text: string): AssistantMessage {
-	return {
-		role: "assistant",
-		content: [{ type: "text", text }],
-		api: "anthropic-messages",
-		provider: "anthropic",
-		model: "mock",
-		usage: {
-			input: 1,
-			output: 1,
-			cacheRead: 0,
-			cacheWrite: 0,
-			totalTokens: 2,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-		},
-		stopReason: "stop",
-		timestamp: Date.now(),
-	};
-}
-
-function createUserMessage(text: string) {
-	return {
-		role: "user" as const,
-		content: text,
-		timestamp: Date.now(),
-	};
-}
-
-function createFetchRecorder(calls: FetchCall[]): typeof fetch {
-	return async (input, init) => {
-		calls.push({ url: String(input), init: init ?? {} });
-		return new Response(
-			JSON.stringify({
-				session_id: "uploaded-session",
-				trace_id: "uploaded-trace",
-				bytes_stored: 123,
-				key: "trace/key.jsonl",
-			}),
-			{ status: 200, headers: { "content-type": "application/json" } },
-		);
-	};
-}
-
-function writeSession(cwd: string, sessionDir: string, id: string, parentSession?: string): SessionManager {
-	const sessionManager = SessionManager.create(cwd, sessionDir);
-	sessionManager.newSession({ id, parentSession });
-	sessionManager.appendMessage(createUserMessage(`user ${id}`));
-	sessionManager.appendMessage(createAssistantMessage(`assistant ${id}`));
-	return sessionManager;
-}
-
-/** Mirrors the outbox on-disk format: one JSON entry per session file, named by path hash. */
-function outboxEntryPath(agentDir: string, sessionFile: string): string {
-	const key = createHash("sha256").update(sessionFile).digest("hex").slice(0, 32);
-	return join(agentDir, "agent-traces-outbox", `${key}.json`);
-}
-
-function writeOutboxEntry(agentDir: string, sessionFile: string, signature?: { size: number; mtimeMs: number }): void {
-	mkdirSync(join(agentDir, "agent-traces-outbox"), { recursive: true });
-	writeFileSync(outboxEntryPath(agentDir, sessionFile), JSON.stringify({ sessionFile, ...signature }));
-}
-
-function readOutboxEntry(
-	agentDir: string,
-	sessionFile: string,
-): { sessionFile: string; kind?: string; size?: number; mtimeMs?: number; uploadedBytes?: number } | undefined {
-	if (!existsSync(outboxEntryPath(agentDir, sessionFile))) {
-		return undefined;
-	}
-	return JSON.parse(readFileSync(outboxEntryPath(agentDir, sessionFile), "utf8")) as {
-		sessionFile: string;
-		kind?: string;
-		size?: number;
-		mtimeMs?: number;
-		uploadedBytes?: number;
-	};
-}
-
-function writeLedgerOutboxEntry(agentDir: string, ledgerFile: string, uploadedBytes?: number): void {
-	mkdirSync(join(agentDir, "agent-traces-outbox"), { recursive: true });
+let root: string;
+let agentDir: string;
+let dir: string;
+let now: number;
+let options: AgentTraceUploadInstallOptions;
+let fetchFn: ReturnType<typeof vi.fn<typeof fetch>>;
+function file(name = "trace", cwd = root, extra: object[] = []): string {
+	const path = join(root, `${name}.jsonl`);
+	mkdirSync(join(path, ".."), { recursive: true });
 	writeFileSync(
-		outboxEntryPath(agentDir, ledgerFile),
-		JSON.stringify({
-			sessionFile: ledgerFile,
-			kind: "semantic-edges",
-			...(uploadedBytes === undefined ? {} : { uploadedBytes }),
-		}),
+		path,
+		`${[
+			{ type: "session", version: 3, id: name, timestamp: "2026-09-08T00:00:00.000Z", cwd },
+			{
+				type: "message",
+				id: "msg",
+				parentId: null,
+				message: { role: "assistant", content: [{ type: "text", text: "synthetic response" }] },
+			},
+			...extra,
+		]
+			.map((value) => JSON.stringify(value))
+			.join("\n")}\n`,
 	);
+	return path;
+}
+function autoPath(sessionFile: string): string {
+	return join(dir, `${createHash("sha256").update(sessionFile).digest("hex").slice(0, 32)}.json`);
+}
+function entries(): Array<{ path: string; job: Job }> {
+	return readdirSync(dir)
+		.filter((name) => name.endsWith(".json") && !name.startsWith("batch-"))
+		.map((name) => {
+			const path = join(dir, name);
+			return { path, job: JSON.parse(readFileSync(path, "utf8")) as Job };
+		});
+}
+function job(sessionFile: string): Job {
+	return entries().find((entry) => entry.job.sessionFile === sessionFile)!.job;
+}
+async function queue(sessionFile: string, manual = false, signal?: AbortSignal) {
+	return uploadAgentTraceFile({ ...options, sessionFile, requireEnabled: !manual, signal });
+}
+async function run(): Promise<void> {
+	await new AgentTraceDeliveryQueue(options).runOnce();
+}
+function globalSettings(enabled: boolean): void {
+	mkdirSync(agentDir, { recursive: true });
+	writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ agentTraces: { enabled } }));
+}
+function projectSettings(cwd: string, enabled: boolean): void {
+	mkdirSync(join(cwd, CONFIG_DIR_NAME), { recursive: true });
+	writeFileSync(join(cwd, CONFIG_DIR_NAME, "settings.json"), JSON.stringify({ agentTraces: { enabled } }));
 }
 
-async function advanceTimersUntil(condition: () => boolean): Promise<void> {
-	for (let step = 0; step < 200 && !condition(); step += 1) {
-		await stat(new URL(import.meta.url));
-		if (!condition() && vi.getTimerCount() > 0) {
-			await vi.advanceTimersToNextTimerAsync();
-		}
-	}
-	if (!condition()) {
-		throw new Error("Timed out advancing fake timers to the expected condition");
-	}
-}
+beforeEach(async () => {
+	root = await mkdtemp(join(tmpdir(), "trace-queue-"));
+	agentDir = join(root, "agent");
+	dir = join(agentDir, "agent-traces-outbox");
+	now = Date.now() + 10_000;
+	vi.spyOn(Date, "now").mockImplementation(() => now);
+	vi.spyOn(AgentTraceDeliveryQueue.prototype, "start").mockImplementation(() => {});
+	vi.stubEnv(ENV_AGENT_DIR, agentDir);
+	vi.stubEnv("PRIME_AGENT_TRACES_API_KEY", "");
+	vi.stubEnv("PRIME_API_KEY", "");
+	vi.stubEnv("PRIME_AGENT_TRACES_BASE_URL", "");
+	fetchFn = vi.fn<typeof fetch>(async () => new Response("", { status: 200 }));
+	options = {
+		agentDir,
+		configPath: join(root, "missing-prime-config.json"),
+		authStorage: AuthStorage.inMemory({
+			[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "synthetic-key" },
+		}),
+		settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
+		fetchFn,
+	};
+});
+afterEach(() => {
+	stopAgentTraceUploads(agentDir);
+	vi.restoreAllMocks();
+	vi.unstubAllEnvs();
+	rmSync(root, { recursive: true, force: true });
+});
 
-describe("agent trace upload", () => {
-	let tempDir: string;
-	let originalTraceApiKey: string | undefined;
-	let originalPrimeApiKey: string | undefined;
-	let originalTraceBaseUrl: string | undefined;
-	let originalPrimeBaseUrl: string | undefined;
-	let originalAgentDir: string | undefined;
-
-	beforeEach(() => {
-		tempDir = mkdtempSync(join(tmpdir(), "agent-traces-test-"));
-		originalAgentDir = process.env[ENV_AGENT_DIR];
-		process.env[ENV_AGENT_DIR] = tempDir;
-		originalTraceApiKey = process.env.PRIME_AGENT_TRACES_API_KEY;
-		originalPrimeApiKey = process.env.PRIME_API_KEY;
-		originalTraceBaseUrl = process.env.PRIME_AGENT_TRACES_BASE_URL;
-		originalPrimeBaseUrl = process.env.PRIME_API_BASE_URL;
-		delete process.env.PRIME_AGENT_TRACES_API_KEY;
-		delete process.env.PRIME_API_KEY;
-		delete process.env.PRIME_AGENT_TRACES_BASE_URL;
-		delete process.env.PRIME_API_BASE_URL;
+describe("durable background trace delivery", () => {
+	it("acknowledges current, bulk and startup work before any preparation or request", async () => {
+		const prepare = vi.spyOn(payloadWorker, "prepareTracePayload");
+		expect(await queue(file(), true)).toMatchObject({ status: "queued" });
+		expect(await uploadAllAgentTraces({ ...options, sessionDir: root, requireEnabled: false })).toMatchObject({
+			status: "queued",
+		});
+		expect(catchUpAgentTraceUploads(options)).toBeUndefined();
+		expect(fetchFn).not.toHaveBeenCalled();
+		expect(prepare).not.toHaveBeenCalled();
+		expect(readdirSync(dir).filter((name) => name.endsWith(".json"))).toHaveLength(2);
 	});
-
-	afterEach(() => {
-		vi.restoreAllMocks();
-		vi.useRealTimers();
-		if (originalAgentDir === undefined) {
-			delete process.env[ENV_AGENT_DIR];
-		} else {
-			process.env[ENV_AGENT_DIR] = originalAgentDir;
-		}
-		if (originalTraceApiKey === undefined) {
-			delete process.env.PRIME_AGENT_TRACES_API_KEY;
-		} else {
-			process.env.PRIME_AGENT_TRACES_API_KEY = originalTraceApiKey;
-		}
-		if (originalPrimeApiKey === undefined) {
-			delete process.env.PRIME_API_KEY;
-		} else {
-			process.env.PRIME_API_KEY = originalPrimeApiKey;
-		}
-		if (originalTraceBaseUrl === undefined) {
-			delete process.env.PRIME_AGENT_TRACES_BASE_URL;
-		} else {
-			process.env.PRIME_AGENT_TRACES_BASE_URL = originalTraceBaseUrl;
-		}
-		if (originalPrimeBaseUrl === undefined) {
-			delete process.env.PRIME_API_BASE_URL;
-		} else {
-			process.env.PRIME_API_BASE_URL = originalPrimeBaseUrl;
-		}
-		if (tempDir && existsSync(tempDir)) {
-			rmSync(tempDir, { recursive: true, force: true });
-		}
-	});
-
-	it("does not upload when trace sharing is disabled", async () => {
-		const sessionManager = writeSession(tempDir, join(tempDir, "sessions"), "disabled-session");
-		const calls: FetchCall[] = [];
-		const result = await uploadAgentTraceFile({
-			sessionFile: sessionManager.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: false } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-			reloadConfig: false,
-		});
-
-		expect(result).toEqual({ status: "disabled" });
-		expect(calls).toHaveLength(0);
-	});
-
-	it("allows an explicit one-shot upload without enabling automatic sharing", async () => {
-		const sessionManager = writeSession(tempDir, join(tempDir, "sessions"), "one-shot-session");
-		const calls: FetchCall[] = [];
-		const result = await uploadAgentTraceFile({
-			sessionFile: sessionManager.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: false } }),
-			requireEnabled: false,
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-			reloadConfig: false,
-		});
-
-		expect(result.status).toBe("uploaded");
-		expect(calls).toHaveLength(1);
-	});
-
-	it("stops before reading the session body when trace sharing is disabled after upload starts", async () => {
-		const sessionManager = writeSession(tempDir, join(tempDir, "sessions"), "disabled-before-read-session");
-		const settingsManager = SettingsManager.inMemory({ agentTraces: { enabled: true } });
-		const enabledSpy = vi.spyOn(settingsManager, "getAgentTracesEnabled");
-		enabledSpy.mockReturnValueOnce(true).mockReturnValue(false);
-
-		const calls: FetchCall[] = [];
-		const result = await uploadAgentTraceFile({
-			sessionFile: sessionManager.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager,
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-			reloadConfig: false,
-		});
-
-		expect(result).toEqual({ status: "disabled" });
-		expect(calls).toHaveLength(0);
-		expect(enabledSpy).toHaveBeenCalledTimes(2);
-	});
-
-	it("rechecks trace sharing before sending the upload request", async () => {
-		const sessionManager = writeSession(tempDir, join(tempDir, "sessions"), "disabled-before-fetch-session");
-		const settingsManager = SettingsManager.inMemory({ agentTraces: { enabled: true } });
-		const enabledSpy = vi.spyOn(settingsManager, "getAgentTracesEnabled");
-		enabledSpy.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValue(false);
-
-		const calls: FetchCall[] = [];
-		const result = await uploadAgentTraceFile({
-			sessionFile: sessionManager.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager,
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-			reloadConfig: false,
-		});
-
-		expect(result).toEqual({ status: "disabled" });
-		expect(calls).toHaveLength(0);
-		expect(enabledSpy).toHaveBeenCalledTimes(3);
-	});
-
-	it("uploads raw session JSONL with trace headers", async () => {
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const parent = writeSession(cwd, sessionDir, "parent-session");
-		const child = writeSession(cwd, sessionDir, "child-session", parent.getSessionFile());
-		const childSessionFile = child.getSessionFile();
-		expect(childSessionFile).toBeDefined();
-
-		const calls: FetchCall[] = [];
-		const result = await uploadAgentTraceFile({
-			sessionFile: childSessionFile,
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-			reloadConfig: false,
-		});
-
-		expect(result).toEqual({
-			status: "uploaded",
-			sessionId: "uploaded-session",
-			traceId: "uploaded-trace",
-			bytesStored: 123,
-			key: "trace/key.jsonl",
-		});
-		expect(calls).toHaveLength(1);
-		const call = calls[0];
-		expect(call.url).toBe("https://api.example.test/api/v1/agent-traces/sessions/child-session");
-		expect(call.init.method).toBe("PUT");
-		expect(call.init.body).toBe(readFileSync(childSessionFile!, "utf8"));
-
-		const headers = new Headers(call.init.headers);
-		expect(headers.get("authorization")).toBe("Bearer trace-key");
-		expect(headers.get("content-type")).toBe("application/x-ndjson");
-		expect(headers.get("x-trace-id")).toBe("parent-session");
-		expect(headers.get("x-parent-session")).toBe("parent-session");
-		expect(headers.get("x-cwd")).toBe(cwd);
-		expect(headers.get("x-agent-version")).toBeTruthy();
-		expect(headers.get("content-length")).toBeNull();
-	});
-
-	it("uses the production trace API unless a trace-specific base URL is configured", async () => {
-		const sessionManager = writeSession(tempDir, join(tempDir, "sessions"), "prod-session");
-		const configPath = join(tempDir, "prime-config.json");
-		writeFileSync(configPath, JSON.stringify({ base_url: "https://dev-api.example/api/v1" }));
-		process.env.PRIME_API_BASE_URL = "https://wrong-api.example";
-
-		const calls: FetchCall[] = [];
-		const result = await uploadAgentTraceFile({
-			sessionFile: sessionManager.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			configPath,
-			fetchFn: createFetchRecorder(calls),
-			reloadConfig: false,
-		});
-
-		expect(result.status).toBe("uploaded");
-		expect(calls).toHaveLength(1);
-		expect(calls[0].url).toBe("https://api.primeintellect.ai/api/v1/agent-traces/sessions/prod-session");
-	});
-
-	it("uses PRIME_AGENT_TRACES_BASE_URL for trace API overrides", async () => {
-		const sessionManager = writeSession(tempDir, join(tempDir, "sessions"), "override-session");
-		process.env.PRIME_AGENT_TRACES_BASE_URL = "https://trace-api.example/api/v1";
-
-		const calls: FetchCall[] = [];
-		const result = await uploadAgentTraceFile({
-			sessionFile: sessionManager.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			fetchFn: createFetchRecorder(calls),
-			reloadConfig: false,
-		});
-
-		expect(result.status).toBe("uploaded");
-		expect(calls).toHaveLength(1);
-		expect(calls[0].url).toBe("https://trace-api.example/api/v1/agent-traces/sessions/override-session");
-	});
-
-	it("runs a startup catch-up on the first trace-upload install", async () => {
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const missed = writeSession(cwd, sessionDir, "missed-session");
-		const missedFile = missed.getSessionFile();
-		expect(missedFile).toBeDefined();
-		writeOutboxEntry(tempDir, missedFile as string);
-
-		const live = SessionManager.create(cwd, sessionDir);
-		live.newSession({ id: "live-session" });
-		const calls: FetchCall[] = [];
-		installAgentTraceUpload(live, {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-		});
-
-		await vi.waitFor(() => expect(calls).toHaveLength(1));
-		expect(calls[0].url).toBe("https://api.example.test/api/v1/agent-traces/sessions/missed-session");
-		expect(calls[0].init.body).toBe(readFileSync(missedFile as string, "utf8"));
-		const stats = await stat(missedFile as string);
-		await vi.waitFor(() =>
-			expect(readOutboxEntry(tempDir, missedFile as string)).toEqual({
-				sessionFile: missedFile,
-				size: stats.size,
-				mtimeMs: stats.mtimeMs,
-			}),
-		);
-	});
-
-	it("schedules upload only after the session file is persisted", async () => {
-		vi.useFakeTimers();
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const sessionManager = SessionManager.create(cwd, sessionDir);
-		sessionManager.newSession({ id: "listener-session" });
-
-		const calls: FetchCall[] = [];
-		installAgentTraceUpload(sessionManager, {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-		});
-
-		sessionManager.appendMessage(createUserMessage("hello"));
-		expect(vi.getTimerCount()).toBe(0);
-
-		sessionManager.appendMessage(createAssistantMessage("hi"));
-		await advanceTimersUntil(() => calls.length === 1);
-		expect(calls[0].url).toBe("https://api.example.test/api/v1/agent-traces/sessions/listener-session");
-	});
-
-	it("coalesces new content that persists during an in-flight upload into one follow-up upload", async () => {
-		vi.useFakeTimers();
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const sessionManager = SessionManager.create(cwd, sessionDir);
-		sessionManager.newSession({ id: "concurrent-upload-session" });
-
-		let releaseFetch: () => void = () => {};
-		const fetchReleased = new Promise<void>((resolve) => {
-			releaseFetch = resolve;
-		});
-		const calls: FetchCall[] = [];
-		const fetchFn: typeof fetch = async (input, init) => {
-			calls.push({ url: String(input), init: init ?? {} });
-			if (calls.length === 1) {
-				await fetchReleased;
-			}
-			return new Response(JSON.stringify({ bytes_stored: 123 }), {
-				status: 200,
-				headers: { "content-type": "application/json" },
-			});
-		};
-
-		installAgentTraceUpload(sessionManager, {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn,
-		});
-
-		sessionManager.appendMessage(createUserMessage("hello"));
-		sessionManager.appendMessage(createAssistantMessage("hi"));
-		await advanceTimersUntil(() => calls.length === 1);
-
-		// New content lands while the first upload is still in flight.
-		sessionManager.appendMessage(createUserMessage("more"));
-		sessionManager.appendMessage(createAssistantMessage("content"));
-		await advanceTimersUntil(() => vi.getTimerCount() > 0);
-		await vi.advanceTimersToNextTimerAsync();
-		expect(calls).toHaveLength(1);
-
-		releaseFetch();
-		await advanceTimersUntil(() => calls.length === 2);
-		const finalBody = readFileSync(sessionManager.getSessionFile() as string, "utf8");
-		expect(calls[1].init.body).toBe(finalBody);
-		// Drain the follow-up upload's completion so its chain cannot leak into later fake-timer tests.
-		await advanceTimersUntil(
-			() =>
-				readOutboxEntry(tempDir, sessionManager.getSessionFile() as string)?.size === Buffer.byteLength(finalBody),
-		);
-	});
-
-	it("schedules automatic uploads at most once per minute and only after new entries persist", async () => {
-		vi.useFakeTimers();
-		const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const sessionManager = SessionManager.create(cwd, sessionDir);
-		sessionManager.newSession({ id: "throttled-session" });
-
-		const calls: FetchCall[] = [];
-		installAgentTraceUpload(sessionManager, {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-		});
-
-		sessionManager.appendMessage(createUserMessage("hello"));
-		sessionManager.appendMessage(createAssistantMessage("hi"));
-		expect(Number(setTimeoutSpy.mock.calls.at(-1)?.[1])).toBe(1_000);
-		await advanceTimersUntil(() => calls.length === 1);
-
-		setTimeoutSpy.mockClear();
-		sessionManager.appendMessage(createUserMessage("next"));
-		expect(Number(setTimeoutSpy.mock.calls.at(-1)?.[1])).toBe(60_000);
-	});
-
-	it("surfaces the underlying fetch cause and logs the failure", async () => {
-		const session = writeSession(tempDir, join(tempDir, "sessions"), "failing-session");
-		const sessionFile = session.getSessionFile();
-
-		const failingFetch: typeof fetch = async () => {
-			const error = new TypeError("fetch failed");
-			(error as { cause?: unknown }).cause = { code: "ENOTFOUND", message: "getaddrinfo ENOTFOUND host" };
-			throw error;
-		};
-
-		const result = await uploadAgentTraceFile({
-			sessionFile,
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: failingFetch,
-			reloadConfig: false,
-		});
-
-		expect(result.status).toBe("failed");
-		if (result.status === "failed") {
-			expect(result.message).toBe("fetch failed (ENOTFOUND)");
-		}
-
-		const logContents = readFileSync(getAgentTracesLogPath(), "utf8");
-		expect(logContents).toContain("upload failed");
-		expect(logContents).toContain("fetch failed (ENOTFOUND)");
-		expect(logContents).toContain(sessionFile ?? "");
-	});
-
-	it("retries once on a transient connection failure, then succeeds", async () => {
-		const session = writeSession(tempDir, join(tempDir, "sessions"), "retry-session");
-		const calls: FetchCall[] = [];
-		let attempts = 0;
-		const flakyFetch: typeof fetch = async (input, init) => {
-			attempts += 1;
-			if (attempts === 1) {
-				const error = new TypeError("fetch failed");
-				(error as { cause?: unknown }).cause = { code: "ECONNRESET" };
-				throw error;
-			}
-			return createFetchRecorder(calls)(input, init);
-		};
-
-		const result = await uploadAgentTraceFile({
-			sessionFile: session.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: flakyFetch,
-			reloadConfig: false,
-		});
-
-		expect(attempts).toBe(2);
-		expect(result.status).toBe("uploaded");
-		expect(calls).toHaveLength(1);
-	});
-
-	it("uses bounded exponential backoff with jitter for transient failures", async () => {
-		const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
-		const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
-		const session = writeSession(tempDir, join(tempDir, "sessions"), "bounded-retry-session");
-		let attempts = 0;
-		const failingFetch: typeof fetch = async () => {
-			attempts += 1;
-			const error = new TypeError("fetch failed");
-			(error as { cause?: unknown }).cause = { code: "ECONNRESET" };
-			throw error;
-		};
-
-		const result = await uploadAgentTraceFile({
-			sessionFile: session.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: failingFetch,
-			reloadConfig: false,
-		});
-		expect(attempts).toBe(4);
-		expect(result.status).toBe("failed");
-		const retryDelays = timeoutSpy.mock.calls.map((call) => Number(call[1])).filter((delay) => delay < 15_000);
-		expect(retryDelays).toEqual([400, 800, 1_600]);
-		randomSpy.mockRestore();
-	});
-
-	it("retries request timeouts within the retry bound", async () => {
-		vi.useFakeTimers();
-		const session = writeSession(tempDir, join(tempDir, "sessions"), "timeout-retry-session");
-		let markFirstAttemptStarted: () => void = () => {};
-		const firstAttemptStarted = new Promise<void>((resolve) => {
-			markFirstAttemptStarted = resolve;
-		});
-		let attempts = 0;
-		const timeoutFetch: typeof fetch = async (_input, init) => {
-			attempts += 1;
-			if (attempts === 1) {
-				markFirstAttemptStarted();
-			}
-			return await new Promise<Response>((_resolve, reject) => {
-				const signal = init?.signal;
-				signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
-			});
-		};
-
-		const upload = uploadAgentTraceFile({
-			sessionFile: session.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: timeoutFetch,
-			requestTimeoutMs: 100,
-			reloadConfig: false,
-		});
-
-		await firstAttemptStarted;
-		await vi.runAllTimersAsync();
-		const result = await upload;
-		expect(attempts).toBe(4);
-		expect(result).toEqual({ status: "failed", message: "Trace upload timed out after 100ms" });
-	});
-
-	it("retries transient HTTP responses but not permanent HTTP responses", async () => {
-		const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
-		const session = writeSession(tempDir, join(tempDir, "sessions"), "http-retry-session");
-		let attempts = 0;
-		const fetchFn: typeof fetch = async () => {
-			attempts += 1;
-			if (attempts < 3) {
-				return new Response(JSON.stringify({ detail: "temporarily unavailable" }), { status: 503 });
-			}
-			return new Response(JSON.stringify({ bytes_stored: 42 }), { status: 200 });
-		};
-
-		const result = await uploadAgentTraceFile({
-			sessionFile: session.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn,
-			reloadConfig: false,
-		});
-		expect(attempts).toBe(3);
-		expect(result.status).toBe("uploaded");
-		randomSpy.mockRestore();
-	});
-
-	it("returns a rate-limited upload immediately instead of sleeping in-request", async () => {
-		const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
-		const session = writeSession(tempDir, join(tempDir, "sessions"), "rate-limit-session");
-		let attempts = 0;
-		const fetchFn: typeof fetch = async () => {
-			attempts += 1;
-			return new Response(JSON.stringify({ detail: "Too Many Requests" }), { status: 429 });
-		};
-
-		const result = await uploadAgentTraceFile({
-			sessionFile: session.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn,
-			reloadConfig: false,
-		});
-
-		expect(attempts).toBe(1);
-		expect(result).toMatchObject({ status: "failed", statusCode: 429 });
-		expect(timeoutSpy.mock.calls.map((call) => Number(call[1]))).not.toContain(60_000);
-	});
-
-	it("reschedules a rate-limited automatic upload without blocking and retries on the next cycle", async () => {
-		vi.useFakeTimers();
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const sessionManager = SessionManager.create(cwd, sessionDir);
-		sessionManager.newSession({ id: "rate-limit-reschedule-session" });
-
-		let attempts = 0;
-		const calls: FetchCall[] = [];
-		const fetchFn: typeof fetch = async (input, init) => {
-			attempts += 1;
-			if (attempts === 1) {
-				return new Response(JSON.stringify({ detail: "Too Many Requests" }), { status: 429 });
-			}
-			return createFetchRecorder(calls)(input, init);
-		};
-
-		installAgentTraceUpload(sessionManager, {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn,
-		});
-
-		sessionManager.appendMessage(createUserMessage("hello"));
-		sessionManager.appendMessage(createAssistantMessage("hi"));
-		await advanceTimersUntil(() => attempts === 1);
-		// The rate-limited cycle re-arms itself; the retry succeeds without any caller waiting.
-		await advanceTimersUntil(() => calls.length === 1);
-		expect(attempts).toBe(2);
-	});
-
-	it.each([503])("honors Retry-After when retrying HTTP %i", async (status) => {
-		vi.useFakeTimers();
-		const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
-		const session = writeSession(tempDir, join(tempDir, "sessions"), `retry-after-session-${status}`);
-		let markFirstAttemptStarted: () => void = () => {};
-		const firstAttemptStarted = new Promise<void>((resolve) => {
-			markFirstAttemptStarted = resolve;
-		});
-		let attempts = 0;
-		const fetchFn: typeof fetch = async () => {
-			attempts += 1;
-			if (attempts === 1) {
-				markFirstAttemptStarted();
-				return new Response(null, { status, headers: { "retry-after": "17" } });
-			}
-			return new Response(JSON.stringify({ bytes_stored: 42 }), { status: 200 });
-		};
-
-		const upload = uploadAgentTraceFile({
-			sessionFile: session.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn,
-			reloadConfig: false,
-		});
-
-		await firstAttemptStarted;
-		await vi.runAllTimersAsync();
-		const result = await upload;
-		expect(attempts).toBe(2);
-		expect(result.status).toBe("uploaded");
-		expect(timeoutSpy.mock.calls.map((call) => Number(call[1]))).toContain(17_000);
-	});
-
-	it("caps Retry-After at the platform rate-limit window", async () => {
-		vi.useFakeTimers();
-		const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
-		const session = writeSession(tempDir, join(tempDir, "sessions"), "bounded-retry-after-session");
-		let markFirstAttemptStarted: () => void = () => {};
-		const firstAttemptStarted = new Promise<void>((resolve) => {
-			markFirstAttemptStarted = resolve;
-		});
-		let attempts = 0;
-		const fetchFn: typeof fetch = async () => {
-			attempts += 1;
-			if (attempts === 1) {
-				markFirstAttemptStarted();
-				return new Response(null, { status: 503, headers: { "retry-after": "3600" } });
-			}
-			return new Response(JSON.stringify({ bytes_stored: 42 }), { status: 200 });
-		};
-
-		const upload = uploadAgentTraceFile({
-			sessionFile: session.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn,
-			reloadConfig: false,
-		});
-
-		await firstAttemptStarted;
-		await vi.runAllTimersAsync();
-		const result = await upload;
-		expect(attempts).toBe(2);
-		expect(result.status).toBe("uploaded");
-		expect(timeoutSpy.mock.calls.map((call) => Number(call[1]))).toContain(60_000);
-		expect(timeoutSpy.mock.calls.map((call) => Number(call[1]))).not.toContain(3_600_000);
-	});
-
-	it("surfaces the cancellation reason when aborted during the retry backoff", async () => {
-		const session = writeSession(tempDir, join(tempDir, "sessions"), "aborted-retry-session");
-		const controller = new AbortController();
-		const abortReason = new Error("upload cancelled");
-		let attempts = 0;
-		const flakyFetch: typeof fetch = async () => {
-			attempts += 1;
-			controller.abort(abortReason);
-			const error = new TypeError("fetch failed");
-			(error as { cause?: unknown }).cause = { code: "ECONNRESET" };
-			throw error;
-		};
-
-		const result = await uploadAgentTraceFile({
-			sessionFile: session.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: flakyFetch,
-			signal: controller.signal,
-			reloadConfig: false,
-		});
-
-		expect(attempts).toBe(1);
-		expect(result.status).toBe("failed");
-		if (result.status === "failed") {
-			expect(result.message).toBe("upload cancelled");
-		}
-	});
-
-	it("does not back off when an HTTP response cleanup aborts the upload", async () => {
-		vi.useFakeTimers();
-		const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
-		const session = writeSession(tempDir, join(tempDir, "sessions"), "aborted-http-retry-session");
-		const controller = new AbortController();
-		const abortReason = new Error("upload cancelled during cleanup");
-		let attempts = 0;
-		const fetchFn: typeof fetch = async () => {
-			attempts += 1;
-			return {
-				status: 503,
-				headers: new Headers(),
-				body: {
-					cancel: async () => {
-						controller.abort(abortReason);
-					},
-				},
-			} as unknown as Response;
-		};
-
-		const upload = uploadAgentTraceFile({
-			sessionFile: session.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn,
-			signal: controller.signal,
-			reloadConfig: false,
-		});
-
-		await vi.runAllTimersAsync();
-		const result = await upload;
-		expect(attempts).toBe(1);
-		expect(result).toEqual({ status: "failed", message: "upload cancelled during cleanup" });
-		const retryDelays = timeoutSpy.mock.calls.map((call) => Number(call[1])).filter((delay) => delay < 15_000);
-		expect(retryDelays).toEqual([]);
-	});
-
-	it("does not retry a permanent DNS failure", async () => {
-		const session = writeSession(tempDir, join(tempDir, "sessions"), "dns-failure-session");
-		let attempts = 0;
-		const dnsFailFetch: typeof fetch = async () => {
-			attempts += 1;
-			const error = new TypeError("fetch failed");
-			(error as { cause?: unknown }).cause = { code: "ENOTFOUND", message: "getaddrinfo ENOTFOUND host" };
-			throw error;
-		};
-
-		const result = await uploadAgentTraceFile({
-			sessionFile: session.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: dnsFailFetch,
-			reloadConfig: false,
-		});
-
-		expect(attempts).toBe(1);
-		expect(result.status).toBe("failed");
-		if (result.status === "failed") {
-			expect(result.message).toBe("fetch failed (ENOTFOUND)");
-		}
-	});
-
-	it("does not retry on an HTTP error response", async () => {
-		const session = writeSession(tempDir, join(tempDir, "sessions"), "http-error-session");
-		let attempts = 0;
-		const erroringFetch: typeof fetch = async () => {
-			attempts += 1;
-			return new Response(JSON.stringify({ detail: "bad request" }), {
-				status: 400,
-				headers: { "content-type": "application/json" },
-			});
-		};
-
-		const result = await uploadAgentTraceFile({
-			sessionFile: session.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: erroringFetch,
-			reloadConfig: false,
-		});
-
-		expect(attempts).toBe(1);
-		expect(result.status).toBe("failed");
-		if (result.status === "failed") {
-			expect(result.statusCode).toBe(400);
-		}
-	});
-
-	it("previews the current trace without requiring sharing or credentials", async () => {
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const parent = writeSession(cwd, sessionDir, "preview-parent");
-		const child = writeSession(cwd, sessionDir, "preview-child", parent.getSessionFile());
-
-		const result = await previewAgentTraceFile({
-			sessionFile: child.getSessionFile(),
-			baseUrl: "https://api.example.test",
-			maxContentChars: 256,
-		});
-
-		expect(result.status).toBe("ready");
-		if (result.status === "ready") {
-			expect(result).toMatchObject({
-				sessionId: "preview-child",
-				traceId: "preview-parent",
-				parentSessionId: "preview-parent",
-				cwd,
-				uploadable: true,
-				endpoint: "https://api.example.test/api/v1/agent-traces/sessions/preview-child",
-				truncated: true,
-			});
-			expect(result.contentPreview).toContain("middle of trace omitted");
-			expect(result.contentPreview).toContain("preview-child");
-		}
-	});
-
-	it("discovers and uploads saved parent and subagent traces", async () => {
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const parent = writeSession(cwd, sessionDir, "all-parent");
-		const childDir = join(tempDir, "session-artifacts", "all-parent", "sub-12345678");
-		const child = writeSession(cwd, childDir, "all-child", parent.getSessionFile());
-		const grandchildDir = join(childDir, "sub-87654321");
-		const grandchild = writeSession(cwd, grandchildDir, "all-grandchild", child.getSessionFile());
-		writeFileSync(join(childDir, "not-a-session.jsonl"), '{"type":"diagnostic"}\n');
-
-		const discovered = await findAgentTraceFiles(sessionDir);
-		expect(discovered).toEqual([child.getSessionFile(), grandchild.getSessionFile(), parent.getSessionFile()].sort());
-
-		vi.useFakeTimers();
-		const calls: FetchCall[] = [];
-		let resolveFirstCompletion: () => void = () => {};
-		const firstCompletion = new Promise<void>((resolve) => {
-			resolveFirstCompletion = resolve;
-		});
-		const progress: Array<{ completed: number; total: number }> = [];
-		const upload = uploadAllAgentTraces({
-			sessionDir,
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: false } }),
-			requireEnabled: false,
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-			reloadConfig: false,
-			concurrency: 0.5,
-			onProgress: ({ completed, total }) => {
-				progress.push({ completed, total });
-				if (completed === 1) {
-					resolveFirstCompletion();
-				}
+	it("sends the unchanged raw JSONL PUT with parent/root and active-branch git headers", async () => {
+		const parent = file("parent");
+		const child = file("child", root, [
+			{
+				type: "git_state",
+				id: "git-main",
+				parentId: null,
+				git: { repoUrl: "https://example.invalid/repo", commit: "main" },
 			},
+			{ type: "message", id: "leaf", parentId: "git-main" },
+			{ type: "git_state", id: "sibling", parentId: null, git: { commit: "wrong" } },
+			{ type: "message", id: "active", parentId: "leaf" },
+		]);
+		const lines = readFileSync(child, "utf8").split("\n");
+		lines[0] = JSON.stringify({ ...JSON.parse(lines[0]!), parentSession: parent });
+		writeFileSync(child, lines.join("\n"));
+		await queue(child, true);
+		await run();
+		const [url, init] = fetchFn.mock.calls[0]!;
+		expect(url).toBe("https://api.primeintellect.ai/api/v1/agent-traces/sessions/child");
+		expect(init?.method).toBe("PUT");
+		expect(Buffer.from(init!.body as ArrayBuffer).toString()).toBe(readFileSync(child, "utf8"));
+		expect(init?.headers).toMatchObject({
+			Authorization: "Bearer synthetic-key",
+			"Content-Type": "application/x-ndjson",
+			"X-Trace-Id": "parent",
+			"X-Parent-Session": "parent",
+			"X-Cwd": root,
+			"X-Git-Commit": "main",
+			"X-Git-Repo": "https://example.invalid/repo",
 		});
-		await firstCompletion;
-		await advanceTimersUntil(() => calls.length === 3);
-		const result = await upload;
-
-		expect(result).toMatchObject({ total: 3, uploaded: 3, failed: 0, skipped: 0, bytesStored: 369 });
-		expect(calls.map((call) => call.url).sort()).toEqual(
-			[
-				"https://api.example.test/api/v1/agent-traces/sessions/all-child",
-				"https://api.example.test/api/v1/agent-traces/sessions/all-grandchild",
-				"https://api.example.test/api/v1/agent-traces/sessions/all-parent",
-			].sort(),
+		expect(job(child).state).toBe("delivered");
+	});
+	it("keeps automatic uploads disabled by default and lets project settings only restrict global consent", async () => {
+		globalSettings(false);
+		projectSettings(root, true);
+		options.settingsManager = SettingsManager.create(root, agentDir);
+		expect(await queue(file())).toEqual({ status: "disabled" });
+		globalSettings(true);
+		projectSettings(root, false);
+		expect(await queue(file())).toEqual({ status: "disabled" });
+		projectSettings(root, true);
+		expect(await queue(file())).toMatchObject({ status: "queued" });
+	});
+	it("reads each backlog session's own project instead of the queue owner's project", async () => {
+		globalSettings(true);
+		projectSettings(root, true);
+		const other = join(root, "other");
+		projectSettings(other, false);
+		options.settingsManager = SettingsManager.create(root, agentDir);
+		const allowed = file("allowed");
+		const blocked = file("blocked", other);
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(autoPath(allowed), JSON.stringify({ sessionFile: allowed }));
+		writeFileSync(autoPath(blocked), JSON.stringify({ sessionFile: blocked }));
+		await run();
+		now += 61_000;
+		await run();
+		expect(fetchFn).toHaveBeenCalledOnce();
+		expect(job(blocked).state).toBe("paused");
+		projectSettings(other, true);
+		now += 61_000;
+		await run();
+		expect(fetchFn).toHaveBeenCalledTimes(2);
+	});
+	it.each(["global", "project"])("rechecks %s consent after queueing and after backoff", async (scope) => {
+		globalSettings(true);
+		projectSettings(root, true);
+		options.settingsManager = SettingsManager.create(root, agentDir);
+		const path = file();
+		await queue(path);
+		const set = (enabled: boolean) => (scope === "global" ? globalSettings(enabled) : projectSettings(root, enabled));
+		set(false);
+		await run();
+		expect(fetchFn).not.toHaveBeenCalled();
+		set(true);
+		fetchFn.mockResolvedValueOnce(new Response("", { status: 503, headers: { "Retry-After": "180" } }));
+		await run();
+		set(false);
+		now += 181_000;
+		await run();
+		expect(fetchFn).toHaveBeenCalledOnce();
+		set(true);
+		await run();
+		expect(fetchFn).toHaveBeenCalledTimes(2);
+	});
+	it("aborts an in-flight automatic request when consent is revoked", async () => {
+		globalSettings(true);
+		options.settingsManager = SettingsManager.create(root, agentDir);
+		fetchFn.mockImplementation(
+			async (_url, init) =>
+				new Promise((_resolve, reject) =>
+					init?.signal?.addEventListener("abort", () => reject(init.signal?.reason)),
+				),
 		);
-		const grandchildCall = calls.find((call) => call.url.endsWith("/all-grandchild"));
-		const grandchildHeaders = new Headers(grandchildCall?.init.headers);
-		expect(grandchildHeaders.get("x-trace-id")).toBe("all-parent");
-		expect(grandchildHeaders.get("x-parent-session")).toBe("all-child");
-		expect(progress[0]).toEqual({ completed: 0, total: 3 });
-		expect(progress.at(-1)).toEqual({ completed: 3, total: 3 });
+		const path = file();
+		await queue(path);
+		const active = run();
+		await vi.waitFor(() => expect(fetchFn).toHaveBeenCalledOnce());
+		globalSettings(false);
+		await active;
+		expect(fetchFn.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+		expect(job(path).state).toBe("paused");
 	});
-
-	it("paces batch request starts within the platform rate limit", async () => {
-		const sessionDir = join(tempDir, "sessions");
-		for (let index = 0; index < 6; index += 1) {
-			writeSession(tempDir, sessionDir, `rate-limited-all-${index}`);
+	it("rechecks consent after delayed credential resolution and preparation", async () => {
+		globalSettings(true);
+		options.settingsManager = SettingsManager.create(root, agentDir);
+		const real = payloadWorker.prepareTracePayload;
+		vi.spyOn(payloadWorker, "prepareTracePayload").mockImplementation(async (input) => {
+			const payload = await real(input);
+			globalSettings(false);
+			return payload;
+		});
+		await queue(file());
+		await run();
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+	it("persists Retry-After across replacement workers and new transcript content", async () => {
+		const path = file();
+		await queue(path);
+		fetchFn.mockResolvedValueOnce(new Response("", { status: 429, headers: { "Retry-After": "3600" } }));
+		await run();
+		const deadline = job(path).nextAttemptAt!;
+		appendFileSync(path, '{"id":"new-content"}\n');
+		now += 600_000;
+		await run();
+		expect(fetchFn).toHaveBeenCalledOnce();
+		expect(job(path).nextAttemptAt).toBe(deadline);
+		now = deadline;
+		await run();
+		expect(fetchFn).toHaveBeenCalledTimes(2);
+		expect(job(path).state).toBe("delivered");
+	});
+	it("uses capped exponential jitter for repeated network failures, without sleeping in the queue", async () => {
+		const path = file();
+		await queue(path, true);
+		vi.spyOn(Math, "random").mockReturnValue(0);
+		fetchFn.mockRejectedValue(new TypeError("fetch failed: secret synthetic-key"));
+		for (let attempt = 1; attempt <= 12; attempt++) {
+			await run();
+			const saved = job(path);
+			expect(saved.attempts).toBe(attempt);
+			const delay = saved.nextAttemptAt! - now;
+			expect(delay).toBe(Math.min(300_000, Math.min(300_000, 1_000 * 2 ** (attempt - 1)) * 0.8));
+			now = Math.max(saved.nextAttemptAt!, now + 12_100);
 		}
-
-		vi.useFakeTimers();
-		let markFirstRequestStarted: () => void = () => {};
-		const firstRequestStarted = new Promise<void>((resolve) => {
-			markFirstRequestStarted = resolve;
-		});
-		const requestStarts: number[] = [];
-		const fetchFn: typeof fetch = async () => {
-			requestStarts.push(Date.now());
-			if (requestStarts.length === 1) {
-				markFirstRequestStarted();
-			}
-			return new Response(JSON.stringify({ bytes_stored: 1 }), { status: 200 });
-		};
-
-		const upload = uploadAllAgentTraces({
-			sessionDir,
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: false } }),
-			requireEnabled: false,
-			baseUrl: "https://api.example.test",
-			fetchFn,
-			reloadConfig: false,
-		});
-
-		await firstRequestStarted;
-		await advanceTimersUntil(() => requestStarts.length === 6);
-		const result = await upload;
-		expect(result).toMatchObject({ total: 6, uploaded: 6, failed: 0, skipped: 0 });
-		expect(requestStarts).toHaveLength(6);
-		for (let index = 1; index < requestStarts.length; index += 1) {
-			expect(requestStarts[index]! - requestStarts[index - 1]!).toBeGreaterThanOrEqual(12_000);
+		expect(readFileSync(join(agentDir, "logs", "agent-traces.log"), "utf8").match(/Trace delivery/g)).toHaveLength(1);
+	});
+	it("backs off preparation failures exponentially and isolates a corrupt entry", async () => {
+		const path = file();
+		await queue(path, true);
+		writeFileSync(join(dir, "000-corrupt.json"), JSON.stringify({ sessionFile: path, manual: true }));
+		vi.spyOn(payloadWorker, "prepareTracePayload").mockRejectedValue(new Error("disk read failed"));
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		for (let attempt = 1; attempt <= 3; attempt++) {
+			await run();
+			expect(job(path).attempts).toBe(attempt);
+			expect(job(path).nextAttemptAt).toBe(now + 1_000 * 2 ** (attempt - 1));
+			now = job(path).nextAttemptAt!;
 		}
-		expect(requestStarts[5]! - requestStarts[0]!).toBeGreaterThanOrEqual(60_000);
+		expect(fetchFn).not.toHaveBeenCalled();
 	});
-
-	it("stops scheduling batch uploads after cancellation", async () => {
-		const sessionDir = join(tempDir, "sessions");
-		writeSession(tempDir, sessionDir, "abort-all-a");
-		writeSession(tempDir, sessionDir, "abort-all-b");
-		writeSession(tempDir, sessionDir, "abort-all-c");
-		const controller = new AbortController();
-		const calls: FetchCall[] = [];
-
-		const result = await uploadAllAgentTraces({
-			sessionDir,
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: false } }),
-			requireEnabled: false,
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-			reloadConfig: false,
-			concurrency: 1,
-			signal: controller.signal,
-			onProgress: ({ completed }) => {
-				if (completed === 1) {
-					controller.abort(new Error("cancel batch"));
-				}
-			},
-		});
-
-		expect(calls).toHaveLength(1);
-		expect(result).toMatchObject({ total: 3, uploaded: 1, failed: 0, skipped: 2 });
-		expect(result.results).toHaveLength(1);
+	it("times out a stalled request and preserves its retry", async () => {
+		options.requestTimeoutMs = 30;
+		fetchFn.mockImplementation(
+			async (_url, init) =>
+				new Promise((_resolve, reject) =>
+					init?.signal?.addEventListener("abort", () => reject(init.signal?.reason)),
+				),
+		);
+		const path = file();
+		await queue(path, true);
+		await run();
+		expect(job(path)).toMatchObject({ state: "retrying", failure: { reason: "timeout" } });
 	});
-
-	it("counts in-flight batch cancellations as skipped", async () => {
-		const sessionDir = join(tempDir, "sessions");
-		writeSession(tempDir, sessionDir, "abort-in-flight-a");
-		writeSession(tempDir, sessionDir, "abort-in-flight-b");
-		writeSession(tempDir, sessionDir, "abort-in-flight-c");
-		const controller = new AbortController();
-		const abortReason = new Error("cancel in-flight batch");
-		vi.useFakeTimers();
-		let markFirstRequestStarted: () => void = () => {};
-		const firstRequestStarted = new Promise<void>((resolve) => {
-			markFirstRequestStarted = resolve;
-		});
-		let attempts = 0;
-		const fetchFn: typeof fetch = async (_input, init) => {
-			attempts += 1;
-			if (attempts === 1) {
-				markFirstRequestStarted();
-			}
-			return await new Promise<Response>((_resolve, reject) => {
-				init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
-				if (attempts === 2) {
-					queueMicrotask(() => controller.abort(abortReason));
-				}
+	it("shares ownership and request spacing between queue instances", async () => {
+		const one = file("one"),
+			two = file("two");
+		await queue(one, true);
+		await queue(two, true);
+		let finish!: (response: Response) => void;
+		fetchFn.mockImplementationOnce(
+			async () =>
+				new Promise((resolve) => {
+					finish = resolve;
+				}),
+		);
+		const first = run();
+		await vi.waitFor(() => expect(fetchFn).toHaveBeenCalledOnce());
+		await run();
+		expect(fetchFn).toHaveBeenCalledOnce();
+		const status = await readAgentTraceStatus({ ...options, sessionFile: one });
+		expect(status.inProgress).toBe(1);
+		finish(new Response("", { status: 200 }));
+		await first;
+		await run();
+		expect(fetchFn).toHaveBeenCalledOnce();
+		now += 12_100;
+		await run();
+		expect(fetchFn).toHaveBeenCalledTimes(2);
+	});
+	it.each(["credential", "response"] as const)(
+		"does not commit stale state after ownership is lost during %s",
+		async (phase) => {
+			const path = file();
+			await queue(path, true);
+			const realLock = lockfile.lock;
+			let loseOwnership: (() => void) | undefined;
+			vi.spyOn(lockfile, "lock").mockImplementation(async (path, lockOptions) => {
+				loseOwnership = () => lockOptions?.onCompromised?.(new Error("lost"));
+				return realLock(path, lockOptions);
 			});
-		};
-
-		const upload = uploadAllAgentTraces({
-			sessionDir,
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: false } }),
-			requireEnabled: false,
-			baseUrl: "https://api.example.test",
-			fetchFn,
-			reloadConfig: false,
-			concurrency: 2,
-			signal: controller.signal,
-		});
-		await firstRequestStarted;
-		await advanceTimersUntil(() => attempts === 2);
-		const result = await upload;
-
-		expect(attempts).toBe(2);
-		expect(result).toMatchObject({ total: 3, uploaded: 0, failed: 0, skipped: 3 });
-		expect(result.results).toHaveLength(0);
+			if (phase === "credential")
+				vi.spyOn(options.authStorage, "readApiKeyConfig").mockImplementation(async () => {
+					loseOwnership?.();
+					throw new Error("aborted");
+				});
+			else
+				fetchFn.mockImplementation(async () => {
+					loseOwnership?.();
+					return new Response("", { status: 200 });
+				});
+			await run();
+			expect(job(path).state).toBe(phase === "credential" ? "queued" : "uploading");
+			expect(readdirSync(dir).some((name) => name.startsWith(".delivered-"))).toBe(false);
+			if (phase === "credential") expect(fetchFn).not.toHaveBeenCalled();
+		},
+	);
+	it("recovers an abandoned uploading job and a stale process lease", async () => {
+		const path = file();
+		await queue(path, true);
+		const entry = entries()[0]!;
+		writeFileSync(entry.path, JSON.stringify({ ...entry.job, state: "uploading" }));
+		mkdirSync(join(dir, ".delivery.lock"));
+		// Date.now is already ten seconds ahead; advance beyond the lock's stale interval.
+		now += 40_000;
+		await run();
+		expect(fetchFn).toHaveBeenCalledOnce();
+		expect(job(path).state).toBe("delivered");
 	});
-
-	it("durably records upload intent on disk before any upload happens", async () => {
-		vi.useFakeTimers();
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const sessionManager = SessionManager.create(cwd, sessionDir);
-		sessionManager.newSession({ id: "unflushed-session" });
-
-		const calls: FetchCall[] = [];
-		installAgentTraceUpload(sessionManager, {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-		});
-
-		sessionManager.appendMessage(createUserMessage("hello"));
-		sessionManager.appendMessage(createAssistantMessage("hi"));
-		const sessionFile = sessionManager.getSessionFile();
-		expect(sessionFile).toBeDefined();
-
-		// Synchronously durable: the intent marker is on disk the moment the persist returns.
-		expect(readOutboxEntry(tempDir, sessionFile as string)).toEqual({ sessionFile });
-		expect(calls).toHaveLength(0);
+	it("does not starve manual jobs behind continuously changing automatic sessions", async () => {
+		const automatic = Array.from({ length: 5 }, (_, index) => file(`auto-${index}`));
+		for (const path of automatic) await queue(path);
+		for (let i = 0; i < 5; i++) {
+			await run();
+			now += 12_100;
+		}
+		const manual = file("manual-last");
+		await queue(manual, true);
+		for (let i = 0; i < 6; i++) {
+			for (const path of automatic) appendFileSync(path, `{"id":"dirty-${i}"}\n`);
+			await run();
+			now += 12_100;
+		}
+		expect(job(manual).state).toBe("delivered");
 	});
-
-	it("catch-up uploads exactly the content a previous process never uploaded, then goes quiet", async () => {
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const missed = writeSession(cwd, sessionDir, "crash-lost-session");
-		const missedFile = missed.getSessionFile() as string;
-		writeOutboxEntry(tempDir, missedFile);
-
-		const calls: FetchCall[] = [];
-		const options = {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-			reloadConfig: false,
-		};
-
-		const first = await catchUpAgentTraceUploads(options);
-		expect(first.results.map(({ result }) => result.status)).toEqual(["uploaded"]);
-		expect(calls).toHaveLength(1);
-		expect(calls[0].init.body).toBe(readFileSync(missedFile, "utf8"));
-		const stats = await stat(missedFile);
-		expect(readOutboxEntry(tempDir, missedFile)).toEqual({
-			sessionFile: missedFile,
-			size: stats.size,
-			mtimeMs: stats.mtimeMs,
-		});
-
-		// Unchanged content: subsequent cycles and restarts never re-POST.
-		const second = await catchUpAgentTraceUploads(options);
-		expect(second.results).toEqual([]);
-		const automatic = await uploadAgentTraceFile({ ...options, sessionFile: missedFile });
-		expect(automatic).toEqual({ status: "unchanged" });
-		expect(calls).toHaveLength(1);
+	it("pauses an invalid credential globally and resumes when it changes", async () => {
+		await queue(file("one"), true);
+		await queue(file("two"), true);
+		fetchFn.mockResolvedValueOnce(new Response("synthetic-key", { status: 401 }));
+		await run();
+		now += 61_000;
+		await run();
+		await run();
+		expect(fetchFn).toHaveBeenCalledOnce();
+		options.authStorage.set(PRIME_AGENT_TRACES_PROVIDER_ID, { type: "api_key", key: "replacement" });
+		await run();
+		expect(fetchFn).toHaveBeenCalledTimes(2);
 	});
-
-	it("prunes cursor entries whose session file was deleted", async () => {
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const kept = writeSession(cwd, sessionDir, "kept-session");
-		const keptFile = kept.getSessionFile() as string;
-		const keptStats = await stat(keptFile);
-		const keptSignature = { size: keptStats.size, mtimeMs: keptStats.mtimeMs };
-		const deletedFile = join(sessionDir, "deleted-session.jsonl");
-		writeOutboxEntry(tempDir, deletedFile);
-		writeOutboxEntry(tempDir, keptFile, keptSignature);
-
-		const calls: FetchCall[] = [];
-		const result = await catchUpAgentTraceUploads({
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-			reloadConfig: false,
-		});
-
-		expect(result).toEqual({ pruned: 1, semanticEdgeLedgersPending: 0, results: [] });
-		expect(calls).toHaveLength(0);
-		expect(existsSync(outboxEntryPath(tempDir, deletedFile))).toBe(false);
-		expect(readOutboxEntry(tempDir, keptFile)).toEqual({ sessionFile: keptFile, ...keptSignature });
+	it("recovers missing credentials without a restart or explicit upload", async () => {
+		options.authStorage.remove(PRIME_AGENT_TRACES_PROVIDER_ID);
+		const path = file();
+		await queue(path, true);
+		await run();
+		expect(job(path).state).toBe("paused");
+		options.authStorage.set(PRIME_AGENT_TRACES_PROVIDER_ID, { type: "api_key", key: "restored" });
+		await run();
+		expect(job(path).state).toBe("delivered");
 	});
-
-	it("registers the semantic-edge ledger with a kind-tagged durable intent at persist", async () => {
-		vi.useFakeTimers();
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const sessionManager = SessionManager.create(cwd, sessionDir);
-		sessionManager.newSession({ id: "ledger-intent-session" });
-		const ledgerPath = join(tempDir, "artifacts", "semantic-edges.jsonl");
-
-		const calls: FetchCall[] = [];
-		installAgentTraceUpload(sessionManager, {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-			semanticEdgesLedgerPath: ledgerPath,
-		});
-		sessionManager.appendMessage(createUserMessage("hello"));
-		sessionManager.appendMessage(createAssistantMessage("hi"));
-
-		// Synchronously durable, tagged with its own delivery kind, before any wire call.
-		expect(readOutboxEntry(tempDir, ledgerPath)).toEqual({ sessionFile: ledgerPath, kind: "semantic-edges" });
-		expect(calls).toHaveLength(0);
-
-		// A re-install with a DIFFERENT ledger path registers the new ledger at the next persist.
-		const movedLedgerPath = join(tempDir, "artifacts-moved", "semantic-edges.jsonl");
-		installAgentTraceUpload(sessionManager, {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-			semanticEdgesLedgerPath: movedLedgerPath,
-		});
-		sessionManager.appendMessage(createAssistantMessage("after re-install"));
-		expect(readOutboxEntry(tempDir, movedLedgerPath)).toEqual({
-			sessionFile: movedLedgerPath,
-			kind: "semantic-edges",
-		});
-		expect(calls).toHaveLength(0);
+	it("pauses permanent HTTP failures until the automatic file or endpoint changes", async () => {
+		const path = file();
+		await queue(path);
+		fetchFn.mockResolvedValueOnce(new Response("", { status: 404 }));
+		await run();
+		now += 61_000;
+		await run();
+		expect(fetchFn).toHaveBeenCalledOnce();
+		options.baseUrl = "https://synthetic.invalid";
+		await run();
+		expect(fetchFn).toHaveBeenCalledTimes(2);
 	});
-
-	it("creates no outbox intent while trace sharing is disabled", async () => {
-		vi.useFakeTimers();
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const sessionManager = SessionManager.create(cwd, sessionDir);
-		sessionManager.newSession({ id: "opted-out-session" });
-		const ledgerPath = join(tempDir, "artifacts", "semantic-edges.jsonl");
-
-		installAgentTraceUpload(sessionManager, {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: false } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder([]),
-			semanticEdgesLedgerPath: ledgerPath,
-		});
-		sessionManager.appendMessage(createUserMessage("private"));
-		sessionManager.appendMessage(createAssistantMessage("also private"));
-
-		// Neither kind leaves a durable entry: enabling sharing later must not
-		// retroactively collect sessions recorded while sharing was off.
-		expect(readOutboxEntry(tempDir, sessionManager.getSessionFile() as string)).toBeUndefined();
-		expect(readOutboxEntry(tempDir, ledgerPath)).toBeUndefined();
+	it("retries an oversized automatic file only after its signature changes", async () => {
+		const path = file();
+		appendFileSync(path, "x".repeat(21 * 1024 * 1024));
+		await queue(path);
+		await run();
+		expect(job(path)).toMatchObject({ state: "failed", failure: { reason: "too_large" } });
+		const prepare = vi.spyOn(payloadWorker, "prepareTracePayload");
+		now += 61_000;
+		await run();
+		expect(prepare).not.toHaveBeenCalled();
+		file();
+		await run();
+		expect(fetchFn).toHaveBeenCalledOnce();
 	});
+});
 
-	it("re-registers the ledger at the next persist after its entry is pruned", async () => {
-		vi.useFakeTimers();
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const sessionManager = SessionManager.create(cwd, sessionDir);
-		sessionManager.newSession({ id: "pruned-ledger-session" });
-		const ledgerPath = join(tempDir, "artifacts", "semantic-edges.jsonl");
-
-		installAgentTraceUpload(sessionManager, {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder([]),
-			semanticEdgesLedgerPath: ledgerPath,
-		});
-		sessionManager.appendMessage(createUserMessage("hello"));
-		sessionManager.appendMessage(createAssistantMessage("hi"));
-		expect(readOutboxEntry(tempDir, ledgerPath)).toEqual({ sessionFile: ledgerPath, kind: "semantic-edges" });
-
-		// A concurrent catch-up pruned the entry (missing ledger file at scan time).
-		rmSync(outboxEntryPath(tempDir, ledgerPath));
-		sessionManager.appendMessage(createUserMessage("still here"));
-		expect(readOutboxEntry(tempDir, ledgerPath)).toEqual({ sessionFile: ledgerPath, kind: "semantic-edges" });
+describe("one-shot authorization", () => {
+	it.each(["append", "replace"])("expires safely when the file is changed by %s before capture", async (change) => {
+		options.settingsManager = SettingsManager.inMemory();
+		const path = file();
+		await queue(path, true);
+		if (change === "append") appendFileSync(path, '{"id":"later"}\n');
+		else {
+			const replacement = file("replacement");
+			renameSync(replacement, path);
+		}
+		await run();
+		expect(fetchFn).not.toHaveBeenCalled();
+		expect(job(path)).toMatchObject({ state: "failed", failure: { reason: "snapshot_changed" } });
+		expect(formatAgentTraceStatus(await readAgentTraceStatus({ ...options, sessionFile: path }))).toContain(
+			"authorize its current content",
+		);
 	});
-
-	it("counts appended ledger bytes as pending, stays quiet at the cursor, and prunes deleted ledgers", async () => {
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(sessionDir, { recursive: true });
-		const ledgerFile = join(sessionDir, "semantic-edges.jsonl");
-		writeFileSync(ledgerFile, `${JSON.stringify({ type: "session_registered", session_id: "s" })}\n`);
-		writeLedgerOutboxEntry(tempDir, ledgerFile);
-		const deletedLedger = join(sessionDir, "gone", "semantic-edges.jsonl");
-		writeLedgerOutboxEntry(tempDir, deletedLedger);
-
-		const calls: FetchCall[] = [];
-		const options = {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-			reloadConfig: false,
-		};
-
-		// Catch-up after a kill: the never-delivered ledger is pending; the deleted one is pruned.
-		const first = await catchUpAgentTraceUploads(options);
-		expect(first).toEqual({ pruned: 1, semanticEdgeLedgersPending: 1, results: [] });
-		expect(existsSync(outboxEntryPath(tempDir, deletedLedger))).toBe(false);
-		// The cursor stays untouched: the first real sender must deliver the whole backlog.
-		expect(readOutboxEntry(tempDir, ledgerFile)).toEqual({ sessionFile: ledgerFile, kind: "semantic-edges" });
-
-		// A cursor at the file size means unchanged: never re-counted, never resent.
-		const { size } = await stat(ledgerFile);
-		writeLedgerOutboxEntry(tempDir, ledgerFile, size);
-		const second = await catchUpAgentTraceUploads(options);
-		expect(second).toEqual({ pruned: 0, semanticEdgeLedgersPending: 0, results: [] });
-
-		// Appended bytes beyond the cursor become pending again.
-		writeFileSync(ledgerFile, `${JSON.stringify({ type: "request_started", request_id: "r", session_id: "s" })}\n`, {
-			flag: "a",
-		});
-		const third = await catchUpAgentTraceUploads(options);
-		expect(third).toEqual({ pruned: 0, semanticEdgeLedgersPending: 1, results: [] });
-		expect(calls).toHaveLength(0);
+	it.each(["append", "replace", "delete"])(
+		"retries only the captured bytes after %s and owner replacement",
+		async (change) => {
+			options.settingsManager = SettingsManager.inMemory();
+			const path = file();
+			const original = readFileSync(path, "utf8");
+			await queue(path, true);
+			fetchFn.mockRejectedValueOnce(new TypeError("offline"));
+			await run();
+			if (change === "append") appendFileSync(path, '{"id":"later"}\n');
+			else if (change === "replace") renameSync(file("replacement"), path);
+			else rmSync(path);
+			now += 61_000;
+			await run();
+			expect(fetchFn).toHaveBeenCalledTimes(2);
+			expect(Buffer.from(fetchFn.mock.calls[1]![1]!.body as ArrayBuffer).toString()).toBe(original);
+			expect(options.settingsManager.getAgentTracesEnabled()).toBe(false);
+			expect(existsSync(autoPath(path))).toBe(false);
+		},
+	);
+	it("does not let an older manual retry overwrite a newer automatic delivery", async () => {
+		const path = file();
+		await queue(path, true);
+		fetchFn.mockRejectedValueOnce(new TypeError("offline"));
+		await run();
+		const manualEntry = entries()[0]!;
+		const deadline = now + 120_000;
+		writeFileSync(manualEntry.path, JSON.stringify({ ...job(path), nextAttemptAt: deadline }));
+		appendFileSync(path, '{"id":"newer"}\n');
+		await queue(path);
+		now += 61_000;
+		await run();
+		expect(fetchFn).toHaveBeenCalledTimes(2);
+		now = deadline;
+		await run();
+		expect(fetchFn).toHaveBeenCalledTimes(2);
+		expect(JSON.parse(readFileSync(manualEntry.path, "utf8")).state).toBe("superseded");
 	});
-
-	it("arms upload timers that never hold the process open", async () => {
-		const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const sessionManager = SessionManager.create(cwd, sessionDir);
-		sessionManager.newSession({ id: "unref-session" });
-
-		const calls: FetchCall[] = [];
-		installAgentTraceUpload(sessionManager, {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-		});
-
-		sessionManager.appendMessage(createUserMessage("hello"));
-		sessionManager.appendMessage(createAssistantMessage("hi"));
-		const timer = setTimeoutSpy.mock.results.at(-1)?.value as NodeJS.Timeout;
-		expect(timer.hasRef()).toBe(false);
+	it("persists cancellation before owner replacement and does not resume a cancelled retry", async () => {
+		const controller = new AbortController();
+		const path = file();
+		const receipt = await queue(path, true, controller.signal);
+		expect(receipt.status).toBe("queued");
+		fetchFn.mockRejectedValueOnce(new TypeError("offline"));
+		await run();
+		controller.abort();
+		now += 61_000;
+		await run();
+		expect(fetchFn).toHaveBeenCalledOnce();
+		expect(job(path).state).toBe("cancelled");
 	});
-
-	it("honors an advertised Retry-After on the next scheduled cycle without blocking", async () => {
-		vi.useFakeTimers();
-		const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const sessionManager = SessionManager.create(cwd, sessionDir);
-		sessionManager.newSession({ id: "retry-after-reschedule-session" });
-
-		let attempts = 0;
-		const calls: FetchCall[] = [];
-		const fetchFn: typeof fetch = async (input, init) => {
-			attempts += 1;
-			if (attempts === 1) {
-				return new Response(null, { status: 429, headers: { "retry-after": "300" } });
-			}
-			return createFetchRecorder(calls)(input, init);
-		};
-
-		installAgentTraceUpload(sessionManager, {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn,
-		});
-
-		sessionManager.appendMessage(createUserMessage("hello"));
-		sessionManager.appendMessage(createAssistantMessage("hi"));
-		await advanceTimersUntil(() => attempts === 1);
-		await advanceTimersUntil(() => vi.getTimerCount() > 0);
-		expect(Number(setTimeoutSpy.mock.calls.at(-1)?.[1])).toBe(300_000);
-
-		// A fresh persist must not re-arm inside the advertised window.
-		sessionManager.appendMessage(createUserMessage("more"));
-		expect(Number(setTimeoutSpy.mock.calls.at(-1)?.[1])).toBeGreaterThanOrEqual(299_000);
-
-		await advanceTimersUntil(() => calls.length === 1);
-		expect(attempts).toBe(2);
+	it("cancels an active owner through a separately persisted request cancellation", async () => {
+		const receipt = await queue(file(), true);
+		if (receipt.status !== "queued") throw new Error("not queued");
+		fetchFn.mockImplementation(
+			async (_url, init) =>
+				new Promise((_resolve, reject) =>
+					init?.signal?.addEventListener("abort", () => reject(init.signal?.reason)),
+				),
+		);
+		const running = run();
+		await vi.waitFor(() => expect(fetchFn).toHaveBeenCalledOnce());
+		await cancelAgentTraceRequest(receipt.requestId, agentDir);
+		await running;
+		expect(entries()[0]!.job.state).toBe("cancelled");
 	});
-
-	it("retries the intent marker on the next persist after a failed write", async () => {
-		vi.useFakeTimers();
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const sessionManager = SessionManager.create(cwd, sessionDir);
-		sessionManager.newSession({ id: "marker-retry-session" });
-		const blocker = join(tempDir, "agent-traces-outbox");
-		writeFileSync(blocker, "not a directory");
-
-		const calls: FetchCall[] = [];
-		installAgentTraceUpload(sessionManager, {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-		});
-
-		sessionManager.appendMessage(createUserMessage("hello"));
-		sessionManager.appendMessage(createAssistantMessage("hi"));
-		const sessionFile = sessionManager.getSessionFile() as string;
-		expect(readOutboxEntry(tempDir, sessionFile)).toBeUndefined();
-
-		rmSync(blocker);
-		sessionManager.appendMessage(createUserMessage("again"));
-		expect(readOutboxEntry(tempDir, sessionFile)).toEqual({ sessionFile });
+	it("does bulk discovery in the background and excludes versions created after the request", async () => {
+		const existing = file("existing");
+		await uploadAllAgentTraces({ ...options, sessionDir: root, requireEnabled: false });
+		now += 1;
+		const later = file("later");
+		// Simulate a file created after the request despite the synthetic clock.
+		const batch = readdirSync(dir).find((name) => name.startsWith("batch-"))!;
+		const data = JSON.parse(readFileSync(join(dir, batch), "utf8"));
+		data.requestedAt = statSync(existing).ctimeMs + 0.1;
+		writeFileSync(join(dir, batch), JSON.stringify(data));
+		await run();
+		expect(fetchFn).not.toHaveBeenCalled();
+		expect(entries().map((item) => item.job.sessionFile)).toEqual([existing]);
+		expect(entries().some((item) => item.job.sessionFile === later)).toBe(false);
+		await run();
+		expect(fetchFn).toHaveBeenCalledOnce();
 	});
-
-	it("caps an absurd Retry-After at the max timer delay instead of retrying immediately", async () => {
-		vi.useFakeTimers();
-		const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const sessionManager = SessionManager.create(cwd, sessionDir);
-		sessionManager.newSession({ id: "absurd-retry-after-session" });
-
-		let attempts = 0;
-		const fetchFn: typeof fetch = async () => {
-			attempts += 1;
-			// 30 days, far beyond Node's ~24.8-day timer maximum.
-			return new Response(null, { status: 429, headers: { "retry-after": "2592000" } });
-		};
-
-		installAgentTraceUpload(sessionManager, {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn,
-		});
-
-		sessionManager.appendMessage(createUserMessage("hello"));
-		sessionManager.appendMessage(createAssistantMessage("hi"));
-		await advanceTimersUntil(() => attempts === 1);
-		await advanceTimersUntil(() => vi.getTimerCount() > 0);
-		expect(Number(setTimeoutSpy.mock.calls.at(-1)?.[1])).toBe(2_147_483_647);
+	it("cancels persisted manual and bulk requests after the client has restarted", async () => {
+		await queue(file("one"), true);
+		await uploadAllAgentTraces({ ...options, sessionDir: root, requireEnabled: false });
+		expect(await cancelPendingAgentTraceRequests(agentDir)).toEqual({ cancelled: 2, failed: 0 });
+		await run();
+		expect(fetchFn).not.toHaveBeenCalled();
 	});
+	it("contains cancellation marker failures instead of throwing from an AbortSignal listener", async () => {
+		const controller = new AbortController();
+		await queue(file(), true, controller.signal);
+		rmSync(dir, { recursive: true });
+		writeFileSync(dir, "not a directory");
+		expect(() => controller.abort()).not.toThrow();
+		expect(readFileSync(join(agentDir, "logs", "agent-traces.log"), "utf8")).toContain("could not be recorded");
+	});
+	it("keeps a cancelled bulk request cancelled after discovery and retries", async () => {
+		file("one");
+		file("two");
+		const controller = new AbortController();
+		await uploadAllAgentTraces({ ...options, sessionDir: root, requireEnabled: false, signal: controller.signal });
+		await run();
+		controller.abort();
+		await run();
+		expect(fetchFn).not.toHaveBeenCalled();
+		expect(entries().every((entry) => entry.job.state === "cancelled")).toBe(true);
+	});
+});
 
-	it("returns a retryable failure when the upload cursor cannot be persisted", async () => {
-		const session = writeSession(tempDir, join(tempDir, "sessions"), "cursor-persist-failure");
-		writeFileSync(join(tempDir, "agent-traces-outbox"), "not a directory");
-
-		const calls: FetchCall[] = [];
-		const result = await uploadAgentTraceFile({
-			sessionFile: session.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-			reloadConfig: false,
+describe("status and responsiveness", () => {
+	it("reads shared progress without credential resolution, network, writes, or secrets", async () => {
+		const path = file();
+		await queue(path, true);
+		fetchFn.mockResolvedValueOnce(new Response("payload secret synthetic-key", { status: 403 }));
+		await run();
+		const key = vi
+			.spyOn(options.authStorage, "getApiKey")
+			.mockRejectedValue(new Error("must not resolve credentials"));
+		const before = readdirSync(dir).map((name) => [name, statSync(join(dir, name)).mtimeMs]);
+		const status = await readAgentTraceStatus({
+			...options,
+			sessionFile: path,
+			baseUrl: "https://user:synthetic-key@host.invalid/custom?key=synthetic-key",
 		});
-
-		expect(calls).toHaveLength(1);
-		expect(result.status).toBe("failed");
-		if (result.status === "failed") {
-			expect(result.message).toContain("cursor");
+		const output = formatAgentTraceStatus(status);
+		expect(key).not.toHaveBeenCalled();
+		expect(fetchFn).toHaveBeenCalledOnce();
+		expect(status.paused).toBe(1);
+		expect(output).toContain("run /traces login");
+		expect(output).toContain("https://host.invalid/custom");
+		expect(output).toContain(`Session file: ${path}`);
+		expect(output).toContain("Prime Agent Traces credential");
+		expect(output).not.toContain("synthetic-key");
+		expect(output).not.toContain("payload secret");
+		expect(readdirSync(dir).map((name) => [name, statSync(join(dir, name)).mtimeMs])).toEqual(before);
+	});
+	it("isolates malformed delivery metadata during status reads and queue scans", async () => {
+		const path = file();
+		await queue(path, true);
+		writeFileSync(
+			join(dir, "malformed.json"),
+			JSON.stringify({ sessionFile: path, failure: { reason: "http", at: 1e99, statusCode: "secret" } }),
+		);
+		expect(formatAgentTraceStatus(await readAgentTraceStatus(options))).not.toContain("secret");
+		await run();
+		expect(fetchFn).toHaveBeenCalledOnce();
+	});
+	it("reports queued, retrying, delivered and changed current content without claiming future content was shared", async () => {
+		const path = file();
+		await queue(path, true);
+		expect((await readAgentTraceStatus({ ...options, sessionFile: path })).pending).toBe(1);
+		fetchFn.mockRejectedValueOnce(new TypeError("offline"));
+		await run();
+		expect((await readAgentTraceStatus({ ...options, sessionFile: path })).currentSession).toContain("retrying");
+		now += 61_000;
+		await run();
+		appendFileSync(path, '{"id":"unshared"}\n');
+		const status = await readAgentTraceStatus({ ...options, sessionFile: path });
+		expect(status.lastSuccessAt).toBe(now);
+		expect(status.currentSession).toContain("newer or changed content");
+	});
+	it("preserves semantic-edge and unknown-kind entries and excludes them from JSONL counts", async () => {
+		mkdirSync(dir, { recursive: true });
+		const ledger = join(root, "semantic-edges.jsonl");
+		writeFileSync(ledger, "edge\n");
+		const saved = JSON.stringify({ sessionFile: ledger, kind: SEMANTIC_EDGES_OUTBOX_KIND, uploadedBytes: 1 });
+		writeFileSync(join(dir, "edges.json"), saved);
+		writeFileSync(join(dir, "future.json"), '{"kind":"future","cursor":7}');
+		await run();
+		expect(readFileSync(join(dir, "edges.json"), "utf8")).toBe(saved);
+		const status = await readAgentTraceStatus(options);
+		expect(status.pending + status.inProgress + status.paused + status.failed).toBe(0);
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+	it("registers persisted sessions synchronously without waiting for a stalled network", () => {
+		const session = SessionManager.create(root, join(root, "sessions"));
+		installAgentTraceUpload(session, options);
+		session.appendMessage({ role: "user", content: "synthetic user", timestamp: now });
+		session.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "synthetic assistant" }],
+			api: "openai-completions",
+			provider: "faux",
+			model: "faux",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: now,
+		});
+		expect(existsSync(autoPath(session.getSessionFile()!))).toBe(true);
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+	it("observes enablement in another process before the first response without retroactive registration", async () => {
+		globalSettings(false);
+		options.settingsManager = SettingsManager.create(root, agentDir);
+		const session = SessionManager.create(root, join(root, "sessions"));
+		installAgentTraceUpload(session, options);
+		session.appendMessage({ role: "user", content: "synthetic", timestamp: now });
+		expect(existsSync(dir)).toBe(false);
+		globalSettings(true);
+		session.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "synthetic" }],
+			api: "openai-completions",
+			provider: "faux",
+			model: "faux",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: now,
+		});
+		expect(options.settingsManager.getAgentTracesEnabled()).toBe(false);
+		expect(existsSync(autoPath(session.getSessionFile()!))).toBe(true);
+		await run();
+		expect(fetchFn).toHaveBeenCalledOnce();
+	});
+	it("monitors the prepared transcript's project after an atomic replacement", async () => {
+		globalSettings(true);
+		projectSettings(root, true);
+		const other = join(root, "other");
+		projectSettings(other, true);
+		options.settingsManager = SettingsManager.create(root, agentDir);
+		const path = file();
+		await queue(path);
+		const original = payloadWorker.prepareTracePayload;
+		vi.spyOn(payloadWorker, "prepareTracePayload").mockImplementation(async (input) => {
+			renameSync(file("replacement", other), path);
+			return original(input);
+		});
+		fetchFn.mockImplementation(
+			async (_url, init) =>
+				new Promise((_resolve, reject) =>
+					init?.signal?.addEventListener("abort", () => reject(init.signal?.reason)),
+				),
+		);
+		const running = run();
+		await vi.waitFor(() => expect(fetchFn).toHaveBeenCalledOnce());
+		projectSettings(other, false);
+		await running;
+		expect(job(path).state).toBe("paused");
+		expect(fetchFn.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+	});
+	it("keeps event-loop timers running while preparing a large transcript", async () => {
+		const path = file();
+		appendFileSync(
+			path,
+			JSON.stringify({ type: "message", id: "large", parentId: "msg", content: "x".repeat(15 * 1024 * 1024) }) +
+				"\n",
+		);
+		let ticks = 0;
+		const timer = setInterval(() => {
+			ticks++;
+		}, 2);
+		try {
+			const prepared = await payloadWorker.prepareTracePayload({
+				sessionFile: path,
+				signal: new AbortController().signal,
+			});
+			expect(prepared.body.byteLength).toBe(statSync(path).size);
+			expect(ticks).toBeGreaterThan(5);
+		} finally {
+			clearInterval(timer);
 		}
 	});
-
-	it("a corrupt outbox entry costs only itself; other cursors survive", async () => {
-		const cwd = join(tempDir, "project");
-		const sessionDir = join(tempDir, "sessions");
-		mkdirSync(cwd, { recursive: true });
-		const kept = writeSession(cwd, sessionDir, "kept-cursor-session");
-		const keptFile = kept.getSessionFile() as string;
-		const keptStats = await stat(keptFile);
-		writeOutboxEntry(tempDir, keptFile, { size: keptStats.size, mtimeMs: keptStats.mtimeMs });
-		writeFileSync(join(tempDir, "agent-traces-outbox", "deadbeef.json"), "not json");
-
-		const calls: FetchCall[] = [];
-		const options = {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			fetchFn: createFetchRecorder(calls),
-			reloadConfig: false,
-		};
-
-		const result = await catchUpAgentTraceUploads(options);
-		expect(result).toEqual({ pruned: 1, semanticEdgeLedgersPending: 0, results: [] });
-		expect(calls).toHaveLength(0);
-		expect(existsSync(join(tempDir, "agent-traces-outbox", "deadbeef.json"))).toBe(false);
-		expect(await uploadAgentTraceFile({ ...options, sessionFile: keptFile })).toEqual({ status: "unchanged" });
-		expect(calls).toHaveLength(0);
-	});
-
-	it("prefers the prime-inference credential over the prime-cli config key", async () => {
-		const session = writeSession(tempDir, join(tempDir, "sessions"), "credential-order-session");
-		const calls: FetchCall[] = [];
-		const configPath = join(tempDir, "prime-config.json");
-		writeFileSync(configPath, JSON.stringify({ api_key: "cli-fallback-key" }));
-
-		const result = await uploadAgentTraceFile({
-			sessionFile: session.getSessionFile(),
-			authStorage: AuthStorage.inMemory({
-				[PRIME_INFERENCE_PROVIDER_ID]: { type: "api_key", key: "inference-key" },
-			}),
-			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
-			baseUrl: "https://api.example.test",
-			configPath,
-			fetchFn: createFetchRecorder(calls),
-			reloadConfig: false,
+	it("keeps timers and status responsive during a stalled credential command", async () => {
+		options.authStorage.set(PRIME_AGENT_TRACES_PROVIDER_ID, {
+			type: "api_key",
+			key: `!"${process.execPath}" -e "setTimeout(()=>process.stdout.write('synthetic-command-key'),200)"`,
 		});
-
-		expect(result.status).toBe("uploaded");
-		expect(calls).toHaveLength(1);
-		expect(calls[0]?.init.headers).toMatchObject({ Authorization: "Bearer inference-key" });
+		const path = file();
+		await queue(path, true);
+		let ticks = 0;
+		const timer = setInterval(() => {
+			ticks++;
+		}, 5);
+		try {
+			const running = run();
+			const status = await readAgentTraceStatus({ ...options, sessionFile: path });
+			expect(status.pending).toBe(1);
+			await running;
+			expect(ticks).toBeGreaterThan(10);
+			expect(fetchFn).toHaveBeenCalledOnce();
+		} finally {
+			clearInterval(timer);
+		}
+	});
+	it("previews without credentials and recursively discovers valid parent/child traces", async () => {
+		const parent = file("parent"),
+			child = file("artifacts/child");
+		writeFileSync(join(root, "non-session.jsonl"), '{"type":"edge"}\n');
+		const preview = await previewAgentTraceFile({ sessionFile: parent });
+		expect(preview).toMatchObject({ status: "ready", sessionId: "parent", uploadable: true });
+		expect(await findAgentTraceFiles(root)).toEqual([child, parent].sort());
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+	it("retains trace/environment/inference/CLI credential preference using async reads", async () => {
+		options.authStorage.set(PRIME_INFERENCE_PROVIDER_ID, { type: "api_key", key: "inference" });
+		writeFileSync(options.configPath!, JSON.stringify({ api_key: "cli" }));
+		expect((await getPrimeAgentTraceCredential(options.authStorage, options))?.apiKey).toBe("synthetic-key");
+		options.authStorage.remove(PRIME_AGENT_TRACES_PROVIDER_ID);
+		expect((await getPrimeAgentTraceCredential(options.authStorage, options))?.apiKey).toBe("inference");
+		options.authStorage.remove(PRIME_INFERENCE_PROVIDER_ID);
+		expect((await getPrimeAgentTraceCredential(options.authStorage, options))?.apiKey).toBe("cli");
+		vi.stubEnv("PRIME_AGENT_TRACES_API_KEY", "environment");
+		expect((await getPrimeAgentTraceCredential(options.authStorage, options))?.apiKey).toBe("environment");
 	});
 });

--- a/packages/coding-agent/test/agent-traces.test.ts
+++ b/packages/coding-agent/test/agent-traces.test.ts
@@ -450,6 +450,35 @@ describe("durable background trace delivery", () => {
 		expect(fingerprints[0]).not.toBe(fingerprints[1]);
 		expect(fetchFn).toHaveBeenCalledTimes(2);
 	});
+	it.each([
+		{ label: "non-string", salt: 123 },
+		{ label: "wrong-length", salt: "corrupt" },
+		{ label: "non-hex", salt: "z".repeat(64) },
+	])("recovers a $label credential salt and discards the old rejected-key fingerprint", async ({ salt }) => {
+		const path = file();
+		await queue(path, true);
+		fetchFn.mockResolvedValueOnce(new Response("", { status: 401 }));
+		await run();
+		const coordinatorPath = join(dir, ".delivery-state");
+		const state = JSON.parse(readFileSync(coordinatorPath, "utf8")) as {
+			credentialSalt: string;
+			invalidCredential?: string;
+		};
+		expect(state.invalidCredential).toBeDefined();
+		writeFileSync(coordinatorPath, JSON.stringify({ ...state, credentialSalt: salt }));
+		let resumedState: typeof state | undefined;
+		fetchFn.mockImplementationOnce(async () => {
+			resumedState = JSON.parse(readFileSync(coordinatorPath, "utf8")) as typeof state;
+			return new Response("", { status: 200 });
+		});
+		now += 61_000;
+		await run();
+		expect(fetchFn).toHaveBeenCalledTimes(2);
+		expect(job(path).state).toBe("delivered");
+		expect(resumedState?.credentialSalt).toMatch(/^[a-f0-9]{64}$/);
+		expect(resumedState?.credentialSalt).not.toBe(state.credentialSalt);
+		expect(resumedState?.invalidCredential).toBeUndefined();
+	});
 	it("pauses permanent HTTP failures until the automatic file or endpoint changes", async () => {
 		const path = file();
 		await queue(path);

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -9807,7 +9807,7 @@ function installGatedTraceUpload(sessionManager: SessionManager): {
 		settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
 		baseUrl: "https://api.example.test",
 		fetchFn: (async (input: unknown, init?: RequestInit) => {
-			calls.push({ url: String(input), body: String(init?.body ?? "") });
+			calls.push({ url: String(input), body: await new Response(init?.body).text() });
 			await gate;
 			return new Response(JSON.stringify({ bytes_stored: 1 }), {
 				status: 200,

--- a/packages/coding-agent/test/interactive-mode-traces-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-traces-command.test.ts
@@ -1,145 +1,147 @@
-import { describe, expect, it, vi } from "vitest";
-import type { AgentTraceUploadAllResult, AgentTraceUploadResult } from "../src/core/agent-traces.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as traces from "../src/core/agent-traces.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
-import { PRIME_AGENT_TRACES_PROVIDER_ID } from "../src/core/prime-inference-auth.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
 
 interface TracesCommandContext {
 	traceUploadAllAbortController?: AbortController;
-	agentConnection: { getState: () => Promise<{ sessionDir?: string }> };
-	settingsManager: {
-		getAgentTracesEnabled: () => boolean;
-		setAgentTracesEnabled: (enabled: boolean) => void;
-		flush: () => Promise<void>;
-	};
+	traceUploadAllRequestId?: string;
+	agentConnection: { getState: () => Promise<{ sessionDir?: string; sessionFile?: string }> };
+	settingsManager: SettingsManager;
 	modelRegistry: { authStorage: AuthStorage };
+	chatContainer: { addChild: (child: unknown) => void };
+	ui: { requestRender: () => void };
 	previewCurrentTrace: () => Promise<void>;
-	uploadCurrentTraceOnce: () => Promise<AgentTraceUploadResult>;
-	uploadAllTraces: (sessionDir?: string, signal?: AbortSignal) => Promise<AgentTraceUploadAllResult>;
-	formatTraceUploadResult: (result: AgentTraceUploadResult) => string;
+	uploadCurrentTraceOnce: (requireEnabled?: boolean) => Promise<traces.AgentTraceUploadResult>;
+	uploadAllTraces: (sessionDir?: string, signal?: AbortSignal) => Promise<traces.AgentTraceUploadAllResult>;
+	formatTraceUploadResult: (result: traces.AgentTraceUploadResult) => string;
 	showStatus: (message: string) => void;
 	showWarning: (message: string) => void;
 	showError: (message: string) => void;
 }
-
 interface TracesCommandPrototype {
 	handleTracesCommand(this: TracesCommandContext, text: string): Promise<void>;
 }
-
 const prototype = InteractiveMode.prototype as unknown as TracesCommandPrototype;
-
-function makeContext(enabled = true): TracesCommandContext {
+function makeContext(): TracesCommandContext {
 	return {
-		agentConnection: { getState: vi.fn(async () => ({ sessionDir: "/custom/sessions" })) },
-		settingsManager: {
-			getAgentTracesEnabled: () => enabled,
-			setAgentTracesEnabled: vi.fn(),
-			flush: vi.fn(async () => {}),
+		agentConnection: {
+			getState: vi.fn(async () => ({ sessionDir: "/custom/sessions", sessionFile: "/custom/session.jsonl" })),
 		},
-		modelRegistry: {
-			authStorage: AuthStorage.inMemory({
-				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
-			}),
-		},
+		settingsManager: SettingsManager.inMemory(),
+		modelRegistry: { authStorage: AuthStorage.inMemory() },
+		chatContainer: { addChild: vi.fn() },
+		ui: { requestRender: vi.fn() },
 		previewCurrentTrace: vi.fn(async () => {}),
-		uploadCurrentTraceOnce: vi.fn(
-			async (): Promise<AgentTraceUploadResult> => ({
-				status: "uploaded",
-				sessionId: "current",
-				traceId: "current",
-				bytesStored: 12,
-			}),
-		),
-		uploadAllTraces: vi.fn(
-			async (): Promise<AgentTraceUploadAllResult> => ({
-				total: 2,
-				uploaded: 2,
-				failed: 0,
-				skipped: 0,
-				bytesStored: 24,
-				results: [],
-			}),
-		),
-		formatTraceUploadResult: vi.fn(() => "Trace uploaded (12 bytes)."),
+		uploadCurrentTraceOnce: vi.fn(async () => ({ status: "queued" as const, requestId: "current" })),
+		uploadAllTraces: vi.fn(async () => ({ status: "queued" as const, requestId: "batch" })),
+		formatTraceUploadResult: vi.fn(() => "Trace queued for background delivery."),
 		showStatus: vi.fn(),
 		showWarning: vi.fn(),
 		showError: vi.fn(),
 	};
 }
-
+afterEach(() => vi.restoreAllMocks());
 describe("InteractiveMode /traces", () => {
-	it("previews without enabling trace sharing", async () => {
-		const context = makeContext(false);
-
+	it("previews without enabling or queueing", async () => {
+		const context = makeContext();
 		await prototype.handleTracesCommand.call(context, "/traces preview");
-
 		expect(context.previewCurrentTrace).toHaveBeenCalledOnce();
 		expect(context.uploadCurrentTraceOnce).not.toHaveBeenCalled();
-		expect(context.uploadAllTraces).not.toHaveBeenCalled();
+		expect(context.settingsManager.getAgentTracesEnabled()).toBe(false);
 	});
-
-	it.each(["/traces upload", "/traces upload-current"])("uploads only the current trace for %s", async (command) => {
-		const context = makeContext(false);
-
-		await prototype.handleTracesCommand.call(context, command);
-
-		expect(context.uploadCurrentTraceOnce).toHaveBeenCalledOnce();
-		expect(context.uploadAllTraces).not.toHaveBeenCalled();
-		expect(context.showStatus).toHaveBeenCalledWith("Trace uploaded (12 bytes).");
+	it.each(["/traces upload", "/traces upload-current"])(
+		"queues the current trace for %s without resolving credentials",
+		async (command) => {
+			const context = makeContext();
+			const key = vi.spyOn(context.modelRegistry.authStorage, "getApiKey");
+			await prototype.handleTracesCommand.call(context, command);
+			expect(context.uploadCurrentTraceOnce).toHaveBeenCalledWith();
+			expect(context.uploadAllTraces).not.toHaveBeenCalled();
+			expect(context.showStatus).toHaveBeenCalledWith("Trace queued for background delivery.");
+			expect(key).not.toHaveBeenCalled();
+			expect(context.settingsManager.getAgentTracesEnabled()).toBe(false);
+		},
+	);
+	it("enables only global automatic consent and retains the project opt-out", async () => {
+		const context = makeContext();
+		context.settingsManager = SettingsManager.fromStorage({
+			withLock: (scope, fn) => {
+				fn(JSON.stringify(scope === "project" ? { agentTraces: { enabled: false } } : {}));
+			},
+		});
+		vi.mocked(context.uploadCurrentTraceOnce).mockResolvedValue({ status: "disabled" });
+		await prototype.handleTracesCommand.call(context, "/traces on");
+		expect(context.uploadCurrentTraceOnce).toHaveBeenCalledWith(true);
+		expect(context.settingsManager.getAgentTracesEnabled()).toBe(false);
 	});
-
 	it.each(["no_session_file", "empty_session"] as const)(
-		"keeps future upload guidance when enabling from %s",
+		"keeps future guidance when enabling from %s",
 		async (status) => {
-			const context = makeContext(false);
+			const context = makeContext();
 			vi.mocked(context.uploadCurrentTraceOnce).mockResolvedValue({ status });
-
 			await prototype.handleTracesCommand.call(context, "/traces on");
-
-			expect(context.settingsManager.setAgentTracesEnabled).toHaveBeenCalledWith(true);
 			expect(context.showStatus).toHaveBeenCalledWith(
-				"Trace sharing enabled. Current session will upload after the first assistant response.",
+				"Global automatic trace sharing enabled. Current session will queue after the first assistant response.",
 			);
 		},
 	);
-
-	it("backfills all discovered traces only for upload-all", async () => {
-		const context = makeContext(false);
-
+	it("queues bulk work promptly and keeps its cancellation handle after acknowledgement", async () => {
+		const context = makeContext();
 		await prototype.handleTracesCommand.call(context, "/traces upload-all");
-
 		expect(context.uploadAllTraces).toHaveBeenCalledWith("/custom/sessions", expect.any(AbortSignal));
-		expect(context.uploadCurrentTraceOnce).not.toHaveBeenCalled();
-		expect(context.showStatus).toHaveBeenCalledWith("Uploaded 2 of 2 traces; 24 bytes stored.");
+		expect(context.traceUploadAllRequestId).toBe("batch");
+		expect(context.traceUploadAllAbortController).toBeDefined();
+		expect(context.showStatus).toHaveBeenCalledWith(expect.stringContaining("queued for background"));
+		expect(context.showStatus).not.toHaveBeenCalledWith(expect.stringContaining("Uploaded"));
 	});
-
-	it("reports a cancelled upload-all without a success summary", async () => {
-		const context = makeContext(false);
-		vi.mocked(context.uploadAllTraces).mockImplementation(async (_sessionDir, signal) => {
-			return await new Promise<AgentTraceUploadAllResult>((resolve) => {
-				signal?.addEventListener(
-					"abort",
-					() =>
-						resolve({
-							total: 2,
-							uploaded: 0,
-							failed: 0,
-							skipped: 2,
-							bytesStored: 0,
-							results: [],
-						}),
-					{ once: true },
-				);
-			});
+	it("does not claim cancellation when this task has no request handle", async () => {
+		const context = makeContext();
+		await prototype.handleTracesCommand.call(context, "/traces cancel");
+		expect(context.showStatus).toHaveBeenCalledWith(expect.stringContaining("no bulk trace request"));
+	});
+	it("reports cancellation persistence errors without throwing or claiming success", async () => {
+		const context = makeContext();
+		context.traceUploadAllRequestId = "batch";
+		vi.spyOn(traces, "cancelAgentTraceRequest").mockRejectedValue(new Error("read-only"));
+		await prototype.handleTracesCommand.call(context, "/traces cancel");
+		expect(context.showError).toHaveBeenCalledWith(expect.stringContaining("Could not record"));
+		expect(context.showStatus).not.toHaveBeenCalled();
+	});
+	it("cancels persisted requests across tasks only for explicit cancel-all", async () => {
+		const context = makeContext();
+		const cancel = vi.spyOn(traces, "cancelPendingAgentTraceRequests").mockResolvedValue({ cancelled: 2, failed: 0 });
+		await prototype.handleTracesCommand.call(context, "/traces cancel-all");
+		expect(cancel).toHaveBeenCalledOnce();
+		expect(context.showStatus).toHaveBeenCalledWith(
+			expect.stringContaining("2 pending one-shot requests across tasks"),
+		);
+	});
+	it("reads shared status with configuration inspection and no credential resolution", async () => {
+		const context = makeContext();
+		const status = vi.spyOn(traces, "readAgentTraceStatus").mockResolvedValue({
+			consent: { enabled: false, reason: "global_off" },
+			endpoint: "https://example.invalid",
+			credentialSource: "Not configured",
+			sessionFile: "/custom/session.jsonl",
+			pending: 2,
+			inProgress: 1,
+			paused: 0,
+			failed: 0,
+			discovering: 0,
+			currentSession: "queued",
+			pauseReasons: [],
 		});
-
-		const command = prototype.handleTracesCommand.call(context, "/traces upload-all");
-		await vi.waitFor(() => expect(context.traceUploadAllAbortController).toBeDefined());
-		context.traceUploadAllAbortController?.abort();
-		await command;
-
-		expect(context.showStatus).toHaveBeenCalledWith("Trace upload cancelled.");
-		expect(context.showStatus).not.toHaveBeenCalledWith(expect.stringContaining("Uploaded 0 of 2"));
-		expect(context.traceUploadAllAbortController).toBeUndefined();
+		const credential = vi.spyOn(context.modelRegistry.authStorage, "getApiKey");
+		await prototype.handleTracesCommand.call(context, "/traces status");
+		expect(status).toHaveBeenCalledWith({
+			settingsManager: context.settingsManager,
+			authStorage: context.modelRegistry.authStorage,
+			sessionFile: "/custom/session.jsonl",
+		});
+		expect(credential).not.toHaveBeenCalled();
+		expect(context.uploadAllTraces).not.toHaveBeenCalled();
+		expect(context.uploadCurrentTraceOnce).not.toHaveBeenCalled();
 	});
 });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -517,6 +517,38 @@ describe("SettingsManager", () => {
 		});
 	});
 
+	describe("trace sharing consent", () => {
+		const cases = [undefined, false, true].flatMap((global) =>
+			[undefined, false, true].flatMap((project) =>
+				[undefined, false, true].map((runtime) => ({ global, project, runtime })),
+			),
+		);
+		it.each(cases)("global=$global project=$project runtime=$runtime", async ({ global, project, runtime }) => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ agentTraces: { enabled: global } }));
+			writeFileSync(
+				join(projectDir, ".prime", "agent", "settings.json"),
+				JSON.stringify({ agentTraces: { enabled: project } }),
+			);
+			const manager = SettingsManager.create(projectDir, agentDir);
+			manager.applyOverrides({ agentTraces: { enabled: runtime } });
+			const enabled = global === true && project !== false && runtime !== false;
+			expect(manager.getAgentTracesEnabled()).toBe(enabled);
+			expect((await manager.readAgentTracesConsent(projectDir)).enabled).toBe(enabled);
+		});
+		it.each(['{"agentTraces":{"enabled":"false"}}', '{"agentTraces":null}', "{ invalid"])(
+			"fails closed for invalid consent settings: %s",
+			async (value) => {
+				writeFileSync(join(agentDir, "settings.json"), '{"agentTraces":{"enabled":true}}');
+				const manager = SettingsManager.create(projectDir, agentDir);
+				writeFileSync(join(projectDir, ".prime", "agent", "settings.json"), value);
+				expect(await manager.readAgentTracesConsent(projectDir)).toEqual({
+					enabled: false,
+					reason: "settings_unavailable",
+				});
+			},
+		);
+	});
+
 	describe("telemetry privacy controls", () => {
 		it("does not let project settings override a global opt-out or disclosure state", () => {
 			writeFileSync(


### PR DESCRIPTION
- makes global opt-out authoritative and scopes one-shot uploads to requested content ([eng-5979](https://linear.app/primeintellect/issue/ENG-5979/make-global-trace-sharing-opt-out-authoritative)).
- adds background delivery, durable retries, shared pacing, cancellation, and delivery status ([eng-5980](https://linear.app/primeintellect/issue/ENG-5980/make-trace-delivery-background-only-with-persistent-coordinated), [eng-5981](https://linear.app/primeintellect/issue/ENG-5981/extend-traces-status-with-delivery-health-and-retry-progress)).
- covers [eng-5978](https://linear.app/primeintellect/issue/ENG-5978/improve-voluntary-trace-sharing-controls-and-reliability); passes 395 synthetic tests, including bundled cross-process crash recovery, and npm run check.
