### PR TITLE
verify self-update tarball origin and digest before installing

### DIFF
--- a/packages/coding-agent/.changes/eng-5341-self-update-integrity.md
+++ b/packages/coding-agent/.changes/eng-5341-self-update-integrity.md
@@ -1,0 +1,1 @@
+- Fixed `prime-agent update` installing release tarballs unverified: the tarball must now be on the release origin over https, match the manifest package name and version, and pass a SHA-256 check against the manifest digest before the package manager runs; the npm-registry fallback was removed.

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -260,6 +260,8 @@ See [docs/settings.md](docs/settings.md) for all options.
 
 Prime Agent stable builds fetch `https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/latest.json` to check whether a newer version exists. Beta builds fetch `beta.json` and remain on the beta channel. Override the base URL with `PRIME_AGENT_DOWNLOAD_BASE_URL`. Disable version checks with `PI_SKIP_VERSION_CHECK=1`.
 
+`prime-agent update` only installs a release tarball that the manifest names on the same https origin and carries a SHA-256 digest for; the tarball is downloaded and verified before the package manager runs. See [docs/settings.md](docs/settings.md#update-checks).
+
 Use `--offline` or `PI_OFFLINE=1` to disable startup network operations, including update checks and package update checks.
 
 ## Context Files
@@ -680,6 +682,7 @@ prime-agent --thinking high "Solve this complex problem"
 | `PRIME_AGENT_TELEMETRY_ENDPOINT` | Override the aggregate analytics ingestion endpoint |
 | `DO_NOT_TRACK` | Disable aggregate usage analytics when set to `1`/`true`/`yes` |
 | `PRIME_AGENT_DOWNLOAD_BASE_URL` | Override the Prime Agent release manifest and tarball base URL |
+| `PRIME_AGENT_ALLOW_INSECURE_DOWNLOAD_BASE_URL` | Set to `1` to allow a plaintext `http://` `PRIME_AGENT_DOWNLOAD_BASE_URL` mirror; release downloads otherwise require https |
 | `PI_CACHE_RETENTION` | Set to `long` for extended prompt cache (Anthropic: 1h, OpenAI: 24h) |
 | `PRIME_API_KEY` | Prime Inference API key; also used for trace sharing if it has `agent_traces` scope |
 | `PRIME_AGENT_TRACES_API_KEY` | Prime API key used only for opt-in trace sharing |

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -58,11 +58,17 @@ The stable `latest.json` and beta `beta.json` manifests use the same JSON shape:
 {
   "version": "0.73.1",
   "package": "prime-agent",
-  "tarball": "releases/v0.73.1/prime-agent-0.73.1.tgz"
+  "tarball": "releases/v0.73.1/prime-agent-0.73.1.tgz",
+  "sha256": "<hex sha-256 of prime-agent-0.73.1.tgz>",
+  "tarballs": [{ "package": "prime-agent", "file": "prime-agent-0.73.1.tgz", "sha256": "<hex>" }]
 }
 ```
 
-`version` is required. `package` is optional and may also be named `packageName`; it defaults to the current package name. `tarball` is optional; when present, Prime Agent installs that tarball instead of the package name. Relative tarball paths resolve against `PRIME_AGENT_DOWNLOAD_BASE_URL`.
+`version` is required. `package` is optional and may also be named `packageName`; it must equal the installed package name. `tarball` is required for `prime-agent update`: the tarball must live on the same origin as the release base URL, be served over https, be named `<package>-<version>.tgz`, and have a SHA-256 digest in the manifest (top-level `sha256`, or a `tarballs[]` entry whose `file` matches). Relative tarball paths resolve against `PRIME_AGENT_DOWNLOAD_BASE_URL`.
+
+`prime-agent update` downloads the tarball to a temporary directory, verifies its SHA-256 against the manifest, and only then hands the local file to the package manager. Any manifest or digest check that fails aborts the update before the package manager runs; nothing is ever installed straight from a URL or from the npm registry by name.
+
+The base URL must be https. For a local or private plaintext mirror, set `PRIME_AGENT_ALLOW_INSECURE_DOWNLOAD_BASE_URL=1` together with an `http://` `PRIME_AGENT_DOWNLOAD_BASE_URL`; `file:` base URLs are never accepted.
 
 ### Pseudonymous usage analytics
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -358,6 +358,7 @@ prime-agent --tools ipython -p "Review the code"
 | `PI_OFFLINE` | Disable startup network operations, including update checks and package update checks |
 | `PI_SKIP_VERSION_CHECK` | Skip the Prime Agent version update check at startup. This prevents the release manifest request |
 | `PRIME_AGENT_DOWNLOAD_BASE_URL` | Override the Prime Agent release manifest and tarball base URL |
+| `PRIME_AGENT_ALLOW_INSECURE_DOWNLOAD_BASE_URL` | Set to `1` to allow a plaintext `http://` `PRIME_AGENT_DOWNLOAD_BASE_URL` mirror; release downloads otherwise require https |
 | `PI_CACHE_RETENTION` | Set to `long` for extended prompt cache where supported |
 | `PRIME_API_KEY` | Prime Inference API key; also used for trace sharing when it has `agent_traces` scope |
 | `PRIME_AGENT_TRACES_API_KEY` | Prime API key used only for opt-in trace sharing |

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -68,7 +68,13 @@ import {
 	DAEMON_WORKER_SUPERVISOR_SOCKET_ENV,
 } from "./modes/daemon/daemon-worker-protocol.js";
 import { shouldUseWindowsShell } from "./utils/child-process.js";
-import { getLatestPiRelease, isNewerPackageVersion } from "./utils/version-check.js";
+import { downloadVerifiedReleaseTarball } from "./utils/self-update-artifact.js";
+import {
+	getLatestPiRelease,
+	isNewerPackageVersion,
+	type LatestPiRelease,
+	type ReleaseTarball,
+} from "./utils/version-check.js";
 
 export type PackageCommand = "install" | "remove" | "update" | "list";
 
@@ -426,38 +432,44 @@ function printSelfUpdateFallback(command: SelfUpdateCommand): void {
 	console.error(chalk.dim(`If this keeps failing, run this command yourself: ${command.display}`));
 }
 
-interface SelfUpdatePlan {
-	installSpec: string;
+// Package names a release manifest may announce as the successor of the installed package.
+// Empty until a rename is scheduled; anything else is rejected before the package manager runs.
+const SELF_UPDATE_RENAMED_PACKAGE_NAMES: readonly string[] = [];
+
+interface VerifiedSelfUpdateRelease extends LatestPiRelease {
 	packageName: string;
-	shouldRun: boolean;
-	targetVersion?: string;
+	tarball: ReleaseTarball;
 }
+
+type SelfUpdatePlan = { shouldRun: false } | { shouldRun: true; release: VerifiedSelfUpdateRelease };
 
 function setSelfUpdateNoChangeExitCode(): void {
 	process.exitCode =
 		process.env[SELF_UPDATE_INTERACTIVE_CHILD_ENV] === "1" ? SELF_UPDATE_NOT_ATTEMPTED_EXIT_CODE : undefined;
 }
 
+// Self-updates install only a release tarball that the manifest names and carries a digest for.
+// Validation failures throw and are reported before any package manager runs.
 async function getSelfUpdatePlan(force: boolean): Promise<SelfUpdatePlan> {
-	try {
-		const latestRelease = await getLatestPiRelease(VERSION);
-		const packageName = latestRelease?.packageName ?? PACKAGE_NAME;
-		const installSpec = latestRelease?.installSpec ?? packageName;
-		const packageRenameRequiresUpdate = !latestRelease?.installSpec && packageName !== PACKAGE_NAME;
-		if (
-			force ||
-			!latestRelease ||
-			packageRenameRequiresUpdate ||
-			isNewerPackageVersion(latestRelease.version, VERSION)
-		) {
-			return { installSpec, packageName, shouldRun: true, targetVersion: latestRelease?.version };
-		}
-	} catch {
-		return { installSpec: PACKAGE_NAME, packageName: PACKAGE_NAME, shouldRun: true };
+	const latestRelease = await getLatestPiRelease(VERSION, {
+		explicit: true,
+		packageName: PACKAGE_NAME,
+		allowedPackageNames: SELF_UPDATE_RENAMED_PACKAGE_NAMES,
+	});
+	if (!latestRelease) {
+		throw new Error(`Could not fetch the ${APP_NAME} release manifest. Try again later.`);
 	}
-
-	console.log(chalk.green(`${APP_NAME} is already up to date (v${VERSION})`));
-	return { installSpec: PACKAGE_NAME, packageName: PACKAGE_NAME, shouldRun: false };
+	const packageName = latestRelease.packageName ?? PACKAGE_NAME;
+	if (!force && packageName === PACKAGE_NAME && !isNewerPackageVersion(latestRelease.version, VERSION)) {
+		console.log(chalk.green(`${APP_NAME} is already up to date (v${VERSION})`));
+		return { shouldRun: false };
+	}
+	if (!latestRelease.tarball) {
+		throw new Error(
+			`The ${APP_NAME} release manifest for v${latestRelease.version} does not name a release tarball with a SHA-256 digest, so there is nothing verifiable to install.`,
+		);
+	}
+	return { shouldRun: true, release: { ...latestRelease, packageName, tarball: latestRelease.tarball } };
 }
 
 async function runSelfUpdate(command: SelfUpdateCommand): Promise<void> {
@@ -1570,18 +1582,12 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 						setSelfUpdateNoChangeExitCode();
 						return true;
 					}
-					const selfUpdateCommand = getSelfUpdateCommand(
-						PACKAGE_NAME,
-						selfUpdateNpmCommand,
-						selfUpdatePlan.installSpec,
-						selfUpdatePlan.packageName,
-					);
-					if (!selfUpdateCommand) {
-						printSelfUpdateUnavailable(
-							selfUpdateNpmCommand,
-							selfUpdatePlan.installSpec,
-							selfUpdatePlan.packageName,
-						);
+					const { release } = selfUpdatePlan;
+					// Probe with the manifest URL so an unmanaged install is reported before anything downloads.
+					if (
+						!getSelfUpdateCommand(PACKAGE_NAME, selfUpdateNpmCommand, release.tarball.url, release.packageName)
+					) {
+						printSelfUpdateUnavailable(selfUpdateNpmCommand, release.tarball.url, release.packageName);
 						process.exitCode = 1;
 						return true;
 					}
@@ -1595,19 +1601,33 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 						process.exitCode = 1;
 						return true;
 					}
+					console.log(chalk.dim(`Downloading and verifying ${release.tarball.fileName}...`));
+					const artifact = await downloadVerifiedReleaseTarball(release.tarball, { currentVersion: VERSION });
 					try {
-						await runSelfUpdate(selfUpdateCommand);
-					} catch (error: unknown) {
-						const message = error instanceof Error ? error.message : "Unknown package command error";
-						console.error(chalk.red(`Error: ${message}`));
-						printSelfUpdateFallback(selfUpdateCommand);
-						process.exitCode = 1;
-						return true;
+						const selfUpdateCommand = getSelfUpdateCommand(
+							PACKAGE_NAME,
+							selfUpdateNpmCommand,
+							artifact.path,
+							release.packageName,
+						);
+						if (!selfUpdateCommand) {
+							printSelfUpdateUnavailable(selfUpdateNpmCommand, release.tarball.url, release.packageName);
+							process.exitCode = 1;
+							return true;
+						}
+						try {
+							await runSelfUpdate(selfUpdateCommand);
+						} catch (error: unknown) {
+							const message = error instanceof Error ? error.message : "Unknown package command error";
+							console.error(chalk.red(`Error: ${message}`));
+							printSelfUpdateFallback(selfUpdateCommand);
+							process.exitCode = 1;
+							return true;
+						}
+					} finally {
+						artifact.cleanup();
 					}
-					const versionChange = selfUpdatePlan.targetVersion
-						? ` from v${VERSION} to v${selfUpdatePlan.targetVersion}`
-						: "";
-					console.log(chalk.green(`Updated ${APP_NAME}${versionChange}`));
+					console.log(chalk.green(`Updated ${APP_NAME} from v${VERSION} to v${release.version}`));
 					if (process.env[SELF_UPDATE_INTERACTIVE_CHILD_ENV] === "1") {
 						return true;
 					}

--- a/packages/coding-agent/src/utils/self-update-artifact.ts
+++ b/packages/coding-agent/src/utils/self-update-artifact.ts
@@ -1,0 +1,83 @@
+import { createHash } from "node:crypto";
+import { createWriteStream, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable, Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { ReadableStream as WebReadableStream } from "node:stream/web";
+import { getPiUserAgent } from "./pi-user-agent.js";
+import type { ReleaseTarball } from "./version-check.js";
+
+const DEFAULT_DOWNLOAD_TIMEOUT_MS = 10 * 60 * 1000;
+
+export interface VerifiedReleaseArtifact {
+	/** Local path of the tarball whose SHA-256 matched the manifest digest. */
+	path: string;
+	sha256: string;
+	cleanup(): void;
+}
+
+/** The downloaded release artifact could not be fetched or did not match its manifest digest. */
+export class ReleaseArtifactError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ReleaseArtifactError";
+	}
+}
+
+export interface DownloadReleaseTarballOptions {
+	currentVersion: string;
+	timeoutMs?: number;
+	tempRoot?: string;
+}
+
+/**
+ * Downloads the release tarball into a fresh temp directory and verifies its SHA-256 against the
+ * manifest digest before returning. A mismatch removes the download and throws; nothing is ever
+ * handed to a package manager unverified.
+ */
+export async function downloadVerifiedReleaseTarball(
+	tarball: ReleaseTarball,
+	options: DownloadReleaseTarballOptions,
+): Promise<VerifiedReleaseArtifact> {
+	const tempDir = mkdtempSync(join(options.tempRoot ?? tmpdir(), "prime-agent-update-"));
+	const cleanup = (): void => {
+		rmSync(tempDir, { recursive: true, force: true });
+	};
+	const path = join(tempDir, tarball.fileName);
+
+	try {
+		const response = await fetch(tarball.url, {
+			headers: { "User-Agent": getPiUserAgent(options.currentVersion), accept: "application/octet-stream" },
+			redirect: "error",
+			signal: AbortSignal.timeout(options.timeoutMs ?? DEFAULT_DOWNLOAD_TIMEOUT_MS),
+		});
+		if (!response.ok || !response.body) {
+			throw new ReleaseArtifactError(
+				`Failed to download ${tarball.url}: HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ""}`,
+			);
+		}
+
+		const hash = createHash("sha256");
+		const tap = new Transform({
+			transform(chunk: Buffer, _encoding, callback) {
+				hash.update(chunk);
+				callback(null, chunk);
+			},
+		});
+		await pipeline(Readable.fromWeb(response.body as WebReadableStream<Uint8Array>), tap, createWriteStream(path));
+
+		const sha256 = hash.digest("hex");
+		if (sha256 !== tarball.sha256) {
+			throw new ReleaseArtifactError(
+				`SHA-256 mismatch for ${tarball.fileName}: the release manifest expects ${tarball.sha256} but the download hashed to ${sha256}. The download was discarded.`,
+			);
+		}
+		return { path, sha256, cleanup };
+	} catch (error) {
+		cleanup();
+		if (error instanceof ReleaseArtifactError) throw error;
+		const message = error instanceof Error ? error.message : String(error);
+		throw new ReleaseArtifactError(`Failed to download ${tarball.url}: ${message}`);
+	}
+}

--- a/packages/coding-agent/src/utils/version-check.ts
+++ b/packages/coding-agent/src/utils/version-check.ts
@@ -4,11 +4,36 @@ const DEFAULT_PRIME_AGENT_DOWNLOAD_BASE_URL = "https://pub-728493de92a943e2a9b2d
 const STABLE_VERSION_MANIFEST_PATH = "latest.json";
 const BETA_VERSION_MANIFEST_PATH = "beta.json";
 const DEFAULT_VERSION_CHECK_TIMEOUT_MS = 10000;
+export const ALLOW_INSECURE_DOWNLOAD_BASE_URL_ENV = "PRIME_AGENT_ALLOW_INSECURE_DOWNLOAD_BASE_URL";
+const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/;
+
+export interface ReleaseTarball {
+	url: string;
+	fileName: string;
+	sha256: string;
+}
 
 export interface LatestPiRelease {
 	version: string;
 	packageName?: string;
-	installSpec?: string;
+	tarball?: ReleaseTarball;
+}
+
+export interface LatestPiReleaseOptions {
+	timeoutMs?: number;
+	/** Installed package name; the manifest `package` must match it or one of `allowedPackageNames`. */
+	packageName?: string;
+	allowedPackageNames?: readonly string[];
+	/** Explicit user request: ignore PI_SKIP_VERSION_CHECK and PI_OFFLINE. */
+	explicit?: boolean;
+}
+
+/** The release manifest was reachable but failed validation; nothing from it may be installed. */
+export class ReleaseManifestError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ReleaseManifestError";
+	}
 }
 
 interface ParsedVersion {
@@ -85,11 +110,28 @@ export function isNewerPackageVersion(candidateVersion: string, currentVersion: 
 	return candidateVersion.trim() !== currentVersion.trim();
 }
 
-function getPrimeAgentDownloadBaseUrl(): string {
-	return (process.env.PRIME_AGENT_DOWNLOAD_BASE_URL?.trim() || DEFAULT_PRIME_AGENT_DOWNLOAD_BASE_URL).replace(
-		/\/+$/,
-		"",
-	);
+function getPrimeAgentDownloadBaseUrl(): URL {
+	const configured = process.env.PRIME_AGENT_DOWNLOAD_BASE_URL?.trim();
+	const raw = configured || DEFAULT_PRIME_AGENT_DOWNLOAD_BASE_URL;
+	let url: URL;
+	try {
+		url = new URL(raw);
+	} catch {
+		throw new ReleaseManifestError(`PRIME_AGENT_DOWNLOAD_BASE_URL is not an absolute URL: ${raw}`);
+	}
+	if (url.protocol === "http:" && process.env[ALLOW_INSECURE_DOWNLOAD_BASE_URL_ENV] === "1") {
+		return url;
+	}
+	if (url.protocol !== "https:") {
+		throw new ReleaseManifestError(
+			`Release downloads require an https base URL (got ${raw}). Set ${ALLOW_INSECURE_DOWNLOAD_BASE_URL_ENV}=1 to allow a plaintext http mirror.`,
+		);
+	}
+	return url;
+}
+
+function joinReleaseUrl(baseUrl: URL, relativePath: string): string {
+	return `${baseUrl.toString().replace(/\/+$/, "")}/${relativePath.replace(/^\/+/, "")}`;
 }
 
 function normalizeReleaseVersion(version: string): string {
@@ -101,24 +143,118 @@ function getReleaseManifestPath(currentVersion: string): string {
 	return prerelease?.match(/^beta(?:\.|$)/) ? BETA_VERSION_MANIFEST_PATH : STABLE_VERSION_MANIFEST_PATH;
 }
 
-function resolveReleaseUrl(baseUrl: string, pathOrUrl: string): string | undefined {
-	const trimmed = pathOrUrl.trim();
-	if (!trimmed) return undefined;
-	try {
-		return new URL(trimmed).toString();
-	} catch {
-		return `${baseUrl}/${trimmed.replace(/^\/+/, "")}`;
-	}
+/** Mirrors the artifact naming in scripts/pack-prime-agent-release.mjs. */
+export function getReleaseTarballFileName(packageName: string, version: string): string {
+	return `${packageName.replace(/^@/, "").replace("/", "-")}-${version}.tgz`;
 }
 
+function readOptionalString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function resolveTarballUrl(baseUrl: URL, tarball: string): URL {
+	let url: URL;
+	try {
+		url = new URL(tarball);
+	} catch {
+		try {
+			url = new URL(joinReleaseUrl(baseUrl, tarball));
+		} catch {
+			throw new ReleaseManifestError(`The release manifest tarball path is not a valid URL: ${tarball}`);
+		}
+	}
+	if (url.protocol !== baseUrl.protocol || url.origin !== baseUrl.origin || url.origin === "null") {
+		throw new ReleaseManifestError(
+			`The release manifest lists tarball ${url.toString()}, which is not on the release origin ${baseUrl.origin}.`,
+		);
+	}
+	return url;
+}
+
+function findManifestDigest(data: Record<string, unknown>, fileName: string): string {
+	const candidates: unknown[] = [data.sha256];
+	if (Array.isArray(data.tarballs)) {
+		for (const entry of data.tarballs) {
+			if (typeof entry === "object" && entry !== null) {
+				const record = entry as Record<string, unknown>;
+				if (readOptionalString(record.file) === fileName) {
+					candidates.push(record.sha256);
+				}
+			}
+		}
+	}
+	const digest = candidates.find((candidate): candidate is string => typeof candidate === "string");
+	if (!digest) {
+		throw new ReleaseManifestError(`The release manifest has no SHA-256 digest for ${fileName}.`);
+	}
+	const normalized = digest.trim().toLowerCase();
+	if (!SHA256_HEX_PATTERN.test(normalized)) {
+		throw new ReleaseManifestError(`The release manifest SHA-256 digest for ${fileName} is malformed.`);
+	}
+	return normalized;
+}
+
+function parseReleaseManifest(data: unknown, baseUrl: URL, options: LatestPiReleaseOptions): LatestPiRelease {
+	if (typeof data !== "object" || data === null || Array.isArray(data)) {
+		throw new ReleaseManifestError("The release manifest is not a JSON object.");
+	}
+	const manifest = data as Record<string, unknown>;
+	const rawVersion = readOptionalString(manifest.version);
+	if (!rawVersion) {
+		throw new ReleaseManifestError("The release manifest has no version.");
+	}
+	const version = normalizeReleaseVersion(rawVersion);
+	if (!parsePackageVersion(version)) {
+		throw new ReleaseManifestError(`The release manifest version is not a valid package version: ${rawVersion}`);
+	}
+
+	const packageName = readOptionalString(manifest.package) ?? readOptionalString(manifest.packageName);
+	if (packageName && options.packageName) {
+		const accepted = [options.packageName, ...(options.allowedPackageNames ?? [])];
+		if (!accepted.includes(packageName)) {
+			throw new ReleaseManifestError(
+				`The release manifest names package "${packageName}", but this installation is "${options.packageName}".`,
+			);
+		}
+	}
+
+	const release: LatestPiRelease = { version };
+	if (packageName) {
+		release.packageName = packageName;
+	}
+
+	const tarballSpec = readOptionalString(manifest.tarball);
+	if (tarballSpec) {
+		const url = resolveTarballUrl(baseUrl, tarballSpec);
+		const fileName = url.pathname.split("/").pop() ?? "";
+		const expectedPackageName = packageName ?? options.packageName;
+		const expectedFileName = expectedPackageName
+			? getReleaseTarballFileName(expectedPackageName, version)
+			: undefined;
+		const fileNameMatches = expectedFileName ? fileName === expectedFileName : fileName.endsWith(`-${version}.tgz`);
+		if (!fileNameMatches) {
+			throw new ReleaseManifestError(
+				`The release manifest tarball "${fileName}" does not match release version ${version}` +
+					(expectedFileName ? ` (expected ${expectedFileName}).` : "."),
+			);
+		}
+		release.tarball = { url: url.toString(), fileName, sha256: findManifestDigest(manifest, fileName) };
+	}
+	return release;
+}
+
+/**
+ * Fetches and validates the release manifest. Returns undefined when checks are disabled or the
+ * manifest is unreachable; throws ReleaseManifestError when the manifest fails validation.
+ */
 export async function getLatestPiRelease(
 	currentVersion: string,
-	options: { timeoutMs?: number } = {},
+	options: LatestPiReleaseOptions = {},
 ): Promise<LatestPiRelease | undefined> {
-	if (process.env.PI_SKIP_VERSION_CHECK || process.env.PI_OFFLINE) return undefined;
+	if (!options.explicit && (process.env.PI_SKIP_VERSION_CHECK || process.env.PI_OFFLINE)) return undefined;
 
 	const baseUrl = getPrimeAgentDownloadBaseUrl();
-	const response = await fetch(`${baseUrl}/${getReleaseManifestPath(currentVersion)}`, {
+	const response = await fetch(joinReleaseUrl(baseUrl, getReleaseManifestPath(currentVersion)), {
 		headers: {
 			"User-Agent": getPiUserAgent(currentVersion),
 			accept: "application/json",
@@ -127,30 +263,13 @@ export async function getLatestPiRelease(
 	});
 	if (!response.ok) return undefined;
 
-	const data = (await response.json()) as {
-		package?: unknown;
-		packageName?: unknown;
-		tarball?: unknown;
-		version?: unknown;
-	};
-	if (typeof data.version !== "string" || !data.version.trim()) {
-		return undefined;
+	let data: unknown;
+	try {
+		data = await response.json();
+	} catch {
+		throw new ReleaseManifestError("The release manifest is not valid JSON.");
 	}
-	const packageName =
-		typeof data.package === "string" && data.package.trim()
-			? data.package.trim()
-			: typeof data.packageName === "string" && data.packageName.trim()
-				? data.packageName.trim()
-				: undefined;
-	const installSpec = typeof data.tarball === "string" ? resolveReleaseUrl(baseUrl, data.tarball) : undefined;
-	const release: LatestPiRelease = { version: normalizeReleaseVersion(data.version) };
-	if (packageName) {
-		release.packageName = packageName;
-	}
-	if (installSpec) {
-		release.installSpec = installSpec;
-	}
-	return release;
+	return parseReleaseManifest(data, baseUrl, options);
 }
 
 export async function getLatestPiVersion(

--- a/packages/coding-agent/test/package-self-update-daemon.test.ts
+++ b/packages/coding-agent/test/package-self-update-daemon.test.ts
@@ -1,6 +1,7 @@
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, isAbsolute, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type * as DaemonUpdateRestartModule from "../src/cli/daemon-update-restart.js";
 import {
@@ -26,6 +27,34 @@ import {
 	prepareDaemonUpdateRestart,
 	runDaemonUpdateRestartCoordinator,
 } from "../src/package-manager-cli.js";
+import { getReleaseTarballFileName } from "../src/utils/version-check.js";
+
+const releaseTarballBytes = Buffer.from("prime-agent release tarball fixture");
+const releaseTarballDigest = createHash("sha256").update(releaseTarballBytes).digest("hex");
+
+function releaseManifest(version: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	const fileName = getReleaseTarballFileName(PACKAGE_NAME, version);
+	return { version, tarball: `releases/v${version}/${fileName}`, sha256: releaseTarballDigest, ...overrides };
+}
+
+function stubReleaseFetch(manifest: unknown, tarballBody: Buffer = releaseTarballBytes): void {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async (input: string | URL | Request) => {
+			const url = String(input);
+			mockState.calls.push(`fetch:${url}`);
+			if (url.endsWith(".tgz")) {
+				return new Response(tarballBody, { status: 200 });
+			}
+			return Response.json(manifest);
+		}),
+	);
+}
+
+function npmInstallSpec(): string | undefined {
+	const call = mockState.calls.find((entry) => entry.startsWith("spawn:npm ") && entry.includes(" install -g "));
+	return call?.split(" install -g ")[1];
+}
 
 interface MockSessionSummary {
 	id: string;
@@ -520,10 +549,7 @@ describe("self-update daemon restart", () => {
 			configurable: true,
 		});
 		writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ npmCommand: ["npm"] }, null, 2));
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(async () => Response.json({ version: "999.0.0" })),
-		);
+		stubReleaseFetch(releaseManifest("999.0.0"));
 	});
 
 	afterEach(() => {
@@ -567,10 +593,7 @@ describe("self-update daemon restart", () => {
 
 	it("uses the interactive no-change sentinel only when self-update is unchanged", async () => {
 		process.env[SELF_UPDATE_INTERACTIVE_CHILD_ENV] = "1";
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(async () => Response.json({ version: "0.2.6" })),
-		);
+		stubReleaseFetch({ version: "0.2.6" });
 
 		await expect(handlePackageCommand(["update", "--self"])).resolves.toBe(true);
 
@@ -620,6 +643,107 @@ describe("self-update daemon restart", () => {
 			errorSpy.mockRestore();
 			logSpy.mockRestore();
 		}
+	});
+
+	it("installs the verified local tarball instead of the manifest URL (ENG-5341)", async () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		try {
+			await expect(handlePackageCommand(["update", "--self"])).resolves.toBe(true);
+		} finally {
+			logSpy.mockRestore();
+		}
+
+		expect(process.exitCode).toBeUndefined();
+		const installSpec = npmInstallSpec();
+		expect(installSpec).toBeDefined();
+		expect(installSpec?.startsWith("http")).toBe(false);
+		expect(isAbsolute(installSpec ?? "")).toBe(true);
+		expect(basename(installSpec ?? "")).toBe(getReleaseTarballFileName(PACKAGE_NAME, "999.0.0"));
+		expect(existsSync(installSpec ?? "")).toBe(false);
+		const tarballFetchIndex = mockState.calls.findIndex((call) => call.startsWith("fetch:") && call.endsWith(".tgz"));
+		const spawnIndex = mockState.calls.findIndex((call) => call.startsWith("spawn:npm "));
+		expect(tarballFetchIndex).toBeGreaterThanOrEqual(0);
+		expect(tarballFetchIndex).toBeLessThan(spawnIndex);
+	});
+
+	it.each([
+		["a digest mismatch", releaseManifest("999.0.0"), Buffer.from("tampered tarball"), /SHA-256 mismatch/, true],
+		[
+			"a tarball off the release origin",
+			releaseManifest("999.0.0", { tarball: "https://attacker.invalid/pkg-999.0.0.tgz" }),
+			releaseTarballBytes,
+			/not on the release origin/,
+			false,
+		],
+		[
+			"a manifest naming another package",
+			releaseManifest("999.0.0", { package: "@attacker/anything" }),
+			releaseTarballBytes,
+			/names package "@attacker\/anything"/,
+			false,
+		],
+		[
+			"a tarball whose version does not match",
+			releaseManifest("999.0.0", { tarball: `releases/v1.0.0/${getReleaseTarballFileName(PACKAGE_NAME, "1.0.0")}` }),
+			releaseTarballBytes,
+			/does not match release version 999\.0\.0/,
+			false,
+		],
+		[
+			"a manifest without a tarball digest",
+			releaseManifest("999.0.0", { sha256: undefined }),
+			releaseTarballBytes,
+			/no SHA-256 digest/,
+			false,
+		],
+		[
+			"a manifest without a tarball",
+			{ version: "999.0.0" },
+			releaseTarballBytes,
+			/nothing verifiable to install/,
+			false,
+		],
+	])(
+		"rejects %s before invoking the package manager (ENG-5341)",
+		async (_name, manifest, tarballBody, expectedError, expectsDownload) => {
+			stubReleaseFetch(manifest, tarballBody);
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+			try {
+				await expect(handlePackageCommand(["update", "--self"])).resolves.toBe(true);
+				expect(errorSpy.mock.calls.flat().join("\n")).toMatch(expectedError);
+			} finally {
+				errorSpy.mockRestore();
+				logSpy.mockRestore();
+			}
+
+			expect(process.exitCode).toBe(1);
+			expect(mockState.calls.some((call) => call.startsWith("spawn:"))).toBe(false);
+			expect(mockState.calls.some((call) => call.startsWith("fetch:") && call.endsWith(".tgz"))).toBe(
+				expectsDownload,
+			);
+			expect(mockState.calls.some((call) => call === "daemon-request:prepare_update_restart")).toBe(false);
+		},
+	);
+
+	it("does not fall back to a registry install when the manifest is unreachable (ENG-5341)", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response(null, { status: 503 })),
+		);
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		try {
+			await expect(handlePackageCommand(["update", "--self"])).resolves.toBe(true);
+			expect(errorSpy.mock.calls.flat().join("\n")).toMatch(/Could not fetch the .* release manifest/);
+		} finally {
+			errorSpy.mockRestore();
+		}
+
+		expect(process.exitCode).toBe(1);
+		expect(mockState.calls.some((call) => call.startsWith("spawn:"))).toBe(false);
 	});
 
 	it("defers the exact custom-socket restart to the interactive parent", async () => {

--- a/packages/coding-agent/test/self-update-artifact.test.ts
+++ b/packages/coding-agent/test/self-update-artifact.test.ts
@@ -1,0 +1,80 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { downloadVerifiedReleaseTarball, ReleaseArtifactError } from "../src/utils/self-update-artifact.js";
+
+const tarballBytes = Buffer.from("not really a tarball, but hashed like one");
+const tarball = {
+	url: "https://releases.example/releases/v99.0.0/prime-agent-99.0.0.tgz",
+	fileName: "prime-agent-99.0.0.tgz",
+	sha256: createHash("sha256").update(tarballBytes).digest("hex"),
+};
+
+let tempRoot: string;
+
+function stubDownload(body: Buffer | null, status = 200): ReturnType<typeof vi.fn> {
+	const fetchMock = vi.fn(async () => new Response(body, { status }));
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+}
+
+beforeEach(() => {
+	tempRoot = mkdtempSync(join(tmpdir(), "self-update-artifact-test-"));
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	rmSync(tempRoot, { recursive: true, force: true });
+});
+
+describe("downloadVerifiedReleaseTarball", () => {
+	it("writes the tarball into a private temp directory when the digest matches", async () => {
+		const fetchMock = stubDownload(tarballBytes);
+
+		const artifact = await downloadVerifiedReleaseTarball(tarball, { currentVersion: "0.9.4", tempRoot });
+
+		expect(fetchMock).toHaveBeenCalledWith(tarball.url, expect.objectContaining({ redirect: "error" }));
+		expect(artifact.sha256).toBe(tarball.sha256);
+		expect(dirname(dirname(artifact.path))).toBe(tempRoot);
+		expect(artifact.path.endsWith(join("", tarball.fileName))).toBe(true);
+		expect(readFileSync(artifact.path)).toEqual(tarballBytes);
+
+		artifact.cleanup();
+		expect(existsSync(artifact.path)).toBe(false);
+		expect(readdirSync(tempRoot)).toEqual([]);
+	});
+
+	it("discards the download and throws when the digest does not match", async () => {
+		stubDownload(Buffer.concat([tarballBytes, Buffer.from("tampered")]));
+
+		await expect(downloadVerifiedReleaseTarball(tarball, { currentVersion: "0.9.4", tempRoot })).rejects.toThrow(
+			/SHA-256 mismatch for prime-agent-99\.0\.0\.tgz/,
+		);
+		expect(readdirSync(tempRoot)).toEqual([]);
+	});
+
+	it("throws a ReleaseArtifactError and cleans up on an HTTP error", async () => {
+		stubDownload(null, 404);
+
+		await expect(
+			downloadVerifiedReleaseTarball(tarball, { currentVersion: "0.9.4", tempRoot }),
+		).rejects.toBeInstanceOf(ReleaseArtifactError);
+		expect(readdirSync(tempRoot)).toEqual([]);
+	});
+
+	it("wraps network failures and cleans up", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				throw new TypeError("fetch failed");
+			}),
+		);
+
+		await expect(downloadVerifiedReleaseTarball(tarball, { currentVersion: "0.9.4", tempRoot })).rejects.toThrow(
+			/Failed to download .*fetch failed/,
+		);
+		expect(readdirSync(tempRoot)).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/version-check.test.ts
+++ b/packages/coding-agent/test/version-check.test.ts
@@ -1,16 +1,21 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+	ALLOW_INSECURE_DOWNLOAD_BASE_URL_ENV,
 	checkForNewPiVersion,
 	comparePackageVersions,
 	getLatestPiRelease,
 	getLatestPiVersion,
+	getReleaseTarballFileName,
 	isNewerPackageVersion,
+	ReleaseManifestError,
 } from "../src/utils/version-check.js";
 
 const defaultPrimeAgentDownloadBaseUrl = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev";
 const originalSkipVersionCheck = process.env.PI_SKIP_VERSION_CHECK;
 const originalOffline = process.env.PI_OFFLINE;
 const originalPrimeAgentDownloadBaseUrl = process.env.PRIME_AGENT_DOWNLOAD_BASE_URL;
+const originalAllowInsecure = process.env[ALLOW_INSECURE_DOWNLOAD_BASE_URL_ENV];
+const digest = "b8d752a53d11a8c9a7580e1fb5fc24f7ce74ccad979c7e6e6aa8880fc3ad90b0";
 
 function restoreEnv(name: string, value: string | undefined): void {
 	if (value === undefined) {
@@ -25,7 +30,15 @@ afterEach(() => {
 	restoreEnv("PI_SKIP_VERSION_CHECK", originalSkipVersionCheck);
 	restoreEnv("PI_OFFLINE", originalOffline);
 	restoreEnv("PRIME_AGENT_DOWNLOAD_BASE_URL", originalPrimeAgentDownloadBaseUrl);
+	restoreEnv(ALLOW_INSECURE_DOWNLOAD_BASE_URL_ENV, originalAllowInsecure);
 });
+
+function stubManifest(manifest: unknown): void {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async () => Response.json(manifest)),
+	);
+}
 
 describe("version checks", () => {
 	it("compares package versions", () => {
@@ -69,19 +82,21 @@ describe("version checks", () => {
 		expect(fetchMock).toHaveBeenCalledWith(`${defaultPrimeAgentDownloadBaseUrl}/beta.json`, expect.any(Object));
 	});
 
-	it("returns the active package and tarball install spec from the release manifest", async () => {
-		const fetchMock = vi.fn(async () =>
-			Response.json({
-				package: "prime-agent",
-				tarball: "releases/v1.2.4/prime-agent-1.2.4.tgz",
-				version: "v1.2.4",
-			}),
-		);
-		vi.stubGlobal("fetch", fetchMock);
+	it("returns the package and the verified tarball descriptor from the release manifest", async () => {
+		stubManifest({
+			package: "prime-agent",
+			tarball: "releases/v1.2.4/prime-agent-1.2.4.tgz",
+			tarballs: [{ package: "prime-agent", file: "prime-agent-1.2.4.tgz", sha256: digest }],
+			version: "v1.2.4",
+		});
 
-		await expect(getLatestPiRelease("1.2.3")).resolves.toEqual({
-			installSpec: `${defaultPrimeAgentDownloadBaseUrl}/releases/v1.2.4/prime-agent-1.2.4.tgz`,
+		await expect(getLatestPiRelease("1.2.3", { packageName: "prime-agent" })).resolves.toEqual({
 			packageName: "prime-agent",
+			tarball: {
+				fileName: "prime-agent-1.2.4.tgz",
+				sha256: digest,
+				url: `${defaultPrimeAgentDownloadBaseUrl}/releases/v1.2.4/prime-agent-1.2.4.tgz`,
+			},
 			version: "1.2.4",
 		});
 	});
@@ -93,5 +108,157 @@ describe("version checks", () => {
 
 		await expect(getLatestPiVersion("1.2.3")).resolves.toBeUndefined();
 		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});
+
+describe("release manifest validation (ENG-5341)", () => {
+	const baseManifest = {
+		package: "prime-agent",
+		version: "v99.0.0",
+		tarball: "releases/v99.0.0/prime-agent-99.0.0.tgz",
+		sha256: digest,
+	};
+	const options = { packageName: "prime-agent" };
+
+	it("derives release tarball names the way the pack script does", () => {
+		expect(getReleaseTarballFileName("prime-agent", "1.2.3")).toBe("prime-agent-1.2.3.tgz");
+		expect(getReleaseTarballFileName("@earendil-works/pi-coding-agent", "1.2.3-beta.1")).toBe(
+			"earendil-works-pi-coding-agent-1.2.3-beta.1.tgz",
+		);
+	});
+
+	it("accepts a same-origin https tarball with a top-level digest", async () => {
+		stubManifest(baseManifest);
+		const release = await getLatestPiRelease("0.9.4", options);
+		expect(release?.tarball).toEqual({
+			fileName: "prime-agent-99.0.0.tgz",
+			sha256: digest,
+			url: `${defaultPrimeAgentDownloadBaseUrl}/releases/v99.0.0/prime-agent-99.0.0.tgz`,
+		});
+	});
+
+	it("accepts an absolute tarball URL on the release origin and an uppercase digest", async () => {
+		stubManifest({
+			...baseManifest,
+			sha256: undefined,
+			tarball: `${defaultPrimeAgentDownloadBaseUrl}/releases/v99.0.0/prime-agent-99.0.0.tgz`,
+			tarballs: [{ file: "prime-agent-99.0.0.tgz", sha256: digest.toUpperCase() }],
+		});
+		const release = await getLatestPiRelease("0.9.4", options);
+		expect(release?.tarball?.sha256).toBe(digest);
+	});
+
+	it("rejects a tarball on a foreign origin", async () => {
+		stubManifest({ ...baseManifest, tarball: "https://attacker.invalid/prime-agent-99.0.0.tgz" });
+		await expect(getLatestPiRelease("0.9.4", options)).rejects.toThrow(
+			/attacker\.invalid.*not on the release origin/,
+		);
+	});
+
+	it("rejects plaintext http and file tarballs even when the host matches", async () => {
+		const host = new URL(defaultPrimeAgentDownloadBaseUrl).host;
+		stubManifest({ ...baseManifest, tarball: `http://${host}/releases/v99.0.0/prime-agent-99.0.0.tgz` });
+		await expect(getLatestPiRelease("0.9.4", options)).rejects.toBeInstanceOf(ReleaseManifestError);
+
+		stubManifest({ ...baseManifest, tarball: "file:///tmp/prime-agent-99.0.0.tgz" });
+		await expect(getLatestPiRelease("0.9.4", options)).rejects.toThrow(/not on the release origin/);
+	});
+
+	it("rejects a plaintext base URL unless the insecure mirror override is set", async () => {
+		process.env.PRIME_AGENT_DOWNLOAD_BASE_URL = "http://127.0.0.1:9/mirror";
+		const fetchMock = vi.fn(async () => Response.json(baseManifest));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(getLatestPiRelease("0.9.4", options)).rejects.toThrow(/require an https base URL/);
+		expect(fetchMock).not.toHaveBeenCalled();
+
+		process.env[ALLOW_INSECURE_DOWNLOAD_BASE_URL_ENV] = "1";
+		const release = await getLatestPiRelease("0.9.4", options);
+		expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:9/mirror/latest.json", expect.any(Object));
+		expect(release?.tarball?.url).toBe("http://127.0.0.1:9/mirror/releases/v99.0.0/prime-agent-99.0.0.tgz");
+	});
+
+	it("rejects a file: base URL even with the insecure override", async () => {
+		process.env.PRIME_AGENT_DOWNLOAD_BASE_URL = "file:///tmp/mirror";
+		process.env[ALLOW_INSECURE_DOWNLOAD_BASE_URL_ENV] = "1";
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(getLatestPiRelease("0.9.4", options)).rejects.toBeInstanceOf(ReleaseManifestError);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects a manifest package that differs from the installed package", async () => {
+		stubManifest({
+			...baseManifest,
+			package: "@attacker/anything",
+			tarball: "releases/v99.0.0/attacker-anything-99.0.0.tgz",
+		});
+		await expect(getLatestPiRelease("0.9.4", options)).rejects.toThrow(
+			/names package "@attacker\/anything", but this installation is "prime-agent"/,
+		);
+	});
+
+	it("accepts an allowlisted package rename", async () => {
+		stubManifest({
+			...baseManifest,
+			package: "prime-agent-next",
+			tarball: "releases/v99.0.0/prime-agent-next-99.0.0.tgz",
+		});
+		const release = await getLatestPiRelease("0.9.4", { ...options, allowedPackageNames: ["prime-agent-next"] });
+		expect(release?.packageName).toBe("prime-agent-next");
+		expect(release?.tarball?.fileName).toBe("prime-agent-next-99.0.0.tgz");
+	});
+
+	it("rejects a tarball whose file name does not carry the manifest version", async () => {
+		stubManifest({ ...baseManifest, tarball: "releases/v1.0.0/prime-agent-1.0.0.tgz" });
+		await expect(getLatestPiRelease("0.9.4", options)).rejects.toThrow(
+			/"prime-agent-1\.0\.0\.tgz" does not match release version 99\.0\.0 \(expected prime-agent-99\.0\.0\.tgz\)/,
+		);
+	});
+
+	it("rejects a tarball named after another package", async () => {
+		stubManifest({ ...baseManifest, tarball: "releases/v99.0.0/other-99.0.0.tgz" });
+		await expect(getLatestPiRelease("0.9.4", options)).rejects.toThrow(/expected prime-agent-99\.0\.0\.tgz/);
+	});
+
+	it("rejects a manifest without a digest for the tarball", async () => {
+		stubManifest({
+			...baseManifest,
+			sha256: undefined,
+			tarballs: [{ file: "prime-agent-ai-99.0.0.tgz", sha256: digest }],
+		});
+		await expect(getLatestPiRelease("0.9.4", options)).rejects.toThrow(
+			/no SHA-256 digest for prime-agent-99\.0\.0\.tgz/,
+		);
+	});
+
+	it("rejects a malformed digest", async () => {
+		stubManifest({ ...baseManifest, sha256: "sha512-AAAA" });
+		await expect(getLatestPiRelease("0.9.4", options)).rejects.toThrow(/digest .* is malformed/);
+	});
+
+	it("rejects a manifest whose version is not a package version", async () => {
+		stubManifest({ ...baseManifest, version: "latest" });
+		await expect(getLatestPiRelease("0.9.4", options)).rejects.toThrow(/not a valid package version/);
+	});
+
+	it("keeps the startup version notice quiet when the manifest fails validation", async () => {
+		stubManifest({ ...baseManifest, tarball: "https://attacker.invalid/prime-agent-99.0.0.tgz" });
+		await expect(checkForNewPiVersion("0.9.4")).resolves.toBeUndefined();
+	});
+
+	it("still reports a newer version from a manifest without a tarball", async () => {
+		stubManifest({ version: "v99.0.0" });
+		await expect(getLatestPiRelease("0.9.4", options)).resolves.toEqual({ version: "99.0.0" });
+	});
+
+	it("fetches the manifest for an explicit update even when startup checks are disabled", async () => {
+		process.env.PI_SKIP_VERSION_CHECK = "1";
+		stubManifest(baseManifest);
+		await expect(getLatestPiRelease("0.9.4", options)).resolves.toBeUndefined();
+		await expect(getLatestPiRelease("0.9.4", { ...options, explicit: true })).resolves.toMatchObject({
+			version: "99.0.0",
+		});
 	});
 });

--- a/scripts/pack-prime-agent-release.mjs
+++ b/scripts/pack-prime-agent-release.mjs
@@ -325,10 +325,17 @@ function main() {
 	);
 	writeFileSync(join(artifactsDir, args.channel), `v${releaseVersion}\n`);
 	const manifestName = args.channel === "stable" ? "latest.json" : "beta.json";
+	const cliTarballFile = artifactFiles.get("coding-agent");
+	const cliTarball = tarballs.find((tarball) => tarball.file === cliTarballFile);
+	if (!cliTarball) {
+		throw new Error(`Missing release tarball entry for ${cliTarballFile}`);
+	}
+	// The self-updater verifies the downloaded tarball against this digest before installing it.
 	writeJson(join(artifactsDir, manifestName), {
 		version: `v${releaseVersion}`,
 		package: publicPackageName,
-		tarball: `releases/v${releaseVersion}/${artifactFiles.get("coding-agent")}`,
+		tarball: `releases/v${releaseVersion}/${cliTarballFile}`,
+		sha256: cliTarball.sha256,
 		tarballs: tarballs.map((tarball) => ({
 			package: tarball.name,
 			file: tarball.file,


### PR DESCRIPTION
Linear: ENG-5341 — https://linear.app/primeintellect/issue/ENG-5341

## Context

`prime-agent update` fetched `latest.json`/`beta.json` and passed whatever `tarball` it named straight to `npm install -g <spec>` (pnpm/yarn/bun variants too). Nothing checked the tarball origin or scheme (`https://attacker.invalid/…`, `http://…`, `file:///…` were all accepted), the manifest `sha256` digests were ignored, a `package` differing from the installed one was accepted (and the installed package uninstalled), and a version/filename mismatch went through. When the manifest was unreachable or had no tarball it fell back to `npm install -g <package name>` from the npm registry, where `prime-agent` is not published. `install.sh` already verifies against `SHA256SUMS` and was left untouched.

Root cause: `getLatestPiRelease` (`src/utils/version-check.ts`) returned an unvalidated `installSpec`, and `getSelfUpdatePlan` (`src/package-manager-cli.ts`) handed it to `getSelfUpdateCommand`, whose `isDirectPackageArtifactSpec` treats any http/https/file spec as an installable artifact.

## Changes

- `src/utils/version-check.ts`: the manifest is now validated. Base URL must be https (`http://` only with the documented `PRIME_AGENT_ALLOW_INSECURE_DOWNLOAD_BASE_URL=1`; `file:` never). The tarball must be same-origin with the release base, be named `<package>-<version>.tgz` for the installed package (or an allowlisted rename), and carry a SHA-256 digest (top-level `sha256` or a matching `tarballs[]` entry). `package` must equal the installed name. Failures throw `ReleaseManifestError`; the startup notice swallows it and stays quiet.
- `src/utils/self-update-artifact.ts` (new): downloads the tarball to a fresh temp dir with `redirect: "error"`, hashes it while streaming, discards it on mismatch, and returns the local path plus a cleanup handle.
- `src/package-manager-cli.ts`: the plan requires a verified tarball; the package manager is invoked with the verified local path, never a URL; the registry-name fallback is removed; every rejection is reported as `Error: …` with exit code 1 before any package manager call. `update` is an explicit request, so it now fetches the manifest even under `PI_SKIP_VERSION_CHECK`/`PI_OFFLINE` (it already hit the network via npm before).
- `scripts/pack-prime-agent-release.mjs`: emits a top-level `sha256` for the CLI tarball (the `tarballs[].sha256` entries it already wrote are also accepted, so current published manifests verify as-is).
- Docs (`docs/settings.md`, `docs/usage.md`, `README.md`) describe the new manifest requirements and the insecure-mirror override; changelog fragment added.

Model-facing surface (tool names, system prompt, kernel API) is untouched.

## Validation

Local: `npm run check` passes (biome, tsgo, check-installer, browser smoke). Focused tests from `packages/coding-agent`:

```
npx tsx ../../node_modules/vitest/dist/cli.js --run test/version-check.test.ts test/self-update-artifact.test.ts \
  test/package-self-update-daemon.test.ts test/interactive-update-relaunch.test.ts test/config.test.ts
# 5 files, 100 tests passed
```

New coverage: `version-check.test.ts` (accept + each rejection: foreign origin, http/file tarball, http base without/with override, file base, package mismatch, rename allowlist, version/filename mismatch, missing/malformed digest, bad version, startup notice quiet, explicit bypass), `self-update-artifact.test.ts` (verified download, digest mismatch discard, HTTP error, network error, cleanup), `package-self-update-daemon.test.ts` (installs the local verified path, and six rejection cases plus unreachable manifest assert no `spawn:` before exit 1).

Prime Sandbox (`node:24-bookworm`, user `tester`, fresh HOME, local `http://127.0.0.1:18555` mirror, fake global `npm` that records invocations; both trees run through `handlePackageCommand(["update","--self"])` via tsx):

| case | main @ 427ea4c72 | this branch |
|---|---|---|
| valid manifest + tarball | `npm install -g http://127.0.0.1:18555/…/earendil-works-pi-coding-agent-99.0.0.tgz` | `npm install -g /tmp/prime-agent-update-XXXX/earendil-works-pi-coding-agent-99.0.0.tgz`, fake npm hashed the file to the manifest digest, temp dir removed |
| tampered tarball bytes | npm invoked with the URL, "Updated" | `Error: SHA-256 mismatch … The download was discarded.` exit 1, npm not invoked |
| `https://attacker.invalid/pkg-99.0.0.tgz` | `npm install -g https://attacker.invalid/pkg-99.0.0.tgz` | `Error: … not on the release origin` exit 1, no download, npm not invoked |
| `file:///tmp/evil-99.0.0.tgz` | `npm install -g file:///tmp/evil-99.0.0.tgz` | rejected, exit 1 |
| `package: "@attacker/anything"` | `npm install -g <url> && npm uninstall -g @earendil-works/pi-coding-agent` | `Error: … names package "@attacker/anything", but this installation is …` exit 1 |
| tarball version 1.0.0 vs manifest 99.0.0 | n/a | rejected (expected `…-99.0.0.tgz`) |
| no digest / no tarball | n/a | rejected, npm not invoked |
| http base without override | accepted | `Error: Release downloads require an https base URL …` exit 1, no fetch |

Existing tests in the sandbox: 100/100 on this branch; main baseline 71/71 for the same four pre-existing files. Sandbox deleted afterwards.

Not validated: a real `npm install -g <local tarball>` against the R2 bucket (fake npm only), and pnpm/yarn/bun accepting an absolute local `.tgz` path (npm does; yarn v1 may prefer a `file:` prefix — worth a check before release). Internal dependency tarballs referenced by URL from the release `package.json` are still fetched by npm itself, as with `install.sh`; verifying those would need the manifest's other `tarballs[]` digests and a rewritten package.json — follow-up.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Verify self-update tarball origin and digest before installing
> - Replaces the registry-install-spec self-update flow with one that downloads the manifest tarball to a temporary directory and SHA-256-verifies it before invoking the package manager with a local path
> - Adds strict manifest validation in `parseReleaseManifest` and `getLatestPiRelease`: package names must match the installed package, tarball URLs must be same-origin HTTPS, filenames must match package and version, and digests must be valid 64-char hex SHA-256
> - Removes the npm-registry fallback; explicit update requests now fail when the manifest is unreachable, names an unacceptable package, or lacks a verifiable tarball
> - Adds an opt-in environment variable to allow an HTTP release mirror; `getPrimeAgentDownloadBaseUrl` otherwise requires HTTPS and rejects `file:` URLs
> - Release pack script now emits the coding-agent tarball digest at the top level of the manifest
> - Behavioral Change: `getSelfUpdatePlan` no longer returns a registry install spec or falls back on manifest failure; out-of-tree consumers of the old plan shape will break. `resolveTarballUrl` and `findManifestDigest` reject foreign-origin or digest-less tarballs that were previously accepted
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c1ac22.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->