### PR TITLE
fold the twin agent rosters into one

### DIFF
--- a/packages/coding-agent/.changes/res-1335-one-roster.md
+++ b/packages/coding-agent/.changes/res-1335-one-roster.md
@@ -1,0 +1,1 @@
+- Removed `agent_message.list_agents()`; `agent_observe.list_agents()` is now the single family roster and lists inactive parents, siblings, and children with a `relationship` field.

--- a/packages/coding-agent/docs/long-running-agents.md
+++ b/packages/coding-agent/docs/long-running-agents.md
@@ -76,10 +76,10 @@ The daemon routes direct messages between active sessions and retained daemon-ba
 prime-agent send <agent> "Please verify the latest migration"
 ```
 
-From the Python kernel, use the preloaded `agent_message` Python skill:
+From the Python kernel, use the preloaded `agent_observe` and `agent_message` Python skills:
 
 ```python
-roster = await agent_message.list_agents()
+roster = await agent_observe.list_agents()
 receipt = await agent_message.send(
     "Recheck the endpoint after the latest edit",
     receiver_role="sibling",

--- a/packages/coding-agent/skills/agent-message/SKILL.md
+++ b/packages/coding-agent/skills/agent-message/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-message
-description: Message an agent's parent, siblings, or direct children through the daemon. Use the family roster to discover reachable agents and send direct text without spoofing sender identity.
+description: Message an agent's parent, siblings, or direct children through the daemon. Discover reachable agents with agent_observe.list_agents, then send direct text without spoofing sender identity.
 ---
 
 # Agent Message
@@ -26,14 +26,14 @@ if child is not None:
 
 ## API
 
-- `await agent_message.list_agents()` — returns `current` (`name`, `id`, `depth`)
-  and family-scoped `entries` (`relationship`, `name`, `id`, `depth`, `status`)
-  for the current agent's parent, siblings, and children. It includes inactive
-  family members and sorts parent, siblings by name, then children by name; it
-  does not expose a global daemon session list.
+- `await agent_observe.list_agents()` (agent-observe skill) is the roster: it
+  lists the parent, siblings, and children this skill can reach, active or not,
+  with the `relationship` and `sessionName` that `send` takes as
+  `receiver_role` and `receiver_name`.
 - `await agent_message.send(message, receiver_role="parent" | "sibling" | "child", receiver_name=None)` — sends one direct
-  text message to an active session. Sending to an idle completed subagent
-  starts an ordinary follow-up turn in that same child session and context.
+  text message to one family member. Sending to an inactive or idle completed
+  subagent wakes it and starts an ordinary follow-up turn in that same session
+  and context.
   The child remains available only until its parent session closes. The daemon
   resolves `receiver_role` within the current agent family; `receiver_name` is
   required for siblings and children and omitted for the unique parent.

--- a/packages/coding-agent/skills/agent-message/src/agent_message/__init__.py
+++ b/packages/coding-agent/skills/agent-message/src/agent_message/__init__.py
@@ -14,11 +14,6 @@ ReceiverRole = Literal["parent", "sibling", "child"]
 _MESSAGE_DISPLAY_MIME = "application/vnd.prime-agent.agent-message+json"
 
 
-async def list_agents() -> dict[str, Any]:
-    """List this agent's parent, siblings, and children, including inactive family."""
-    return await host_request("agent_message.list_agents")
-
-
 async def send(
     message: str,
     broadcast_message: str | None = None,

--- a/packages/coding-agent/skills/agent-observe/SKILL.md
+++ b/packages/coding-agent/skills/agent-observe/SKILL.md
@@ -7,9 +7,9 @@ description: Read-only roster and observation of an agent's parent, siblings, an
 
 Observe the current agent's nuclear family through the local daemon: parent,
 siblings, direct children, and self. `list_agents` is the one family roster and
-covers every member `agent_message.send` can reach. Transcript reads need a live
-session in this worker, so `get_agent` and `recent_messages` do not work on
-inactive members or on root siblings held by another worker.
+covers every member `agent_message.send` can reach. `get_agent` and
+`recent_messages` hydrate an inactive child before reading it, but they cannot
+read a root sibling held by another worker.
 This skill is read-only: it can list family sessions, inspect one session, and fetch
 bounded recent message previews. It cannot prompt, steer, clear, kill, rename, or
 otherwise mutate another session.

--- a/packages/coding-agent/skills/agent-observe/SKILL.md
+++ b/packages/coding-agent/skills/agent-observe/SKILL.md
@@ -8,8 +8,8 @@ description: Read-only roster and observation of an agent's parent, siblings, an
 Observe the current agent's nuclear family through the local daemon: parent,
 siblings, direct children, and self. `list_agents` is the one family roster and
 covers every member `agent_message.send` can reach. `get_agent` and
-`recent_messages` hydrate an inactive child before reading it, but they cannot
-read a root sibling held by another worker.
+`recent_messages` hydrate an inactive child before reading it. They cannot read
+a root sibling that has no live session in this worker.
 This skill is read-only: it can list family sessions, inspect one session, and fetch
 bounded recent message previews. It cannot prompt, steer, clear, kill, rename, or
 otherwise mutate another session.
@@ -32,9 +32,11 @@ if child is not None:
   nuclear family: parent, siblings, and direct children, active or not. Each
   agent carries `sessionId`, optional `sessionName`, `relationship`
   (`parent`/`sibling`/`child`), `status`, `isSessionActive`, and the counts and
-  latest message preview known for it. A member with no live session in this
-  worker has no `activeSessionId` and no live detail; use `relationship` and
-  `sessionName` to address it with `agent_message.send`. For direct children,
+  message previews known for it: `latestMessage` for a live session,
+  `firstMessage` for a member read from disk. A member with no live session has
+  no `activeSessionId` and no live detail; address it with `agent_message.send`
+  using its `relationship` plus its `sessionName`, or its `sessionId` when the
+  member has no name. For direct children,
   `await rlm.list_subagents()` also exposes parent-owned lifecycle handles.
 - `await agent_observe.get_agent(target)` returns `agent`, where `agent`
   contains one live agent summary. `target` is resolved like other live-session

--- a/packages/coding-agent/skills/agent-observe/SKILL.md
+++ b/packages/coding-agent/skills/agent-observe/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: agent-observe
-description: Read-only observation of an agent's parent, siblings, and direct children. Use to inspect family status and bounded recent-message previews without mutating sessions.
+description: Read-only roster and observation of an agent's parent, siblings, and direct children. Use to discover reachable agents and to inspect family status and bounded recent-message previews without mutating sessions.
 ---
 
 # Agent Observe
 
 Observe the current agent's nuclear family through the local daemon: parent,
-siblings, direct children, and self. Observation is currently limited to family
-members in the same worker; root siblings in other workers are not observable yet.
+siblings, direct children, and self. `list_agents` is the one family roster and
+covers every member `agent_message.send` can reach. Transcript reads need a live
+session in this worker, so `get_agent` and `recent_messages` do not work on
+inactive members or on root siblings held by another worker.
 This skill is read-only: it can list family sessions, inspect one session, and fetch
 bounded recent message previews. It cannot prompt, steer, clear, kill, rename, or
 otherwise mutate another session.
@@ -26,14 +28,16 @@ if child is not None:
 
 ## API
 
-- `await agent_observe.list_agents()` returns `current` and `agents`. Each
-  agent includes active session id, session id, optional name, runtime kind,
-  cwd, status, streaming state, message count, pending count, and a latest
-  message preview. The list is restricted to self, parent, siblings, and direct
-  children. For direct children, `await rlm.list_subagents()` also exposes
-  parent-owned lifecycle handles.
+- `await agent_observe.list_agents()` returns `current` and `agents`, the full
+  nuclear family: parent, siblings, and direct children, active or not. Each
+  agent carries `sessionId`, optional `sessionName`, `relationship`
+  (`parent`/`sibling`/`child`), `status`, `isSessionActive`, and the counts and
+  latest message preview known for it. A member with no live session in this
+  worker has no `activeSessionId` and no live detail; use `relationship` and
+  `sessionName` to address it with `agent_message.send`. For direct children,
+  `await rlm.list_subagents()` also exposes parent-owned lifecycle handles.
 - `await agent_observe.get_agent(target)` returns `agent`, where `agent`
-  contains one agent summary. `target` is resolved like other live-session
+  contains one live agent summary. `target` is resolved like other live-session
   selectors: active id, session id/name, or unambiguous suffix.
 - `await agent_observe.recent_messages(target, limit=8, max_chars=800)`
   returns up to `limit` recent bounded message previews for the target session.

--- a/packages/coding-agent/skills/agent-observe/SKILL.md
+++ b/packages/coding-agent/skills/agent-observe/SKILL.md
@@ -33,7 +33,7 @@ if child is not None:
   agent carries `sessionId`, optional `sessionName`, `relationship`
   (`parent`/`sibling`/`child`), `status`, `isSessionActive`, and the counts and
   message previews known for it: `latestMessage` for a live session,
-  `firstMessage` for a member read from disk. A member with no live session has
+  `firstMessage` for an inactive child. A member with no live session has
   no `activeSessionId` and no live detail; address it with `agent_message.send`
   using its `relationship` plus its `sessionName`, or its `sessionId` when the
   member has no name. For direct children,

--- a/packages/coding-agent/skills/agent-observe/src/agent_observe/__init__.py
+++ b/packages/coding-agent/skills/agent-observe/src/agent_observe/__init__.py
@@ -13,12 +13,12 @@ from rlm import host_request
 
 
 async def list_agents() -> dict[str, Any]:
-    """List active daemon sessions visible to this agent."""
+    """List the full nuclear family: parent, siblings, children, active or not."""
     return await host_request("agent_observe.list")
 
 
 async def get_agent(target: str) -> dict[str, Any]:
-    """Read one active session summary by active id, session id/name, or suffix."""
+    """Read one live session summary by active id, session id/name, or suffix."""
     if not isinstance(target, str):
         raise TypeError(f"target must be str, got {type(target).__name__}")
     return await host_request("agent_observe.get", {"target": target})

--- a/packages/coding-agent/src/core/agent-messages.ts
+++ b/packages/coding-agent/src/core/agent-messages.ts
@@ -85,6 +85,8 @@ export interface AgentFamilyCatalogEntry {
 	sessionPath?: string;
 	cwd?: string;
 	rlmChildId?: string;
+	/** Set only for peers live in another worker; local rows read residency directly. */
+	activeSessionId?: string;
 	/** Persisted transcript facts; known only for entries read from disk. */
 	messageCount?: number;
 	firstMessage?: string;

--- a/packages/coding-agent/src/core/agent-messages.ts
+++ b/packages/coding-agent/src/core/agent-messages.ts
@@ -83,20 +83,16 @@ export interface AgentFamilyCatalogEntry {
 	parentSessionId?: string;
 	parentSessionPath?: string;
 	sessionPath?: string;
+	cwd?: string;
+	rlmChildId?: string;
+	/** Persisted transcript facts; known only for entries read from disk. */
+	messageCount?: number;
+	firstMessage?: string;
 }
 
-export interface AgentFamilyRosterEntry {
+export interface AgentFamilyMember {
 	relationship: AgentFamilyRelationship;
-	name: string;
-	id: string;
-	depth: number;
-	status: AgentFamilyStatus;
-	repliedSinceTask?: boolean;
-}
-
-export interface AgentFamilyRosterResult {
-	current: { name: string; id: string; depth: number };
-	entries: AgentFamilyRosterEntry[];
+	entry: AgentFamilyCatalogEntry;
 }
 
 export interface AgentSessionNameScope {
@@ -157,7 +153,7 @@ export interface AgentSessionMessageSendInput {
 
 export interface AgentSessionMessageController {
 	listAgents(): AgentSessionMessageListResult | Promise<AgentSessionMessageListResult>;
-	roster?(): AgentFamilyRosterResult | Promise<AgentFamilyRosterResult>;
+	family?(): AgentFamilyMember[] | Promise<AgentFamilyMember[]>;
 	awaitPendingChildPublication?(selector: string): Promise<string | undefined>;
 	assertSessionNameAvailable?(input: AgentSessionNameAvailabilityInput): void | Promise<void>;
 	setSessionName?(name: string): void | Promise<void>;
@@ -214,40 +210,27 @@ export function assertAgentSessionNameAvailable(
 	}
 }
 
-export function buildAgentFamilyRoster(
+export function selectAgentFamily(
 	current: AgentFamilyCatalogEntry,
 	catalog: readonly AgentFamilyCatalogEntry[],
-): AgentFamilyRosterResult {
+): AgentFamilyMember[] {
 	const parent = catalog.find((entry) => isAgentFamilyParent(entry, current));
 	const siblings = catalog.filter(
 		(entry) =>
 			entry.id !== current.id && entry.depth === current.depth && sameAgentFamilyParent(entry, current, catalog),
 	);
 	const children = catalog.filter((entry) => entry.depth === current.depth + 1 && isAgentFamilyParent(current, entry));
-	const row = (relationship: AgentFamilyRelationship, entry: AgentFamilyCatalogEntry): AgentFamilyRosterEntry => ({
-		relationship,
-		name: entry.name ?? entry.id,
-		id: entry.id,
-		depth: entry.depth,
-		status: entry.status,
-		...(relationship === "child" && entry.repliedSinceTask !== undefined
-			? { repliedSinceTask: entry.repliedSinceTask }
-			: {}),
-	});
-	return {
-		current: {
-			name: current.name ?? current.id,
-			id: current.id,
-			depth: current.depth,
-		},
-		entries: [
-			...(parent ? [row("parent", parent)] : []),
-			...siblings
-				.sort((a, b) => (a.name ?? a.id).localeCompare(b.name ?? b.id))
-				.map((entry) => row("sibling", entry)),
-			...children.sort((a, b) => (a.name ?? a.id).localeCompare(b.name ?? b.id)).map((entry) => row("child", entry)),
-		],
-	};
+	const byName = (a: AgentFamilyCatalogEntry, b: AgentFamilyCatalogEntry) =>
+		agentFamilyMemberName(a).localeCompare(agentFamilyMemberName(b));
+	return [
+		...(parent ? [{ relationship: "parent" as const, entry: parent }] : []),
+		...siblings.sort(byName).map((entry) => ({ relationship: "sibling" as const, entry })),
+		...children.sort(byName).map((entry) => ({ relationship: "child" as const, entry })),
+	];
+}
+
+export function agentFamilyMemberName(entry: AgentFamilyCatalogEntry): string {
+	return entry.name ?? entry.id;
 }
 
 function sameAgentSessionNameParent(
@@ -535,12 +518,16 @@ export class AgentSessionMessageRateLimiter {
 }
 
 export function createAgentMessageHostHandlers(
-	controller: Pick<AgentSessionMessageController, "roster" | "sendAgentMessage" | "awaitPendingChildPublication">,
+	controller: Pick<AgentSessionMessageController, "sendAgentMessage" | "awaitPendingChildPublication"> & {
+		family(): Promise<AgentFamilyMember[]>;
+	},
 ): Record<string, HostRequestHandler> {
 	return {
 		"agent_message.list_agents": async () => {
-			if (!controller.roster) throw new Error("agent family roster is not available in this session");
-			return (await controller.roster()) as unknown as Record<string, unknown>;
+			throw new Error(
+				"agent_message.list_agents was removed; the family roster now lives in agent_observe.list_agents(). " +
+					"Restart the Python kernel to load the current skills, then call await agent_observe.list_agents().",
+			);
 		},
 		"agent_message.send": async (payload) => {
 			if (typeof payload.message !== "string") {
@@ -556,14 +543,13 @@ export function createAgentMessageHostHandlers(
 				if (payload.receiver_role !== undefined || payload.receiver_name !== undefined) {
 					throw new Error("agent_message.send broadcast cannot be combined with receiver_role/receiver_name");
 				}
-				if (!controller.roster) throw new Error("agent family roster is not available in this session");
-				const roster = await controller.roster();
+				const family = await controller.family();
 				const results = await Promise.allSettled(
-					roster.entries.map((entry) =>
+					family.map((member) =>
 						controller.sendAgentMessage({
-							target: entry.id,
+							target: member.entry.id,
 							message: payload.message as string,
-							receiverRole: entry.relationship,
+							receiverRole: member.relationship,
 						}),
 					),
 				);
@@ -571,7 +557,7 @@ export function createAgentMessageHostHandlers(
 					result.status === "fulfilled"
 						? result.value
 						: {
-								target: roster.entries[index]!.id,
+								target: family[index]!.entry.id,
 								error: result.reason instanceof Error ? result.reason.message : String(result.reason),
 							},
 				);
@@ -588,17 +574,18 @@ export function createAgentMessageHostHandlers(
 				if (role !== "parent" && (typeof receiverName !== "string" || !receiverName.trim())) {
 					throw new Error("agent_message.send receiver_name is required for sibling and child messages");
 				}
-				if (!controller.roster) throw new Error("agent family roster is not available in this session");
 				const selector = typeof receiverName === "string" ? receiverName.trim() : undefined;
 				const publishedId =
 					role === "child" && selector && controller.awaitPendingChildPublication
 						? await controller.awaitPendingChildPublication(selector)
 						: undefined;
-				const roster = await controller.roster();
-				const matches = roster.entries.filter(
-					(entry) =>
-						entry.relationship === role &&
-						(role === "parent" || entry.name === selector || entry.id === selector || entry.id === publishedId),
+				const matches = (await controller.family()).filter(
+					(member) =>
+						member.relationship === role &&
+						(role === "parent" ||
+							agentFamilyMemberName(member.entry) === selector ||
+							member.entry.id === selector ||
+							member.entry.id === publishedId),
 				);
 				if (matches.length !== 1) {
 					throw new Error(
@@ -607,7 +594,7 @@ export function createAgentMessageHostHandlers(
 							: `${role} selector ${JSON.stringify(receiverName)} is ambiguous`,
 					);
 				}
-				target = matches[0]!.id;
+				target = matches[0]!.entry.id;
 			}
 			return (await controller.sendAgentMessage({
 				target,

--- a/packages/coding-agent/src/core/agent-observe.ts
+++ b/packages/coding-agent/src/core/agent-observe.ts
@@ -2,6 +2,8 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { AgentFamilyRelationship } from "./agent-messages.js";
 
 export const AGENT_OBSERVE_SKILL_NAME = "agent-observe";
+/** Shared cap for the message previews carried by roster rows. */
+export const AGENT_OBSERVE_PREVIEW_MAX_CHARS = 240;
 export const AGENT_OBSERVE_IMPORT_NAME = "agent_observe";
 export const ORCHESTRATION_HEARTBEAT_SKILL_NAME = "orchestration-heartbeat";
 

--- a/packages/coding-agent/src/core/agent-observe.ts
+++ b/packages/coding-agent/src/core/agent-observe.ts
@@ -1,23 +1,28 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AgentFamilyRelationship } from "./agent-messages.js";
 
 export const AGENT_OBSERVE_SKILL_NAME = "agent-observe";
 export const AGENT_OBSERVE_IMPORT_NAME = "agent_observe";
 export const ORCHESTRATION_HEARTBEAT_SKILL_NAME = "orchestration-heartbeat";
 
 export interface AgentObserveAgentSummary {
-	activeSessionId: string;
+	/** Absent for family members that have no live session in this daemon. */
+	activeSessionId?: string;
 	sessionId: string;
 	sessionName?: string;
+	/** Absent only for the current agent. */
+	relationship?: AgentFamilyRelationship;
 	runtimeKind?: "top-level" | "subagent";
-	cwd: string;
+	cwd?: string;
 	status: string;
 	isCurrent: boolean;
 	isStreaming: boolean;
 	isCompacting: boolean;
 	attachedClients: number;
-	messageCount: number;
+	messageCount?: number;
 	queuedCount: number;
 	isSessionActive: boolean;
+	repliedSinceTask?: boolean;
 	parentActiveSessionId?: string;
 	parentSessionId?: string;
 	rlmChildId?: string;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -42,12 +42,12 @@ import {
 	AGENT_MESSAGE_RECEIVED_PREVIEW_LABEL,
 	AGENT_MESSAGE_SKILL_NAME,
 	type AgentFamilyCatalogEntry,
-	type AgentFamilyRosterResult,
 	type AgentSessionMessage,
 	type AgentSessionMessageAgentSummary,
 	type AgentSessionMessageController,
 	type AgentSessionMessageListResult,
 	type AgentSessionMessageReceipt,
+	agentFamilyMemberName,
 	assertAgentMessageQueueCapacity,
 	assertAgentSessionNameAvailable,
 	assertDirectAgentMessageTarget,
@@ -3316,18 +3316,11 @@ export class AgentSession {
 	handleAgentMessageHostRequest(
 		type: string,
 		payload: Record<string, unknown> = {},
-	):
-		| Promise<AgentSessionMessageListResult | AgentSessionMessageReceipt | AgentFamilyRosterResult>
-		| AgentSessionMessageListResult
-		| AgentFamilyRosterResult {
+	): Promise<AgentSessionMessageReceipt> {
 		if (!this._agentMessageController) {
 			throw new Error("agent messaging is not available in this session");
 		}
 		switch (type) {
-			case "agent_message.list_agents":
-				if (!this._agentMessageController.roster)
-					throw new Error("agent family roster is not available in this session");
-				return this._agentMessageController.roster();
 			case "agent_message.send": {
 				if (typeof payload.target !== "string") {
 					throw new Error("agent_message.send target must be a string");
@@ -9620,12 +9613,16 @@ export class AgentSession {
 				.filter((skill) => !skill.disableModelInvocation)
 				.map((skill) => skill.name),
 		);
-		if (this._agentMessageController && visibleKernelSkillNames.has(AGENT_MESSAGE_SKILL_NAME)) {
+		const messageController = this._agentMessageController;
+		if (messageController && visibleKernelSkillNames.has(AGENT_MESSAGE_SKILL_NAME)) {
 			Object.assign(
 				handlers,
 				createAgentMessageHostHandlers({
-					roster: async () =>
-						(await this.handleAgentMessageHostRequest("agent_message.list_agents")) as AgentFamilyRosterResult,
+					family: async () => {
+						if (!messageController.family)
+							throw new Error("agent family roster is not available in this session");
+						return messageController.family();
+					},
 					awaitPendingChildPublication: (selector) => this._awaitPendingRlmChildPublication(selector),
 					sendAgentMessage: async (input) => {
 						const receipt = (await this.handleAgentMessageHostRequest("agent_message.send", {
@@ -9634,13 +9631,13 @@ export class AgentSession {
 						})) as AgentSessionMessageReceipt;
 						if (this._rlmDepth > 0) {
 							let addressedParent = input.receiverRole === "parent";
-							if (input.receiverRole === undefined && this._agentMessageController?.roster) {
+							if (input.receiverRole === undefined && messageController.family) {
 								try {
-									const roster = await this._agentMessageController.roster();
-									addressedParent = roster.entries.some(
-										(entry) =>
-											entry.relationship === "parent" &&
-											(entry.id === input.target || entry.name === input.target),
+									addressedParent = (await messageController.family()).some(
+										(member) =>
+											member.relationship === "parent" &&
+											(member.entry.id === input.target ||
+												agentFamilyMemberName(member.entry) === input.target),
 									);
 								} catch {
 									addressedParent = false;

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -160,13 +160,16 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			"Choose a stable child name with `await rlm('sub-task', name='api-reviewer')`; names must be unique among siblings. If omitted, the host generates a readable unique name.",
 			"A child inherits your model. If a different model is explicitly requested, use `await rlm.find_models(...)` and an exact returned selector. An unavailable requested model fails spawn; decide whether to retry or omit `model`. Children also inherit your thinking level; the `thinking` option overrides it with any level the resolved child model supports, and an unsupported level fails spawn.",
 		);
+		parts.push(
+			hasAgentObserve
+				? "Use `await agent_observe.list_agents()` to discover family, including inactive members, and `await rlm.list_subagents()` to recover direct child handles."
+				: "Use `await rlm.list_subagents()` to recover direct child handles after admission.",
+		);
 		if (hasAgentMessage) {
 			parts.push(
 				"Children reply explicitly with `await agent_message.send(message, receiver_role='parent')` when an answer is needed. Replies and follow-ups arrive as ordinary agent messages; not every task requires a reply.",
-				"Use `await agent_message.list_agents()` to discover family and `await rlm.list_subagents()` to recover direct child handles. Use `agent_message.send(..., receiver_role='child', receiver_name=child.name)` for follow-ups.",
+				"Use `agent_message.send(..., receiver_role='child', receiver_name=child.name)` for follow-ups.",
 			);
-		} else {
-			parts.push("Use `await rlm.list_subagents()` to recover direct child handles after admission.");
 		}
 		if (hasAgentObserve) {
 			parts.push(

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -25,8 +25,8 @@ import {
 	AGENT_FAMILY_REACH_ERROR,
 	AGENT_MESSAGE_SOURCE,
 	type AgentFamilyCatalogEntry,
+	type AgentFamilyMember,
 	type AgentFamilyRelationship,
-	type AgentFamilyRosterResult,
 	type AgentSessionMessageAgentSummary,
 	type AgentSessionMessageController,
 	type AgentSessionMessageDeliveryStatus,
@@ -40,7 +40,6 @@ import {
 	assertAgentFamilyReach,
 	assertAgentSessionNameAvailable,
 	assertDirectAgentMessageTarget,
-	buildAgentFamilyRoster,
 	createAgentSessionMessage,
 	createAgentSessionMessageId,
 	createAgentSessionMessageReceipt,
@@ -50,6 +49,7 @@ import {
 	DEFAULT_AGENT_MESSAGE_RATE_LIMIT_REFILL_MS,
 	formatAgentSessionNameUnavailable,
 	normalizeAgentSessionMessage,
+	selectAgentFamily,
 	sessionNameReservationKey,
 } from "../../core/agent-messages.js";
 import {
@@ -3327,7 +3327,7 @@ export class AgentDaemon {
 		};
 		return {
 			listAgents: () => this.createAgentMessageListResult(requireCurrentState()),
-			roster: () => this.createAgentFamilyRoster(requireCurrentState()),
+			family: () => this.createAgentFamily(requireCurrentState()),
 			assertSessionNameAvailable: (input) => this.assertFamilySessionNameAvailable(input),
 			setSessionName: (name) => this.setStateSessionNameViaSupervisor(requireCurrentState(), name),
 			sendAgentMessage: (input) =>
@@ -3356,49 +3356,51 @@ export class AgentDaemon {
 	}
 
 	private async createAgentObserveListResult(currentState: ActiveSessionState): Promise<AgentObserveListResult> {
-		const agents = this.listTargetableSessionStates(currentState)
-			.filter(
-				(state) =>
-					state.activeSessionId === currentState.activeSessionId ||
-					this.isAgentFamilyReachable(currentState, state),
-			)
-			.map((state) => this.createAgentObserveSummary(state, currentState));
-		const residentIds = new Set(agents.map((agent) => agent.activeSessionId));
-		for (const passive of await this.listPassiveRlmSubagents()) {
-			if (residentIds.has(passive.info.id)) continue;
-			try {
-				assertAgentFamilyReach(this.agentFamilyEntry(currentState), this.passiveAgentFamilyEntry(passive));
-			} catch (error) {
-				if (error instanceof Error && error.message === AGENT_FAMILY_REACH_ERROR) continue;
-				throw error;
-			}
-			agents.push({
-				activeSessionId: passive.info.id,
-				sessionId: passive.info.id,
-				sessionName: passive.info.name ?? passive.entry.sessionName,
-				runtimeKind: "subagent",
-				cwd: passive.info.cwd,
-				status: "idle",
-				isCurrent: false,
-				isStreaming: false,
-				isCompacting: false,
-				attachedClients: 0,
-				messageCount: passive.info.messageCount,
-				queuedCount: 0,
-				isSessionActive: false,
-				...(passive.chain.length === 1 && passive.rootParentState
-					? { parentActiveSessionId: passive.rootParentState.activeSessionId }
-					: {}),
-				parentSessionId: passive.entry.parentSessionId,
-				rlmChildId: passive.entry.childId,
-				...(passive.entry.rlmParentNodeId ? { rlmParentNodeId: passive.entry.rlmParentNodeId } : {}),
-				...(passive.info.firstMessage ? { firstMessage: passive.info.firstMessage } : {}),
-			});
-			residentIds.add(passive.info.id);
-		}
+		const residentBySessionId = new Map(
+			this.listTargetableSessionStates(currentState).map((state) => [state.runtime.session.sessionId, state]),
+		);
+		const agents = (await this.createAgentFamily(currentState)).map((member) => {
+			const state = residentBySessionId.get(member.entry.id);
+			return state
+				? {
+						...this.createAgentObserveSummary(state, currentState),
+						relationship: member.relationship,
+						...(member.entry.repliedSinceTask !== undefined
+							? { repliedSinceTask: member.entry.repliedSinceTask }
+							: {}),
+					}
+				: this.createPersistedAgentObserveSummary(member);
+		});
 		return {
 			current: this.createAgentObserveSummary(currentState, currentState),
 			agents,
+		};
+	}
+
+	/**
+	 * Family member without a live session in this daemon: only persisted catalog
+	 * facts are known, so the runtime flags stay false and `activeSessionId` is absent.
+	 */
+	private createPersistedAgentObserveSummary(member: AgentFamilyMember): AgentObserveAgentSummary {
+		const entry = member.entry;
+		return {
+			sessionId: entry.id,
+			...(entry.name ? { sessionName: entry.name } : {}),
+			relationship: member.relationship,
+			runtimeKind: entry.depth > 0 ? "subagent" : "top-level",
+			...(entry.cwd ? { cwd: entry.cwd } : {}),
+			status: entry.status,
+			isCurrent: false,
+			isStreaming: false,
+			isCompacting: false,
+			attachedClients: 0,
+			...(entry.messageCount !== undefined ? { messageCount: entry.messageCount } : {}),
+			queuedCount: 0,
+			isSessionActive: entry.status === "running",
+			...(entry.repliedSinceTask !== undefined ? { repliedSinceTask: entry.repliedSinceTask } : {}),
+			...(entry.parentSessionId ? { parentSessionId: entry.parentSessionId } : {}),
+			...(entry.rlmChildId ? { rlmChildId: entry.rlmChildId } : {}),
+			...(entry.firstMessage ? { firstMessage: entry.firstMessage } : {}),
 		};
 	}
 
@@ -5796,6 +5798,9 @@ export class AgentDaemon {
 					depth: info.rlmDepth ?? 0,
 					status: "inactive",
 					sessionPath: canonicalSessionPath(info.path),
+					cwd: info.cwd,
+					messageCount: info.messageCount,
+					firstMessage: info.firstMessage,
 				}),
 			);
 		const byId = new Map<string, AgentFamilyCatalogEntry>(savedRoots.map((entry) => [entry.id, entry]));
@@ -5818,6 +5823,8 @@ export class AgentDaemon {
 					? { parentSessionPath: canonicalSessionPath(agent.parentSessionPath) }
 					: {}),
 				...(agent.sessionPath ? { sessionPath: canonicalSessionPath(agent.sessionPath) } : {}),
+				...(agent.rlmChildId ? { rlmChildId: agent.rlmChildId } : {}),
+				cwd: agent.cwd,
 			});
 		};
 		for (const peer of remotePeers) addAgent(peer);
@@ -5829,16 +5836,19 @@ export class AgentDaemon {
 		}
 		for (const passive of await this.listPassiveRlmSubagents()) {
 			const entry = byId.get(passive.info.id);
-			if (entry) entry.sessionPath = canonicalSessionPath(passive.entry.sessionFile);
+			if (!entry) continue;
+			entry.sessionPath = canonicalSessionPath(passive.entry.sessionFile);
+			entry.messageCount = passive.info.messageCount;
+			entry.firstMessage = passive.info.firstMessage;
 		}
 		return [...byId.values()];
 	}
 
-	private async createAgentFamilyRoster(currentState: ActiveSessionState): Promise<AgentFamilyRosterResult> {
+	private async createAgentFamily(currentState: ActiveSessionState): Promise<AgentFamilyMember[]> {
 		const catalog = await this.createAgentFamilyCatalog(currentState);
 		const current = catalog.find((entry) => entry.id === currentState.runtime.session.sessionId);
 		if (!current) throw new Error("Current agent is missing from the family catalog");
-		return buildAgentFamilyRoster(current, catalog);
+		return selectAgentFamily(current, catalog);
 	}
 
 	private async assertFamilySessionNameAvailable(

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -3356,10 +3356,11 @@ export class AgentDaemon {
 	}
 
 	private async createAgentObserveListResult(currentState: ActiveSessionState): Promise<AgentObserveListResult> {
+		const family = await this.createAgentFamily(currentState);
 		const residentBySessionId = new Map(
 			this.listTargetableSessionStates(currentState).map((state) => [state.runtime.session.sessionId, state]),
 		);
-		const agents = (await this.createAgentFamily(currentState)).map((member) => {
+		const agents = family.map((member) => {
 			const state = residentBySessionId.get(member.entry.id);
 			return state
 				? {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -53,6 +53,7 @@ import {
 	sessionNameReservationKey,
 } from "../../core/agent-messages.js";
 import {
+	AGENT_OBSERVE_PREVIEW_MAX_CHARS,
 	type AgentObserveAgentSnapshot,
 	type AgentObserveAgentSummary,
 	type AgentObserveController,
@@ -3379,12 +3380,14 @@ export class AgentDaemon {
 	}
 
 	/**
-	 * Family member without a live session in this daemon: only persisted catalog
-	 * facts are known, so the runtime flags stay false and `activeSessionId` is absent.
+	 * Family member with no live session in this daemon: only catalog facts are known,
+	 * so the runtime flags stay false. A peer working in another worker keeps its
+	 * `activeSessionId` and its live status; everything else is absent or inactive.
 	 */
 	private createPersistedAgentObserveSummary(member: AgentFamilyMember): AgentObserveAgentSummary {
 		const entry = member.entry;
 		return {
+			...(entry.activeSessionId ? { activeSessionId: entry.activeSessionId } : {}),
 			sessionId: entry.id,
 			...(entry.name ? { sessionName: entry.name } : {}),
 			relationship: member.relationship,
@@ -3401,7 +3404,9 @@ export class AgentDaemon {
 			...(entry.repliedSinceTask !== undefined ? { repliedSinceTask: entry.repliedSinceTask } : {}),
 			...(entry.parentSessionId ? { parentSessionId: entry.parentSessionId } : {}),
 			...(entry.rlmChildId ? { rlmChildId: entry.rlmChildId } : {}),
-			...(entry.firstMessage ? { firstMessage: entry.firstMessage } : {}),
+			...(entry.firstMessage
+				? { firstMessage: entry.firstMessage.slice(0, AGENT_OBSERVE_PREVIEW_MAX_CHARS) }
+				: {}),
 		};
 	}
 
@@ -3477,7 +3482,7 @@ export class AgentDaemon {
 			...(summary.firstMessage ? { firstMessage: summary.firstMessage } : {}),
 			...(latest
 				? {
-						latestMessage: createAgentObserveMessagePreview(latest, messages.length - 1, 240),
+						latestMessage: createAgentObserveMessagePreview(latest, messages.length - 1, AGENT_OBSERVE_PREVIEW_MAX_CHARS),
 					}
 				: {}),
 		};
@@ -5801,11 +5806,12 @@ export class AgentDaemon {
 					sessionPath: canonicalSessionPath(info.path),
 					cwd: info.cwd,
 					messageCount: info.messageCount,
-					firstMessage: info.firstMessage,
 				}),
 			);
 		const byId = new Map<string, AgentFamilyCatalogEntry>(savedRoots.map((entry) => [entry.id, entry]));
-		const addAgent = (agent: AgentSessionMessageAgentSummary) => {
+		// `remote` peers live in another worker: their active id stays routable, while a
+		// local summary's stand-in id for a passive child does not.
+		const addAgent = (agent: AgentSessionMessageAgentSummary, remote = false) => {
 			const depth = agent.rlmDepth ?? 0;
 			byId.set(agent.sessionId, {
 				id: agent.sessionId,
@@ -5825,10 +5831,11 @@ export class AgentDaemon {
 					: {}),
 				...(agent.sessionPath ? { sessionPath: canonicalSessionPath(agent.sessionPath) } : {}),
 				...(agent.rlmChildId ? { rlmChildId: agent.rlmChildId } : {}),
+				...(remote ? { activeSessionId: agent.activeSessionId } : {}),
 				cwd: agent.cwd,
 			});
 		};
-		for (const peer of remotePeers) addAgent(peer);
+		for (const peer of remotePeers) addAgent(peer, true);
 		for (const agent of localAgents) addAgent(agent);
 		for (const state of this.sessions.values()) {
 			const entry = byId.get(state.runtime.session.sessionId);

--- a/packages/coding-agent/test/acp-kernel-features.test.ts
+++ b/packages/coding-agent/test/acp-kernel-features.test.ts
@@ -217,11 +217,6 @@ print(json.dumps({
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [AGENT_MESSAGE_SKILL],
 			hostHandlers: {
-				// The family roster: parent, siblings, and children of this agent.
-				"agent_message.list_agents": async () => ({
-					current: { name: "root", id: "session-alpha", depth: 0 },
-					entries: [{ relationship: "child", name: "reviewer", id: "session-beta", depth: 1, status: "idle" }],
-				}),
 				"agent_message.send": async (payload) => ({
 					id: "agentmsg-acp",
 					source: "agent_message",
@@ -247,16 +242,11 @@ print(json.dumps({
 
 		const result = await manager.execute(`
 import json
-roster = await agent_message.list_agents()
 receipt = await agent_message.send("status update", receiver_role="child", receiver_name="reviewer")
-print(json.dumps({
-    "roster": [e["name"] for e in roster["entries"]],
-    "status": receipt["deliveryStatus"],
-}))
+print(json.dumps({"status": receipt["deliveryStatus"]}))
 `);
 		expect(result.status, why(result)).toBe("ok");
 		const payload = JSON.parse(result.stdout.trim());
-		expect(payload.roster).toEqual(["reviewer"]);
 		expect(payload.status).toBe("queued");
 
 		// The kernel reports the send; ACP carries it as namespaced metadata.

--- a/packages/coding-agent/test/agent-session-bus.test.ts
+++ b/packages/coding-agent/test/agent-session-bus.test.ts
@@ -6,12 +6,12 @@ import {
 	assertAgentMessageQueueCapacity,
 	assertAgentSessionNameAvailable,
 	assertDirectAgentMessageTarget,
-	buildAgentFamilyRoster,
 	createAgentMessageHostHandlers,
 	createAgentSessionMessagePrompt,
 	createAgentSessionMessageReceipt,
 	normalizeAgentSessionMessage,
 	parseAgentSessionMessagePromptId,
+	selectAgentFamily,
 	sessionNameReservationKey,
 } from "../src/core/agent-messages.js";
 
@@ -170,14 +170,11 @@ describe("agent session bus", () => {
 			deliveredAt: new Date(0).toISOString(),
 		}));
 		const handlers = createAgentMessageHostHandlers({
-			roster: () => ({
-				current: { name: "builder", id: "builder", depth: 1 },
-				entries: [
-					{ relationship: "parent", name: "root", id: "root", depth: 0, status: "running" },
-					{ relationship: "sibling", name: "reviewer", id: "sibling", depth: 1, status: "idle" },
-					{ relationship: "child", name: "tester", id: "child", depth: 2, status: "inactive" },
-				],
-			}),
+			family: async () => [
+				{ relationship: "parent", entry: { id: "root", name: "root", depth: 0, status: "running" } },
+				{ relationship: "sibling", entry: { id: "sibling", name: "reviewer", depth: 1, status: "idle" } },
+				{ relationship: "child", entry: { id: "child", name: "tester", depth: 2, status: "inactive" } },
+			],
 			sendAgentMessage,
 		});
 
@@ -214,18 +211,18 @@ describe("agent session bus", () => {
 		expect(sendAgentMessage).not.toHaveBeenCalled();
 	});
 
-	it("rejects non-all string targets at the host boundary", async () => {
+	it("rejects non-all string targets and the removed roster call at the host boundary", async () => {
 		const sendAgentMessage = vi.fn();
 		const handlers = createAgentMessageHostHandlers({
-			roster: () => ({
-				current: { name: "builder", id: "builder", depth: 1 },
-				entries: [],
-			}),
+			family: async () => [],
 			sendAgentMessage,
 		});
 
 		await expect(handlers["agent_message.send"]!({ target: "reviewer", message: "status" })).rejects.toThrow(
 			"use receiver_role and receiver_name",
+		);
+		await expect(handlers["agent_message.list_agents"]!({})).rejects.toThrow(
+			"the family roster now lives in agent_observe.list_agents()",
 		);
 		expect(sendAgentMessage).not.toHaveBeenCalled();
 	});
@@ -243,13 +240,10 @@ describe("agent session bus", () => {
 			};
 		});
 		const handlers = createAgentMessageHostHandlers({
-			roster: () => ({
-				current: { name: "builder", id: "builder", depth: 1 },
-				entries: [
-					{ relationship: "parent", name: "root", id: "root", depth: 0, status: "running" },
-					{ relationship: "sibling", name: "reviewer", id: "sibling", depth: 1, status: "idle" },
-				],
-			}),
+			family: async () => [
+				{ relationship: "parent", entry: { id: "root", name: "root", depth: 0, status: "running" } },
+				{ relationship: "sibling", entry: { id: "sibling", name: "reviewer", depth: 1, status: "idle" } },
+			],
 			sendAgentMessage,
 		});
 
@@ -389,9 +383,9 @@ describe("agent session bus", () => {
 				parentSessionPath: "/unknown-root",
 			}),
 		).not.toThrow();
-		expect(buildAgentFamilyRoster(catalog[1]!, catalog).entries).toEqual([
-			{ relationship: "parent", name: "orchestrator", id: "root", depth: 0, status: "running" },
-			{ relationship: "sibling", name: "builder", id: "path-child", depth: 1, status: "inactive" },
+		expect(selectAgentFamily(catalog[1]!, catalog).map((member) => [member.relationship, member.entry.id])).toEqual([
+			["parent", "root"],
+			["sibling", "path-child"],
 		]);
 	});
 
@@ -413,16 +407,13 @@ describe("agent session bus", () => {
 			{ id: "cousin", name: "ignored", depth: 2, status: "idle" as const, parentSessionPath: "/other" },
 		];
 
-		expect(buildAgentFamilyRoster(catalog[1]!, catalog)).toEqual({
-			current: { name: "builder", id: "current", depth: 1 },
-			entries: [
-				{ relationship: "parent", name: "orchestrator", id: "root", depth: 0, status: "running" },
-				{ relationship: "sibling", name: "alpha", id: "sibling-a", depth: 1, status: "inactive" },
-				{ relationship: "sibling", name: "zeta", id: "sibling-z", depth: 1, status: "running" },
-				{ relationship: "child", name: "reviewer", id: "child-a", depth: 2, status: "idle" },
-				{ relationship: "child", name: "tester", id: "child-z", depth: 2, status: "inactive" },
-			],
-		});
+		expect(selectAgentFamily(catalog[1]!, catalog)).toEqual([
+			{ relationship: "parent", entry: catalog[0] },
+			{ relationship: "sibling", entry: catalog[3] },
+			{ relationship: "sibling", entry: catalog[2] },
+			{ relationship: "child", entry: catalog[5] },
+			{ relationship: "child", entry: catalog[4] },
+		]);
 	});
 
 	it("rate limits senders with a token bucket", () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -909,10 +909,9 @@ describe("AgentSession rlm recursion", () => {
 			depth: 1,
 			agentMessageController: {
 				listAgents: () => ({ agents: [] }),
-				roster: () => ({
-					current: { name: "child", id: "child-session", depth: 1 },
-					entries: [{ relationship: "parent", name: "parent", id: "parent-session", depth: 0, status: "idle" }],
-				}),
+				family: async () => [
+					{ relationship: "parent", entry: { id: "parent-session", name: "parent", depth: 0, status: "idle" } },
+				],
 				sendAgentMessage,
 			},
 		});
@@ -943,24 +942,25 @@ describe("AgentSession rlm recursion", () => {
 			message: input.message,
 			deliveryStatus: "delivered" as const,
 		}));
-		const roster = vi.fn(() => ({
-			current: { name: "root", id: root.sessionId, depth: 0 },
-			entries: publishedChild
+		const family = vi.fn(async () =>
+			publishedChild
 				? [
 						{
 							relationship: "child" as const,
-							name: publishedChild.sessionName ?? publishedChild.sessionId,
-							id: publishedChild.sessionId,
-							depth: 1,
-							status: "running" as const,
+							entry: {
+								id: publishedChild.sessionId,
+								name: publishedChild.sessionName ?? publishedChild.sessionId,
+								depth: 1,
+								status: "running" as const,
+							},
 						},
 					]
 				: [],
-		}));
+		);
 		const root = createSession({
 			agentMessageController: {
 				listAgents: () => ({ agents: [] }),
-				roster,
+				family,
 				sendAgentMessage,
 			},
 			subagentRuntimeHost: {
@@ -989,12 +989,12 @@ describe("AgentSession rlm recursion", () => {
 			receiver_name: spawned.rlm_child_id,
 		});
 		await sleep(0);
-		expect(roster).not.toHaveBeenCalled();
+		expect(family).not.toHaveBeenCalled();
 		expect(sendAgentMessage).not.toHaveBeenCalled();
 		publishChild?.();
 
 		await expect(pendingSend).resolves.toMatchObject({ message: "hello" });
-		expect(roster).toHaveBeenCalledTimes(1);
+		expect(family).toHaveBeenCalledTimes(1);
 		expect(sendAgentMessage).toHaveBeenCalledWith(
 			expect.objectContaining({ target: publishedChild?.sessionId, message: "hello" }),
 		);
@@ -1012,18 +1012,17 @@ describe("AgentSession rlm recursion", () => {
 		const root = createSession({
 			agentMessageController: {
 				listAgents: () => ({ agents: [] }),
-				roster: () => ({
-					current: { name: "root", id: root.sessionId, depth: 0 },
-					entries: [
-						{
-							relationship: "child" as const,
-							name: child.sessionName ?? child.sessionId,
+				family: async () => [
+					{
+						relationship: "child" as const,
+						entry: {
 							id: child.sessionId,
+							name: child.sessionName ?? child.sessionId,
 							depth: 1,
 							status: "idle" as const,
 						},
-					],
-				}),
+					},
+				],
 				sendAgentMessage,
 			},
 			subagentRuntimeHost: {
@@ -1053,10 +1052,7 @@ describe("AgentSession rlm recursion", () => {
 		const root = createSession({
 			agentMessageController: {
 				listAgents: () => ({ agents: [] }),
-				roster: () => ({
-					current: { name: "root", id: root.sessionId, depth: 0 },
-					entries: [],
-				}),
+				family: async () => [],
 				sendAgentMessage: async () => {
 					throw new Error("unexpected send");
 				},
@@ -1092,18 +1088,12 @@ describe("AgentSession rlm recursion", () => {
 		const root = createSession({
 			agentMessageController: {
 				listAgents: () => ({ agents: [] }),
-				roster: () => ({
-					current: { name: "root", id: root.sessionId, depth: 0 },
-					entries: [
-						{
-							relationship: "child" as const,
-							name: "shared-child",
-							id: "healthy-child-session",
-							depth: 1,
-							status: "idle" as const,
-						},
-					],
-				}),
+				family: async () => [
+					{
+						relationship: "child" as const,
+						entry: { id: "healthy-child-session", name: "shared-child", depth: 1, status: "idle" as const },
+					},
+				],
 				sendAgentMessage,
 			},
 			subagentRuntimeHost: {
@@ -1145,10 +1135,7 @@ describe("AgentSession rlm recursion", () => {
 		const root = createSession({
 			agentMessageController: {
 				listAgents: () => ({ agents: [] }),
-				roster: () => ({
-					current: { name: "root", id: root.sessionId, depth: 0 },
-					entries: [],
-				}),
+				family: async () => [],
 				sendAgentMessage: async () => {
 					throw new Error("unexpected send");
 				},
@@ -1177,18 +1164,12 @@ describe("AgentSession rlm recursion", () => {
 	});
 
 	it("marks a broadcast delivery to the parent as replied without reloading the roster", async () => {
-		const roster = vi.fn(() => ({
-			current: { name: "child", id: "child-session", depth: 1 },
-			entries: [
-				{
-					relationship: "parent" as const,
-					name: "parent",
-					id: "parent-session",
-					depth: 0,
-					status: "idle" as const,
-				},
-			],
-		}));
+		const family = vi.fn(async () => [
+			{
+				relationship: "parent" as const,
+				entry: { id: "parent-session", name: "parent", depth: 0, status: "idle" as const },
+			},
+		]);
 		const sendAgentMessage = vi.fn(async () => ({
 			id: "agentmsg-broadcast-reply",
 			source: "agent_message" as const,
@@ -1200,7 +1181,7 @@ describe("AgentSession rlm recursion", () => {
 			depth: 1,
 			agentMessageController: {
 				listAgents: () => ({ agents: [] }),
-				roster,
+				family,
 				sendAgentMessage,
 			},
 		});
@@ -1211,7 +1192,7 @@ describe("AgentSession rlm recursion", () => {
 		await expect(send({ target: "all", message: "status" })).resolves.toMatchObject({
 			receipts: [{ message: "status" }],
 		});
-		expect(roster).toHaveBeenCalledTimes(1);
+		expect(family).toHaveBeenCalledTimes(1);
 		expect(child.repliedToParentSinceTask).toBe(true);
 	});
 
@@ -1446,10 +1427,9 @@ describe("AgentSession rlm recursion", () => {
 			rlmSessionDir: join(tempDir, "replying-child"),
 			agentMessageController: {
 				listAgents: () => ({ agents: [] }),
-				roster: () => ({
-					current: { name: "reply-worker", id: child.sessionId, depth: 1 },
-					entries: [{ relationship: "parent", name: "parent", id: "parent-session", depth: 0, status: "idle" }],
-				}),
+				family: async () => [
+					{ relationship: "parent", entry: { id: "parent-session", name: "parent", depth: 0, status: "idle" } },
+				],
 				sendAgentMessage: async () => ({
 					id: "agentmsg-reply-before-follow-up",
 					source: "agent_message",
@@ -1761,7 +1741,7 @@ describe("AgentSession rlm recursion", () => {
 			rlmSessionDir: join(tempDir, "paused-terminal-child"),
 			agentMessageController: {
 				listAgents: () => ({ agents: [] }),
-				roster: () => ({ current: { name: "child", id: "child", depth: 1 }, entries: [] }),
+				family: async () => [],
 				sendAgentMessage: synthesizedAgentMessageSend,
 			},
 			streamFn: (_model, context) => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -29,7 +29,11 @@ import {
 	DEFAULT_AGENT_MESSAGE_MAX_CHARS,
 	sessionNameReservationKey,
 } from "../src/core/agent-messages.js";
-import type { AgentObserveController, AgentObserveListResult } from "../src/core/agent-observe.js";
+import {
+	AGENT_OBSERVE_PREVIEW_MAX_CHARS,
+	type AgentObserveController,
+	type AgentObserveListResult,
+} from "../src/core/agent-observe.js";
 import type { CreateAgentSessionRuntimeFactory } from "../src/core/agent-session-runtime.js";
 import { installAgentTraceUpload } from "../src/core/agent-traces.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
@@ -2160,7 +2164,14 @@ describe("daemon mode helpers", () => {
 			const handlers = createAgentMessageHostHandlers({ ...controller, family: async () => controller.family!() });
 			await expect(controller.family!()).resolves.toContainEqual({
 				relationship: "sibling",
-				entry: { id: "session-remote", name: "Remote", depth: 0, status: "idle", cwd: "/tmp/remote" },
+				entry: {
+					id: "session-remote",
+					name: "Remote",
+					depth: 0,
+					status: "idle",
+					cwd: "/tmp/remote",
+					activeSessionId: remoteSelector,
+				},
 			});
 			await expect(
 				handlers["agent_message.send"]!({
@@ -3135,6 +3146,16 @@ describe("daemon mode helpers", () => {
 				sessionPath: "/tmp/archivist.jsonl",
 				cwd: "/tmp/archivist",
 				messageCount: 3,
+				firstMessage: "x".repeat(1000),
+			},
+			{
+				id: "session-remote",
+				name: "peer",
+				depth: 0,
+				status: "running",
+				sessionPath: "/tmp/peer.jsonl",
+				cwd: "/tmp/peer",
+				activeSessionId: "remote-active",
 			},
 		]);
 
@@ -3154,6 +3175,22 @@ describe("daemon mode helpers", () => {
 				messageCount: 3,
 				queuedCount: 0,
 				isSessionActive: false,
+				firstMessage: "x".repeat(AGENT_OBSERVE_PREVIEW_MAX_CHARS),
+			},
+			{
+				activeSessionId: "remote-active",
+				relationship: "sibling",
+				sessionId: "session-remote",
+				sessionName: "peer",
+				runtimeKind: "top-level",
+				cwd: "/tmp/peer",
+				status: "running",
+				isCurrent: false,
+				isStreaming: false,
+				isCompacting: false,
+				attachedClients: 0,
+				queuedCount: 0,
+				isSessionActive: true,
 			},
 		]);
 	});
@@ -4398,7 +4435,8 @@ describe("daemon mode helpers", () => {
 					const controller = options.sessionOptions?.agentMessageController;
 					const result = await controller?.listAgents();
 					expect(result?.current?.activeSessionId).toBeTruthy();
-					// Resolves only when the family catalog contains the binding session itself.
+					// The catalog must resolve around the binding session, which is the selection
+					// origin and therefore never one of its own family members.
 					const family = await controller?.family?.();
 					expect(family?.some((member) => member.entry.id === session.sessionId)).toBe(false);
 					listedAgentsDuringBind++;

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -29,7 +29,7 @@ import {
 	DEFAULT_AGENT_MESSAGE_MAX_CHARS,
 	sessionNameReservationKey,
 } from "../src/core/agent-messages.js";
-import type { AgentObserveController } from "../src/core/agent-observe.js";
+import type { AgentObserveController, AgentObserveListResult } from "../src/core/agent-observe.js";
 import type { CreateAgentSessionRuntimeFactory } from "../src/core/agent-session-runtime.js";
 import { installAgentTraceUpload } from "../src/core/agent-traces.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
@@ -1047,10 +1047,10 @@ describe("daemon mode helpers", () => {
 
 			expect((await internals.listPassiveRlmSubagents()).map(({ entry }) => entry.childId)).toContain("child-1");
 			expect((await internals.findPassiveRlmSubagent("real-worker"))?.entry.childId).toBe("child-1");
-			const roster = await internals.createAgentMessageController(() => parentState).roster?.();
-			const passiveRosterEntry = roster?.entries.find((entry) => entry.name === "real-worker");
-			expect(passiveRosterEntry).toMatchObject({ relationship: "child", status: "inactive" });
-			expect(passiveRosterEntry).not.toHaveProperty("repliedSinceTask");
+			const family = await internals.createAgentMessageController(() => parentState).family?.();
+			const passiveMember = family?.find((member) => member.entry.name === "real-worker");
+			expect(passiveMember).toMatchObject({ relationship: "child", entry: { status: "inactive" } });
+			expect(passiveMember?.entry).not.toHaveProperty("repliedSinceTask");
 			const listed = await internals.buildSessionListWithPassiveRlmSubagents(
 				[parentState],
 				await SessionManager.listAll(undefined, sessionDir),
@@ -1159,9 +1159,12 @@ describe("daemon mode helpers", () => {
 			expect((await internals.listPassiveRlmSubagents()).map(({ entry }) => entry)).toContainEqual(
 				expect.objectContaining({ childId: fixture.childId, status: "running" }),
 			);
-			await expect(internals.createAgentMessageController(() => parentState).roster?.()).resolves.toMatchObject({
-				entries: [expect.objectContaining({ relationship: "child", name: "renamed-worker" })],
-			});
+			await expect(internals.createAgentMessageController(() => parentState).family?.()).resolves.toEqual([
+				expect.objectContaining({
+					relationship: "child",
+					entry: expect.objectContaining({ name: "renamed-worker" }),
+				}),
+			]);
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -2153,15 +2156,11 @@ describe("daemon mode helpers", () => {
 		);
 		const listAll = vi.spyOn(SessionManager, "listAll").mockResolvedValue([]);
 		try {
-			const handlers = createAgentMessageHostHandlers(internals.createAgentMessageController(() => source));
-			const roster = await handlers["agent_message.list_agents"]!({});
-			expect(roster.current).toMatchObject({ name: "Source", id: "session-source", depth: 0 });
-			expect(roster.entries).toContainEqual({
+			const controller = internals.createAgentMessageController(() => source);
+			const handlers = createAgentMessageHostHandlers({ ...controller, family: async () => controller.family!() });
+			await expect(controller.family!()).resolves.toContainEqual({
 				relationship: "sibling",
-				name: "Remote",
-				id: "session-remote",
-				depth: 0,
-				status: "idle",
+				entry: { id: "session-remote", name: "Remote", depth: 0, status: "idle", cwd: "/tmp/remote" },
 			});
 			await expect(
 				handlers["agent_message.send"]!({
@@ -3092,6 +3091,73 @@ describe("daemon mode helpers", () => {
 		expect((await internals.createAgentObserveListResult(targetState)).current.status).toBe("compacting");
 	});
 
+	it("lists inactive family members in the agent-observe roster", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const currentState = makeState("current");
+		currentState.runtime = {
+			...currentState.runtime,
+			cwd: "/tmp",
+			diagnostics: [],
+			modelFallbackMessage: undefined,
+			session: {
+				sessionId: "session-current",
+				sessionName: "Current",
+				sessionFile: "/tmp/current.jsonl",
+				sessionManager: { getCwd: () => "/tmp" },
+				isStreaming: false,
+				isCompacting: false,
+				isSessionActive: false,
+				unfinishedActionCount: 0,
+				getSessionActionSnapshot: () => ({ queuedCount: 0, steering: [], followUps: [] }),
+				messages: [],
+				state: { pendingToolCalls: new Set(), streamingMessage: undefined },
+				hasRunningRlmChildren: () => false,
+			},
+		} as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			createAgentFamilyCatalog: ReturnType<typeof vi.fn>;
+			createAgentObserveListResult(current: ActiveSessionState): Promise<AgentObserveListResult>;
+		};
+		internals.sessions.set(currentState.activeSessionId, currentState);
+		internals.createAgentFamilyCatalog = vi.fn(async () => [
+			{ id: "session-current", name: "Current", depth: 0, status: "running", sessionPath: "/tmp/current.jsonl" },
+			{
+				id: "session-archived",
+				name: "archivist",
+				depth: 0,
+				status: "inactive",
+				sessionPath: "/tmp/archivist.jsonl",
+				cwd: "/tmp/archivist",
+				messageCount: 3,
+			},
+		]);
+
+		const listed = await internals.createAgentObserveListResult(currentState);
+		expect(listed.agents).toEqual([
+			{
+				relationship: "sibling",
+				sessionId: "session-archived",
+				sessionName: "archivist",
+				runtimeKind: "top-level",
+				cwd: "/tmp/archivist",
+				status: "inactive",
+				isCurrent: false,
+				isStreaming: false,
+				isCompacting: false,
+				attachedClients: 0,
+				messageCount: 3,
+				queuedCount: 0,
+				isSessionActive: false,
+			},
+		]);
+	});
+
 	it("canonicalizes symlinked family paths before comparison", () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-family-paths-"));
 		try {
@@ -3324,11 +3390,12 @@ describe("daemon mode helpers", () => {
 		const messaging = internals.createAgentMessageController(() => child);
 		const observe = internals.createAgentObserveController(() => child);
 
-		expect((await observe.listAgents()).agents.map((agent) => agent.activeSessionId)).toEqual([
-			"root",
-			"child",
-			"sibling",
-			"grandchild",
+		const observed = await observe.listAgents();
+		expect(observed.current.activeSessionId).toBe("child");
+		expect(observed.agents.map((agent) => [agent.relationship, agent.activeSessionId])).toEqual([
+			["parent", "root"],
+			["sibling", "sibling"],
+			["child", "grandchild"],
 		]);
 		await expect(observe.getAgent("cousin")).rejects.toThrow(
 			"Agent reach is limited to parent, siblings, and children",
@@ -4331,9 +4398,9 @@ describe("daemon mode helpers", () => {
 					const controller = options.sessionOptions?.agentMessageController;
 					const result = await controller?.listAgents();
 					expect(result?.current?.activeSessionId).toBeTruthy();
-					await expect(controller?.roster?.()).resolves.toMatchObject({
-						current: { id: session.sessionId },
-					});
+					// Resolves only when the family catalog contains the binding session itself.
+					const family = await controller?.family?.();
+					expect(family?.some((member) => member.entry.id === session.sessionId)).toBe(false);
 					listedAgentsDuringBind++;
 				});
 				return {
@@ -5044,25 +5111,25 @@ describe("daemon mode helpers", () => {
 				}
 			).createAgentObserveController(() => parentState);
 			const observedAgents = await observeController.listAgents();
-			expect(observedAgents.agents).toContainEqual(
-				expect.objectContaining({
-					activeSessionId: expect.any(String),
-					sessionName: "renamed-worker",
-					runtimeKind: "subagent",
-					status: "idle",
-					messageCount: 1,
-					rlmChildId: fixture.childId,
-				}),
-			);
+			const observedChild = observedAgents.agents.find((agent) => agent.sessionName === "renamed-worker");
+			expect(observedChild).toMatchObject({
+				relationship: "child",
+				runtimeKind: "subagent",
+				status: "inactive",
+				isSessionActive: false,
+				messageCount: 1,
+				rlmChildId: fixture.childId,
+			});
+			expect(observedChild).not.toHaveProperty("activeSessionId");
 			expect(fixture.createRuntime).toHaveBeenCalledOnce();
 
 			const messageController = internals.createAgentMessageController(() => parentState);
-			await expect(messageController.roster?.()).resolves.toMatchObject({
-				current: { id: parentState.runtime.session.sessionId, depth: 0 },
-				entries: [
-					expect.objectContaining({ relationship: "child", name: "renamed-worker", depth: 1, status: "inactive" }),
-				],
-			});
+			await expect(messageController.family?.()).resolves.toEqual([
+				expect.objectContaining({
+					relationship: "child",
+					entry: expect.objectContaining({ name: "renamed-worker", depth: 1, status: "inactive" }),
+				}),
+			]);
 			await expect(
 				messageController.assertSessionNameAvailable?.({
 					name: "renamed-worker",

--- a/packages/coding-agent/test/kernel-agent-message-skill.test.ts
+++ b/packages/coding-agent/test/kernel-agent-message-skill.test.ts
@@ -40,18 +40,11 @@ describe("agent-message skill over the kernel host bridge", () => {
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
-	it("lists agents and sends without exposing a spoofable sender", async () => {
+	it("sends without exposing a spoofable sender and rejects the removed roster call", async () => {
 		const requests: Array<{ type: string; payload: Record<string, unknown> }> = [];
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAgentMessageSkill()],
 			hostHandlers: {
-				"agent_message.list_agents": async (payload) => {
-					requests.push({ type: "agent_message.list_agents", payload });
-					return {
-						current: { name: "alpha", id: "session-alpha", depth: 0 },
-						entries: [{ relationship: "sibling", name: "Beta", id: "session-beta", depth: 0, status: "idle" }],
-					};
-				},
 				"agent_message.send": async (payload) => {
 					requests.push({ type: "agent_message.send", payload });
 					return {
@@ -70,19 +63,15 @@ describe("agent-message skill over the kernel host bridge", () => {
 		const manager = await provisioner.ensure();
 		const result = await manager.execute(`
 import json
-agents = await agent_message.list_agents()
 receipt = await agent_message.send(
     "hello beta", receiver_role="sibling", receiver_name="beta"
 )
-print(json.dumps({"agents": agents, "receipt": receipt}, sort_keys=True))
+print(json.dumps({"has_list_agents": hasattr(agent_message, "list_agents"), "receipt": receipt}, sort_keys=True))
 `);
 
 		expect(result.status).toBe("ok");
 		const output = JSON.parse(result.stdout.trim());
-		expect(output.agents).toMatchObject({
-			current: { id: "session-alpha", depth: 0 },
-			entries: [{ relationship: "sibling", id: "session-beta", status: "idle" }],
-		});
+		expect(output.has_list_agents).toBe(false);
 		expect(output.receipt).toMatchObject({
 			id: "agentmsg-test",
 			source: "agent_message",
@@ -99,10 +88,6 @@ print(json.dumps({"agents": agents, "receipt": receipt}, sort_keys=True))
 			},
 		]);
 		expect(requests[0]).toMatchObject({
-			type: "agent_message.list_agents",
-			payload: { type: "agent_message.list_agents" },
-		});
-		expect(requests[1]).toMatchObject({
 			type: "agent_message.send",
 			payload: {
 				type: "agent_message.send",
@@ -111,7 +96,7 @@ print(json.dumps({"agents": agents, "receipt": receipt}, sort_keys=True))
 				receiver_name: "beta",
 			},
 		});
-		expect(requests[1].payload).not.toHaveProperty("from");
+		expect(requests[0].payload).not.toHaveProperty("from");
 	});
 
 	it("emits successful broadcast receipts and leaves short errors in the result", async () => {

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -99,7 +99,6 @@ describe("buildRlmPrompt", () => {
 			depth: 1,
 		});
 		expect(withoutCapabilities).not.toContain("agent_message.send");
-		expect(withoutCapabilities).not.toContain("agent_message.list_agents");
 		expect(withoutCapabilities).not.toContain("agent_observe");
 
 		const systemPromptWithoutCapabilities = buildSystemPrompt({
@@ -120,7 +119,7 @@ describe("buildRlmPrompt", () => {
 			depth: 1,
 		});
 		expect(withCapabilities).toContain("agent_message.send");
-		expect(withCapabilities).toContain("agent_message.list_agents");
+		expect(withCapabilities).toContain("agent_observe.list_agents()");
 		expect(withCapabilities).toContain("agent_observe");
 		expect(withCapabilities).toContain("restricted to your parent, siblings, and direct children");
 	});


### PR DESCRIPTION
## Purpose

Family discovery had two entry points that disagreed. `agent_message.list_agents()` returned the nuclear family from the family catalog, including members that exist only on disk. `agent_observe.list_agents()` returned live sessions in this worker plus passive RLM subagents. Neither list was a superset of the other, so an agent had to call both to learn who it could reach, and the two answers could differ for the same family.

`agent_observe.list_agents()` is now the one roster. `agent_message.list_agents()` is removed.

## What the roster returns

The roster is built from the family catalog that `agent_message.send` already uses to resolve `receiver_role` and `receiver_name`, so membership and relationships have a single definition. Every reachable member appears: parent, siblings, and children, active or not.

The distinction between a live member and a persisted one is carried by fields, not by a flag or a second function:

- `activeSessionId` is present only for a member with a live session in this daemon.
- `status` keeps the live vocabulary (`model`, `tool`, `busy`, `user`, `idle`, `compacting`) for live members and the catalog vocabulary (`running`, `idle`, `inactive`) for the rest.
- `relationship` (`parent`, `sibling`, `child`) is on every entry, so a roster row maps directly onto a `send` call.
- Live members keep their runtime detail (streaming, queued count, latest message preview); persisted members report only what the catalog knows (cwd, message count, first message, child id).

The current agent is no longer duplicated: it stays in `current` and is not repeated in `agents`.

I did not add a boolean mode flag. The two old lists differed in scope, not in mode: the message roster added saved root siblings and supervisor peers, the observe list added live detail. Both are expressible as per-entry fields on one union, which is what this does.

## Source archaeology

- `createAgentFamilyCatalog` (daemon-mode) is the fuller family: active local sessions, supervisor peers from other workers, passive RLM subagents from the ledger, and saved root sessions marked `inactive`.
- The old `createAgentObserveListResult` walked `listTargetableSessionStates` plus passive subagents only, so saved inactive roots and peers in other workers were never observable. That is the scope gap the unified roster closes.
- `buildAgentFamilyRoster` is replaced by `selectAgentFamily`, which returns `{relationship, entry}` members over the same catalog entries. The observe list maps those members to summaries; `send` resolution filters the same members. One backend, one truth.

## Messaging without observation

Checked, and no such configuration ships. `agentMessageController` and `agentObserveController` are constructed only by daemon-mode, always as a pair (three construction sites). `sdk.ts` and `main.ts` only forward the options. So removing discovery from the messaging skill cannot leave a shipped configuration able to send but unable to discover, and no gating change was needed. Some unit tests install only a message controller; those are fixtures, not a runtime mode.

## Mixed versions

The `agent_message.list_agents` host request still exists and now always fails with:

```
agent_message.list_agents was removed; the family roster now lives in agent_observe.list_agents(). Restart the Python kernel to load the current skills, then call await agent_observe.list_agents().
```

An old kernel, or a new kernel imitating an old transcript, gets that guidance instead of an opaque unknown-request error.

## Prose

System prompt family-discovery guidance, both SKILL.md files, the skill docstrings, and `docs/long-running-agents.md` now point at `agent_observe.list_agents()`. `send` guidance is unchanged.

## LOC

| area | + | - | net |
| --- | --- | --- | --- |
| src | 128 | 131 | -3 |
| skills (python + SKILL.md) | 22 | 18 | +4 |
| docs + changelog | 4 | 2 | +2 |
| tests | 180 | 168 | +12 |

One new test (inactive family member appears in the observe roster with persisted-only fields). Every other test change is an update of an existing roster test; the removed `agent_message.list_agents` kernel assertions were merged into the existing send tests, and the removed-call guidance is pinned in the existing host-boundary test.

## Validation

Prime sandbox, node:24:

- `npm run check` at the repo root: clean.
- `npx tsgo --noEmit -p tsconfig.json`: clean.
- vitest: `daemon-mode`, `agent-session-bus`, `agent-session-recursion`, `system-prompt`, `agent-session-services`, `suite/agent-session-observe`, `kernel-agent-message-skill`, `kernel-agent-observe-skill`, `acp-kernel-features`, `suite/regressions/617-subagent-terminal-agent-message` - 388 passed, 5 skipped, 0 failed.

Wake-on-send for a non-resident target is already pinned by the existing daemon passivation and supervisor-wake tests, which still pass.

## Deliberate drops and known corners

- Passive subagent rows no longer carry `parentActiveSessionId` or `rlmParentNodeId`. That is deliberate: `relationship` already names the link to the current agent, and `rlm.list_subagents()` owns the child handles. No in-tree consumer reads those fields off observe rows.
- Roster membership is catalog-based, like `send` resolution. `get_agent` and `recent_messages` keep their header-aware family check, so a live child whose parent link exists only in its session header can be readable while absent from the roster. The roster now matches what `send` can address, which is the invariant worth keeping; the header-only case is rare (in-daemon spawns and passive hydration both write metadata).
- One roster call is not a single instant: the family catalog resolves first (supervisor call, session scan, passive walk), then live rows are read. A member that replies or closes during that window can show a slightly stale `repliedSinceTask` or status. It self-heals on the next call, so no mechanism was added for it.
- A saved root's first user message is no longer copied onto sibling rows, and every preview a row carries is capped at the same length as the live latest-message preview.
- A peer working in another worker keeps the active session id its peer summary reports, so `activeSessionId` means "a live session exists" rather than "a live session exists here". Transcript reads still need a session in this worker.

Fixes RES-1335

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches daemon family catalog, observe listing, and message target resolution—core orchestration paths—with a breaking API removal mitigated by a guided host error.
> 
> **Overview**
> **Removes duplicate family discovery** by deleting `agent_message.list_agents()` (Python skill and session host path) and making **`agent_observe.list_agents()`** the one roster for parent, siblings, and children—including inactive, on-disk, and remote peers—with a **`relationship`** field aligned with `agent_message.send` addressing.
> 
> **Backend consolidation:** `roster()` / `buildAgentFamilyRoster` become **`family()` / `selectAgentFamily`** over an expanded family catalog; observe listing maps those members to live or persisted summaries (optional `activeSessionId`, previews capped at `AGENT_OBSERVE_PREVIEW_MAX_CHARS`). Broadcast and role-based **`agent_message.send`** resolution use the same **`family()`** list. Stale callers hitting **`agent_message.list_agents`** get an explicit migration error.
> 
> Docs, RLM prompts, and skill text now point discovery at **`agent_observe.list_agents()`**; messaging behavior is unchanged aside from roster source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 415e7136e647f2f4b251cd5094f35b228211d3c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify twin agent rosters into `agent_observe.list_agents`
> - Consolidates the two agent rosters by removing `agent_message.list_agents` and making `agent_observe.list_agents` the single source for family discovery.
> - `agent_observe.list_agents` now returns the full nuclear family, including inactive, persisted, and remote members with relationship data.
> - Message handlers and daemon mode update to resolve broadcast and role-based sends through the shared family list.
> - Behavioral Change: `agent_message.list_agents` now rejects with a migration error directing callers to `agent_observe.list_agents`. The controller contract now requires `family()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 415e713.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->