### PR TITLE
test: keep the harness memory digest out of literal-prompt-argument assertions

### DIFF
--- a/packages/coding-agent/test/suite/regressions/6014-literal-prompt-arguments.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6014-literal-prompt-arguments.test.ts
@@ -2,6 +2,7 @@ import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { describe, expect, test } from "vitest";
+import { HARNESS_DIGEST_PREFIX } from "../../../src/core/messages.js";
 import {
 	expandPromptTemplate,
 	loadPromptTemplates,
@@ -63,7 +64,12 @@ describe("ENG-6014 literal prompt arguments", () => {
 			const providerTexts: string[] = [];
 			harness.setResponses([
 				(context) => {
-					providerTexts.push(...context.messages.filter((message) => message.role === "user").map(getMessageText));
+					providerTexts.push(
+						...context.messages
+							.filter((message) => message.role === "user")
+							.map(getMessageText)
+							.filter((text) => !text.startsWith(HARNESS_DIGEST_PREFIX)),
+					);
 					return fauxAssistantMessage("ok");
 				},
 			]);


### PR DESCRIPTION
Fixes the `6014-literal-prompt-arguments.test.ts` failures that appear on every branch containing both #2128 and #2098.

#2128 merged with assertions that count provider user messages exactly (`toEqual([expected])`). #2098 injects a first-turn harness memory digest that reaches the provider as an additional user message. Each PR was green on its own base; main now carries both, so the six parameterized cases fail together.

The digest is unrelated to what this test pins (literal `$` sequences surviving template expansion), so the provider-side collector now excludes messages starting with `HARNESS_DIGEST_PREFIX` — imported from `messages.ts`, so the filter follows any future prefix change. The session-side assertion needs no change: the digest is a custom-type entry, not a user entry.

Total src: **+0/−0 (net 0)**; tests: +7/−1 (net +6). Pure test fix, no mechanism.

Fixes RES-1318