### PR TITLE
fix(coding-agent): collapse MCP tool output on Ctrl+O like built-in tools

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/collapsed-output.ts
+++ b/packages/coding-agent/src/modes/interactive/components/collapsed-output.ts
@@ -1,0 +1,61 @@
+import { type Component, truncateToWidth } from "@earendil-works/pi-tui";
+import { theme } from "../theme/theme.js";
+import { expandCollapseHint } from "./keybinding-hints.js";
+import { truncateToVisualLines } from "./visual-truncate.js";
+
+/** Default number of trailing visual lines shown when a tool output is collapsed. */
+export const DEFAULT_COLLAPSED_PREVIEW_LINES = 5;
+
+export interface CollapsedOutputPreviewOptions {
+	/** Visual lines to keep visible when collapsed. Defaults to 5. */
+	previewLines?: number;
+	/** Whether to render the `(Ctrl+O to expand)` hint when lines are hidden. */
+	showExpandHint?: boolean;
+}
+
+/**
+ * Create a component that renders the LAST `previewLines` visual lines of
+ * `output`, prefixed with `... N earlier lines (Ctrl+O to expand)` when the
+ * output was truncated. Truncation is width-aware (long lines wrap before
+ * being counted) and cached per render width.
+ *
+ * This is the shared collapsed-output behavior used by tool components whose
+ * results have no custom renderer (e.g. MCP tools) and can be adopted by any
+ * other renderer that wants Ctrl+O expand/collapse support for free.
+ */
+export function createCollapsedOutputPreview(output: string, options: CollapsedOutputPreviewOptions = {}): Component {
+	const previewLines = options.previewLines ?? DEFAULT_COLLAPSED_PREVIEW_LINES;
+	const showExpandHint = options.showExpandHint ?? true;
+	const styledOutput = output
+		.split("\n")
+		.map((line) => theme.fg("toolOutput", line))
+		.join("\n");
+
+	let cachedLines: string[] | undefined;
+	let cachedSkipped: number | undefined;
+	let cachedWidth: number | undefined;
+
+	return {
+		render(width: number): string[] {
+			if (cachedLines === undefined || cachedWidth !== width) {
+				const preview = truncateToVisualLines(styledOutput, previewLines, width);
+				cachedLines = preview.visualLines;
+				cachedSkipped = preview.skippedCount;
+				cachedWidth = width;
+			}
+			const lines = [...(cachedLines ?? [])];
+			if (cachedSkipped && cachedSkipped > 0) {
+				const hint = showExpandHint
+					? `${theme.fg("muted", `... ${cachedSkipped} earlier lines`)} ${expandCollapseHint("app.tools.expand", false)}`
+					: theme.fg("muted", `... (${cachedSkipped} earlier lines)`);
+				lines.unshift(truncateToWidth(hint, width, "..."));
+			}
+			return lines;
+		},
+		invalidate: () => {
+			cachedLines = undefined;
+			cachedSkipped = undefined;
+			cachedWidth = undefined;
+		},
+	};
+}

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -1,5 +1,5 @@
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
-import { type Component, Container, Image, Text, type TUI } from "@earendil-works/pi-tui";
+import { type Component, Container, Image, Text, type TUI, truncateToWidth } from "@earendil-works/pi-tui";
 import type { ToolDefinition, ToolRenderContext, ToolRenderResultOptions } from "../../../core/extensions/types.js";
 import type { KernelSentAgentMessage } from "../../../core/kernel/index.js";
 import { createBashToolDefinition } from "../../../core/tools/bash.js";
@@ -9,8 +9,14 @@ import { getTextOutput as getRenderedTextOutput } from "../../../core/tools/rend
 import type { AgentConnectionToolDefinition } from "../../agent-connection/index.js";
 import { type Theme, theme } from "../theme/theme.js";
 import { getWorkingPulseFrame, workingIconFrame } from "../theme/working-icon.js";
+import { createCollapsedOutputPreview } from "./collapsed-output.js";
 import { getIpythonCodeFromArgs, IPythonCellComponent } from "./ipython-cell.js";
 import { ToolPanel } from "./tool-panel.js";
