### PR TITLE
agents view: restore input/output token columns

### DIFF
--- a/packages/coding-agent/.changes/res-1329-token-columns.md
+++ b/packages/coding-agent/.changes/res-1329-token-columns.md
@@ -1,0 +1,1 @@
+- Added input/output token columns (`↑in ↓out`) back to agents view rows and the column legend; the column drops first on narrow terminals.

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -45,6 +45,7 @@ import {
 	listDaemonSavedSessions,
 	renameDaemonSavedSession,
 } from "../daemon/saved-session-catalog.js";
+import { formatTokenCount } from "../interactive/agent-activity.js";
 import { CustomEditor } from "../interactive/components/custom-editor.js";
 import { keyText } from "../interactive/components/keybinding-hints.js";
 import { BrandSplashHeader, InteractiveMode } from "../interactive/interactive-mode.js";
@@ -2823,12 +2824,21 @@ export function buildCompactAgentsViewLayout(rows: readonly AgentsViewRow[], wid
 	const sessions = rows.filter((row) => row.kind === "agent" || row.kind === "subagent");
 	const entries = sessions.map((row) => ({
 		identity: row.identity,
+		tokens: `↑${formatTokenCount(row.summary.usage?.inputTokens ?? 0)} ↓${formatTokenCount(row.summary.usage?.outputTokens ?? 0)}`,
 		cost: `$${row.recursiveCost.toFixed(2)}`,
 		age: formatSessionDuration(row.summary),
 	}));
+	const tokensLabel = "↑in ↓out";
+	const tokensWidth = entries.reduce(
+		(size, entry) => Math.max(size, visibleWidth(entry.tokens)),
+		visibleWidth(tokensLabel),
+	);
 	const costWidth = entries.reduce((size, entry) => Math.max(size, visibleWidth(entry.cost)), 4);
 	const ageWidth = entries.reduce((size, entry) => Math.max(size, visibleWidth(entry.age)), 3);
-	const detailsWidth = costWidth + 2 + ageWidth;
+	// Tokens are the first detail dropped on narrow terminals: session and model
+	// keep their usual room (28 + 12) before the column earns its place.
+	const showTokens = width - (tokensWidth + 2 + costWidth + 2 + ageWidth) - 4 >= 40;
+	const detailsWidth = (showTokens ? tokensWidth + 2 : 0) + costWidth + 2 + ageWidth;
 	const available = Math.max(0, width - detailsWidth - 4);
 	const desiredModelWidth = sessions.reduce(
 		(size, row) => Math.max(size, visibleWidth(formatSessionModel(row.summary))),
@@ -2837,13 +2847,14 @@ export function buildCompactAgentsViewLayout(rows: readonly AgentsViewRow[], wid
 	const modelWidth = Math.min(desiredModelWidth, 32, Math.max(0, available - 12));
 	const nameWidth = Math.min(28, Math.max(0, available - modelWidth));
 	const activityWidth = Math.max(0, available - modelWidth - nameWidth - 2);
-	const detailLine = (cost: string, age: string) => `${padCellStart(cost, costWidth)}  ${padCellStart(age, ageWidth)}`;
+	const detailLine = (tokens: string, cost: string, age: string) =>
+		`${showTokens ? `${padCellStart(tokens, tokensWidth)}  ` : ""}${padCellStart(cost, costWidth)}  ${padCellStart(age, ageWidth)}`;
 	const headings = [formatTableCell("Session", nameWidth), formatTableCell("Model", modelWidth)];
 	if (activityWidth > 0) headings.push(formatTableCell("Activity", activityWidth));
-	headings.push(detailLine("Cost", "Age"));
+	headings.push(detailLine(tokensLabel, "Cost", "Age"));
 	return {
 		legend: formatTableCell(headings.join("  "), width),
-		details: new Map(entries.map((entry) => [entry.identity, detailLine(entry.cost, entry.age)])),
+		details: new Map(entries.map((entry) => [entry.identity, detailLine(entry.tokens, entry.cost, entry.age)])),
 		nameWidth,
 		modelWidth,
 		activityWidth,

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -2825,15 +2825,23 @@ export function buildCompactAgentsViewLayout(rows: readonly AgentsViewRow[], wid
 	const entries = sessions.map((row) => ({
 		identity: row.identity,
 		// Same scope as the cost column: own plus every descendant's tokens.
-		tokens: `↑${formatTokenCount(row.recursiveInputTokens)} ↓${formatTokenCount(row.recursiveOutputTokens)}`,
+		tokensIn: `↑${formatTokenCount(row.recursiveInputTokens)}`,
+		tokensOut: `↓${formatTokenCount(row.recursiveOutputTokens)}`,
 		cost: `$${row.recursiveCost.toFixed(2)}`,
 		age: formatSessionDuration(row.summary),
 	}));
-	const tokensLabel = "↑in ↓out";
-	const tokensWidth = entries.reduce(
-		(size, entry) => Math.max(size, visibleWidth(entry.tokens)),
-		visibleWidth(tokensLabel),
+	// Independent in/out sub-columns so each label sits over its value group.
+	const tokensInLabel = "↑in";
+	const tokensOutLabel = "↓out";
+	const tokensInWidth = entries.reduce(
+		(size, entry) => Math.max(size, visibleWidth(entry.tokensIn)),
+		visibleWidth(tokensInLabel),
 	);
+	const tokensOutWidth = entries.reduce(
+		(size, entry) => Math.max(size, visibleWidth(entry.tokensOut)),
+		visibleWidth(tokensOutLabel),
+	);
+	const tokensWidth = tokensInWidth + 1 + tokensOutWidth;
 	const costWidth = entries.reduce((size, entry) => Math.max(size, visibleWidth(entry.cost)), 4);
 	const ageWidth = entries.reduce((size, entry) => Math.max(size, visibleWidth(entry.age)), 3);
 	const desiredModelWidth = sessions.reduce(
@@ -2849,14 +2857,16 @@ export function buildCompactAgentsViewLayout(rows: readonly AgentsViewRow[], wid
 	const modelWidth = Math.min(desiredModelWidth, 32, Math.max(0, available - 12));
 	const nameWidth = Math.min(28, Math.max(0, available - modelWidth));
 	const activityWidth = Math.max(0, available - modelWidth - nameWidth - 2);
-	const detailLine = (tokens: string, cost: string, age: string) =>
-		`${showTokens ? `${padCellStart(tokens, tokensWidth)}  ` : ""}${padCellStart(cost, costWidth)}  ${padCellStart(age, ageWidth)}`;
+	const detailLine = (tokensIn: string, tokensOut: string, cost: string, age: string) =>
+		`${showTokens ? `${padCellStart(tokensIn, tokensInWidth)} ${padCellStart(tokensOut, tokensOutWidth)}  ` : ""}${padCellStart(cost, costWidth)}  ${padCellStart(age, ageWidth)}`;
 	const headings = [formatTableCell("Session", nameWidth), formatTableCell("Model", modelWidth)];
 	if (activityWidth > 0) headings.push(formatTableCell("Activity", activityWidth));
-	headings.push(detailLine(tokensLabel, "Cost", "Age"));
+	headings.push(detailLine(tokensInLabel, tokensOutLabel, "Cost", "Age"));
 	return {
 		legend: formatTableCell(headings.join("  "), width),
-		details: new Map(entries.map((entry) => [entry.identity, detailLine(entry.tokens, entry.cost, entry.age)])),
+		details: new Map(
+			entries.map((entry) => [entry.identity, detailLine(entry.tokensIn, entry.tokensOut, entry.cost, entry.age)]),
+		),
 		nameWidth,
 		modelWidth,
 		activityWidth,

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -2824,7 +2824,8 @@ export function buildCompactAgentsViewLayout(rows: readonly AgentsViewRow[], wid
 	const sessions = rows.filter((row) => row.kind === "agent" || row.kind === "subagent");
 	const entries = sessions.map((row) => ({
 		identity: row.identity,
-		tokens: `↑${formatTokenCount(row.summary.usage?.inputTokens ?? 0)} ↓${formatTokenCount(row.summary.usage?.outputTokens ?? 0)}`,
+		// Same scope as the cost column: own plus every descendant's tokens.
+		tokens: `↑${formatTokenCount(row.recursiveInputTokens)} ↓${formatTokenCount(row.recursiveOutputTokens)}`,
 		cost: `$${row.recursiveCost.toFixed(2)}`,
 		age: formatSessionDuration(row.summary),
 	}));
@@ -2835,15 +2836,16 @@ export function buildCompactAgentsViewLayout(rows: readonly AgentsViewRow[], wid
 	);
 	const costWidth = entries.reduce((size, entry) => Math.max(size, visibleWidth(entry.cost)), 4);
 	const ageWidth = entries.reduce((size, entry) => Math.max(size, visibleWidth(entry.age)), 3);
-	// Tokens are the first detail dropped on narrow terminals: session and model
-	// keep their usual room (28 + 12) before the column earns its place.
-	const showTokens = width - (tokensWidth + 2 + costWidth + 2 + ageWidth) - 4 >= 40;
-	const detailsWidth = (showTokens ? tokensWidth + 2 : 0) + costWidth + 2 + ageWidth;
-	const available = Math.max(0, width - detailsWidth - 4);
 	const desiredModelWidth = sessions.reduce(
 		(size, row) => Math.max(size, visibleWidth(formatSessionModel(row.summary))),
 		12,
 	);
+	// Tokens are the first detail dropped on narrow terminals: the Session and
+	// Model columns keep the room they would get without a tokens column.
+	const showTokens =
+		width - (tokensWidth + 2 + costWidth + 2 + ageWidth) - 4 >= 28 + Math.min(desiredModelWidth, 32) + 2;
+	const detailsWidth = (showTokens ? tokensWidth + 2 : 0) + costWidth + 2 + ageWidth;
+	const available = Math.max(0, width - detailsWidth - 4);
 	const modelWidth = Math.min(desiredModelWidth, 32, Math.max(0, available - 12));
 	const nameWidth = Math.min(28, Math.max(0, available - modelWidth));
 	const activityWidth = Math.max(0, available - modelWidth - nameWidth - 2);

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -77,6 +77,9 @@ export interface AgentsViewRow {
 	selectable: boolean;
 	runningSubagentCount: number;
 	recursiveCost: number;
+	/** Own tokens plus every descendant's, same scope as recursiveCost. */
+	recursiveInputTokens: number;
+	recursiveOutputTokens: number;
 	/** Total descendant sessions (resident + passive) under this row. */
 	descendantCount: number;
 	/** Unique selection identity for this row. */
@@ -432,6 +435,9 @@ export interface UnifiedSessionIndex {
 export interface AgentsViewRecursiveRollup {
 	/** Own cost plus every descendant's cost. */
 	cost: number;
+	/** Own tokens plus every descendant's tokens, same scope as cost. */
+	inputTokens: number;
+	outputTokens: number;
 	/** Total descendant sessions (resident + passive) under this record. */
 	descendantCount: number;
 }
@@ -454,15 +460,20 @@ export function computeRecursiveRollups(
 	const rollups = new Map<UnifiedSessionRecord, AgentsViewRecursiveRollup>();
 	for (let position = order.length - 1; position >= 0; position--) {
 		const record = order[position]!;
-		let cost = record.daemon?.usage?.cost ?? record.saved?.usage?.cost ?? 0;
+		const usage = record.daemon?.usage ?? record.saved?.usage;
+		let cost = usage?.cost ?? 0;
+		let inputTokens = usage?.inputTokens ?? 0;
+		let outputTokens = usage?.outputTokens ?? 0;
 		let descendantCount = 0;
 		for (const child of index.childrenByParent.get(record) ?? []) {
 			if (!isSubagentDescendantRecord(child, record)) continue;
 			const childRollup = rollups.get(child);
 			cost += childRollup?.cost ?? 0;
+			inputTokens += childRollup?.inputTokens ?? 0;
+			outputTokens += childRollup?.outputTokens ?? 0;
 			descendantCount += 1 + (childRollup?.descendantCount ?? 0);
 		}
-		rollups.set(record, { cost, descendantCount });
+		rollups.set(record, { cost, inputTokens, outputTokens, descendantCount });
 	}
 	return rollups;
 }
@@ -762,6 +773,8 @@ export function buildAgentsViewRows(
 			selectable: true,
 			runningSubagentCount: 0,
 			recursiveCost: summary.usage?.cost ?? 0,
+			recursiveInputTokens: summary.usage?.inputTokens ?? 0,
+			recursiveOutputTokens: summary.usage?.outputTokens ?? 0,
 			descendantCount: 0,
 			identity: record?.identity ?? getAgentsViewSummaryIdentity(summary),
 			...(record ? { record, heartbeat: record.heartbeat } : {}),
@@ -805,15 +818,22 @@ export function buildAgentsViewRows(
 		const row = tallyOrder[index]!;
 		let count = 0;
 		let descendantsCost = 0;
+		let descendantsInputTokens = 0;
+		let descendantsOutputTokens = 0;
 		let descendants = 0;
 		for (const child of childrenByParent.get(row) ?? []) {
 			count += (child.section === "running" ? 1 : 0) + child.runningSubagentCount;
 			descendantsCost += child.recursiveCost;
+			descendantsInputTokens += child.recursiveInputTokens;
+			descendantsOutputTokens += child.recursiveOutputTokens;
 			descendants += 1 + child.descendantCount;
 		}
 		row.runningSubagentCount = count;
 		const rollup = row.record ? recursiveRollups?.get(row.record) : undefined;
 		row.recursiveCost = rollup?.cost ?? (row.summary.usage?.cost ?? 0) + descendantsCost;
+		row.recursiveInputTokens = rollup?.inputTokens ?? (row.summary.usage?.inputTokens ?? 0) + descendantsInputTokens;
+		row.recursiveOutputTokens =
+			rollup?.outputTokens ?? (row.summary.usage?.outputTokens ?? 0) + descendantsOutputTokens;
 		row.descendantCount = rollup?.descendantCount ?? descendants;
 	}
 
@@ -894,6 +914,8 @@ function createSubagentSummaryRow(
 		selectable: true,
 		runningSubagentCount: running,
 		recursiveCost: 0,
+		recursiveInputTokens: 0,
+		recursiveOutputTokens: 0,
 		descendantCount: 0,
 		identity: `subagents:${parent.identity}`,
 		parentIdentity: parent.identity,
@@ -950,6 +972,8 @@ function buildSpawnCodeRows(
 		selectable: false,
 		runningSubagentCount: 0,
 		recursiveCost: 0,
+		recursiveInputTokens: 0,
+		recursiveOutputTokens: 0,
 		descendantCount: 0,
 		identity: `code:${parent.identity}:${groupIndex}:${lineIndex}`,
 		parentIdentity: parent.identity,

--- a/packages/coding-agent/src/modes/interactive/agent-activity.ts
+++ b/packages/coding-agent/src/modes/interactive/agent-activity.ts
@@ -129,7 +129,7 @@ export class AgentActivityTracker {
 export function formatTokenCount(count: number): string {
 	if (count < 1000) return count.toString();
 	if (count < 10000) return `${(count / 1000).toFixed(1)}k`;
-	if (count < 1000000) return `${Math.round(count / 1000)}k`;
+	if (count < 999500) return `${Math.round(count / 1000)}k`;
 	if (count < 10000000) return `${(count / 1000000).toFixed(1)}M`;
 	return `${Math.round(count / 1000000)}M`;
 }

--- a/packages/coding-agent/test/agent-activity.test.ts
+++ b/packages/coding-agent/test/agent-activity.test.ts
@@ -168,6 +168,7 @@ describe("formatTokenCount", () => {
 	test("drops the decimal at 10k and above", () => {
 		expect(formatTokenCount(12340)).toBe("12k");
 		expect(formatTokenCount(250400)).toBe("250k");
+		expect(formatTokenCount(999999)).toBe("1.0M");
 	});
 
 	test("formats millions", () => {

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -801,7 +801,8 @@ describe("AgentsViewMode", () => {
 			expect(savedLine).toContain("glm-5.2-fast");
 			expect(parentLine).toContain("$1.10");
 			expect(parentLine).not.toContain("$0.42");
-			expect(parentLine).toContain("↑12k ↓1.2k");
+			// Token scope matches the cost column: own plus descendants.
+			expect(parentLine).toContain("↑13k ↓1.3k");
 			expect(savedLine).toContain("↑900 ↓80");
 			expect(parentLine).toMatch(/2m\s*$/);
 			expect(parentLine.indexOf("$1.10") + "$1.10".length).toBe(savedLine.indexOf("$123.45") + "$123.45".length);
@@ -814,6 +815,20 @@ describe("AgentsViewMode", () => {
 				expect(narrow.length).toBeLessThanOrEqual(width);
 				expect(/[↑↓]/.test(narrow)).toBe(width >= 80);
 			}
+			// A long model id claims its column room before tokens earn theirs.
+			const longModelRows = buildAgentsViewRows([
+				summary({
+					id: "wide",
+					activeSessionId: "wide",
+					sessionId: "wide-session",
+					model: { ...getModel("openai", "gpt-4o"), id: "a-very-long-model-identifier-32ch" },
+					created,
+					usage: { inputTokens: 12437, outputTokens: 1234, cost: 0.42 },
+				}),
+			]);
+			expect(stripAnsi(buildCompactAgentsViewLayout(longModelRows, 80).legend)).not.toContain("↑in");
+			expect(stripAnsi(buildCompactAgentsViewLayout(longModelRows, 80).legend)).toContain("Cost");
+			expect(stripAnsi(buildCompactAgentsViewLayout(longModelRows, 120).legend)).toContain("↑in ↓out");
 		} finally {
 			stopThemeWatcher();
 		}

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -803,7 +803,12 @@ describe("AgentsViewMode", () => {
 			expect(parentLine).not.toContain("$0.42");
 			// Token scope matches the cost column: own plus descendants.
 			expect(parentLine).toContain("↑13k ↓1.3k");
-			expect(savedLine).toContain("↑900 ↓80");
+			expect(savedLine).toContain("↑900");
+			// Each legend label right-aligns exactly over its value sub-column.
+			const legend = stripAnsi(buildCompactAgentsViewLayout(rows, 120).legend);
+			expect(legend.indexOf("↑in") + "↑in".length).toBe(parentLine.indexOf("↑13k") + "↑13k".length);
+			expect(legend.indexOf("↓out") + "↓out".length).toBe(parentLine.indexOf("↓1.3k") + "↓1.3k".length);
+			expect(legend.indexOf("↓out") + "↓out".length).toBe(savedLine.indexOf("↓80") + "↓80".length);
 			expect(parentLine).toMatch(/2m\s*$/);
 			expect(parentLine.indexOf("$1.10") + "$1.10".length).toBe(savedLine.indexOf("$123.45") + "$123.45".length);
 			// Shrink order: tokens drop before cost and age on narrow terminals.
@@ -828,7 +833,7 @@ describe("AgentsViewMode", () => {
 			]);
 			expect(stripAnsi(buildCompactAgentsViewLayout(longModelRows, 80).legend)).not.toContain("↑in");
 			expect(stripAnsi(buildCompactAgentsViewLayout(longModelRows, 80).legend)).toContain("Cost");
-			expect(stripAnsi(buildCompactAgentsViewLayout(longModelRows, 120).legend)).toContain("↑in ↓out");
+			expect(stripAnsi(buildCompactAgentsViewLayout(longModelRows, 120).legend)).toMatch(/↑in\s+↓out/);
 		} finally {
 			stopThemeWatcher();
 		}

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -801,15 +801,18 @@ describe("AgentsViewMode", () => {
 			expect(savedLine).toContain("glm-5.2-fast");
 			expect(parentLine).toContain("$1.10");
 			expect(parentLine).not.toContain("$0.42");
-			expect(parentLine).not.toMatch(/[↑↓]/);
+			expect(parentLine).toContain("↑12k ↓1.2k");
+			expect(savedLine).toContain("↑900 ↓80");
 			expect(parentLine).toMatch(/2m\s*$/);
 			expect(parentLine.indexOf("$1.10") + "$1.10".length).toBe(savedLine.indexOf("$123.45") + "$123.45".length);
+			// Shrink order: tokens drop before cost and age on narrow terminals.
 			for (const width of [60, 80]) {
 				const narrow = render(parentRow, width);
 				expect(narrow).toContain("gpt-5.6-sol");
 				expect(narrow).toContain("$1.10");
 				expect(narrow).toMatch(/2m\s*$/);
 				expect(narrow.length).toBeLessThanOrEqual(width);
+				expect(/[↑↓]/.test(narrow)).toBe(width >= 80);
 			}
 		} finally {
 			stopThemeWatcher();
@@ -852,7 +855,8 @@ describe("AgentsViewMode", () => {
 			expect(lines.filter((line) => /Model/.test(line) && /Age/i.test(line))).toHaveLength(1);
 			expect(lines.some((line) => line.startsWith("Running"))).toBe(true);
 			expect(lines.some((line) => line.startsWith("Idle"))).toBe(true);
-			expect(lines.join("\n")).not.toMatch(/show program|#sub|\$agent|↑in|↓out/);
+			expect(lines.join("\n")).not.toMatch(/show program|#sub|\$agent/);
+			expect(lines.find((line) => /Model/.test(line))).toContain("↑in ↓out");
 			const rows = Reflect.get(view, "rows") as AgentsViewRow[];
 			expect(rows.filter((row) => row.kind === "subagent-summary")).toHaveLength(0);
 			for (const line of rendered) {

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -669,12 +669,18 @@ describe("agents view state", () => {
 		});
 
 		const branchOnly = reconcileUnifiedSessions([source], [branch]);
-		expect(computeRecursiveRollups(branchOnly).get(branchOnly[0]!)).toEqual({ cost: 0.4, descendantCount: 0 });
+		expect(computeRecursiveRollups(branchOnly).get(branchOnly[0]!)).toEqual({
+			cost: 0.4,
+			inputTokens: 100,
+			outputTokens: 10,
+			descendantCount: 0,
+		});
 
 		const withChild = reconcileUnifiedSessions([source], [branch, child]);
 		const rollup = computeRecursiveRollups(withChild).get(withChild[0]!);
 		expect(rollup?.descendantCount).toBe(1);
 		expect(rollup?.cost).toBeCloseTo(0.5);
+		expect(rollup).toMatchObject({ inputTokens: 120, outputTokens: 12 });
 
 		// The tree shares that definition of "child": the branch renders as its
 		// own top-level session while only the spawned child nests and counts.


### PR DESCRIPTION
## LOC

+22 / −6 across 3 files: agents-view-mode.ts (+14), agents-view-mode.test.ts (+7), one changelog fragment.

## Purpose

Row details show cost and age but not tokens, so there is no way to see how much a session has actually read/written without opening its actions panel. This adds the input/output token column back in the compact-abbreviated format used before the view was simplified: `↑12k ↓1.2k`.

## Changes

- `buildCompactAgentsViewLayout` gains a right-aligned tokens cell (`↑<in> ↓<out>`, k/M-abbreviated via the existing `formatTokenCount`) ahead of Cost and Age, and the shared legend gains the matching `↑in ↓out` label.
- Shrink order respects the existing priorities: tokens are the first detail dropped on narrow terminals (before Session/Model shrink below their usual room); cost and age never drop, as today.

Review follow-up: the tokens cell shares the cost column's scope (own plus descendants) via the same rollup machinery, and the drop threshold accounts for the model column's real desired width so tokens disappear before Session/Model lose their normal room. `formatTokenCount` now rounds 999,5xx+ into `1.0M` instead of `1000k`.

## Validation

- Extended the existing layout pin: rows show `↑12k ↓1.2k` at width 120, the legend shows `↑in ↓out`, and at width 60 the tokens column drops while model, cost, and age stay. Fails on unfixed main (2 tests).
- agents-view suites + interactive rendering suites in a Prime sandbox; root `npm run check` (pre-commit) passes.

Fixes RES-1329


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore input/output token columns in agents view
> - Adds recursive input and output token totals to `AgentsViewRow` and `AgentsViewRecursiveRollup`, accumulating own-plus-descendant counts in `computeRecursiveRollups` and `buildAgentsViewRows`
> - Renders aligned input/output token columns with legend headings in `buildCompactAgentsViewLayout`, removing token columns first when terminal width is constrained (cost, age, session, and model remain)
> - Cost in `computeRecursiveRollups` now reads from the daemon usage object when present, falling back to saved usage — previously cost could fall back independently of the usage selection
> - Fixes `formatTokenCount` so counts ≥999,500 display in millions notation (e.g., 999,999 shows as `1.0M` instead of `1000k`)
> - Behavioral Change: `computeRecursiveRollups` cost source now follows the selected usage object (daemon before saved) rather than falling back separately; reviewers should check `agents-view-state.ts` rollup expectations and any out-of-tree consumers of `AgentsViewRecursiveRollup`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e42078.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and rollup logic in the agents view only; no auth, persistence, or API contract changes beyond aligned usage totals in the TUI.
> 
> **Overview**
> Restores **↑in / ↓out** token columns on agents view rows and in the shared column legend, using the same abbreviated `formatTokenCount` style as elsewhere (`↑13k ↓1.3k`).
> 
> Token totals use the **same recursive scope as cost** (session plus subagent descendants): `AgentsViewRow` and `computeRecursiveRollups` now track `recursiveInputTokens` / `recursiveOutputTokens`, and `buildCompactAgentsViewLayout` renders right-aligned in/out sub-columns ahead of Cost and Age. On narrow terminals, **tokens drop first** while Session/Model keep their usual width and cost/age stay visible.
> 
> Also tweaks **`formatTokenCount`** so values from ~999.5k through 999,999 display as `1.0M` instead of `1000k`, with matching tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e4207802b0421c973bfa64e6a44e2e3cd2eab6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->