### PR TITLE
fix(ai): send x-opencode-session header for OpenCode Go provider

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -542,6 +542,10 @@ function createClient(
 		if (teamId) headers["X-Prime-Team-ID"] = teamId;
 	}
 
+	if (model.provider === "opencode-go" && sessionId) {
+		headers["x-opencode-session"] = sessionId;
+	}
+
 	if (sessionId && compat.sendSessionAffinityHeaders) {
 		headers.session_id = sessionId;
 		headers["x-client-request-id"] = sessionId;

--- a/packages/ai/test/openai-completions-prompt-cache.test.ts
+++ b/packages/ai/test/openai-completions-prompt-cache.test.ts
@@ -196,4 +196,24 @@ describe("openai-completions prompt caching", () => {
 		expect(headers["x-client-request-id"]).toBe("override-request");
 		expect(headers["x-session-affinity"]).toBe("override-affinity");
 	});
+
+	it("sends x-opencode-session for opencode-go regardless of sendSessionAffinityHeaders", async () => {
+		const model = createModel({
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+		});
+		const { headers } = await captureRequest({ sessionId: "session-go" }, model);
+
+		expect(headers["x-opencode-session"]).toBe("session-go");
+	});
+
+	it("omits x-opencode-session for opencode-go when cacheRetention is none", async () => {
+		const model = createModel({
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+		});
+		const { headers } = await captureRequest({ cacheRetention: "none", sessionId: "session-go" }, model);
+
+		expect(headers["x-opencode-session"]).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## Summary
- OpenCode Go requires a stable `x-opencode-session` header per conversation for routing/prompt-cache affinity (see https://opencode.ai/docs/go/), but `opencode-go` model entries don't set `compat.sendSessionAffinityHeaders`, so no session headers are sent at all — every request 400s with `Request is missing x-opencode-session and cannot be routed efficiently.`
- Even with that flag set, the generic session-affinity path sends `session_id`/`x-client-request-id`/`x-session-affinity`, not the `x-opencode-session` header OpenCode Go actually checks for.
- Special-cases the `opencode-go` provider in `createClient` to send `x-opencode-session`, following the same pattern already used for `prime-inference`'s `X-Prime-Team-ID` header.

Fixes #2141.

## Test plan
- [x] Added unit tests in `packages/ai/test/openai-completions-prompt-cache.test.ts` covering: header is sent for `opencode-go` regardless of `sendSessionAffinityHeaders`, and omitted when `cacheRetention` is `"none"` (consistent with existing session-affinity behavior).
- [x] `npx vitest run test/openai-completions-prompt-cache.test.ts` — 10/10 passing.
- [x] `npx tsgo --noEmit` — clean.
- [x] `npx biome check --error-on-warnings` on changed files — clean.
- [ ] Manual repro: confirmed the underlying 400 by curling the OpenCode Go endpoint directly without the header; have not yet re-tested through prime-agent's TUI end-to-end (no access to that harness from this environment) — would appreciate a maintainer or CI confirming against a live OpenCode Go session.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Send `x-opencode-session` header for `opencode-go` provider in `createClient`
> - Adds a provider-specific branch in [openai-completions.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2142/files#diff-d3f9c03940767ab76191513078367a64d9e38e58fbdff99f5ad7bf65786b4246) that sets `x-opencode-session` to the supplied session ID for `opencode-go` models, independent of `sendSessionAffinityHeaders`.
> - Omits the header when `cacheRetention` is `none`; optional caller headers applied later can still override it.
> - Adds prompt-cache tests covering both presence and omission scenarios.
> - Risk: later-applied caller headers can replace `x-opencode-session`; verify header precedence in `createClient` if unexpected overrides occur.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e219af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->