### PR TITLE
prevent foreign updates from stopping daemon sessions

### DIFF
--- a/packages/coding-agent/.changes/validate-daemon-update-owner.md
+++ b/packages/coding-agent/.changes/validate-daemon-update-owner.md
@@ -1,0 +1,1 @@
+- Fixed updates from a different home or agent directory stopping another daemon's sessions before rejecting the restart.

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -590,6 +590,71 @@ export async function isDaemonShutdownAdmissionActive(): Promise<boolean> {
 	return withDaemonSupervisorRegistryGuard(registryDir, () => readActiveShutdownAdmission(registryDir) !== undefined);
 }
 
+function requireMatchingDaemonSupervisorOwner(
+	socketPath: string,
+	hello: DaemonSupervisorHelloIdentity,
+	registryDir: string,
+	legacyRegistryDir: string | undefined,
+): DaemonSupervisorOwnerRecord {
+	const normalizedSocketPath = normalizeSocketPath(socketPath);
+	const owners = listOwnerDirectories(registryDir).flatMap((directory) => {
+		const owner = readOwnerRecordForScope(directory, (scope) => scope.socketPath === normalizedSocketPath);
+		return owner ? [owner] : [];
+	});
+	let matchingOwners = owners.filter((owner) => owner.socketPath === normalizedSocketPath);
+	if (matchingOwners.length === 0 && legacyRegistryDir) {
+		// Stale legacy leftovers are expected; keep only records matching the
+		// identity the caller already holds.
+		matchingOwners = readLegacyOwnersForSocket(legacyRegistryDir, normalizedSocketPath).filter(
+			(owner) => owner.token === hello.supervisorOwnerToken && owner.pid === hello.supervisorPid,
+		);
+	}
+	if (matchingOwners.length === 0) {
+		throw new Error(`Daemon supervisor owner does not match ${socketPath}`);
+	}
+	if (matchingOwners.length > 1) {
+		throw new Error(`Multiple daemon supervisor owners match ${socketPath}`);
+	}
+	const owner = matchingOwners[0];
+	if (!owner) {
+		throw new Error(`Daemon supervisor owner disappeared for ${socketPath}`);
+	}
+	const helloSocketPath = hello.supervisorSocketPath;
+	if (
+		!Number.isInteger(hello.supervisorPid) ||
+		hello.supervisorPid !== owner.pid ||
+		hello.supervisorGeneration !== owner.generation ||
+		hello.supervisorOwnerToken !== owner.token ||
+		typeof helloSocketPath !== "string" ||
+		normalizeSocketPath(helloSocketPath) !== owner.socketPath ||
+		typeof owner.processStartId !== "string" ||
+		hello.supervisorProcessStartId !== owner.processStartId
+	) {
+		throw new Error(`Daemon supervisor hello does not match its durable owner for ${socketPath}`);
+	}
+	const observedProcessStartId = getProcessStartId(owner.pid);
+	if (observedProcessStartId !== owner.processStartId) {
+		throw new Error(`Daemon supervisor process identity changed for ${socketPath}`);
+	}
+	return owner;
+}
+
+export async function assertDaemonUpdateRestartOwner(
+	socketPath: string,
+	hello: DaemonSupervisorHelloIdentity,
+	agentDir: string,
+	registryDir?: string,
+	legacyRegistryDir: string | undefined = registryDir === undefined ? legacyDaemonSupervisorRegistryDir() : undefined,
+): Promise<void> {
+	const effectiveRegistryDir = registryDir ?? defaultDaemonSupervisorRegistryDir();
+	return withDaemonSupervisorRegistryGuard(effectiveRegistryDir, () => {
+		const owner = requireMatchingDaemonSupervisorOwner(socketPath, hello, effectiveRegistryDir, legacyRegistryDir);
+		if (canonicalizeFilesystemPath(owner.agentDir) !== canonicalizeFilesystemPath(agentDir)) {
+			throw new Error(`Daemon supervisor agent directory does not match ${agentDir} for ${socketPath}`);
+		}
+	});
+}
+
 export async function persistDaemonStartupFenceFromOwner(
 	socketPath: string,
 	hello: DaemonSupervisorHelloIdentity,
@@ -601,47 +666,8 @@ export async function persistDaemonStartupFenceFromOwner(
 	const fenceDirectory = resolve(registryDir, "startup-fences");
 	mkdirSync(fenceDirectory, { recursive: true, mode: 0o700 });
 	const path = startupFencePath(fenceDirectory, socketPath);
-	const normalizedSocketPath = normalizeSocketPath(socketPath);
 	return withDaemonSupervisorRegistryGuard(registryDir, () => {
-		const owners = listOwnerDirectories(registryDir).flatMap((directory) => {
-			const owner = readOwnerRecordForScope(directory, (scope) => scope.socketPath === normalizedSocketPath);
-			return owner ? [owner] : [];
-		});
-		let matchingOwners = owners.filter((owner) => owner.socketPath === normalizedSocketPath);
-		if (matchingOwners.length === 0 && legacyRegistryDir) {
-			// Stale legacy leftovers are expected; keep only records matching the
-			// identity the caller already holds.
-			matchingOwners = readLegacyOwnersForSocket(legacyRegistryDir, normalizedSocketPath).filter(
-				(owner) => owner.token === hello.supervisorOwnerToken && owner.pid === hello.supervisorPid,
-			);
-		}
-		if (matchingOwners.length === 0) {
-			throw new Error(`Daemon supervisor owner does not match ${socketPath}`);
-		}
-		if (matchingOwners.length > 1) {
-			throw new Error(`Multiple daemon supervisor owners match ${socketPath}`);
-		}
-		const owner = matchingOwners[0];
-		if (!owner) {
-			throw new Error(`Daemon supervisor owner disappeared for ${socketPath}`);
-		}
-		const helloSocketPath = hello.supervisorSocketPath;
-		if (
-			!Number.isInteger(hello.supervisorPid) ||
-			hello.supervisorPid !== owner.pid ||
-			hello.supervisorGeneration !== owner.generation ||
-			hello.supervisorOwnerToken !== owner.token ||
-			typeof helloSocketPath !== "string" ||
-			normalizeSocketPath(helloSocketPath) !== owner.socketPath ||
-			typeof owner.processStartId !== "string" ||
-			hello.supervisorProcessStartId !== owner.processStartId
-		) {
-			throw new Error(`Daemon supervisor hello does not match its durable owner for ${socketPath}`);
-		}
-		const observedProcessStartId = getProcessStartId(owner.pid);
-		if (observedProcessStartId !== owner.processStartId) {
-			throw new Error(`Daemon supervisor process identity changed for ${socketPath}`);
-		}
+		const owner = requireMatchingDaemonSupervisorOwner(socketPath, hello, registryDir, legacyRegistryDir);
 		const record: DaemonStartupFenceRecord = {
 			version: OWNER_VERSION,
 			token: randomUUID(),

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -60,6 +60,7 @@ import {
 import { defaultDaemonSocketPath, normalizeSocketPath } from "./modes/daemon/daemon-socket.js";
 import {
 	acquireDaemonShutdownAdmission,
+	assertDaemonUpdateRestartOwner,
 	persistDaemonStartupFenceFromOwner,
 	waitForDaemonStartupFence,
 } from "./modes/daemon/daemon-supervisor-ownership.js";
@@ -852,9 +853,15 @@ async function prepareConnectedDaemonUpdateRestart(
 	agentDir: string,
 	hello: DaemonHello | undefined,
 ): Promise<DaemonUpdateRestartManifest> {
+	const connectedHello = hello ?? client.hello ?? (await client.waitForHello());
+	let fixedOwnerIdentity: FixedDaemonSupervisorOwnerIdentity | undefined;
+	if (hasFixedDaemonSupervisorOwnerIdentity(connectedHello)) {
+		fixedOwnerIdentity = connectedHello;
+		// Preparation stops session workers, so validate ownership before sending it.
+		await assertDaemonUpdateRestartOwner(socketPath, fixedOwnerIdentity, agentDir);
+	}
 	const pendingManifest = tryReadPreparedDaemonUpdateRestartManifest(socketPath, agentDir);
 	let startedAt: number | undefined;
-	let fixedOwnerIdentity: FixedDaemonSupervisorOwnerIdentity | undefined;
 	let fencePersistenceStarted = false;
 	const persistPreparedRestartFence = async () => {
 		const currentHello = client.hello;
@@ -868,9 +875,6 @@ async function prepareConnectedDaemonUpdateRestart(
 		await persistDaemonStartupFenceFromOwner(socketPath, fixedOwnerIdentity);
 	};
 	try {
-		if (hasFixedDaemonSupervisorOwnerIdentity(hello)) {
-			fixedOwnerIdentity = hello;
-		}
 		if (pendingManifest && pendingManifest.sessions.length > 0) {
 			const listResponse = await client.request({ type: "list" }, 30000);
 			if (listResponse.success && !responseHasActiveDaemonSessions(listResponse.data)) {
@@ -906,7 +910,6 @@ export async function prepareDaemonUpdateRestart(
 	socketPath: string,
 	agentDir: string,
 ): Promise<DaemonUpdateRestartManifest> {
-	const pendingManifest = tryReadPreparedDaemonUpdateRestartManifest(socketPath, agentDir);
 	const client = new DaemonClient(socketPath);
 	let connected = false;
 	try {
@@ -915,8 +918,11 @@ export async function prepareDaemonUpdateRestart(
 		const hello = await client.waitForHello(2000).catch(() => undefined);
 		return await prepareConnectedDaemonUpdateRestart(client, socketPath, agentDir, hello);
 	} catch (error) {
-		if (!connected && pendingManifest && pendingManifest.sessions.length > 0) {
-			return pendingManifest;
+		if (!connected) {
+			const pendingManifest = tryReadPreparedDaemonUpdateRestartManifest(socketPath, agentDir);
+			if (pendingManifest && pendingManifest.sessions.length > 0) {
+				return pendingManifest;
+			}
 		}
 		throw error;
 	} finally {

--- a/packages/coding-agent/test/package-self-update-daemon.test.ts
+++ b/packages/coding-agent/test/package-self-update-daemon.test.ts
@@ -224,6 +224,9 @@ vi.mock("../src/modes/daemon/daemon-socket.js", async (importOriginal) => ({
 }));
 
 vi.mock("../src/modes/daemon/daemon-supervisor-ownership.js", () => ({
+	assertDaemonUpdateRestartOwner: vi.fn(async () => {
+		mockState.calls.push("validate-daemon-update-owner");
+	}),
 	acquireDaemonShutdownAdmission: vi.fn(async () => {
 		mockState.calls.push("acquire-daemon-shutdown-admission");
 		return {
@@ -890,6 +893,7 @@ describe("self-update daemon restart", () => {
 			const fenceIndex = mockState.calls.indexOf("persist-daemon-startup-fence");
 			const prepareIndex = mockState.calls.indexOf("daemon-request:prepare_update_restart");
 			const admissionIndex = mockState.calls.indexOf("acquire-daemon-shutdown-admission");
+			const validateOwnerIndex = mockState.calls.indexOf("validate-daemon-update-owner");
 			const shutdownIndex = mockState.calls.indexOf("shutdown-daemon");
 			const startupFenceIndex = mockState.calls.indexOf("wait-daemon-startup-fence");
 			const releaseAdmissionIndex = mockState.calls.indexOf("release-daemon-shutdown-admission");
@@ -897,7 +901,8 @@ describe("self-update daemon restart", () => {
 			expect(spawnIndex).toBeGreaterThanOrEqual(0);
 			expect(launchIndex).toBeGreaterThan(spawnIndex);
 			expect(admissionIndex).toBeGreaterThan(launchIndex);
-			expect(prepareIndex).toBeGreaterThan(admissionIndex);
+			expect(validateOwnerIndex).toBeGreaterThan(admissionIndex);
+			expect(prepareIndex).toBeGreaterThan(validateOwnerIndex);
 			expect(fenceIndex).toBeGreaterThan(prepareIndex);
 			expect(shutdownIndex).toBeGreaterThan(fenceIndex);
 			expect(startupFenceIndex).toBeGreaterThan(shutdownIndex);
@@ -939,7 +944,9 @@ describe("self-update daemon restart", () => {
 
 		const prepareIndex = mockState.calls.indexOf("daemon-request:prepare_update_restart");
 		const fenceIndex = mockState.calls.indexOf("persist-daemon-startup-fence");
-		expect(prepareIndex).toBeGreaterThanOrEqual(0);
+		const validateOwnerIndex = mockState.calls.indexOf("validate-daemon-update-owner");
+		expect(validateOwnerIndex).toBeGreaterThanOrEqual(0);
+		expect(prepareIndex).toBeGreaterThan(validateOwnerIndex);
 		expect(fenceIndex).toBeGreaterThan(prepareIndex);
 	});
 

--- a/packages/coding-agent/test/package-update-owner.test.ts
+++ b/packages/coding-agent/test/package-update-owner.test.ts
@@ -1,0 +1,173 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { createServer, type Server, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ENV_AGENT_DIR, getDaemonUpdateRestartManifestPath, VERSION } from "../src/config.js";
+import { DaemonClient, type DaemonHello } from "../src/modes/daemon/daemon-client.js";
+import {
+	DAEMON_DEFAULT_SERVER_CAPABILITIES,
+	DAEMON_PROTOCOL_INFO,
+	DAEMON_SCHEMA_ID,
+	type DaemonCommand,
+	failure,
+	isDaemonCommandEnvelope,
+	success,
+} from "../src/modes/daemon/daemon-protocol.js";
+import { acquireDaemonSupervisorOwnership } from "../src/modes/daemon/daemon-supervisor-ownership.js";
+import { attachJsonlLineReader, serializeJsonLine } from "../src/modes/rpc/jsonl.js";
+import { prepareDaemonUpdateRestart, runDaemonUpdateRestartCoordinator } from "../src/package-manager-cli.js";
+
+describe("update restart owner validation", () => {
+	let root: string;
+	let agentDir: string;
+	let registryDir: string;
+	let socketPath: string;
+	let server: Server;
+	let owner: Awaited<ReturnType<typeof acquireDaemonSupervisorOwnership>>;
+	let hello: DaemonHello;
+	let helloDelayMs: number;
+	let prepared: boolean;
+	const sockets = new Set<Socket>();
+	const commands: DaemonCommand["type"][] = [];
+	const manifest = { formatVersion: 1, createdAt: "2026-09-09T00:00:00.000Z", sessions: [] };
+
+	beforeEach(async () => {
+		root = mkdtempSync(join(tmpdir(), "update-owner-"));
+		agentDir = join(root, "agent");
+		registryDir = join(root, "registry");
+		socketPath =
+			process.platform === "win32" ? `\\\\.\\pipe\\update-owner-${randomUUID()}` : join(root, "daemon.sock");
+		mkdirSync(agentDir);
+		vi.stubEnv(ENV_AGENT_DIR, agentDir);
+		vi.stubEnv("PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR", registryDir);
+		owner = await acquireDaemonSupervisorOwnership({
+			socketPath,
+			agentDir,
+			descriptorDir: join(root, "workers"),
+			registryDir,
+			generation: randomUUID(),
+			appVersion: VERSION,
+		});
+		expect(owner.record.processStartId).toBeDefined();
+		hello = {
+			type: "daemon_hello",
+			socketPath,
+			protocol: DAEMON_PROTOCOL_INFO,
+			schemaId: DAEMON_SCHEMA_ID,
+			appVersion: VERSION,
+			clientId: "owner-validation-test",
+			serverCapabilities: [...DAEMON_DEFAULT_SERVER_CAPABILITIES],
+			supervisorGeneration: owner.record.generation,
+			supervisorOwnerToken: owner.record.token,
+			supervisorPid: owner.record.pid,
+			supervisorProcessStartId: owner.record.processStartId,
+			supervisorSocketPath: socketPath,
+		};
+		helloDelayMs = 0;
+		prepared = false;
+		commands.length = 0;
+		server = createServer((socket) => {
+			sockets.add(socket);
+			const timer = setTimeout(() => socket.write(serializeJsonLine(hello)), helloDelayMs);
+			const detach = attachJsonlLineReader(socket, (line) => {
+				const envelope: unknown = JSON.parse(line);
+				if (!isDaemonCommandEnvelope(envelope)) return;
+				const command = envelope.command;
+				if (command.type === "ack_result") return;
+				commands.push(command.type);
+				if (command.type === "prepare_update_restart") {
+					prepared = true;
+					socket.write(serializeJsonLine(success(envelope.id, command.type, manifest)));
+				} else if (command.type === "list") {
+					socket.write(
+						serializeJsonLine(
+							success(envelope.id, command.type, { sessions: prepared ? [] : [{ id: "active" }] }),
+						),
+					);
+				} else {
+					socket.write(serializeJsonLine(failure(envelope.id, command.type, "Unexpected test command")));
+				}
+			});
+			socket.on("close", () => {
+				clearTimeout(timer);
+				detach();
+				sockets.delete(socket);
+			});
+		});
+		await new Promise<void>((resolve, reject) => {
+			server.once("error", reject);
+			server.listen(socketPath, resolve);
+		});
+	});
+
+	afterEach(async () => {
+		for (const socket of sockets) socket.destroy();
+		await new Promise<void>((resolve) => server?.close(() => resolve()) ?? resolve());
+		await owner?.release();
+		vi.unstubAllEnvs();
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	async function expectDaemonUnchanged(): Promise<void> {
+		expect(commands).not.toContain("prepare_update_restart");
+		expect(commands).not.toContain("shutdown");
+		expect(existsSync(join(registryDir, "startup-fences"))).toBe(false);
+		helloDelayMs = 0;
+		const observer = new DaemonClient(socketPath);
+		try {
+			await observer.connect();
+			await expect(observer.request({ type: "list" })).resolves.toMatchObject({
+				success: true,
+				data: { sessions: [{ id: "active" }] },
+			});
+		} finally {
+			observer.close();
+		}
+	}
+
+	it.each([0, 2100])(
+		"rejects an owner outside the updater registry before preparation (hello delay %i ms)",
+		async (delayMs) => {
+			helloDelayMs = delayMs;
+			vi.stubEnv("PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR", join(root, "other-registry"));
+			await expect(prepareDaemonUpdateRestart(socketPath, agentDir)).rejects.toThrow(/owner does not match/);
+			await expectDaemonUnchanged();
+		},
+	);
+
+	it("rejects a different agent directory without stopping its sessions", async () => {
+		await expect(prepareDaemonUpdateRestart(socketPath, join(root, "other-agent"))).rejects.toThrow(
+			/agent directory/,
+		);
+		await expectDaemonUnchanged();
+	});
+
+	it.each(["valid", "malformed"])("rejects a mismatched hello before consuming %s recovery data", async (state) => {
+		hello.supervisorOwnerToken = "wrong-owner";
+		const manifestPath = getDaemonUpdateRestartManifestPath(socketPath, agentDir);
+		mkdirSync(join(agentDir, "daemon-update-restarts"));
+		const contents = state === "valid" ? `${JSON.stringify(manifest)}\n` : "{incomplete";
+		writeFileSync(manifestPath, contents);
+		await expect(prepareDaemonUpdateRestart(socketPath, agentDir)).rejects.toThrow(/hello does not match/);
+		expect(readFileSync(manifestPath, "utf8")).toBe(contents);
+		await expectDaemonUnchanged();
+	});
+
+	it("leaves a foreign daemon untouched when the restart coordinator runs", async () => {
+		vi.stubEnv("PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR", join(root, "other-registry"));
+		await expect(
+			runDaemonUpdateRestartCoordinator({ socketPath, agentDir, statusPath: join(root, "status.json") }),
+		).resolves.toMatchObject({ phase: "failed", message: expect.stringContaining("owner does not match") });
+		await expectDaemonUnchanged();
+	});
+
+	it("allows the matching owner when the agent directory uses a filesystem alias", async () => {
+		const alias = join(root, "agent-alias");
+		symlinkSync(agentDir, alias, process.platform === "win32" ? "junction" : "dir");
+		await expect(prepareDaemonUpdateRestart(socketPath, alias)).resolves.toEqual(manifest);
+		expect(commands).toEqual(["prepare_update_restart"]);
+		expect(existsSync(join(registryDir, "startup-fences"))).toBe(true);
+	});
+});


### PR DESCRIPTION
- an updater using another home directory could stop live sessions, then reject the daemon owner and leave startup blocked.
- validate the connected daemon's owner and agent directory before preparing a restart or consuming recovery files.
- seven regression cases added; all 43 targeted tests and repository checks pass.

No-Ticket: Fixes a local daemon outage reported directly during troubleshooting.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent foreign update restarts from stopping daemon sessions owned by a different home
> - Adds `assertDaemonUpdateRestartOwner` in [daemon-supervisor-ownership.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2177/files#diff-6f9ef6ce6a9d2bc51c61fe94d59310efffd26d8f7b3966f5355606b2847d06a5), which validates the durable daemon owner and its canonical agent directory before restart preparation proceeds
> - Extracts shared owner-validation logic from startup-fence persistence into `requireMatchingDaemonSupervisorOwner`, removing duplication
> - Updates `prepareConnectedDaemonUpdateRestart` in [package-manager-cli.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2177/files#diff-5855e8a7adb3661c9d72e9b3a139a953b900c9d3f38cc8dcf3e4dca9d205fb5f) to record the fixed supervisor identity from the hello and validate the socket owner and agent directory before reading a pending manifest or issuing preparation, including cases where the hello arrives after the initial probe
> - Restricts pending-manifest fallback in `prepareDaemonUpdateRestart` to disconnected calls only; a connected daemon must pass owner validation first
> - Behavioral Change: a connected update restart with a mismatched supervisor owner or agent directory is now rejected before shutdown or restart preparation, so the daemon's active sessions are preserved. Symlink or junction aliases for the matching agent directory are still accepted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a13d3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->