+
+/** Visual lines of tool output shown by generic fallbacks when collapsed. */
+const RESULT_PREVIEW_LINES = 5;
+/** Max width of the single-line args summary shown by the no-definition fallback when collapsed. */
+const ARGS_SUMMARY_MAX_WIDTH = 120;
 
 export interface ToolExecutionOptions {
 	showImages?: boolean;
@@ -213,6 +219,12 @@ export class ToolExecutionComponent extends Container {
 		if (!output) {
 			return undefined;
 		}
+		if (!this.expanded) {
+			return createCollapsedOutputPreview(output, {
+				previewLines: RESULT_PREVIEW_LINES,
+				showExpandHint: this.showExpandHint,
+			});
+		}
 		return new Text(theme.fg("toolOutput", output), 0, 0);
 	}
 
@@ -380,10 +392,24 @@ export class ToolExecutionComponent extends Container {
 			this.contentPanel.clear();
 			if (this.hasRendererDefinition()) {
 				this.mountRenderers(this.contentPanel, false);
-			} else {
+			} else if (this.expanded) {
 				const fallbackText = this.formatToolExecution();
 				if (fallbackText) {
 					this.contentPanel.addChild(new Text(fallbackText, 0, 0));
+				}
+			} else {
+				const argsSummary = this.createCollapsedArgsSummary();
+				if (argsSummary) {
+					this.contentPanel.addChild(new Text(argsSummary, 0, 0));
+				}
+				const output = this.getTextOutput();
+				if (output) {
+					this.contentPanel.addChild(
+						createCollapsedOutputPreview(output, {
+							previewLines: RESULT_PREVIEW_LINES,
+							showExpandHint: this.showExpandHint,
+						}),
+					);
 				}
 			}
 			hasContent = true;
@@ -516,6 +542,14 @@ export class ToolExecutionComponent extends Container {
 			parts.push(output);
 		}
 		return parts.join("\n\n");
+	}
+
+	private createCollapsedArgsSummary(): string | undefined {
+		const compactArgs = JSON.stringify(this.args);
+		if (!compactArgs) {
+			return undefined;
+		}
+		return truncateToWidth(compactArgs, ARGS_SUMMARY_MAX_WIDTH, "...");
 	}
 }
 

