### PR TITLE
fix(tui): sanitize untrusted terminal text and allowlist hyperlink targets

### DIFF
--- a/packages/coding-agent/.changes/eng-5344-terminal-output-sanitize.md
+++ b/packages/coding-agent/.changes/eng-5344-terminal-output-sanitize.md
@@ -1,0 +1,1 @@
+- Fixed assistant text, thinking, tool output and link targets being able to send terminal control sequences (clipboard writes, screen clears, title changes) to the terminal ([ENG-5344](https://linear.app/primeintellect/issue/ENG-5344)).

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
-import { Container, Text, truncateToWidth } from "@earendil-works/pi-tui";
+import { Container, sanitizeTerminalText, Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { type Static, Type } from "typebox";
 import { expandCollapseHint } from "../../modes/interactive/components/keybinding-hints.js";
 import { truncateToVisualLines } from "../../modes/interactive/components/visual-truncate.js";
@@ -175,7 +175,8 @@ function formatDuration(ms: number): string {
 }
 
 function formatBashCall(args: { command?: string; timeout?: number } | undefined): string {
-	const command = str(args?.command);
+	const rawCommand = str(args?.command);
+	const command = rawCommand === null ? null : sanitizeTerminalText(rawCommand);
 	const timeout = args?.timeout as number | undefined;
 	const timeoutSuffix = timeout ? theme.fg("muted", ` (timeout ${timeout}s)`) : "";
 	let commandDisplay: string;

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -1,5 +1,13 @@
 import type { AgentTool } from "@earendil-works/pi-agent-core";
-import { Box, type Component, Container, Spacer, Text, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import {
+	Box,
+	type Component,
+	Container,
+	Spacer,
+	sanitizeTerminalText,
+	Text,
+	wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
 import { constants } from "fs";
 import { access as fsAccess, readFile as fsReadFile, writeFile as fsWriteFile } from "fs/promises";
 import { type Static, Type } from "typebox";
@@ -201,7 +209,7 @@ function formatEditCall(
 ): string {
 	const invalidArg = invalidArgText(theme);
 	const rawPath = str(args?.file_path ?? args?.path);
-	const path = rawPath !== null ? shortenPath(rawPath) : null;
+	const path = rawPath !== null ? sanitizeTerminalText(shortenPath(rawPath)) : null;
 	const pathDisplay = path === null ? invalidArg : path ? theme.fg("accent", path) : theme.fg("toolOutput", "...");
 	return `${theme.fg("toolTitle", theme.bold("edit"))} ${pathDisplay}`;
 }
@@ -224,7 +232,7 @@ function formatEditResult(
 		if (!errorText || errorText === previewError) {
 			return undefined;
 		}
-		return theme.fg("error", errorText);
+		return theme.fg("error", sanitizeTerminalText(errorText));
 	}
 
 	const resultDiff = result.details?.diff;

--- a/packages/coding-agent/src/core/tools/render-utils.ts
+++ b/packages/coding-agent/src/core/tools/render-utils.ts
@@ -1,6 +1,6 @@
 import * as os from "node:os";
 import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
-import { getImageDimensions, imageFallback } from "@earendil-works/pi-tui";
+import { getImageDimensions, imageFallback, sanitizeTerminalText } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { sanitizeBinaryOutput } from "../../utils/shell.js";
 
@@ -38,7 +38,9 @@ export function getTextOutput(
 	const textBlocks = result.content.filter((c) => c.type === "text");
 	const imageBlocks = result.content.filter((c) => c.type === "image");
 
-	let output = textBlocks.map((c) => sanitizeBinaryOutput(stripAnsi(c.text || "")).replace(/\r/g, "")).join("\n");
+	let output = textBlocks
+		.map((c) => sanitizeTerminalText(sanitizeBinaryOutput(stripAnsi(c.text || "")).replace(/\r/g, "")))
+		.join("\n");
 
 	const includeImageDimensions = options.includeImageDimensions ?? true;
 	if (imageBlocks.length > 0 && !showImages) {

--- a/packages/coding-agent/src/modes/interactive/components/agent-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/agent-message.ts
@@ -3,6 +3,7 @@ import {
 	Container,
 	type MarkdownTheme,
 	Spacer,
+	sanitizeTerminalText,
 	Text,
 	truncateToWidth,
 	visibleWidth,
@@ -13,7 +14,7 @@ import { getMarkdownTheme, theme } from "../theme/theme.js";
 import { expandCollapseHint } from "./keybinding-hints.js";
 
 function collapseText(text: string): string {
-	return text.replace(/\s+/g, " ").trim();
+	return sanitizeTerminalText(text).replace(/\s+/g, " ").trim();
 }
 
 /** `◆ <label> · <participant>[ · <preview>]` summary line shared by received and sent agent-message UI. */
@@ -34,10 +35,12 @@ export function agentMessagePreview(prefixWidth: number, message: string): strin
 export function agentMessageBodyLines(message: string, width: number): string[] {
 	const safeWidth = Math.max(1, width);
 	const textWidth = Math.max(1, safeWidth - 4);
-	const bodyLines = message.split("\n").flatMap((line) => {
-		const wrapped = wrapTextWithAnsi(line, textWidth);
-		return wrapped.length > 0 ? wrapped : [""];
-	});
+	const bodyLines = sanitizeTerminalText(message)
+		.split("\n")
+		.flatMap((line) => {
+			const wrapped = wrapTextWithAnsi(line, textWidth);
+			return wrapped.length > 0 ? wrapped : [""];
+		});
 	return bodyLines.map((line, index) => {
 		const prefix = index === 0 ? theme.fg("dim", "╰─ ") : "   ";
 		return truncateToWidth(` ${prefix}${theme.fg("customMessageText", line)}`, safeWidth, "");

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -7,6 +7,7 @@ import {
 	Markdown,
 	type MarkdownTheme,
 	Spacer,
+	sanitizeTerminalText,
 	Text,
 	truncateToWidth,
 	visibleWidth,
@@ -79,7 +80,7 @@ class CollapsedThinkingRow implements Component {
  * non-empty line, stripped of markdown emphasis and truncated.
  */
 export function thinkingRecap(thinking: string, fallback: string, maxWidth = 120): string {
-	const lines = thinking
+	const lines = sanitizeTerminalText(thinking)
 		.split("\n")
 		.map((line) => line.trim())
 		.filter((line) => line.length > 0);
@@ -365,7 +366,8 @@ export class AssistantMessageComponent extends Container {
 		}
 	}
 
-	private createErrorComponent(message: string, prefix?: string): Component {
+	private createErrorComponent(rawMessage: string, prefix?: string): Component {
+		const message = sanitizeTerminalText(rawMessage);
 		const inlineLoginRecovery = formatInlineLoginRecoveryMessage(message);
 		if (inlineLoginRecovery) {
 			const text = prefix ? `${prefix}: ${inlineLoginRecovery}` : inlineLoginRecovery;

--- a/packages/coding-agent/src/modes/interactive/components/bash-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/bash-execution.ts
@@ -1,4 +1,4 @@
-import { Container, Loader, Spacer, Text, type TUI } from "@earendil-works/pi-tui";
+import { Container, Loader, Spacer, sanitizeTerminalText, Text, type TUI } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import {
 	DEFAULT_MAX_BYTES,
@@ -70,7 +70,7 @@ export class BashExecutionComponent extends Container {
 
 	appendOutput(chunk: string): void {
 		// Note: binary data is already sanitized in tui-renderer.ts executeBashCommand
-		const clean = stripAnsi(chunk).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+		const clean = sanitizeTerminalText(stripAnsi(chunk).replace(/\r\n/g, "\n").replace(/\r/g, "\n"));
 
 		const newLines = clean.split("\n");
 		if (this.outputLines.length > 0 && newLines.length > 0) {

--- a/packages/coding-agent/src/modes/interactive/components/collapsible-error.ts
+++ b/packages/coding-agent/src/modes/interactive/components/collapsible-error.ts
@@ -1,4 +1,10 @@
-import { type Component, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import {
+	type Component,
+	sanitizeTerminalText,
+	truncateToWidth,
+	visibleWidth,
+	wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { theme } from "../theme/theme.js";
 import { expandCollapseHint } from "./keybinding-hints.js";
@@ -12,7 +18,7 @@ export interface CollapsibleErrorOptions {
 }
 
 export function normalizeErrorDetails(text: string): string {
-	return stripAnsi(text).replace(/\r\n/g, "\n").replace(/\r/g, "\n").trimEnd();
+	return sanitizeTerminalText(stripAnsi(text).replace(/\r\n/g, "\n").replace(/\r/g, "\n")).trimEnd();
 }
 
 interface ErrorDetailLine {

--- a/packages/coding-agent/src/modes/interactive/components/diff.ts
+++ b/packages/coding-agent/src/modes/interactive/components/diff.ts
@@ -1,4 +1,4 @@
-import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { sanitizeTerminalText, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import * as Diff from "diff";
 import { highlightCode, theme } from "../theme/theme.js";
 
@@ -78,7 +78,7 @@ export interface RenderDiffOptions {
  * - Added lines: green, with inverse on changed tokens
  */
 export function renderDiff(diffText: string, _options: RenderDiffOptions = {}): string {
-	const lines = diffText.split("\n");
+	const lines = sanitizeTerminalText(diffText).split("\n");
 	const result: string[] = [];
 
 	let i = 0;
@@ -233,7 +233,7 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 	const useBlocks = theme.colorMode === "truecolor";
 	const rows: string[] = [];
 
-	for (const rawLine of diffText.split("\n")) {
+	for (const rawLine of sanitizeTerminalText(diffText).split("\n")) {
 		const parsed = parseDiffLine(rawLine);
 		if (!parsed) {
 			rows.push(

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -1,5 +1,6 @@
 import {
 	type Component,
+	sanitizeTerminalText,
 	truncateToWidth,
 	VersionedRenderCache,
 	visibleWidth,
@@ -132,7 +133,7 @@ export function getIpythonCodeFromArgs(args: unknown): string {
 		return "";
 	}
 	const code = (args as { code?: unknown }).code;
-	return typeof code === "string" ? code : "";
+	return typeof code === "string" ? sanitizeTerminalText(code) : "";
 }
 
 function readDetails(details: unknown): IpythonDetails {
@@ -211,7 +212,7 @@ function readDiffDisplays(value: unknown): DiffDisplay[] | undefined {
 		}
 		return [
 			{
-				path: record.path,
+				path: sanitizeTerminalText(record.path),
 				oldStr: record.oldStr,
 				newStr: record.newStr,
 				startLine: typeof record.startLine === "number" ? record.startLine : undefined,
@@ -268,10 +269,12 @@ function readErrorDetails(value: unknown): IpythonErrorDetails | undefined {
 		return undefined;
 	}
 	return {
-		ename: record.ename,
+		ename: sanitizeTerminalText(record.ename),
 		evalue: typeof record.evalue === "string" ? record.evalue : "",
 		traceback: Array.isArray(record.traceback)
-			? record.traceback.filter((line): line is string => typeof line === "string")
+			? record.traceback
+					.filter((line): line is string => typeof line === "string")
+					.map((line) => normalizeErrorDetails(line))
 			: [],
 	};
 }
@@ -333,17 +336,23 @@ function formatIpythonErrorSummary(error: IpythonErrorDetails): string {
 	return visibleWidth(value) <= 48 ? `${error.ename}: ${value}` : error.ename;
 }
 
+// Model-written code is untrusted; sanitize once per state update, not per render.
+function sanitizeState(state: IPythonCellState): IPythonCellState {
+	const code = sanitizeTerminalText(state.code);
+	return code === state.code ? state : { ...state, code };
+}
+
 export class IPythonCellComponent implements Component {
 	private readonly renderCache = new VersionedRenderCache();
 	private state: IPythonCellState;
 	private stateVersion = 0;
 
 	constructor(state: IPythonCellState) {
-		this.state = state;
+		this.state = sanitizeState(state);
 	}
 
 	update(state: IPythonCellState): void {
-		this.state = state;
+		this.state = sanitizeState(state);
 		this.stateVersion += 1;
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -1,5 +1,5 @@
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
-import { type Component, Container, Image, Text, type TUI } from "@earendil-works/pi-tui";
+import { type Component, Container, Image, sanitizeTerminalText, Text, type TUI } from "@earendil-works/pi-tui";
 import type { ToolDefinition, ToolRenderContext, ToolRenderResultOptions } from "../../../core/extensions/types.js";
 import type { KernelSentAgentMessage } from "../../../core/kernel/index.js";
 import { createBashToolDefinition } from "../../../core/tools/bash.js";
@@ -507,7 +507,8 @@ export class ToolExecutionComponent extends Container {
 
 	private formatToolExecution(): string {
 		const parts: string[] = [];
-		const content = JSON.stringify(this.args, null, 2);
+		// JSON.stringify escapes C0 controls but leaves DEL and C1 controls intact.
+		const content = sanitizeTerminalText(JSON.stringify(this.args, null, 2) ?? "");
 		if (content) {
 			parts.push(content);
 		}

--- a/packages/coding-agent/test/suite/regressions/2108-assistant-message-links.test.ts
+++ b/packages/coding-agent/test/suite/regressions/2108-assistant-message-links.test.ts
@@ -41,7 +41,6 @@ describe("assistant Markdown file links", () => {
 
 	test.each([
 		["audit-out/report.md", reportUrl],
-		["#overview", "#overview"],
 		["./audit-out/report.md", reportUrl],
 		["../report.md", pathToFileURL(resolve(cwd, "../report.md")).href],
 		["/tmp/report.md", pathToFileURL("/tmp/report.md").href],
@@ -49,7 +48,6 @@ describe("assistant Markdown file links", () => {
 		["audit-out/my%20report.md", pathToFileURL(resolve(cwd, "audit-out/my report.md")).href],
 		["audit-out/report%23draft%25.md", pathToFileURL(resolve(cwd, "audit-out/report#draft%.md")).href],
 		["audit-out/report.md#findings", `${reportUrl}#findings`],
-		["file:///tmp/report.md", "file:///tmp/report.md"],
 		["C:/repo/report.md", "file:///C:/repo/report.md"],
 		[String.raw`C:\repo\report.md`, "file:///C:/repo/report.md"],
 		["<D:/repo/my report.md>", "file:///D:/repo/my%20report.md"],
@@ -57,7 +55,6 @@ describe("assistant Markdown file links", () => {
 		["https://example.com/report?q=1#findings", "https://example.com/report?q=1#findings"],
 		["http://example.com/report", "http://example.com/report"],
 		["mailto:reader@example.com", "mailto:reader@example.com"],
-		["https://[invalid", "https://[invalid"],
 	])("resolves %s without changing the label", (href, expected) => {
 		const component = new AssistantMessageComponent(
 			{ ...message, content: [{ type: "text", text: `[Audit report](${href})` }] },
@@ -70,6 +67,25 @@ describe("assistant Markdown file links", () => {
 		expect(linkTargets(lines)).toEqual([expected]);
 		expect(stripAnsi(lines.join("\n")).trim()).toBe("Audit report");
 	});
+
+	// ENG-5344: OSC 8 targets are allowlisted (http, https, mailto, and file only
+	// when resolved from a local path via the session cwd). Anything else renders
+	// like a terminal without hyperlink support.
+	test.each(["#overview", "file:///tmp/report.md", "https://[invalid", "javascript:alert(1)"])(
+		"shows %s as text instead of an OSC 8 target",
+		(href) => {
+			const component = new AssistantMessageComponent(
+				{ ...message, content: [{ type: "text", text: `[Audit report](${href})` }] },
+				false,
+				undefined,
+				undefined,
+				{ cwd },
+			);
+			const lines = component.render(80);
+			expect(linkTargets(lines)).toEqual([]);
+			expect(stripAnsi(lines.join("\n")).trim()).toBe(`Audit report (${href})`);
+		},
+	);
 
 	test.each(["addMessageToChat", "startAssistantStreamingMessage"] as const)(
 		"%s uses the attached session cwd and produces an openable target",

--- a/packages/coding-agent/test/suite/regressions/eng-5344-terminal-output-sanitize.test.ts
+++ b/packages/coding-agent/test/suite/regressions/eng-5344-terminal-output-sanitize.test.ts
@@ -74,9 +74,13 @@ describe("ENG-5344 terminal output sanitization", () => {
 		expect(text?.type === "text" && text.text.includes(OSC52)).toBe(true);
 	});
 
-	test("assistant text keeps bold SGR and zone markers but no foreign sequences", () => {
+	test("assistant text keeps theme SGR and zone markers but no foreign sequences", () => {
 		const output = renderAssistant(message.content);
-		expect(output).toContain(`${ESC}[1m`);
+		// Positive control: renderer-owned styling survives. Theme colors are used
+		// rather than chalk bold, which is disabled under TERM=dumb in CI sandboxes.
+		expect(output).toMatch(/\x1b\[38;[25];/);
+		expect(stripAnsi(output)).toMatch(/\bbold\b/);
+		expect(stripAnsi(output)).not.toContain("**bold**");
 		expect(output).toContain(OSC133_ZONE_START);
 		expect(output).not.toContain(`${ESC}]52;`);
 		expect(output).not.toContain(`${ESC}[2J`);

--- a/packages/coding-agent/test/suite/regressions/eng-5344-terminal-output-sanitize.test.ts
+++ b/packages/coding-agent/test/suite/regressions/eng-5344-terminal-output-sanitize.test.ts
@@ -1,0 +1,179 @@
+// ENG-5344: assistant text, thinking and tool output must not carry terminal
+// control sequences or unsafe OSC 8 targets into rendered lines.
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { type AssistantMessage, fauxAssistantMessage, fauxText, fauxThinking } from "@earendil-works/pi-ai";
+import { getCapabilities, setCapabilities, setKeybindings } from "@earendil-works/pi-tui";
+import stripAnsi from "strip-ansi";
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import { KeybindingsManager } from "../../../src/core/keybindings.js";
+import { AssistantMessageComponent } from "../../../src/modes/interactive/components/assistant-message.js";
+import { IPythonCellComponent } from "../../../src/modes/interactive/components/ipython-cell.js";
+import { initTheme } from "../../../src/modes/interactive/theme/theme.js";
+import { createHarness } from "../harness.js";
+
+const ESC = "\x1b";
+const BEL = "\x07";
+const OSC52 = `${ESC}]52;c;U0VOVElORUw=${BEL}`;
+const CSI_CLEAR = `${ESC}[2J${ESC}[H${ESC}[3J`;
+const OSC_TITLE = `${ESC}]0;evil-title${BEL}`;
+const KITTY_APC = `${ESC}_Ga=q,i=1${ESC}\\`;
+const C1 = "\x9b2J\x90q\x9c";
+const OSC133_ZONE_START = `${ESC}]133;A${BEL}`;
+
+const cwd = resolve("/tmp/eng-5344/project");
+let message: AssistantMessage;
+
+/** Everything except renderer-owned SGR, OSC 8 links and OSC 133 zone markers. */
+function foreignSequences(output: string): string[] {
+	const stripped = output
+		.replace(/\x1b\[[0-9;]*m/g, "")
+		.replace(/\x1b\]8;;[^\x1b\x07]*(?:\x1b\\|\x07)/g, "")
+		.replace(/\x1b\]133;[ABC]\x07/g, "");
+	return [...stripped.matchAll(/[\x00-\x08\x0b-\x1f\x7f-\x9f]/g)].map((match) => JSON.stringify(match[0]));
+}
+
+function linkTargets(output: string): string[] {
+	return [...output.matchAll(/\x1b\]8;;([^\x1b\x07]+)(?:\x1b\\|\x07)/g)].map((match) => match[1]);
+}
+
+function renderAssistant(content: AssistantMessage["content"], hideThinking = false): string {
+	const component = new AssistantMessageComponent({ ...message, content }, hideThinking, undefined, undefined, {
+		cwd,
+	});
+	return component.render(80).join("\n");
+}
+
+describe("ENG-5344 terminal output sanitization", () => {
+	const capabilities = getCapabilities();
+
+	beforeAll(async () => {
+		initTheme("dark");
+		setKeybindings(new KeybindingsManager());
+		const harness = await createHarness();
+		try {
+			harness.setResponses([
+				fauxAssistantMessage([
+					fauxThinking(`I will ${OSC_TITLE} proceed\n\n**Plan**: ${OSC52} done`),
+					fauxText(`Result: ${OSC52}${CSI_CLEAR} done, see [the report](file:///etc/passwd) and **bold**`),
+				]),
+			]);
+			await harness.session.prompt("Summarize.");
+			const response = harness.session.messages.find((entry) => entry.role === "assistant");
+			if (!response || response.role !== "assistant") throw new Error("Missing faux assistant response");
+			message = response;
+		} finally {
+			harness.cleanup();
+		}
+	});
+	beforeEach(() => setCapabilities({ images: null, trueColor: true, hyperlinks: true }));
+	afterEach(() => setCapabilities(capabilities));
+
+	test("the faux transcript carries the raw payload into the assistant message", () => {
+		const text = message.content.find((block) => block.type === "text");
+		expect(text?.type === "text" && text.text.includes(OSC52)).toBe(true);
+	});
+
+	test("assistant text keeps bold SGR and zone markers but no foreign sequences", () => {
+		const output = renderAssistant(message.content);
+		expect(output).toContain(`${ESC}[1m`);
+		expect(output).toContain(OSC133_ZONE_START);
+		expect(output).not.toContain(`${ESC}]52;`);
+		expect(output).not.toContain(`${ESC}[2J`);
+		expect(foreignSequences(output)).toEqual([]);
+		expect(stripAnsi(output)).toContain("Result: ␛]52;c;U0VOVElORUw=␛[2J␛[H␛[3J done");
+	});
+
+	test("expanded thinking and the collapsed recap are sanitized", () => {
+		const expanded = renderAssistant(message.content, false);
+		expect(expanded).not.toContain(`${ESC}]0;`);
+		expect(foreignSequences(expanded)).toEqual([]);
+
+		const collapsed = renderAssistant(message.content, true);
+		expect(collapsed).not.toContain(`${ESC}]52;`);
+		expect(foreignSequences(collapsed)).toEqual([]);
+		expect(stripAnsi(collapsed)).toContain("I will ␛]0;evil-title proceed");
+	});
+
+	test("fenced code blocks, headings and C1 controls are sanitized", () => {
+		const output = renderAssistant([
+			{ type: "text", text: `# Title ${C1}\n\n\`\`\`sh\necho ${OSC_TITLE} ${KITTY_APC}\n\`\`\`` },
+		]);
+		expect(output).not.toContain("\x9b");
+		expect(output).not.toContain(`${ESC}_G`);
+		expect(foreignSequences(output)).toEqual([]);
+	});
+
+	test("link targets follow the scheme allowlist and fall back to text", () => {
+		const output = renderAssistant([
+			{
+				type: "text",
+				text: [
+					"[docs](https://good.example/path)",
+					"[run](javascript:alert(1))",
+					"[passwd](file:///etc/passwd)",
+					"[report](audit-out/report.md)",
+					"[share](//attacker.example/share)",
+					`[inject](https://good.example/${ESC}\\${OSC52})`,
+				].join(" "),
+			},
+		]);
+		expect(linkTargets(output)).toEqual([
+			"https://good.example/path",
+			pathToFileURL(resolve(cwd, "audit-out/report.md")).href,
+			"https://good.example/%E2%90%9B%E2%90%9B]52;c;U0VOVElORUw=",
+		]);
+		expect(output).not.toContain(`${ESC}]52;`);
+		expect(foreignSequences(output)).toEqual([]);
+		const plain = stripAnsi(output).replace(/\s+/g, " ");
+		expect(plain).toContain("run (javascript:alert(1))");
+		expect(plain).toContain("passwd (file:///etc/passwd)");
+		expect(plain).toContain("share (//attacker.example/share)");
+	});
+
+	test("assistant error text is sanitized", () => {
+		const failed = new AssistantMessageComponent({
+			...message,
+			content: [],
+			stopReason: "error",
+			errorMessage: `Provider failed ${OSC52}${C1}`,
+		});
+		const lines = failed.render(80).join("\n");
+		expect(lines).not.toContain(`${ESC}]52;`);
+		expect(foreignSequences(lines)).toEqual([]);
+		expect(stripAnsi(lines)).toContain("Provider failed ␛]52;c;U0VOVElORUw=2Jq");
+	});
+
+	test("ipython cell code, output and tracebacks are sanitized", () => {
+		const component = new IPythonCellComponent({
+			code: `print("hi") ${OSC52}\n!echo ${CSI_CLEAR}`,
+			content: [{ type: "text", text: `out ${OSC_TITLE}` }],
+			details: {
+				status: "error",
+				stdout: `stdout ${OSC52}${C1}`,
+				stderr: `stderr ${KITTY_APC}`,
+				result: `result ${CSI_CLEAR}`,
+				error: {
+					ename: `Boom${OSC52}`,
+					evalue: `value ${OSC_TITLE}`,
+					traceback: [`Traceback ${OSC52}`, `  File ${C1}`],
+				},
+				diffs: [{ path: `file${OSC52}.py`, oldStr: `a ${OSC52}`, newStr: `b ${CSI_CLEAR}` }],
+			},
+			isError: true,
+			expanded: true,
+			editDiffsExpanded: true,
+			executionStarted: true,
+			argsComplete: true,
+			showImages: true,
+			cwd,
+		});
+		const output = component.render(100).join("\n");
+		expect(output).not.toContain(`${ESC}]52;`);
+		expect(output).not.toContain(`${ESC}[2J`);
+		expect(output).not.toContain(`${ESC}]0;`);
+		expect(output).not.toContain(`${ESC}_G`);
+		expect(foreignSequences(output)).toEqual([]);
+		expect(stripAnsi(output)).toContain("Boom␛]52;c;U0VOVElORUw=");
+	});
+});

--- a/packages/tui/.changes/eng-5344-terminal-output-sanitize.md
+++ b/packages/tui/.changes/eng-5344-terminal-output-sanitize.md
@@ -1,0 +1,1 @@
+- Fixed Markdown rendering passing terminal control sequences from untrusted text through to the terminal; escape sequences now render as visible `␛` text, and clickable link targets are limited to http, https, mailto and locally resolved file links ([ENG-5344](https://linear.app/primeintellect/issue/ENG-5344)).

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -9,7 +9,7 @@ import {
 } from "../selection-metadata.js";
 import { getCapabilities, hyperlink, isImageLine } from "../terminal-image.js";
 import type { Component } from "../tui.js";
-import { applyBackgroundToLine, stripAnsi, visibleWidth, wrapTextWithAnsi } from "../utils.js";
+import { applyBackgroundToLine, sanitizeTerminalText, stripAnsi, visibleWidth, wrapTextWithAnsi } from "../utils.js";
 
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 
@@ -127,6 +127,33 @@ function pickMarkdownParser(text: string): Marked {
 	return text.includes("$") || text.includes("\\(") || text.includes("\\[") ? mathMarkdownParser : markdownParser;
 }
 
+const EXPLICIT_FILE_SCHEME_REGEX = /^\s*file:/i;
+const HREF_CONTROL_REGEX = /[\x00-\x1f\x7f-\x9f]/;
+const HREF_NON_ASCII_REGEX = /[^\x21-\x7e]/;
+
+/**
+ * Restrict OSC 8 targets to schemes a terminal can hand to the OS safely.
+ * `file:` is accepted only when this renderer produced it from a local path via
+ * `baseUrl` (never from an href the source spelled as `file:`, never with a host).
+ * Returns undefined when the link must fall back to plain-text rendering.
+ */
+function safeHyperlinkTarget(href: string, sourceHref: string, baseUrl: string | undefined): string | undefined {
+	if (HREF_CONTROL_REGEX.test(href) || !URL.canParse(href)) {
+		return undefined;
+	}
+	const url = new URL(href);
+	// OSC 8 payloads stay printable ASCII; the parser percent-encodes anything else.
+	const target = HREF_NON_ASCII_REGEX.test(href) ? url.href : href;
+	if (url.protocol === "http:" || url.protocol === "https:" || url.protocol === "mailto:") {
+		return target;
+	}
+	if (url.protocol === "file:") {
+		const rendererResolved = baseUrl !== undefined && !EXPLICIT_FILE_SCHEME_REGEX.test(sourceHref);
+		return rendererResolved && url.host === "" ? target : undefined;
+	}
+	return undefined;
+}
+
 /**
  * Default text styling for markdown content.
  * Applied to all text unless overridden by markdown formatting.
@@ -204,7 +231,10 @@ export class Markdown implements Component {
 		defaultTextStyle?: DefaultTextStyle,
 		options?: MarkdownOptions,
 	) {
-		this.text = text;
+		// Markdown sources are untrusted (model output, tool text, files), so control
+		// sequences are neutralized once here, before parsing or any transform adds
+		// renderer-owned styling. Per-frame rendering never re-scans.
+		this.text = sanitizeTerminalText(text);
 		this.paddingX = paddingX;
 		this.paddingY = paddingY;
 		this.theme = theme;
@@ -213,7 +243,7 @@ export class Markdown implements Component {
 	}
 
 	setText(text: string): void {
-		this.text = text;
+		this.text = sanitizeTerminalText(text);
 		// Only the whole-result cache is dropped; the per-block cache stays so a
 		// streaming append re-renders just the blocks that actually changed.
 		this.cachedText = undefined;
@@ -612,15 +642,8 @@ export class Markdown implements Component {
 				case "link": {
 					const linkText = this.renderInlineTokens(token.tokens || [], resolvedStyleContext);
 					const styledLink = this.theme.link(this.theme.underline(linkText));
-					if (getCapabilities().hyperlinks) {
-						// A Windows drive letter is a file path, not a URL scheme.
-						const target = token.href.replace(/^([a-z]:[\\/])/i, "file:///$1");
-						const href =
-							!target.startsWith("#") &&
-							(this.options.baseUrl || target !== token.href) &&
-							URL.canParse(target, this.options.baseUrl)
-								? new URL(target, this.options.baseUrl).href
-								: target;
+					const href = getCapabilities().hyperlinks ? this.resolveHyperlinkTarget(token.href) : undefined;
+					if (href !== undefined) {
 						// OSC 8: render as a clickable hyperlink. The URL is not printed inline,
 						// so we always show only the link text regardless of whether it matches href.
 						result += hyperlink(styledLink, href) + stylePrefix;
@@ -666,6 +689,19 @@ export class Markdown implements Component {
 		}
 
 		return result;
+	}
+
+	/** Resolve a link href to an allowlisted OSC 8 target, or undefined to render the URL as text. */
+	private resolveHyperlinkTarget(sourceHref: string): string | undefined {
+		// A Windows drive letter is a file path, not a URL scheme.
+		const target = sourceHref.replace(/^([a-z]:[\\/])/i, "file:///$1");
+		const href =
+			!target.startsWith("#") &&
+			(this.options.baseUrl || target !== sourceHref) &&
+			URL.canParse(target, this.options.baseUrl)
+				? new URL(target, this.options.baseUrl).href
+				: target;
+		return safeHyperlinkTarget(href, sourceHref, this.options.baseUrl);
 	}
 
 	/**

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -133,4 +133,4 @@ export {
 	TUI,
 	type TuiStopOptions,
 } from "./tui.js";
-export { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "./utils.js";
+export { sanitizeTerminalText, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "./utils.js";

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -10,6 +10,7 @@ import {
 	type Rgb,
 	setDefaultTerminalColors,
 } from "./terminal-colors.js";
+import { sanitizeTerminalText } from "./utils.js";
 
 const cjsRequire = createRequire(import.meta.url);
 
@@ -585,8 +586,9 @@ export class ProcessTerminal implements Terminal {
 	}
 
 	setTitle(title: string): void {
-		// OSC 0;title BEL - set terminal window title
-		process.stdout.write(`\x1b]0;${title}\x07`);
+		// OSC 0;title BEL - set terminal window title. Titles derive from session
+		// names, so control bytes must not be able to terminate the OSC early.
+		process.stdout.write(`\x1b]0;${sanitizeTerminalText(title)}\x07`);
 	}
 
 	setProgress(active: boolean): void {

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -929,6 +929,37 @@ export function stripAnsi(str: string): string {
 	return result.join("");
 }
 
+// C0 controls other than \t and \n, DEL, and C1 controls (U+0080–U+009F, which
+// UTF-8 terminals interpret as CSI/OSC/DCS introducers). ESC is included so the
+// whole class can be detected in one pass.
+const UNSAFE_TERMINAL_TEXT_REGEX = /[\x00-\x08\x0b-\x1f\x7f-\x9f]/;
+const VISIBLE_ESCAPE = "␛";
+
+/**
+ * Make untrusted text safe to hand to the terminal.
+ *
+ * Model, tool and file text must never carry control sequences into the
+ * renderer: strips C0 controls (except `\n` and `\t`), DEL and C1 controls, and
+ * replaces ESC with a visible `␛` so any ESC-initiated sequence (CSI, OSC, DCS,
+ * APC, PM, SOS, SS2/SS3, two-byte escapes) degrades to plain text instead of
+ * executing. Renderer-owned styling must be applied after this call.
+ */
+export function sanitizeTerminalText(text: string): string {
+	if (!UNSAFE_TERMINAL_TEXT_REGEX.test(text)) {
+		return text;
+	}
+	let result = "";
+	for (let i = 0; i < text.length; i++) {
+		const code = text.charCodeAt(i);
+		if (code === 0x1b) {
+			result += VISIBLE_ESCAPE;
+		} else if (code < 0x20 ? code === 0x09 || code === 0x0a : code < 0x7f || code > 0x9f) {
+			result += text[i];
+		}
+	}
+	return result;
+}
+
 /**
  * Check if a character is whitespace.
  */

--- a/packages/tui/test/markdown-sanitize.test.ts
+++ b/packages/tui/test/markdown-sanitize.test.ts
@@ -1,0 +1,182 @@
+// ENG-5344: untrusted Markdown must not carry terminal control sequences or
+// unsafe OSC 8 targets into rendered lines.
+import assert from "node:assert";
+import { afterEach, describe, it } from "node:test";
+import { Markdown } from "../src/components/markdown.js";
+import { resetCapabilitiesCache, setCapabilities } from "../src/terminal-image.js";
+import { sanitizeTerminalText, stripAnsi } from "../src/utils.js";
+import { defaultMarkdownTheme } from "./test-themes.js";
+
+const ESC = "\x1b";
+const BEL = "\x07";
+const OSC52 = `${ESC}]52;c;U0VOVElORUw=${BEL}`;
+const CSI_CLEAR = `${ESC}[2J${ESC}[H${ESC}[3J`;
+const OSC_TITLE = `${ESC}]0;evil-title${BEL}`;
+const KITTY_APC = `${ESC}_Ga=q,i=1${ESC}\\`;
+const DCS = `${ESC}Pq${ESC}\\`;
+const C1 = "\x9b2J\x90q\x9c\x9d0;x\x9c";
+
+function render(markdown: string, hyperlinks = false, baseUrl?: string): string {
+	setCapabilities({ images: null, trueColor: true, hyperlinks });
+	return new Markdown(markdown, 0, 0, defaultMarkdownTheme, undefined, { baseUrl }).render(80).join("\n");
+}
+
+/** Every ESC in the output must belong to renderer-owned SGR or OSC 8. */
+function assertOnlyRendererSequences(output: string): void {
+	const remainder = output.replace(/\x1b\[[0-9;]*m/g, "").replace(/\x1b\]8;;[^\x1b\x07]*(?:\x1b\\|\x07)/g, "");
+	assert.strictEqual(remainder.indexOf(ESC), -1, `unexpected escape in ${JSON.stringify(output)}`);
+	assert.ok(!/[\x00-\x08\x0b-\x1f\x7f-\x9f]/.test(remainder), `control byte in ${JSON.stringify(output)}`);
+}
+
+function linkTargets(output: string): string[] {
+	return [...output.matchAll(/\x1b\]8;;([^\x1b\x07]+)(?:\x1b\\|\x07)/g)].map((match) => match[1]);
+}
+
+describe("sanitizeTerminalText", () => {
+	it("returns safe text unchanged", () => {
+		const text = "plain text\twith tabs\nand newlines, ünïcödé and emoji 🎉";
+		assert.strictEqual(sanitizeTerminalText(text), text);
+	});
+
+	it("strips C0 controls except tab and newline, DEL, and C1 controls", () => {
+		assert.strictEqual(
+			sanitizeTerminalText("a\x00b\x07c\x08d\re\x0bf\x0cg\x7fh\x80i\x9bj\x9fk\tl\nm"),
+			"abcdefghijk\tl\nm",
+		);
+	});
+
+	it("makes every escape-initiated sequence visible instead of executable", () => {
+		const sanitized = sanitizeTerminalText(`${OSC52}${CSI_CLEAR}${OSC_TITLE}${KITTY_APC}${DCS}${ESC}N!${ESC}(B`);
+		assert.strictEqual(sanitized.indexOf(ESC), -1);
+		assert.strictEqual(sanitized, "␛]52;c;U0VOVElORUw=␛[2J␛[H␛[3J␛]0;evil-title␛_Ga=q,i=1␛\\␛Pq␛\\␛N!␛(B");
+	});
+});
+
+describe("Markdown control sequence sanitization", () => {
+	afterEach(() => {
+		resetCapabilitiesCache();
+	});
+
+	it("keeps renderer-owned styling as the positive control", () => {
+		const output = render("plain **bold** text");
+		assert.ok(output.includes(`${ESC}[1m`), "bold SGR expected");
+		assertOnlyRendererSequences(output);
+	});
+
+	it("neutralizes OSC 52 clipboard writes in paragraphs", () => {
+		const output = render(`Here is text ${OSC52} after`);
+		assert.ok(!output.includes(`${ESC}]52;`));
+		assert.ok(stripAnsi(output).includes("Here is text ␛]52;c;U0VOVElORUw= after"));
+		assertOnlyRendererSequences(output);
+	});
+
+	it("neutralizes CSI clear-screen and cursor moves", () => {
+		const output = render(`before ${CSI_CLEAR} after`);
+		assert.ok(!output.includes(`${ESC}[2J`) && !output.includes(`${ESC}[H`));
+		assertOnlyRendererSequences(output);
+	});
+
+	it("neutralizes OSC title and kitty APC inside fenced code blocks", () => {
+		const output = render(`\`\`\`\ncode ${OSC_TITLE} and ${KITTY_APC}\n\`\`\``);
+		assert.ok(!output.includes(`${ESC}]0;`) && !output.includes(`${ESC}_G`));
+		assert.ok(stripAnsi(output).includes("code ␛]0;evil-title and ␛_Ga=q,i=1␛\\"));
+		assertOnlyRendererSequences(output);
+	});
+
+	it("neutralizes DCS and C1 controls in headings", () => {
+		const output = render(`# Title ${DCS}${C1}`);
+		assert.ok(!output.includes(`${ESC}P`) && !output.includes("\x9b") && !output.includes("\x90"));
+		assert.ok(stripAnsi(output).includes("Title ␛Pq␛\\2Jq0;x"));
+		assertOnlyRendererSequences(output);
+	});
+
+	it("neutralizes sequences in code spans, table cells, blockquotes, lists and raw html", () => {
+		const output = render(
+			[
+				`inline \`${OSC52}\` code`,
+				"",
+				`| a | b |`,
+				`| - | - |`,
+				`| ${CSI_CLEAR} | ${C1} |`,
+				"",
+				`> quoted ${OSC_TITLE}`,
+				"",
+				`- item ${KITTY_APC}`,
+				"",
+				`<div>${OSC52}</div>`,
+			].join("\n"),
+		);
+		assert.ok(!output.includes(`${ESC}]52;`) && !output.includes(`${ESC}[2J`) && !output.includes(`${ESC}_G`));
+		assertOnlyRendererSequences(output);
+	});
+
+	it("sanitizes text supplied through setText while streaming", () => {
+		setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+		const markdown = new Markdown("streaming", 0, 0, defaultMarkdownTheme);
+		markdown.render(80);
+		markdown.setText(`streaming ${OSC52} more`);
+		const output = markdown.render(80).join("\n");
+		assert.ok(!output.includes(`${ESC}]52;`));
+		assertOnlyRendererSequences(output);
+	});
+});
+
+describe("Markdown hyperlink target allowlist", () => {
+	afterEach(() => {
+		resetCapabilitiesCache();
+	});
+
+	const baseUrl = "file:///home/user/project/";
+
+	it("keeps http, https and mailto targets", () => {
+		assert.deepStrictEqual(linkTargets(render("[docs](https://good.example/path)", true)), [
+			"https://good.example/path",
+		]);
+		assert.deepStrictEqual(linkTargets(render("[docs](http://good.example/)", true)), ["http://good.example/"]);
+		assert.deepStrictEqual(linkTargets(render("[mail](mailto:user@example.com)", true)), ["mailto:user@example.com"]);
+		assert.deepStrictEqual(linkTargets(render("see https://example.com now", true)), ["https://example.com"]);
+	});
+
+	it("resolves relative and absolute paths to file links only through baseUrl", () => {
+		assert.deepStrictEqual(linkTargets(render("[report](docs/report.md)", true, baseUrl)), [
+			"file:///home/user/project/docs/report.md",
+		]);
+		assert.deepStrictEqual(linkTargets(render("[passwd](/etc/passwd)", true, baseUrl)), ["file:///etc/passwd"]);
+		assert.deepStrictEqual(linkTargets(render("[rel](../../etc/passwd)", true)), []);
+		assert.ok(stripAnsi(render("[rel](../../etc/passwd)", true)).includes("rel (../../etc/passwd)"));
+	});
+
+	it("rejects javascript, explicit file, host-bearing file and anchor targets", () => {
+		for (const markdown of [
+			"[click](javascript:alert(1))",
+			"[passwd](file:///etc/passwd)",
+			"[passwd](FILE:///etc/passwd)",
+			"[share](//attacker.example/share/x)",
+			"[anchor](#overview)",
+			"[data](data:text/html,hi)",
+		]) {
+			for (const base of [undefined, baseUrl]) {
+				const output = render(markdown, true, base);
+				assert.deepStrictEqual(linkTargets(output), [], `${markdown} with base ${base}`);
+				assertOnlyRendererSequences(output);
+			}
+		}
+		const fallback = stripAnsi(render("[click](javascript:alert(1))", true));
+		assert.ok(fallback.includes("click (javascript:alert(1))"), "rejected links show the URL as text");
+	});
+
+	it("cannot terminate the OSC 8 early through an injected href", () => {
+		const output = render(`[click](https://good.example/${ESC}\\${ESC}]52;c;QUFB${BEL})`, true);
+		assert.ok(!output.includes(`${ESC}]52;`));
+		const [target] = linkTargets(output);
+		assert.ok(target?.startsWith("https://good.example/"), `unexpected target ${target}`);
+		assert.ok(/^[\x21-\x7e]+$/.test(target), "OSC 8 target must be printable ASCII");
+		assertOnlyRendererSequences(output);
+	});
+
+	it("rejects unparseable targets", () => {
+		const output = render("[bad](https://[invalid)", true);
+		assert.deepStrictEqual(linkTargets(output), []);
+		assert.ok(stripAnsi(output).includes("bad (https://[invalid)"));
+	});
+});


### PR DESCRIPTION
## Context

Linear: ENG-5344 — https://linear.app/primeintellect/issue/ENG-5344

Model and tool text reached the terminal unfiltered. `Markdown` (pi-tui) and `AssistantMessageComponent` passed raw control sequences from assistant text, thinking and code blocks straight into rendered lines: OSC 52 clipboard writes, CSI `2J`/`H`/`3J`, OSC 0 titles, kitty APC, and C1 controls (0x9b CSI, 0x90 DCS). With hyperlinks enabled, Markdown link hrefs became OSC 8 targets verbatim (`javascript:`, explicit `file:`, unresolvable relative paths), and an href containing `ESC \` closed the OSC 8 early so the remainder executed as its own sequence.

Root cause: no sanitization step exists between untrusted text and the renderer; the renderer's ANSI-aware helpers only account for renderer-owned styling.

## Changes

- `packages/tui/src/utils.ts`: new `sanitizeTerminalText()` — strips C0 controls (except `\n`/`\t`), DEL and C1 controls, and replaces ESC with a visible `␛` so every ESC-initiated sequence (CSI, OSC, DCS, APC, PM, SOS, SS2/SS3, two-byte escapes) degrades to plain text. Fast path returns the input untouched when no such byte is present. Exported from `@earendil-works/pi-tui`.
- `Markdown`: sanitizes the source once per `setText()`/construction (not per frame), before the optional transform so renderer-owned styling (mermaid, theme SGR, OSC 8) is unaffected. OSC 8 hrefs are now allowlisted: `http:`, `https:`, `mailto:` always; `file:` only when this instance resolved a local path via `baseUrl` (never from an explicit `file:` href, never with a host). Unparseable or rejected hrefs fall back to the hyperlinks-off rendering (URL shown as text).
- `ProcessTerminal.setTitle()`: sanitizes the title so a session name cannot terminate the OSC 0 early.
- coding-agent boundaries where model/tool text becomes a rendered line: thinking recap, assistant error text, `normalizeErrorDetails`, tool result text output, ipython cell code/traceback/exception name/diff paths, agent-message previews and bodies, bash tool command display, edit tool path/error text, diff renderers, generic tool fallback, `!` bash output.
- Regression tests: `packages/tui/test/markdown-sanitize.test.ts` (node --test) and `packages/coding-agent/test/suite/regressions/eng-5344-terminal-output-sanitize.test.ts` (vitest) cover each sequence class and the href allowlist while asserting renderer-owned styling still renders (bold SGR in the tui test; theme SGR and OSC 133 zone markers in the coding-agent test, since chalk bold is off under `TERM=dumb`). `2108-assistant-message-links.test.ts` updated for the allowlist (`#anchor`, explicit `file:`, unparseable URL now fall back to text).

## Validation

Local (worktree, `npm run check` clean):

- `packages/tui`: `node --test --import tsx test/markdown-sanitize.test.ts test/markdown.test.ts test/markdown-latex.test.ts test/hyperlink-at-column.test.ts test/wrap-ansi.test.ts test/tui-render.test.ts test/terminal.test.ts test/truncated-text.test.ts test/truncate-to-width.test.ts test/visible-content-span.test.ts test/selection-metadata.test.ts` — 206 pass, 0 fail.
- `packages/coding-agent`: vitest over `suite/regressions/eng-5344-terminal-output-sanitize`, `2108-assistant-message-links`, `marquee-components`, `interactive-mode-streaming`, `assistant-message`, `tool-execution-component`, `ipython-cell-*`, `bash-execution-width`, `edit-tool-*`, `code-preview`, `tools`, `interactive-mode-status` and related regressions — 20 files, 462 tests pass.

Prime Sandbox (`node:24-bookworm`, user `tester`, fresh HOME, `TERM=dumb`, `git archive` of both trees, one `HUSKY=0 npm ci`):

- Before (main @ 427ea4c72), original validation fixtures asserting the vulnerable behaviour: tui `eng5344-render` 6/6 pass, coding-agent `eng5344-assistant` 3/3 pass. Recorded: OSC 52, CSI 2J/H/3J, OSC 0, kitty APC and C1 CSI/DCS all `passedThrough: true`; `javascript:`, `file:///etc/passwd`, `../../etc/passwd` emitted as OSC 8 targets; injected `ESC \` href terminated the OSC 8 and emitted the trailing OSC 52 as its own sequence.
- After (branch): the same fixtures now fail exactly where they assert pass-through (tui 5 pass / 1 fail on the link case; coding-agent 3/3 fail). Recorded: every `passedThrough: false`, rendered text shows `␛]52;c;U0VOVElORUw=`; `javascript:`/`file:`/relative fall back to `label (url)` text; the injected href renders as `https://good.example/%E2%90%9B%E2%90%9B]52;c;QUFB` with no embedded ESC/BEL; `https://good.example/path` still an OSC 8 target; OSC 133 zone markers still present.
- Branch test runs in the sandbox: tui 201 pass / 0 fail; coding-agent 10 files, 167 tests pass.
- Sandbox deleted afterwards.

Not validated: terminal-side effects against a live terminal (clipboard actually set, title changed) — the rendering boundary is the finding and is what the tests assert. `ProcessTerminal.setTitle` sanitization has no dedicated test (it writes to `process.stdout`); the shared `sanitizeTerminalText` it uses is unit-tested.

Model-facing surface (tool names, system prompt, kernel recursion API) is unchanged.
