### PR TITLE
fix(coding-agent): remove plaintext legacy credential files after auth.json migration

### DIFF
--- a/packages/coding-agent/.changes/eng-5346-migration-backup.md
+++ b/packages/coding-agent/.changes/eng-5346-migration-backup.md
@@ -1,0 +1,1 @@
+- Fixed the legacy credential migration to delete `oauth.json` after `auth.json` is verified, merge missing providers into an existing `auth.json`, and clean up or lock down plaintext `oauth.json.migrated` backups on startup.

--- a/packages/coding-agent/src/migrations.ts
+++ b/packages/coding-agent/src/migrations.ts
@@ -4,6 +4,7 @@
 
 import chalk from "chalk";
 import {
+	chmodSync,
 	type Dirent,
 	existsSync,
 	mkdirSync,
@@ -26,10 +27,57 @@ const MIGRATION_GUIDE_URL =
 const EXTENSIONS_DOC_URL =
 	"https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/docs/extensions.md";
 
+type CredentialRecord = Record<string, unknown>;
+
+function readJsonObjectSync(path: string): CredentialRecord | undefined {
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+		if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return undefined;
+		return parsed as CredentialRecord;
+	} catch {
+		return undefined;
+	}
+}
+
+function containsProviders(auth: CredentialRecord | undefined, providers: Iterable<string>): boolean {
+	if (!auth) return false;
+	for (const provider of providers) {
+		if (!(provider in auth)) return false;
+	}
+	return true;
+}
+
+/** Remove a legacy plaintext credential file; a symlinked file loses both the link and its target. */
+function removeCredentialFileSync(path: string): void {
+	const target = realpathIfPresentSync(path);
+	rmSync(target, { force: true });
+	if (target !== path) rmSync(path, { force: true });
+}
+
+function restrictCredentialFileSync(path: string): void {
+	try {
+		chmodSync(realpathIfPresentSync(path), 0o600);
+	} catch {
+		// Best effort; the warning still tells the user the file is there.
+	}
+}
+
+function warnLeftoverCredentialFile(path: string, reason: string): void {
+	console.error(
+		chalk.yellow(
+			`Warning: ${path} still holds plaintext credentials (${reason}). It was restricted to 0600; delete it once you have confirmed auth.json is complete.`,
+		),
+	);
+}
+
 /**
  * Migrate legacy oauth.json and settings.json apiKeys to auth.json.
  *
- * @returns Array of provider names that were migrated
+ * Providers missing from auth.json are merged in; existing entries are never
+ * overwritten. Legacy sources are removed only after auth.json has been
+ * durably written and re-read with every legacy provider present.
+ *
+ * @returns Array of provider names that were added to auth.json
  */
 export function migrateAuthToAuthJson(): string[] {
 	const agentDir = getAgentDir();
@@ -37,23 +85,36 @@ export function migrateAuthToAuthJson(): string[] {
 	const oauthPath = join(agentDir, "oauth.json");
 	const settingsPath = join(agentDir, "settings.json");
 
-	// Skip if auth.json already exists
-	if (existsSync(authPath)) return [];
+	let existing: CredentialRecord = {};
+	if (existsSync(authPath)) {
+		const parsed = readJsonObjectSync(authPath);
+		// An unreadable destination must never be replaced; leave every source alone.
+		if (!parsed) {
+			if (existsSync(oauthPath)) {
+				restrictCredentialFileSync(oauthPath);
+				warnLeftoverCredentialFile(oauthPath, "auth.json could not be parsed, so nothing was migrated");
+			}
+			cleanupMigratedOauthBackup(oauthPath, undefined);
+			return [];
+		}
+		existing = parsed;
+	}
 
-	const migrated: Record<string, unknown> = {};
+	const added: CredentialRecord = {};
 	const providers: string[] = [];
+	const legacyProviders = new Set<string>();
 
 	let oauthReadable = false;
 	if (existsSync(oauthPath)) {
-		try {
-			const oauth = JSON.parse(readFileSync(oauthPath, "utf-8"));
+		const oauth = readJsonObjectSync(oauthPath);
+		if (oauth) {
+			oauthReadable = true;
 			for (const [provider, cred] of Object.entries(oauth)) {
-				migrated[provider] = { type: "oauth", ...(cred as object) };
+				legacyProviders.add(provider);
+				if (provider in existing) continue;
+				added[provider] = { type: "oauth", ...(cred as object) };
 				providers.push(provider);
 			}
-			oauthReadable = true;
-		} catch {
-			// Skip on error
 		}
 	}
 
@@ -65,10 +126,11 @@ export function migrateAuthToAuthJson(): string[] {
 			const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
 			if (settings.apiKeys && typeof settings.apiKeys === "object") {
 				for (const [provider, key] of Object.entries(settings.apiKeys)) {
-					if (!migrated[provider] && typeof key === "string") {
-						migrated[provider] = { type: "api_key", key };
-						providers.push(provider);
-					}
+					if (typeof key !== "string") continue;
+					legacyProviders.add(provider);
+					if (provider in existing || provider in added) continue;
+					added[provider] = { type: "api_key", key };
+					providers.push(provider);
 				}
 				delete settings.apiKeys;
 				settingsWithoutApiKeys = JSON.stringify(settings, null, 2);
@@ -79,35 +141,74 @@ export function migrateAuthToAuthJson(): string[] {
 	}
 
 	// The destination must be durable before any source is destroyed.
-	if (Object.keys(migrated).length > 0) {
+	if (providers.length > 0) {
 		mkdirSync(dirname(authPath), { recursive: true });
-		writeFileAtomicSync(realpathIfPresentSync(authPath), JSON.stringify(migrated, null, 2), {
+		writeFileAtomicSync(realpathIfPresentSync(authPath), JSON.stringify({ ...existing, ...added }, null, 2), {
 			mode: 0o600,
 			fsync: true,
 			fsyncDir: true,
 		});
 	}
-	// Source cleanup is best-effort: with auth.json durable, leftovers are inert.
-	try {
-		if (oauthReadable) {
-			renameSync(oauthPath, `${oauthPath}.migrated`);
+
+	// Re-read what actually landed; the sources go only once every legacy provider is there.
+	const verified = legacyProviders.size > 0 ? readJsonObjectSync(authPath) : existing;
+	const destinationComplete = containsProviders(verified, legacyProviders);
+
+	if (oauthReadable) {
+		if (destinationComplete) {
+			try {
+				removeCredentialFileSync(oauthPath);
+			} catch {
+				restrictCredentialFileSync(oauthPath);
+				warnLeftoverCredentialFile(oauthPath, "could not be deleted");
+			}
+		} else {
+			restrictCredentialFileSync(oauthPath);
+			warnLeftoverCredentialFile(oauthPath, "auth.json could not be verified after migration");
 		}
-	} catch {
-		// Skip on error
 	}
-	try {
-		if (settingsWithoutApiKeys !== undefined) {
+	if (settingsWithoutApiKeys !== undefined && destinationComplete) {
+		try {
 			writeFileAtomicSync(
 				realpathIfPresentSync(settingsPath),
 				settingsWithoutApiKeys,
 				settingsMode === undefined ? {} : { mode: settingsMode },
 			);
+		} catch {
+			// Skip on error
 		}
-	} catch {
-		// Skip on error
 	}
 
+	cleanupMigratedOauthBackup(oauthPath, verified);
+
 	return providers;
+}
+
+/**
+ * Earlier releases renamed oauth.json to oauth.json.migrated at its original mode.
+ * Remove that backup once auth.json holds its providers; otherwise lock it down and warn.
+ */
+function cleanupMigratedOauthBackup(oauthPath: string, auth: CredentialRecord | undefined): void {
+	const backupPath = `${oauthPath}.migrated`;
+	if (!existsSync(backupPath)) return;
+
+	const backup = readJsonObjectSync(backupPath);
+	if (!backup) {
+		restrictCredentialFileSync(backupPath);
+		warnLeftoverCredentialFile(backupPath, "it could not be parsed");
+		return;
+	}
+	if (!containsProviders(auth, Object.keys(backup))) {
+		restrictCredentialFileSync(backupPath);
+		warnLeftoverCredentialFile(backupPath, "auth.json is missing some of its providers");
+		return;
+	}
+	try {
+		removeCredentialFileSync(backupPath);
+	} catch {
+		restrictCredentialFileSync(backupPath);
+		warnLeftoverCredentialFile(backupPath, "could not be deleted");
+	}
 }
 
 /**

--- a/packages/coding-agent/test/migrations.test.ts
+++ b/packages/coding-agent/test/migrations.test.ts
@@ -4,6 +4,7 @@ import {
 	lstatSync,
 	mkdirSync,
 	mkdtempSync,
+	readdirSync,
 	readFileSync,
 	rmSync,
 	statSync,
@@ -133,7 +134,7 @@ describe("session migrations", () => {
 	});
 });
 
-describe("auth migration ordering", () => {
+describe("auth migration", () => {
 	const tempDirs: string[] = [];
 	const previousAgentDir = process.env[ENV_AGENT_DIR];
 
@@ -193,6 +194,137 @@ describe("auth migration ordering", () => {
 
 		expect(lstatSync(join(agentDir, "auth.json")).isSymbolicLink()).toBe(true);
 		expect(JSON.parse(readFileSync(target, "utf-8")).anthropic.type).toBe("oauth");
+	});
+
+	it("successful migration leaves no plaintext legacy file behind", () => {
+		const agentDir = makeAgentDir();
+		const oauthPath = join(agentDir, "oauth.json");
+		const settingsPath = join(agentDir, "settings.json");
+		writeFileSync(oauthPath, JSON.stringify({ anthropic: { access: "token", refresh: "refresh-5346" } }), {
+			mode: 0o644,
+		});
+		writeFileSync(settingsPath, JSON.stringify({ theme: "dark", apiKeys: { openai: "sk-key" } }));
+
+		expect(migrateAuthToAuthJson()).toEqual(["anthropic", "openai"]);
+
+		const authPath = join(agentDir, "auth.json");
+		expect(statSync(authPath).mode & 0o777).toBe(0o600);
+		const auth = JSON.parse(readFileSync(authPath, "utf-8"));
+		expect(auth.anthropic).toEqual({ type: "oauth", access: "token", refresh: "refresh-5346" });
+		expect(auth.openai).toEqual({ type: "api_key", key: "sk-key" });
+		expect(existsSync(oauthPath)).toBe(false);
+		expect(existsSync(`${oauthPath}.migrated`)).toBe(false);
+		expect(readFileSync(settingsPath, "utf-8")).not.toContain("sk-key");
+		expect(readdirSync(agentDir).filter((name) => name.endsWith(".tmp"))).toEqual([]);
+		expect(readdirSync(agentDir).some((name) => name.startsWith("oauth.json"))).toBe(false);
+	});
+
+	it("removes a historical oauth.json.migrated once auth.json holds its providers", () => {
+		const agentDir = makeAgentDir();
+		const backupPath = join(agentDir, "oauth.json.migrated");
+		const authContent = JSON.stringify({ anthropic: { type: "oauth", access: "current", refresh: "r" } });
+		writeFileSync(join(agentDir, "auth.json"), authContent, { mode: 0o600 });
+		writeFileSync(backupPath, JSON.stringify({ anthropic: { access: "old", refresh: "old-refresh" } }), {
+			mode: 0o644,
+		});
+
+		expect(migrateAuthToAuthJson()).toEqual([]);
+
+		expect(existsSync(backupPath)).toBe(false);
+		expect(readFileSync(join(agentDir, "auth.json"), "utf-8")).toBe(authContent);
+	});
+
+	it("locks down an oauth.json.migrated whose providers are missing from auth.json and warns", () => {
+		const agentDir = makeAgentDir();
+		const backupPath = join(agentDir, "oauth.json.migrated");
+		writeFileSync(join(agentDir, "auth.json"), JSON.stringify({ other: { type: "api_key", key: "k" } }), {
+			mode: 0o600,
+		});
+		writeFileSync(backupPath, JSON.stringify({ anthropic: { access: "old", refresh: "old-refresh" } }), {
+			mode: 0o644,
+		});
+		const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		expect(migrateAuthToAuthJson()).toEqual([]);
+
+		expect(existsSync(backupPath)).toBe(true);
+		expect(statSync(backupPath).mode & 0o777).toBe(0o600);
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(String(warn.mock.calls[0]?.[0])).toContain("oauth.json.migrated");
+		expect(JSON.parse(readFileSync(join(agentDir, "auth.json"), "utf-8")).anthropic).toBeUndefined();
+	});
+
+	it("merges providers missing from an existing auth.json and removes the legacy sources", () => {
+		const agentDir = makeAgentDir();
+		const authPath = join(agentDir, "auth.json");
+		const oauthPath = join(agentDir, "oauth.json");
+		const settingsPath = join(agentDir, "settings.json");
+		writeFileSync(
+			authPath,
+			JSON.stringify({
+				anthropic: { type: "oauth", access: "current", refresh: "current-refresh" },
+				openai: { type: "api_key", key: "sk-current" },
+			}),
+			{ mode: 0o600 },
+		);
+		writeFileSync(
+			oauthPath,
+			JSON.stringify({ anthropic: { access: "stale", refresh: "stale-refresh" }, google: { access: "g" } }),
+			{ mode: 0o644 },
+		);
+		writeFileSync(settingsPath, JSON.stringify({ theme: "dark", apiKeys: { openai: "sk-stale", groq: "gsk" } }));
+
+		expect(migrateAuthToAuthJson()).toEqual(["google", "groq"]);
+
+		const auth = JSON.parse(readFileSync(authPath, "utf-8"));
+		expect(auth.anthropic).toEqual({ type: "oauth", access: "current", refresh: "current-refresh" });
+		expect(auth.openai).toEqual({ type: "api_key", key: "sk-current" });
+		expect(auth.google).toEqual({ type: "oauth", access: "g" });
+		expect(auth.groq).toEqual({ type: "api_key", key: "gsk" });
+		expect(statSync(authPath).mode & 0o777).toBe(0o600);
+		expect(existsSync(oauthPath)).toBe(false);
+		expect(existsSync(`${oauthPath}.migrated`)).toBe(false);
+		const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+		expect(settings).toEqual({ theme: "dark" });
+	});
+
+	it("removes legacy sources whose providers are all already in auth.json without rewriting it", () => {
+		const agentDir = makeAgentDir();
+		const authPath = join(agentDir, "auth.json");
+		const oauthPath = join(agentDir, "oauth.json");
+		const settingsPath = join(agentDir, "settings.json");
+		const authContent = JSON.stringify({
+			anthropic: { type: "oauth", access: "current" },
+			openai: { type: "api_key", key: "sk-current" },
+		});
+		writeFileSync(authPath, authContent, { mode: 0o600 });
+		writeFileSync(oauthPath, JSON.stringify({ anthropic: { access: "stale" } }));
+		writeFileSync(settingsPath, JSON.stringify({ theme: "dark", apiKeys: { openai: "sk-stale" } }));
+
+		expect(migrateAuthToAuthJson()).toEqual([]);
+
+		expect(readFileSync(authPath, "utf-8")).toBe(authContent);
+		expect(existsSync(oauthPath)).toBe(false);
+		expect(JSON.parse(readFileSync(settingsPath, "utf-8"))).toEqual({ theme: "dark" });
+	});
+
+	it("leaves an unreadable auth.json and every legacy source in place", () => {
+		const agentDir = makeAgentDir();
+		const authPath = join(agentDir, "auth.json");
+		const oauthPath = join(agentDir, "oauth.json");
+		const settingsPath = join(agentDir, "settings.json");
+		writeFileSync(authPath, "{not json", { mode: 0o600 });
+		writeFileSync(oauthPath, JSON.stringify({ anthropic: { access: "token" } }), { mode: 0o644 });
+		writeFileSync(settingsPath, JSON.stringify({ theme: "dark", apiKeys: { openai: "sk-key" } }));
+		const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		expect(migrateAuthToAuthJson()).toEqual([]);
+
+		expect(readFileSync(authPath, "utf-8")).toBe("{not json");
+		expect(existsSync(oauthPath)).toBe(true);
+		expect(statSync(oauthPath).mode & 0o777).toBe(0o600);
+		expect(JSON.parse(readFileSync(settingsPath, "utf-8")).apiKeys).toEqual({ openai: "sk-key" });
+		expect(warn).toHaveBeenCalledTimes(1);
 	});
 
 	it("keeps every credential source when the auth.json write fails", () => {


### PR DESCRIPTION
## Context

`migrateAuthToAuthJson` moves legacy `oauth.json` and `settings.json` `apiKeys` into `auth.json`. The destination write is already durable (#2028, unreleased), but after a successful migration `oauth.json` was renamed to `oauth.json.migrated` with its original mode (typically 0644) and plaintext access/refresh tokens, nothing ever removed that backup, and when `auth.json` already existed the migration was skipped so the plaintext legacy sources stayed in place indefinitely.

Root cause: the legacy sources were treated as a backup rather than as plaintext credentials to retire once the destination was verified, and the "destination exists" branch short-circuited instead of merging.

## Changes

- `packages/coding-agent/src/migrations.ts`
  - After `auth.json` is written it is re-read and validated to contain every legacy provider; only then is `oauth.json` deleted (no `.migrated` backup). Verification failure leaves the sources, chmods `oauth.json` to 0600 and warns.
  - When `auth.json` already exists, providers missing from it are merged in and the legacy sources are removed; existing entries are never overwritten. An unreadable `auth.json` skips the migration and leaves the sources untouched.
  - On every startup a pre-existing `oauth.json.migrated` is removed once `auth.json` contains its providers; otherwise it is chmodded to 0600 and a warning is printed.
  - `settings.json` mode handling is unchanged.
- `packages/coding-agent/test/migrations.test.ts`: successful migration leaves no plaintext legacy file; historical `.migrated` cleanup (verified and unverified); existing-destination merge without overwrite; existing failure test kept.
- Changelog fragment `packages/coding-agent/.changes/eng-5346-migration-backup.md`.
- Docs: no docs mention `oauth.json` or the `.migrated` backup (checked `packages/coding-agent/docs`, READMEs, CHANGELOG), so nothing to update.

## Validation

- `npm run check` in the worktree: clean (biome, tsgo, installer, browser-smoke).
- `packages/coding-agent`: `npx tsx ../../node_modules/vitest/dist/cli.js --run test/migrations.test.ts` -> 13 passed.
- Prime Sandbox (`node:24-bookworm`, unprivileged `tester` user, synthetic tokens only), `git archive` of `origin/main` @ 427ea4c72 and of this branch @ 4ab255801, `HUSKY=0 npm ci` in each:
  - Before (main): fresh migration leaves `oauth.json.migrated` at mode 0644 containing the refresh token; with a pre-existing `auth.json` the migration is skipped and `oauth.json` (0644, refresh token) and `settings.json` `apiKeys` stay in place; a historical `oauth.json.migrated` is never touched. The earlier validation fixture (`eng5346-migration.test.ts`) passes 4/4, i.e. the vulnerable behaviour reproduces.
  - After (branch): fresh migration leaves only `auth.json` (0600) and the stripped `settings.json`; the existing-`auth.json` case merges `anthropic`/`openai` next to the existing `other` entry and removes both legacy sources; a verifiable `oauth.json.migrated` is deleted; an unverifiable one is chmodded to 0600 with a warning; the read-only-dir write failure still throws `EACCES` with both sources intact. The vulnerable fixture now fails 3/4 (only the unchanged failure-keeps-sources case passes).
  - Regressions in the sandbox: `test/migrations.test.ts` 13 passed, `test/auth-storage.test.ts` 60 passed, `test/auth-flows.test.ts` 4 passed.

Linear: ENG-5346 — https://linear.app/primeintellect/issue/ENG-5346


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `migrateAuthToAuthJson` to remove plaintext legacy credential files after migration
> - Rewrites `migrateAuthToAuthJson` in [migrations.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2167/files#diff-0a96b36fc418ab60e6abdab862d571a29c56ab14753b336d965a8f9fe3320420) to preserve existing `auth.json` entries and merge only missing OAuth and API-key providers, instead of early-returning when `auth.json` exists
> - Deletes `oauth.json` and strips `settings.json` apiKeys only after verifying all legacy providers are present in the re-read `auth.json`; restricts undeleatable files to mode 0600 and warns the user
> - Adds `cleanupMigratedOauthBackup` to remove historical `oauth.json.migrated` backups at startup when their providers are already in `auth.json`; otherwise restricts to 0600 and warns
> - Adds helpers `readJsonObjectSync`, `containsProviders`, `removeCredentialFileSync`, `restrictCredentialFileSync`, and `warnLeftoverCredentialFile` to support the migration flow
> - Behavioral Change: `migrateAuthToAuthJson` now returns only newly added provider names (previously returned all providers); unreadable `auth.json` is no longer replaced and legacy sources are retained instead
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ab2558.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->