### PR TITLE
agents view: show the recorded model on inactive sessions

### DIFF
--- a/packages/coding-agent/.changes/res-1330-inactive-session-model.md
+++ b/packages/coding-agent/.changes/res-1330-inactive-session-model.md
@@ -1,0 +1,1 @@
+- Added the recorded model to inactive session rows in the agents view instead of showing '-'.

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -243,12 +243,19 @@ export interface SessionContext {
 	model: { provider: string; modelId: string } | null;
 }
 
+export interface SessionModelRef {
+	provider: string;
+	modelId: string;
+}
+
 export interface SessionInfo {
 	path: string;
 	id: string;
 	cwd: string;
 	name?: string;
 	state?: SessionState;
+	/** Last model the session ran with, from model_change entries and assistant messages. */
+	model?: SessionModelRef;
 	parentSessionPath?: string;
 	rlmDepth: number;
 	created: Date;
@@ -1042,6 +1049,7 @@ function extractOversizedMessageSummary(line: string): {
 
 interface SessionScanAccumulator {
 	header?: SessionHeader;
+	model?: SessionModelRef;
 	/** The first parsed entry was not a session header; appends cannot repair this. */
 	invalid: boolean;
 	messageCount: number;
@@ -1273,6 +1281,10 @@ function foldSessionScanLine(acc: SessionScanAccumulator, lineBuffer: Buffer): v
 	if (entry.type === "agent_status") {
 		acc.agentStatus = (entry as AgentStatusEntry).status;
 	}
+	if (entry.type === "model_change") {
+		const modelEntry = entry as ModelChangeEntry;
+		acc.model = { provider: modelEntry.provider, modelId: modelEntry.modelId };
+	}
 	if (entry.type === "child_usage_attributed") {
 		const attribution = entry as ChildUsageAttributionEntry;
 		if (acc.assistantUsageById.has(attribution.targetId)) {
@@ -1300,6 +1312,12 @@ function foldSessionScanLine(acc: SessionScanAccumulator, lineBuffer: Buffer): v
 	const message = (entry as SessionMessageEntry).message;
 	if (message.role === "assistant" && (message as { usage?: Usage }).usage) {
 		acc.assistantUsageById.set(entry.id, (message as { usage: Usage }).usage);
+	}
+	if (message.role === "assistant") {
+		const assistant = message as { provider?: string; model?: string };
+		if (typeof assistant.provider === "string" && typeof assistant.model === "string") {
+			acc.model = { provider: assistant.provider, modelId: assistant.model };
+		}
 	}
 	if (!isMessageWithContent(message)) return;
 	if (message.role !== "user" && message.role !== "assistant") return;
@@ -1348,6 +1366,7 @@ function snapshotSessionInfo(
 		cwd,
 		name: acc.name,
 		state: acc.state,
+		model: acc.model,
 		parentSessionPath,
 		rlmDepth,
 		created: new Date(header.timestamp),

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -136,6 +136,8 @@ export interface AgentConnectionSavedSessionInfo {
 	allMessagesText: string;
 	agentStatus?: AgentConnectionAgentStatus;
 	usage?: SessionUsageSummary;
+	/** Last recorded provider/model selector; absent for sessions that never ran a model. */
+	model?: { provider: string; modelId: string };
 }
 
 export type AgentConnectionSessionListProgress = (loaded: number, total: number) => void;

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -2576,7 +2576,7 @@ export class AgentsViewMode implements Component, Focusable {
 		const activity = [status, row.summary.summary].filter(Boolean).join(" · ");
 		const cells = [
 			formatTableCell(title, layout.nameWidth),
-			formatTableCell(theme.fg("muted", formatSessionModel(row.summary)), layout.modelWidth),
+			formatTableCell(theme.fg("muted", formatSessionModel(row)), layout.modelWidth),
 		];
 		if (layout.activityWidth > 0) cells.push(formatTableCell(theme.fg("dim", activity), layout.activityWidth));
 		cells.push(theme.fg("muted", details));
@@ -2830,10 +2830,7 @@ export function buildCompactAgentsViewLayout(rows: readonly AgentsViewRow[], wid
 	const ageWidth = entries.reduce((size, entry) => Math.max(size, visibleWidth(entry.age)), 3);
 	const detailsWidth = costWidth + 2 + ageWidth;
 	const available = Math.max(0, width - detailsWidth - 4);
-	const desiredModelWidth = sessions.reduce(
-		(size, row) => Math.max(size, visibleWidth(formatSessionModel(row.summary))),
-		12,
-	);
+	const desiredModelWidth = sessions.reduce((size, row) => Math.max(size, visibleWidth(formatSessionModel(row))), 12);
 	const modelWidth = Math.min(desiredModelWidth, 32, Math.max(0, available - 12));
 	const nameWidth = Math.min(28, Math.max(0, available - modelWidth));
 	const activityWidth = Math.max(0, available - modelWidth - nameWidth - 2);
@@ -2871,8 +2868,8 @@ function formatTableCell(value: string, width: number): string {
 	return truncated + " ".repeat(Math.max(0, width - visibleWidth(truncated)));
 }
 
-function formatSessionModel(summary: SessionSummary): string {
-	return summary.model?.id ?? "-";
+function formatSessionModel(row: AgentsViewRow): string {
+	return row.summary.model?.id ?? row.record?.saved?.model?.modelId ?? "-";
 }
 
 function formatSessionDuration(summary: SessionSummary): string {

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -2593,11 +2593,17 @@ export class AgentsViewMode implements Component, Focusable {
 		];
 		if (row) {
 			const model = row.summary.model;
+			const savedModel = row.record?.saved?.model;
+			const modelLabel = model
+				? `${model.provider}/${model.id}`
+				: savedModel
+					? `${savedModel.provider}/${savedModel.modelId}`
+					: "unknown";
 			const usage = row.summary.usage;
 			actions.push(
 				"",
 				row.title,
-				`Model: ${model ? `${model.provider}/${model.id}` : "unknown"}${row.summary.thinkingLevel ? ` · ${row.summary.thinkingLevel}` : ""}`,
+				`Model: ${modelLabel}${row.summary.thinkingLevel ? ` · ${row.summary.thinkingLevel}` : ""}`,
 				`Directory: ${row.summary.cwd}`,
 				`Tokens: ${usage?.inputTokens ?? 0} in · ${usage?.outputTokens ?? 0} out`,
 				`Cost: $${(usage?.cost ?? 0).toFixed(2)} session · $${row.recursiveCost.toFixed(2)} including subagents`,

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -73,8 +73,9 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 25 adds capability-gated direct worker peer transport discovery.
 // Revision 26 publishes own-session usage totals on session summary and saved-session rows.
 // Revision 27 adds structured session_recovering failure info for known-but-unaddressable sessions.
-export const DAEMON_SCHEMA_REVISION = 27;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-27-962b8b4c5e35";
+// Revision 28 publishes the last recorded model on saved-session rows.
+export const DAEMON_SCHEMA_REVISION = 28;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-28-92bc5368a082";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -1079,6 +1080,8 @@ export interface DaemonSavedSessionInfo {
 	allMessagesText: string;
 	agentStatus?: AgentConnectionAgentStatus;
 	usage?: SessionUsageSummary;
+	/** Last recorded provider/model selector; absent for sessions that never ran a model. */
+	model?: { provider: string; modelId: string };
 }
 
 export type DaemonDeleteSavedSessionResult = DeleteSessionFileResult;

--- a/packages/coding-agent/src/modes/daemon/saved-session-info.ts
+++ b/packages/coding-agent/src/modes/daemon/saved-session-info.ts
@@ -18,6 +18,7 @@ export function serializeSavedSessionInfo(session: SessionInfo): DaemonSavedSess
 		allMessagesText: session.allMessagesText,
 		agentStatus: session.agentStatus,
 		usage: session.usage,
+		model: session.model,
 	};
 }
 
@@ -37,5 +38,6 @@ export function deserializeSavedSessionInfo(session: DaemonSavedSessionInfo): Ag
 		allMessagesText: session.allMessagesText,
 		agentStatus: session.agentStatus,
 		usage: session.usage,
+		model: session.model,
 	};
 }

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -842,6 +842,14 @@ describe("AgentsViewMode", () => {
 			expect(render("with-model")).toContain("glm-4.7");
 			expect(render("bare")).toMatch(/\s-\s/);
 			expect(render("bare")).not.toContain("glm-4.7");
+			// The actions panel shows the same recorded model instead of "unknown".
+			Reflect.set(
+				view,
+				"selectedIndex",
+				rows.findIndex((row) => row.summary.sessionId === "with-model"),
+			);
+			const actions = (invoke("renderActions", view, 120) as string[]).map(stripAnsi).join("\n");
+			expect(actions).toContain("Model: prime-inference/glm-4.7");
 		} finally {
 			stopThemeWatcher();
 		}

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -816,6 +816,37 @@ describe("AgentsViewMode", () => {
 		}
 	});
 
+	it("shows the recorded model on inactive saved sessions and keeps '-' without one", () => {
+		const saved = (id: string, model?: { provider: string; modelId: string }) => ({
+			path: `/tmp/${id}.jsonl`,
+			id,
+			cwd: "/tmp",
+			created: new Date("2026-01-01T00:00:00Z"),
+			modified: new Date("2026-01-01T00:00:00Z"),
+			messageCount: 1,
+			firstMessage: "hello",
+			allMessagesText: "hello",
+			...(model ? { model } : {}),
+		});
+		const records = reconcileUnifiedSessions(
+			[],
+			[saved("with-model", { provider: "prime-inference", modelId: "glm-4.7" }), saved("bare")],
+		);
+		const rows = buildAgentsViewRows(records);
+		const view = new AgentsViewMode({ config: {}, uiServices: createUiServices() }, {});
+		Reflect.set(view, "rows", rows);
+		Reflect.set(view, "selectedIndex", -1);
+		try {
+			const render = (id: string) =>
+				stripAnsi(invoke("renderRow", view, rows.find((row) => row.summary.sessionId === id)!, 120) as string);
+			expect(render("with-model")).toContain("glm-4.7");
+			expect(render("bare")).toMatch(/\s-\s/);
+			expect(render("bare")).not.toContain("glm-4.7");
+		} finally {
+			stopThemeWatcher();
+		}
+	});
+
 	it("renders one column header across status groups without repeating subagent hints", () => {
 		const summaries = [
 			summary({

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -827,6 +827,35 @@ describe("readSessionInfo incremental scans", () => {
 	});
 	const line = (entry: unknown) => `${JSON.stringify(entry)}\n`;
 
+	it("scans the last recorded model from model_change entries and assistant messages", async () => {
+		const file = join(tempDir, "model.jsonl");
+		writeFileSync(
+			file,
+			[
+				line(header),
+				line({ type: "model_change", id: "mc1", parentId: null, provider: "openai", modelId: "gpt-4o" }),
+				line(msg("m1", "mc1", "user", "hi")),
+				line({
+					type: "message",
+					id: "m2",
+					parentId: "m1",
+					message: {
+						role: "assistant",
+						content: "x",
+						timestamp: 1,
+						provider: "prime-inference",
+						model: "glm-4.7",
+					},
+				}),
+			].join(""),
+		);
+		expect((await readSessionInfo(file))?.model).toEqual({ provider: "prime-inference", modelId: "glm-4.7" });
+
+		const bare = join(tempDir, "bare.jsonl");
+		writeFileSync(bare, line(header));
+		expect((await readSessionInfo(bare))?.model).toBeUndefined();
+	});
+
 	it("coalesces concurrent unchanged readers and gives post-append readers the fresh snapshot", async () => {
 		const file = join(tempDir, "serialized.jsonl");
 		let content = line(header);


### PR DESCRIPTION
## LOC

+93 / −9 across 8 files: session-manager.ts (+18), daemon-protocol.ts / agent-connection types / saved-session serializers (+10 combined), agents-view-mode.ts (+4), two test files (+55), one changelog fragment.

## Purpose

Inactive session rows render `-` in the model column even though the session file records exactly which model the session ran. Persisted sessions now show that model; a session that genuinely never ran one keeps `-`.

## Changes

- The saved-catalog scan (`scanSessionInfo`) already line-parses every session file; it now also keeps the last recorded model from `model_change` entries and assistant messages — same derivation as `buildSessionContext`, no new IO and no extra disk parse on render paths.
- `SessionInfo`, `DaemonSavedSessionInfo`, and `AgentConnectionSavedSessionInfo` gain an optional `model: { provider, modelId }` threaded through the existing serialize/deserialize pair.
- The agents-view model column falls back to the saved record's model when the summary has none (inactive rows); live rows are unchanged.

## Wire compatibility

Backward-compatible additive optional field on saved-session rows: `DAEMON_SCHEMA_REVISION` 28 with the source-hash schema id regenerated. Old daemon → new client: field absent, column stays `-` (pinned). New daemon → old client: the deserializer copies known fields only, extra field ignored. No new command, event, or capability.

Note: unmerged #2100 also claims schema revision 28 (context_limit_state). Whichever lands second rebumps to 29 and regenerates the digest — a one-line follow-up here if #2100 merges first.

## Validation

- New pins: the scan returns the last recorded model (model_change then assistant-message override) and `undefined` for a header-only file; an inactive saved row renders its model and a model-less saved row keeps `-`. Both fail on unfixed main.
- daemon-protocol schema-identity test passes with the regenerated digest.
- agents-view + session-manager + daemon-protocol suites and interactive rendering suites in a Prime sandbox; root `npm run check` (pre-commit) passes.

Fixes RES-1330


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show recorded model on inactive sessions in agents view
> - `foldSessionScanLine` in [session-manager.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2148/files#diff-e514ecbe1ca80031cc52600ee3863d993a99616f116355f3fec33c92b532d2cf) now records the last provider/model from model-change entries and assistant messages during session scans, and `snapshotSessionInfo` copies it into session metadata.
> - `formatSessionModel` in [agents-view-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2148/files#diff-116f4364505fa125d57532296cde69f9a73543363de3d3cd48bd4f48b2ee6e10) falls back from the live summary model to the saved-session model before showing a dash; the actions panel and compact layout width calculation use the same fallback.
> - Daemon protocol advances from schema revision 27 to 28 so serialized saved-session rows carry the recorded provider/model selector.
> - Risk: daemon clients on schema revision < 28 will not see the new `model` field on `DaemonSavedSessionInfo`; the field is optional so older clients are unaffected, but they will not display the recorded model for inactive sessions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec3970f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional metadata and UI fallback only; no changes to auth, prompting, or session persistence semantics beyond scan output.
> 
> **Overview**
> Inactive agents-view rows no longer show **`-`** in the Model column when the session file already records which model ran. The saved-session catalog scan now keeps the **last provider/model** while line-parsing each `.jsonl` file—updated from **`model_change`** entries and later **assistant** messages (same “last wins” idea as live session context), with no extra read on render.
> 
> That **`model`** field is threaded through **`SessionInfo`**, daemon **`DaemonSavedSessionInfo`**, and **`AgentConnectionSavedSessionInfo`** (serialize/deserialize unchanged in shape). **`formatSessionModel`** and the actions panel prefer the live summary model when present, otherwise the saved record’s **`modelId`**; sessions that never ran a model still show **`-`**. Daemon protocol advances to **schema revision 28** so saved-session rows can carry the optional selector on the wire.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec3970f50192ace58934b7d3bf321f0c0208bc99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->