### PR TITLE
fix(coding-agent): park waitForIdle while the session-input pump is blocked

### DIFF
--- a/packages/coding-agent/.changes/res-1332-waitforidle-spin.md
+++ b/packages/coding-agent/.changes/res-1332-waitforidle-spin.md
@@ -1,0 +1,1 @@
+- Fixed a session worker wedging at 100% CPU: waiting for a session to go idle while queued input was blocked by a running bash command, compaction, or retry spun in microtasks without ever yielding to IO, freezing every session in the worker and starving daemon IPC.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -6056,6 +6056,12 @@ export class AgentSession {
 		}
 	}
 
+	/**
+	 * Busy inputs: compaction, retry, bash, plus (for "pump") disposal,
+	 * suspension, queued-work pauses, and branch-summary mutation. Waiters
+	 * parked on this predicate rely on every clear site notifying the
+	 * session-input checkpoint waiters.
+	 */
 	private _isBusyForSessionInput(point: "preflight" | "pump"): boolean {
 		const externalBusy = this.isCompacting || this.isRetrying || this.isBashRunning;
 		if (point === "pump") {
@@ -7033,9 +7039,9 @@ export class AgentSession {
 	private async _waitForIdleOrSettlement(settlement?: PostCompactionContinuationSettlement): Promise<void> {
 		while (settlement === undefined || this._postCompactionContinuationSettlement === settlement) {
 			if (this._actionStore.queuedActions().length > 0) {
-				// Park while the pump would refuse selection: rescheduling a blocked
-				// pump completes on already-resolved promises, so looping here would
-				// spin on the microtask queue and starve the IO that ends the busy state.
+				// Park while the pump would refuse scheduling or selection: rescheduling
+				// a blocked pump completes on already-resolved promises, so looping here
+				// would spin on the microtask queue and starve the IO that ends the busy state.
 				if (this._isBusyForSessionInput("pump")) {
 					let wake = () => {};
 					const changed = new Promise<void>((resolve) => {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -7033,7 +7033,13 @@ export class AgentSession {
 	private async _waitForIdleOrSettlement(settlement?: PostCompactionContinuationSettlement): Promise<void> {
 		while (settlement === undefined || this._postCompactionContinuationSettlement === settlement) {
 			if (this._actionStore.queuedActions().length > 0) {
-				if (this._sessionInputPumpSuspended || this._queuedWorkPauses.size > 0) {
+				// Park while the pump would refuse selection (suspension, pauses, or
+				// external busyness such as bash/compaction/retry): rescheduling a
+				// pump that immediately returns blocked re-resolves every awaited
+				// promise below in the same microtask drain, so this loop would spin
+				// without ever reaching the macrotask queue — starving the IO that
+				// clears the busy state (RES-1332 wedged a 97-session worker this way).
+				if (this._isBusyForSessionInput("pump")) {
 					let wake = () => {};
 					const changed = new Promise<void>((resolve) => {
 						wake = resolve;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -7033,12 +7033,9 @@ export class AgentSession {
 	private async _waitForIdleOrSettlement(settlement?: PostCompactionContinuationSettlement): Promise<void> {
 		while (settlement === undefined || this._postCompactionContinuationSettlement === settlement) {
 			if (this._actionStore.queuedActions().length > 0) {
-				// Park while the pump would refuse selection (suspension, pauses, or
-				// external busyness such as bash/compaction/retry): rescheduling a
-				// pump that immediately returns blocked re-resolves every awaited
-				// promise below in the same microtask drain, so this loop would spin
-				// without ever reaching the macrotask queue — starving the IO that
-				// clears the busy state (RES-1332 wedged a 97-session worker this way).
+				// Park while the pump would refuse selection: rescheduling a blocked
+				// pump completes on already-resolved promises, so looping here would
+				// spin on the microtask queue and starve the IO that ends the busy state.
 				if (this._isBusyForSessionInput("pump")) {
 					let wake = () => {};
 					const changed = new Promise<void>((resolve) => {

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -3667,6 +3667,7 @@ describe("AgentSession scheduler scenarios", () => {
 		setImmediate(() => {
 			// An arrival during the park must not be lost once the busy state clears.
 			secondPrompt = session.prompt("queued during park");
+			secondPrompt.catch(() => undefined);
 			releaseBash();
 		});
 		await idle;

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -29,6 +29,7 @@ import {
 	saveHarnessState,
 } from "../../src/core/refinement/index.js";
 import { parseSessionSlashCommand } from "../../src/core/slash-commands.js";
+import type { BashOperations } from "../../src/core/tools/bash.js";
 import {
 	conversationMessages,
 	createHarness,
@@ -3630,5 +3631,50 @@ describe("AgentSession scheduler scenarios", () => {
 				process.env.PRIME_AGENT_CODING_AGENT_DIR = previousAgentDir;
 			}
 		}
+	});
+
+	it("waitForIdle parks instead of microtask-spinning while a running bash blocks queued input", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const session = harness.session;
+		let releaseBash!: () => void;
+		const gate = new Promise<{ exitCode: number | null }>((resolve) => {
+			releaseBash = () => resolve({ exitCode: 0 });
+		});
+		const operations: BashOperations = { exec: async () => await gate };
+		const bashPromise = session.executeBash("blocked", undefined, { operations });
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(session.isBashRunning).toBe(true);
+
+		harness.setResponses([fauxAssistantMessage("first done"), fauxAssistantMessage("second done")]);
+		const firstPrompt = session.prompt("queued while bash runs");
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		// Count pump scheduling from the idle wait. Unfixed, the wait loop respun the
+		// blocked pump purely in microtasks, so the setImmediate below never fired and
+		// only the 200th reschedule (the escape hatch) released the gate.
+		const internals = session as unknown as { _scheduleSessionInputPump(): void };
+		const originalSchedule = internals._scheduleSessionInputPump.bind(session);
+		let scheduleCount = 0;
+		let secondPrompt: Promise<void> | undefined;
+		internals._scheduleSessionInputPump = () => {
+			scheduleCount++;
+			if (scheduleCount === 200) releaseBash();
+			originalSchedule();
+		};
+
+		const idle = session.waitForIdle();
+		setImmediate(() => {
+			// An arrival during the park must not be lost once the busy state clears.
+			secondPrompt = session.prompt("queued during park");
+			releaseBash();
+		});
+		await idle;
+		await bashPromise;
+		await firstPrompt;
+		await secondPrompt;
+
+		expect(scheduleCount).toBeLessThan(200);
+		expect(getAssistantTexts(harness)).toEqual(["first done", "second done"]);
 	});
 });


### PR DESCRIPTION
Waiting for a session to go idle could wedge an entire session worker at 100% CPU.

## What happened

`AgentSession._waitForIdleOrSettlement` reschedules the session-input pump whenever queued actions exist and the queue is neither suspended nor paused. When the agent itself is idle but the session is externally busy — a running bash command, an in-flight compaction, or a retry — the pump returns "blocked" immediately after notifying checkpoint waiters. Every promise the wait loop then awaits (the pump, the agent's idle promise, the event queue) is already resolved, so the loop respins entirely on the microtask queue. The event loop never reaches its timer/IO phases, which means the very signal that would clear the busy state (the bash exiting, the compaction response, the retry timer) can never be processed. The spin is permanent.

Because one worker process hosts a whole recursive agent tree on one thread, a single session entering this state freezes every session in the tree at the same instant and starves the worker's IPC: attach requests time out, heartbeat listing fails, and no session writes to disk. Idle waits are common — recursive-subagent quiescence, post-compaction continuation, and daemon passivation all sit in this loop — so a busy child with one queued message was enough. The stack sampled on the wedged worker (an async resume calling `Set.prototype.clear` on every iteration) is the pump's blocked-path checkpoint notification.

Two residual paths were checked and do not spin: a mismatched pump epoch cannot recur without an external pause acquire/release per iteration, and each of those either sets a busy bit (now parked on) or notifies the waiters; streaming and refinement application already park inside the pump on genuinely pending promises.

## The fix

Park the idle wait on the existing checkpoint-waiter branch whenever the pump would refuse selection, by reusing the pump's own busy predicate (`_isBusyForSessionInput("pump")`) instead of the narrower suspension/pause check. The wait becomes a genuinely pending promise; every site that clears a busy bit (bash end, compaction end, retry end, refinement end, branch-summary end, disposal's action cancellation) already notifies these waiters, so no wake-up is lost. Input queued while parked is picked up when the busy state clears — the regression test pins that too.

The pinned test drives the exact spin: a gated bash command holds the session busy, one prompt sits queued, and `waitForIdle` starts. Unfixed, the loop reschedules the pump 200 times before a single `setImmediate` can fire (proving the macrotask queue is unreachable); fixed, it parks after one schedule, the `setImmediate` runs, and both the original and a park-time prompt complete. The assertion is an iteration count, not wall-clock.

## LOC

- `packages/coding-agent/src/core/agent-session.ts`: +10/-1 (one condition change plus comments)
- `packages/coding-agent/test/suite/agent-session-queue.test.ts`: +47 (one regression test)
- `packages/coding-agent/.changes/res-1332-waitforidle-spin.md`: +1 (changelog fragment)

Fixes RES-1332

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AgentSession.waitForIdle` CPU spin while session-input pump is blocked
> - `AgentSession._waitForIdleOrSettlement` now checks the pump-level busy-state predicate instead of only pump suspension and queued-work pauses. When the pump cannot schedule or select work, it registers a checkpoint waiter and awaits a checkpoint notification or settlement rather than repeatedly rescheduling the blocked pump.
> - Documents the set of busy states (compaction, retry, bash execution, disposal, suspension, queued-work pauses, branch-summary mutation) whose clear sites must notify checkpoint waiters.
> - Adds a regression test in [agent-session-queue.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2151/files#diff-a2584e16d0c5299a8dbcbebea1767680356b4f11acd67feca44d2874f59ae1cb) that holds bash behind a promise, queues prompts, calls `waitForIdle`, and schedules another prompt from `setImmediate`; it asserts the idle wait yields before 200 pump reschedules and that queued responses arrive in order after the busy state clears.
> - Risk: any new busy state added to `AgentSession._isBusyForSessionInput` must notify checkpoint waiters at its clear site, otherwise `waitForIdle` may hang until settlement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ec3332.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core session idle/admission scheduling; any new pump busy state must notify checkpoint waiters or `waitForIdle` could hang.
> 
> **Overview**
> Fixes a **100% CPU wedge** in session workers when `waitForIdle` runs while queued input exists but the session-input pump cannot make progress (e.g. **bash**, compaction, or retry in flight).
> 
> Previously the idle loop only parked on pump suspension or queued-work pauses. When the pump was blocked for other busy reasons it kept **rescheduling the pump on resolved microtasks**, starving timers/IO so the busy state never cleared and freezing the whole worker tree.
> 
> **`_waitForIdleOrSettlement`** now parks on the same predicate the pump uses — **`_isBusyForSessionInput("pump")`** — and awaits checkpoint waiters until a busy bit clears. Comments document which busy states must notify those waiters. A regression test asserts the wait **yields before 200 pump schedules** while bash is gated and that prompts queued during the park still run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ec33322921575b37d04d9fbeb2e3b7e3dda6a0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->