--- a/packages/coding-agent/test/tool-execution-collapse.test.ts
+++ b/packages/coding-agent/test/tool-execution-collapse.test.ts
@@ -1,0 +1,154 @@
+import type { TUI } from "@earendil-works/pi-tui";
+import { setKeybindings } from "@earendil-works/pi-tui";
+import stripAnsi from "strip-ansi";
+import { Type } from "typebox";
+import { beforeAll, describe, expect, test } from "vitest";
+import type { ToolDefinition } from "../src/core/extensions/types.js";
+import { KeybindingsManager } from "../src/core/keybindings.js";
+import { createCollapsedOutputPreview } from "../src/modes/interactive/components/collapsed-output.js";
+import { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+function createFakeTui(): TUI {
+	return {
+		requestRender: () => {},
+	} as unknown as TUI;
+}
+
+function createMcpStyleToolDefinition(name = "mcp_tool"): ToolDefinition {
+	// Mimics an MCP tool: metadata only, no custom renderCall/renderResult.
+	return {
+		name,
+		label: name,
+		description: "tool without custom renderers",
+		parameters: Type.Object({ code: Type.String() }),
+		execute: async () => ({
+			content: [{ type: "text", text: "ok" }],
+			details: {},
+		}),
+	};
+}
+
+const MANY_LINES = Array.from({ length: 50 }, (_, i) => `out-line-${String(i + 1).padStart(2, "0")}`).join("\n");
+
+function plain(lines: string[]): string[] {
+	return lines.map((line) => stripAnsi(line));
+}
+
+describe("ToolExecutionComponent collapsed output (Ctrl+O)", () => {
+	beforeAll(() => {
+		initTheme("dark");
+		setKeybindings(new KeybindingsManager());
+	});
+
+	test("tool without custom renderers collapses result output when not expanded", () => {
+		const component = new ToolExecutionComponent(
+			"mcp_tool",
+			"tool-1",
+			{ code: "x" },
+			{},
+			createMcpStyleToolDefinition(),
+			createFakeTui(),
+			process.cwd(),
+		);
+		component.updateResult({ content: [{ type: "text", text: MANY_LINES }], isError: false }, false);
+
+		const collapsed = plain(component.render(80));
+		const collapsedText = collapsed.join("\n");
+		expect(collapsedText).toContain("earlier lines");
+		expect(collapsedText).toContain("Ctrl+O to expand");
+		// Last 5 lines visible, earlier ones hidden.
+		expect(collapsedText).toContain("out-line-50");
+		expect(collapsedText).not.toContain("out-line-01");
+		expect(collapsedText).not.toContain("out-line-45");
+
+		component.setExpanded(true);
+		const expanded = plain(component.render(80)).join("\n");
+		for (const line of MANY_LINES.split("\n")) {
+			expect(expanded).toContain(line);
+		}
+
+		// Collapse again restores the preview.
+		component.setExpanded(false);
+		expect(plain(component.render(80)).join("\n")).toContain("earlier lines");
+	});
+
+	test("collapsed preview respects showExpandHint", () => {
+		const component = new ToolExecutionComponent(
+			"mcp_tool",
+			"tool-2",
+			{ code: "x" },
+			{},
+			createMcpStyleToolDefinition(),
+			createFakeTui(),
+			process.cwd(),
+		);
+		component.updateResult({ content: [{ type: "text", text: MANY_LINES }], isError: false }, false);
+		component.setShowExpandHint(false);
+
+		const collapsedText = plain(component.render(80)).join("\n");
+		expect(collapsedText).toContain("earlier lines");
+		expect(collapsedText).not.toContain("Ctrl+O");
+	});
+
+	test("short output is not truncated and gets no hint", () => {
+		const component = new ToolExecutionComponent(
+			"mcp_tool",
+			"tool-3",
+			{ code: "x" },
+			{},
+			createMcpStyleToolDefinition(),
+			createFakeTui(),
+			process.cwd(),
+		);
+		component.updateResult({ content: [{ type: "text", text: "a\nb\nc" }], isError: false }, false);
+
+		const collapsedText = plain(component.render(80)).join("\n");
+		expect(collapsedText).toContain("a");
+		expect(collapsedText).toContain("c");
+		expect(collapsedText).not.toContain("earlier lines");
+	});
+
+	test("no-definition fallback collapses args to one line plus output preview", () => {
+		const component = new ToolExecutionComponent(
+			"unknown_tool",
+			"tool-4",
+			{ code: "let x = 1", other: "y" },
+			{},
+			undefined,
+			createFakeTui(),
+			process.cwd(),
+		);
+		component.updateResult({ content: [{ type: "text", text: MANY_LINES }], isError: false }, false);
+
+		const collapsed = plain(component.render(80));
+		const collapsedText = collapsed.join("\n");
+		// Args summary is a single line, no multi-line pretty JSON.
+		expect(collapsedText).toContain('"code":"let x = 1"');
+		expect(collapsedText).not.toMatch(/\{\n\s+"code"/);
+		// Output preview is collapsed.
+		expect(collapsedText).toContain("earlier lines");
+		expect(collapsedText).toContain("out-line-50");
+		expect(collapsedText).not.toContain("out-line-01");
+
+		component.setExpanded(true);
+		const expanded = plain(component.render(80)).join("\n");
+		expect(expanded).toContain('"code": "let x = 1"');
+		expect(expanded).toContain("out-line-01");
+		expect(expanded).toContain("out-line-50");
+	});
+
+	test("collapsed preview recomputes when render width changes", () => {
+		const preview = createCollapsedOutputPreview(MANY_LINES, { previewLines: 5 });
+		const at80 = plain(preview.render(80));
+		const at40 = plain(preview.render(40));
+		preview.invalidate();
+		const afterInvalidate = plain(preview.render(80));
+		expect(afterInvalidate.join("\n")).toContain("out-line-50");
+		// Both widths keep exactly 5 output lines (plus the hint line).
+		const countOutput = (lines: string[]) => lines.filter((l) => l.includes("out-line-")).length;
+		expect(countOutput(at80)).toBe(5);
+		expect(countOutput(at40)).toBe(5);
+		expect(countOutput(afterInvalidate)).toBe(5);
+	});
+});


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Collapse MCP tool output on `Ctrl+O` using shared `createCollapsedOutputPreview`
- Adds a reusable `createCollapsedOutputPreview` factory in [collapsed-output.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2157/files#diff-7459174ea0a271d5fb09597dc8a167a579e1d743d8942f3d4583c401c39a2096) that renders the last five visual lines of oversized output, reports the skipped-line count, and caches results by render width.
- Updates [tool-execution.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2157/files#diff-21ea0d0f595d9f9cf9801e771170bcf8d1b06e81a2bc4bdd05a50eab6c3f849b) so tools without custom renderers show a one-line compact argument summary (truncated to 120 columns) plus the five-line output preview when collapsed, and full formatted output when expanded.
- Adds tests in [tool-execution-collapse.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2157/files#diff-bdeb04051184b2deb0dcc42753b2a8d0fdf90e4259547dfce4881dd62311c25e) covering collapsed/expanded rendering, hint suppression, short-output handling, width changes, and cache invalidation.
- Behavioral Change: collapsed tools that previously rendered full output now show only the last five visual lines plus a skip count; expanding restores full output.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized be5c325.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->