### PR TITLE
agents view: always render zero-count section headers

### DIFF
--- a/packages/coding-agent/.changes/res-1328-empty-section-headers.md
+++ b/packages/coding-agent/.changes/res-1328-empty-section-headers.md
@@ -1,0 +1,1 @@
+- Changed the agents view to always render every section header with its zero count so the layout stays stable; a search still hides sections it empties.

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1305,8 +1305,11 @@ export class AgentsViewMode implements Component, Focusable {
 	}
 
 	private getFilteredRecords(): UnifiedSessionRecord[] {
-		const query = this.replyTarget || this.renameTarget ? (this.actionModeSearchQuery ?? "") : this.editor.getText();
-		return filterUnifiedSessions(this.scopedRecords, (text) => matchesSearchText(text, query));
+		return filterUnifiedSessions(this.scopedRecords, (text) => matchesSearchText(text, this.getSearchQuery()));
+	}
+
+	private getSearchQuery(): string {
+		return this.replyTarget || this.renameTarget ? (this.actionModeSearchQuery ?? "") : this.editor.getText();
 	}
 
 	/** Rebuild rows from the last fetched summaries, keeping selection on the same row. */
@@ -2490,8 +2493,11 @@ export class AgentsViewMode implements Component, Focusable {
 		const layout = buildCompactAgentsViewLayout(this.rows, width);
 		const displayItems: DisplayItem[] = [];
 		const counts = countRowsBySection(this.allRows.length > 0 ? this.allRows : this.rows);
+		// A search hides sections it empties; without one, empty sections keep
+		// their zero-count headers so the layout stays stable.
+		const hideEmptySections = this.getSearchQuery().trim().length > 0;
 		for (const section of ["running", "idle", "inactive"] as const) {
-			if (counts[section] === 0) continue;
+			if (counts[section] === 0 && hideEmptySections) continue;
 			if (displayItems.length > 0) displayItems.push({ type: "spacer" });
 			displayItems.push({ type: "heading", section });
 			for (const row of getDisplayRowsForSection(this.rows, section)) {

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -943,6 +943,23 @@ describe("AgentsViewMode", () => {
 		}
 	});
 
+	it("renders zero-count section headers unless a search empties them", () => {
+		const view = new AgentsViewMode({ config: {}, uiServices: createUiServices() }, {});
+		const lines = () => (invoke("renderSessionRows", view, 120, 20) as string[]).map(stripAnsi);
+		try {
+			Reflect.set(view, "lastListedSummaries", [summary({ sessionName: "only-idle" })]);
+			invoke("reconcileCatalogs", view);
+			const headers = lines().filter((line) => /^(Running|Idle|Inactive) \(\d+\)/.test(line));
+			expect(headers).toEqual(["Running (0)", "Idle (1)", "Inactive (0)"]);
+			// A filter that empties every section keeps the current search behavior.
+			invoke("setSearchQuery", view, "no-such-session");
+			expect(lines().filter((line) => /^(Running|Idle|Inactive) \(/.test(line))).toEqual([]);
+			expect(lines().join("\n")).toContain("No sessions match your search.");
+		} finally {
+			stopThemeWatcher();
+		}
+	});
+
 	it("keeps a selection at the end of the list visible when the leading ellipsis is shown", () => {
 		const summaries = Array.from({ length: 12 }, (_, index) =>
 			summary({

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -951,6 +951,21 @@ describe("AgentsViewMode", () => {
 			invoke("reconcileCatalogs", view);
 			const headers = lines().filter((line) => /^(Running|Idle|Inactive) \(\d+\)/.test(line));
 			expect(headers).toEqual(["Running (0)", "Idle (1)", "Inactive (0)"]);
+			// A filter that empties some sections hides those and keeps the rest.
+			Reflect.set(view, "lastListedSummaries", [
+				summary({ sessionName: "only-idle" }),
+				summary({
+					id: "busy",
+					activeSessionId: "busy",
+					sessionId: "busy-session",
+					sessionName: "busy",
+					activity: "working",
+					isStreaming: true,
+				}),
+			]);
+			invoke("reconcileCatalogs", view);
+			invoke("setSearchQuery", view, "only-idle");
+			expect(lines().filter((line) => /^(Running|Idle|Inactive) \(/.test(line))).toEqual(["Idle (1)"]);
 			// A filter that empties every section keeps the current search behavior.
 			invoke("setSearchQuery", view, "no-such-session");
 			expect(lines().filter((line) => /^(Running|Idle|Inactive) \(/.test(line))).toEqual([]);

--- a/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
+++ b/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
@@ -404,6 +404,7 @@ describe("#502 unified session view regressions", () => {
 			renameTarget: mode === "rename" ? { identity: "target" } : undefined,
 			actionModeSearchQuery: "needle",
 			editor: { getText: () => "action editor text" },
+			getSearchQuery: privateMethod<(this: unknown) => string>("getSearchQuery"),
 			scopedRecords: [
 				{ identity: "match", identityAliases: [], section: "idle", searchableText: "needle session" },
 				{ identity: "other", identityAliases: [], section: "idle", searchableText: "other session" },


### PR DESCRIPTION
## LOC

+27 / −3 across 3 files: agents-view-mode.ts (+9), agents-view-mode.test.ts (+17), one changelog fragment.

## Purpose

Empty sections were hidden entirely, so the section list jumped around as sessions moved between states and it was impossible to tell "there are zero running agents" from "the section does not exist". Every section header now always renders with its zero count ("Running (0)") when no search is active, keeping the layout stable.

## Changes

- `renderSessionRows` skips a zero-count section only while a search query is active; the unfiltered view renders all three headers, zeros included.
- The query string used by row filtering and by this decision is one helper (`getSearchQuery`), so the two cannot drift.
- Search behavior is unchanged: a filter that empties a section still hides it, and an all-empty result still shows "No sessions match your search."

## Validation

- New pin: unfiltered view renders `Running (0)`, `Idle (1)`, `Inactive (0)` for a single idle session; a non-matching search hides all headers and shows the no-match line. Fails on unfixed main.
- agents-view suites + interactive rendering suites in a Prime sandbox; root `npm run check` (pre-commit) passes.

Fixes RES-1328

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only rendering change in the agents list with preserved search behavior and targeted tests; no auth, data, or daemon protocol changes.
> 
> **Overview**
> The agents view **no longer hides** Running, Idle, and Inactive headers when a section has no sessions. Unfiltered lists always show all three headers with their counts (e.g. **Running (0)**), so the layout stays fixed and empty sections are obvious.
> 
> **Search behavior is unchanged:** when the query is non-empty, sections with zero matches are still omitted; a query that matches nothing still shows *No sessions match your search.*
> 
> Query text for filtering and for this display rule is shared via a new **`getSearchQuery()`** helper (editor text normally; captured search during reply/rename). Tests cover the unfiltered zero headers, search hiding, and the #502 reply/rename filter regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8db57fdfd5d96609357dc0430e14bf08ce2baaef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Always render zero-count section headers in `AgentsViewMode.renderSessionRows`
> - The agents view now shows Running, Idle, and Inactive section headers even when their row count is zero, so the layout stays stable when unfiltered.
> - When a non-whitespace search query is active, empty sections are still omitted as before.
> - Centralizes query selection into a new private `AgentsViewMode.getSearchQuery` method, which returns the action-mode query during reply/rename and the editor text otherwise. This replaces inline query selection in `getFilteredRecords` and is also used by `renderSessionRows`.
> - Adds tests covering zero-count headers without search, empty-section suppression during search, and the no-match state. Updates the #502 regression test harness to exercise the extracted query-selection method.
> - Behavioral Change: callers that previously saw no section headers for empty unfiltered sections now see headers with zero counts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8db57fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->