### PR TITLE
simplify refinement and compaction notices

### DIFF
--- a/packages/coding-agent/.changes/compact-refinement-compaction.md
+++ b/packages/coding-agent/.changes/compact-refinement-compaction.md
@@ -1,4 +1,4 @@
 - Changed refinement notices to show a spaced purple status line and softer semantic summary in overview and details, with full change counts and diffs in all output.
 - Added expandable Title and Description diffs with the same red and green backgrounds as file edits, preserving other fields and failure details.
-- Changed compaction notices to show compact outcomes and expandable summaries without repeated detail shortcuts.
+- Changed successful compaction notices to show a purple Context compacted header and softer summary preview, with the full summary and token/focus metadata in all output.
 - Fixed refinement notices to stay purple across themes and avoid extra blank lines before following prose.

--- a/packages/coding-agent/.changes/compact-refinement-compaction.md
+++ b/packages/coding-agent/.changes/compact-refinement-compaction.md
@@ -1,4 +1,4 @@
-- Changed refinement notices to show a spaced purple status line in overview, a softer semantic summary in details, and full change counts and diffs in all output.
+- Changed refinement notices to show a spaced purple status line and softer semantic summary in overview and details, with full change counts and diffs in all output.
 - Added expandable Title and Description diffs with the same red and green backgrounds as file edits, preserving other fields and failure details.
 - Changed compaction notices to show compact outcomes and expandable summaries without repeated detail shortcuts.
 - Fixed refinement notices to stay purple across themes and avoid extra blank lines before following prose.

--- a/packages/coding-agent/.changes/compact-refinement-compaction.md
+++ b/packages/coding-agent/.changes/compact-refinement-compaction.md
@@ -1,1 +1,2 @@
 - Changed refinement and compaction notices to show readable outcomes with muted metadata and expandable details in a compact layout.
+- Fixed refinement and compaction outcome messages to sit inside the chat's standard left inset, and replaced the refinement detail JSON blob with structured per-edit rows.

--- a/packages/coding-agent/.changes/compact-refinement-compaction.md
+++ b/packages/coding-agent/.changes/compact-refinement-compaction.md
@@ -1,3 +1,4 @@
 - Changed refinement notices to show a spaced purple status line in overview, a softer semantic summary in details, and full change counts and diffs in all output.
 - Added expandable Title and Description diffs with the same red and green backgrounds as file edits, preserving other fields and failure details.
 - Changed compaction notices to show compact outcomes and expandable summaries without repeated detail shortcuts.
+- Fixed refinement notices to stay purple across themes and avoid extra blank lines before following prose.

--- a/packages/coding-agent/.changes/compact-refinement-compaction.md
+++ b/packages/coding-agent/.changes/compact-refinement-compaction.md
@@ -1,0 +1,1 @@
+- Changed refinement and compaction notices to show readable outcomes with muted metadata and expandable details in a compact layout.

--- a/packages/coding-agent/.changes/compact-refinement-compaction.md
+++ b/packages/coding-agent/.changes/compact-refinement-compaction.md
@@ -1,2 +1,3 @@
-- Changed refinement and compaction notices to show readable outcomes with muted metadata and expandable details in a compact layout.
-- Fixed refinement and compaction outcome messages to sit inside the chat's standard left inset, and replaced the refinement detail JSON blob with structured per-edit rows.
+- Changed refinement notices to show a spaced harness header with an accent diamond, accurate change counts, and a semantic summary.
+- Added expandable Title and Description diffs with the same red and green backgrounds as file edits, preserving other fields and failure details.
+- Changed compaction notices to show compact outcomes and expandable summaries without repeated detail shortcuts.

--- a/packages/coding-agent/.changes/compact-refinement-compaction.md
+++ b/packages/coding-agent/.changes/compact-refinement-compaction.md
@@ -1,3 +1,3 @@
-- Changed refinement notices to show a spaced harness header with an accent diamond, accurate change counts, and a semantic summary.
+- Changed refinement notices to show a spaced purple status line in overview, a softer semantic summary in details, and full change counts and diffs in all output.
 - Added expandable Title and Description diffs with the same red and green backgrounds as file edits, preserving other fields and failure details.
 - Changed compaction notices to show compact outcomes and expandable summaries without repeated detail shortcuts.

--- a/packages/coding-agent/src/modes/interactive/components/compaction-outcome-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/compaction-outcome-message.ts
@@ -1,4 +1,4 @@
-import { Box, Container, Text } from "@earendil-works/pi-tui";
+import { Container, Spacer, Text } from "@earendil-works/pi-tui";
 import type { CompactionOutcomeMessage } from "../../../core/messages.js";
 import { theme } from "../theme/theme.js";
 
@@ -7,9 +7,8 @@ export class CompactionOutcomeMessageComponent extends Container {
 	constructor(message: CompactionOutcomeMessage) {
 		super();
 		const color = message.details.outcome === "skipped" ? "warning" : "error";
-		const contentBox = new Box(2, 1, (text: string) => theme.getUserMessageBackgroundColor()(text));
-		contentBox.addChild(new Text(theme.fg(color, message.content), 0, 0));
-		this.addChild(contentBox);
+		this.addChild(new Spacer(1));
+		this.addChild(new Text(theme.fg(color, message.content), 0, 0));
 	}
 
 	setExpanded(_expanded: boolean): void {}
@@ -18,9 +17,8 @@ export class CompactionOutcomeMessageComponent extends Container {
 export class MalformedCompactionOutcomeMessageComponent extends Container {
 	constructor() {
 		super();
-		const contentBox = new Box(2, 1, (text: string) => theme.getUserMessageBackgroundColor()(text));
-		contentBox.addChild(new Text(theme.fg("error", "[Malformed compaction outcome message]"), 0, 0));
-		this.addChild(contentBox);
+		this.addChild(new Spacer(1));
+		this.addChild(new Text(theme.fg("error", "[Malformed compaction outcome message]"), 0, 0));
 	}
 
 	setExpanded(_expanded: boolean): void {}

--- a/packages/coding-agent/src/modes/interactive/components/compaction-outcome-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/compaction-outcome-message.ts
@@ -8,7 +8,7 @@ export class CompactionOutcomeMessageComponent extends Container {
 		super();
 		const color = message.details.outcome === "skipped" ? "warning" : "error";
 		this.addChild(new Spacer(1));
-		this.addChild(new Text(theme.fg(color, message.content), 0, 0));
+		this.addChild(new Text(theme.fg(color, message.content), 1, 0));
 	}
 
 	setExpanded(_expanded: boolean): void {}
@@ -18,7 +18,7 @@ export class MalformedCompactionOutcomeMessageComponent extends Container {
 	constructor() {
 		super();
 		this.addChild(new Spacer(1));
-		this.addChild(new Text(theme.fg("error", "[Malformed compaction outcome message]"), 0, 0));
+		this.addChild(new Text(theme.fg("error", "[Malformed compaction outcome message]"), 1, 0));
 	}
 
 	setExpanded(_expanded: boolean): void {}

--- a/packages/coding-agent/src/modes/interactive/components/compaction-summary-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/compaction-summary-message.ts
@@ -24,7 +24,7 @@ export class CompactionSummaryMessageComponent extends ExpandableEventMessage {
 
 		this.addChild(new Spacer(1));
 		this.addChild(
-			new Markdown(this.message.summary, 0, 0, this.markdownTheme, {
+			new Markdown(this.message.summary, 1, 0, this.markdownTheme, {
 				color: (text: string) => theme.fg("customMessageText", text),
 			}),
 		);

--- a/packages/coding-agent/src/modes/interactive/components/compaction-summary-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/compaction-summary-message.ts
@@ -1,11 +1,10 @@
-import { Markdown, type MarkdownTheme, Spacer, Text } from "@earendil-works/pi-tui";
+import { Markdown, type MarkdownTheme, Spacer } from "@earendil-works/pi-tui";
 import type { CompactionSummaryMessage } from "../../../core/messages.js";
 import { getMarkdownTheme, theme } from "../theme/theme.js";
-import { customMessageLabel, ExpandableCustomMessageBox } from "./expandable-custom-message.js";
-import { expandCollapseHint } from "./keybinding-hints.js";
+import { ExpandableEventMessage } from "./expandable-event-message.js";
 
-/** Compaction summary card: full markdown summary when expanded. */
-export class CompactionSummaryMessageComponent extends ExpandableCustomMessageBox {
+/** Compact context outcome with the full markdown summary available on demand. */
+export class CompactionSummaryMessageComponent extends ExpandableEventMessage {
 	constructor(
 		private readonly message: CompactionSummaryMessage,
 		private readonly markdownTheme: MarkdownTheme = getMarkdownTheme(),
@@ -18,30 +17,16 @@ export class CompactionSummaryMessageComponent extends ExpandableCustomMessageBo
 		this.clear();
 
 		const tokenStr = this.message.tokensBefore.toLocaleString();
-		const label = customMessageLabel("compaction");
-		this.addChild(new Text(label, 0, 0));
-		this.addChild(new Spacer(1));
-
 		const instructions = this.message.customInstructions;
-		if (this.expanded) {
-			let header = `**Compacted from ${tokenStr} tokens**\n\n`;
-			if (instructions) {
-				header += `**Focus:** ${instructions}\n\n`;
-			}
-			this.addChild(
-				new Markdown(header + this.message.summary, 0, 0, this.markdownTheme, {
-					color: (text: string) => theme.fg("customMessageText", text),
-				}),
-			);
-		} else {
-			const focus = instructions ? ` · focus: ${instructions}` : "";
-			this.addChild(
-				new Text(
-					`${theme.fg("customMessageText", `Compacted from ${tokenStr} tokens${focus}`)} ${expandCollapseHint("app.tools.expand", false)}`,
-					0,
-					0,
-				),
-			);
-		}
+		const focus = instructions ? ` · focus: ${instructions}` : "";
+		this.addSummary(`Compacted from ${tokenStr} tokens${focus}`, "Compaction");
+		if (!this.expanded) return;
+
+		this.addChild(new Spacer(1));
+		this.addChild(
+			new Markdown(this.message.summary, 0, 0, this.markdownTheme, {
+				color: (text: string) => theme.fg("customMessageText", text),
+			}),
+		);
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/compaction-summary-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/compaction-summary-message.ts
@@ -1,4 +1,4 @@
-import { Markdown, type MarkdownTheme, Spacer } from "@earendil-works/pi-tui";
+import { Markdown, type MarkdownTheme, Spacer, Text } from "@earendil-works/pi-tui";
 import type { CompactionSummaryMessage } from "../../../core/messages.js";
 import { getMarkdownTheme, theme } from "../theme/theme.js";
 import { ExpandableEventMessage } from "./expandable-event-message.js";
@@ -15,18 +15,25 @@ export class CompactionSummaryMessageComponent extends ExpandableEventMessage {
 
 	protected updateDisplay(): void {
 		this.clear();
+		this.addChild(new Text(theme.fg("refinementHeader", "◆ Context compacted"), 1, 0));
+		const summary = this.message.summary.trim()
+			? this.message.summary
+			: "No summary was recorded for this compaction.";
+		if (!this.expanded) {
+			this.addSummary(summary, undefined, "refinementSummary");
+			return;
+		}
+
+		this.addChild(
+			new Markdown(summary, 1, 0, this.markdownTheme, {
+				color: (text: string) => theme.fg("refinementSummary", text),
+			}),
+		);
 
 		const tokenStr = this.message.tokensBefore.toLocaleString();
 		const instructions = this.message.customInstructions;
 		const focus = instructions ? ` · focus: ${instructions}` : "";
-		this.addSummary(`Compacted from ${tokenStr} tokens${focus}`, "Compaction");
-		if (!this.expanded) return;
-
 		this.addChild(new Spacer(1));
-		this.addChild(
-			new Markdown(this.message.summary, 1, 0, this.markdownTheme, {
-				color: (text: string) => theme.fg("customMessageText", text),
-			}),
-		);
+		this.addChild(new Text(theme.fg("dim", `Compacted from ${tokenStr} tokens${focus}`), 1, 0));
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
+++ b/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
@@ -155,6 +155,7 @@ export function buildConversationComponents(
 				? new RefinementOutcomeMessageComponent(message)
 				: new MalformedRefinementOutcomeMessageComponent();
 			component.setExpanded(expanded);
+			if (component instanceof RefinementOutcomeMessageComponent) component.setEditDiffsExpanded(editDiffsExpanded);
 			components.push(component);
 		} else if (isAgentSessionMessage(message) && message.display) {
 			const component = new AgentMessageComponent(message, options.markdownTheme, {

--- a/packages/coding-agent/src/modes/interactive/components/expandable-event-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/expandable-event-message.ts
@@ -1,10 +1,11 @@
 import { type Component, Container, Text, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
-import { theme } from "../theme/theme.js";
+import { type ThemeColor, theme } from "../theme/theme.js";
 
 class EventSummary implements Component {
 	constructor(
 		private readonly summary: string,
 		private readonly expanded: boolean,
+		private readonly color: ThemeColor,
 	) {}
 
 	render(width: number): string[] {
@@ -17,7 +18,7 @@ class EventSummary implements Component {
 			lines.splice(2);
 			lines[1] = truncateToWidth(`${lines[1]} …`, contentWidth, "…");
 		}
-		return lines.map((line) => theme.fg("customMessageText", ` ${line}`));
+		return lines.map((line) => theme.fg(this.color, ` ${line}`));
 	}
 
 	invalidate(): void {}
@@ -38,8 +39,8 @@ export abstract class ExpandableEventMessage extends Container {
 		this.updateDisplay();
 	}
 
-	protected addSummary(summary: string, metadata?: string): void {
-		this.addChild(new EventSummary(summary, this.expanded));
+	protected addSummary(summary: string, metadata?: string, color: ThemeColor = "customMessageText"): void {
+		this.addChild(new EventSummary(summary, this.expanded, color));
 		if (metadata) this.addChild(new Text(theme.fg("dim", metadata), 1, 0));
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/expandable-event-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/expandable-event-message.ts
@@ -1,6 +1,5 @@
 import { type Component, Container, Text, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import { theme } from "../theme/theme.js";
-import { expandCollapseHint } from "./keybinding-hints.js";
 
 class EventSummary implements Component {
 	constructor(
@@ -39,11 +38,9 @@ export abstract class ExpandableEventMessage extends Container {
 		this.updateDisplay();
 	}
 
-	protected addSummary(summary: string, metadata: string): void {
+	protected addSummary(summary: string, metadata?: string): void {
 		this.addChild(new EventSummary(summary, this.expanded));
-		this.addChild(
-			new Text(`${theme.fg("dim", metadata)} ${expandCollapseHint("app.tools.expand", this.expanded)}`, 1, 0),
-		);
+		if (metadata) this.addChild(new Text(theme.fg("dim", metadata), 1, 0));
 	}
 
 	protected abstract updateDisplay(): void;

--- a/packages/coding-agent/src/modes/interactive/components/expandable-event-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/expandable-event-message.ts
@@ -11,12 +11,14 @@ class EventSummary implements Component {
 	render(width: number): string[] {
 		if (width < 1) return [];
 		const text = this.expanded ? this.summary : this.summary.replace(/\s+/g, " ").trim();
-		const lines = wrapTextWithAnsi(text, width);
+		// Keep the standard one-column chat inset on every summary line.
+		const contentWidth = Math.max(1, width - 1);
+		const lines = wrapTextWithAnsi(text, contentWidth);
 		if (!this.expanded && lines.length > 2) {
 			lines.splice(2);
-			lines[1] = truncateToWidth(`${lines[1]} …`, width, "…");
+			lines[1] = truncateToWidth(`${lines[1]} …`, contentWidth, "…");
 		}
-		return lines.map((line) => theme.fg("customMessageText", line));
+		return lines.map((line) => theme.fg("customMessageText", ` ${line}`));
 	}
 
 	invalidate(): void {}
@@ -40,7 +42,7 @@ export abstract class ExpandableEventMessage extends Container {
 	protected addSummary(summary: string, metadata: string): void {
 		this.addChild(new EventSummary(summary, this.expanded));
 		this.addChild(
-			new Text(`${theme.fg("dim", metadata)} ${expandCollapseHint("app.tools.expand", this.expanded)}`, 0, 0),
+			new Text(`${theme.fg("dim", metadata)} ${expandCollapseHint("app.tools.expand", this.expanded)}`, 1, 0),
 		);
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/expandable-event-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/expandable-event-message.ts
@@ -1,0 +1,48 @@
+import { type Component, Container, Text, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { theme } from "../theme/theme.js";
+import { expandCollapseHint } from "./keybinding-hints.js";
+
+class EventSummary implements Component {
+	constructor(
+		private readonly summary: string,
+		private readonly expanded: boolean,
+	) {}
+
+	render(width: number): string[] {
+		if (width < 1) return [];
+		const text = this.expanded ? this.summary : this.summary.replace(/\s+/g, " ").trim();
+		const lines = wrapTextWithAnsi(text, width);
+		if (!this.expanded && lines.length > 2) {
+			lines.splice(2);
+			lines[1] = truncateToWidth(`${lines[1]} …`, width, "…");
+		}
+		return lines.map((line) => theme.fg("customMessageText", line));
+	}
+
+	invalidate(): void {}
+}
+
+/** Compact outcome first, with quiet metadata and the existing details toggle. */
+export abstract class ExpandableEventMessage extends Container {
+	protected expanded = false;
+
+	setExpanded(expanded: boolean): void {
+		if (this.expanded === expanded) return;
+		this.expanded = expanded;
+		this.updateDisplay();
+	}
+
+	override invalidate(): void {
+		super.invalidate();
+		this.updateDisplay();
+	}
+
+	protected addSummary(summary: string, metadata: string): void {
+		this.addChild(new EventSummary(summary, this.expanded));
+		this.addChild(
+			new Text(`${theme.fg("dim", metadata)} ${expandCollapseHint("app.tools.expand", this.expanded)}`, 0, 0),
+		);
+	}
+
+	protected abstract updateDisplay(): void;
+}

--- a/packages/coding-agent/src/modes/interactive/components/refinement-outcome-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/refinement-outcome-message.ts
@@ -176,8 +176,15 @@ class RefinementEditSection implements Component {
 
 /** Durable refinement outcome with per-edit details available on demand. */
 export class RefinementOutcomeMessageComponent extends ExpandableEventMessage {
+	private summaryExpanded = false;
 	constructor(private readonly message: RefinementOutcomeMessage) {
 		super();
+		this.updateDisplay();
+	}
+
+	setEditDiffsExpanded(expanded: boolean): void {
+		if (this.summaryExpanded === expanded) return;
+		this.summaryExpanded = expanded;
 		this.updateDisplay();
 	}
 
@@ -186,15 +193,19 @@ export class RefinementOutcomeMessageComponent extends ExpandableEventMessage {
 
 		const { summary, edits, scope, rollbackOf, refinementId } = this.message.details;
 		this.addChild(new Spacer(1));
-		this.addChild(new Text(theme.fg("accent", `◆ ${refinementHeader(this.message)}`), 1, 0));
-		this.addSummary(summary.trim() || "No summary was recorded for this harness change.");
+		const outcome = refinementHeader(this.message);
+		const header = outcome.startsWith("Harness refined ·") ? "Harness refined" : outcome;
+		this.addChild(new Text(theme.fg("customMessageLabel", `◆ ${header}`), 1, 0));
+		if (this.summaryExpanded || this.expanded) {
+			this.addSummary(summary.trim() || "No summary was recorded for this harness change.", undefined, "mdHeading");
+		}
 		if (this.expanded) {
 			this.addChild(new Spacer(1));
 			this.addChild(
 				new Text(
 					theme.fg(
 						"dim",
-						`Refinement ${refinementId} · ${scope}${rollbackOf ? ` · rollback of ${rollbackOf}` : ""}`,
+						`${outcome} · Refinement ${refinementId} · ${scope}${rollbackOf ? ` · rollback of ${rollbackOf}` : ""}`,
 					),
 					1,
 					0,

--- a/packages/coding-agent/src/modes/interactive/components/refinement-outcome-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/refinement-outcome-message.ts
@@ -195,9 +195,13 @@ export class RefinementOutcomeMessageComponent extends ExpandableEventMessage {
 		this.addChild(new Spacer(1));
 		const outcome = refinementHeader(this.message);
 		const header = outcome.startsWith("Harness refined ·") ? "Harness refined" : outcome;
-		this.addChild(new Text(theme.fg("customMessageLabel", `◆ ${header}`), 1, 0));
+		this.addChild(new Text(theme.fg("refinementHeader", `◆ ${header}`), 1, 0));
 		if (this.summaryExpanded || this.expanded) {
-			this.addSummary(summary.trim() || "No summary was recorded for this harness change.", undefined, "mdHeading");
+			this.addSummary(
+				summary.trim() || "No summary was recorded for this harness change.",
+				undefined,
+				"refinementSummary",
+			);
 		}
 		if (this.expanded) {
 			this.addChild(new Spacer(1));
@@ -218,7 +222,6 @@ export class RefinementOutcomeMessageComponent extends ExpandableEventMessage {
 				if (edit.reason) this.addChild(new Text(theme.fg("muted", `Reason: ${edit.reason}`), 1, 0));
 			}
 		}
-		this.addChild(new Spacer(1));
 	}
 }
 
@@ -232,6 +235,5 @@ export class MalformedRefinementOutcomeMessageComponent extends ExpandableEventM
 		this.clear();
 		this.addChild(new Spacer(1));
 		this.addChild(new Text(theme.fg("error", "[Malformed refinement outcome message]"), 1, 0));
-		this.addChild(new Spacer(1));
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/refinement-outcome-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/refinement-outcome-message.ts
@@ -1,41 +1,40 @@
-import { Spacer, Text } from "@earendil-works/pi-tui";
+import { type Component, Spacer, Text, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { RefinementOutcomeMessage } from "../../../core/messages.js";
 import type { AppliedRefinementEdit, HarnessEntry } from "../../../core/refinement/refinement.js";
-import { generateDiffString } from "../../../core/tools/edit-diff.js";
 import { theme } from "../theme/theme.js";
-import { renderDiff } from "./diff.js";
 import { ExpandableEventMessage } from "./expandable-event-message.js";
 
-function editableEntry(entry: HarnessEntry): Record<string, unknown> {
-	return {
-		title: entry.title,
-		content: entry.content,
-		path: entry.path,
-		reference: entry.reference,
-		arguments: entry.arguments,
-		metadata: entry.metadata,
-	};
+type EditFieldKey = (typeof EDIT_FIELDS)[number]["key"];
+
+/** Editable harness entry fields shown per edit, in display order. */
+const EDIT_FIELDS = [
+	{ key: "title", label: "Title" },
+	{ key: "content", label: "Content" },
+	{ key: "path", label: "Path" },
+	{ key: "reference", label: "Reference" },
+	{ key: "arguments", label: "Arguments" },
+	{ key: "metadata", label: "Metadata" },
+] as const;
+
+/** Column layout of one expanded edit section, measured from the chat edge. */
+const LABEL_INDENT = 4; // aligns field rows under the ` ╰─ ` label text
+const KEY_WIDTH = 9; // "Arguments"/"Reference"
+const VALUE_COLUMN = LABEL_INDENT + KEY_WIDTH + 2;
+
+interface EditFieldRows {
+	label: string;
+	/** Rendered value lines; empty values produce no rows. */
+	value: string[];
+	/** Changed fields render -/+ rows instead of a plain value. */
+	change?: { removed: string[]; added: string[] };
 }
 
-function proposedEntry(edit: AppliedRefinementEdit): Record<string, unknown> {
-	return {
-		...(edit.title === undefined ? {} : { title: edit.title }),
-		...(edit.content === undefined ? {} : { content: edit.content }),
-		...(edit.path === undefined ? {} : { path: edit.path }),
-		...(edit.reference === undefined ? {} : { reference: edit.reference }),
-		...(edit.arguments === undefined ? {} : { arguments: edit.arguments }),
-		...(edit.metadata === undefined ? {} : { metadata: edit.metadata }),
-	};
-}
+type FieldColor = "toolDiffRemoved" | "toolDiffAdded" | "customMessageText";
 
-function entryText(entry: Record<string, unknown> | undefined): string {
-	return entry === undefined ? "" : `${JSON.stringify(entry, null, 2)}\n`;
-}
-
-function editDiff(edit: AppliedRefinementEdit): string {
-	const before = edit.before ? editableEntry(edit.before) : undefined;
-	const after = edit.after ? editableEntry(edit.after) : edit.action === "delete" ? undefined : proposedEntry(edit);
-	return generateDiffString(entryText(before), entryText(after), 4).diff;
+interface FieldRow {
+	text: string;
+	color: FieldColor;
+	marker?: "-" | "+";
 }
 
 function editScope(edit: AppliedRefinementEdit, fallback: "local" | "global"): "local" | "global" {
@@ -59,7 +58,141 @@ function editCount(edits: AppliedRefinementEdit[]): string {
 		: `${applied}/${edits.length} edits applied`;
 }
 
-/** Durable refinement outcome with per-edit before/after diffs available on demand. */
+function fieldValueLines(value: unknown): string[] {
+	if (typeof value === "string") {
+		return value.length === 0 ? [] : value.split("\n");
+	}
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return [];
+	}
+	return Object.keys(value).length === 0 ? [] : [JSON.stringify(value)];
+}
+
+function proposedRecord(edit: AppliedRefinementEdit): Record<string, unknown> {
+	const proposed: Record<string, unknown> = {};
+	for (const { key } of EDIT_FIELDS) {
+		if (edit[key] !== undefined) {
+			proposed[key] = edit[key];
+		}
+	}
+	return proposed;
+}
+
+function entryFieldRows(entry: Partial<Record<EditFieldKey, unknown>> | undefined): EditFieldRows[] {
+	if (!entry) {
+		return [];
+	}
+	const rows: EditFieldRows[] = [];
+	for (const { key, label } of EDIT_FIELDS) {
+		const value = fieldValueLines(entry[key]);
+		if (value.length > 0) {
+			rows.push({ label, value });
+		}
+	}
+	return rows;
+}
+
+/** Update edits show one plain row per unchanged field and -/+ rows for changed ones. */
+function updateFieldRows(before: HarnessEntry, after: HarnessEntry): EditFieldRows[] {
+	const rows: EditFieldRows[] = [];
+	for (const { key, label } of EDIT_FIELDS) {
+		const removed = fieldValueLines(before[key]);
+		const added = fieldValueLines(after[key]);
+		if (removed.length === 0 && added.length === 0) {
+			continue;
+		}
+		if (removed.length === 0 || added.length === 0) {
+			rows.push({ label, value: removed.length > 0 ? removed : added });
+			continue;
+		}
+		if (removed.join("\n") === added.join("\n")) {
+			rows.push({ label, value: added });
+			continue;
+		}
+		rows.push({ label, value: [], change: { removed, added } });
+	}
+	return rows;
+}
+
+function editFieldRows(edit: AppliedRefinementEdit): EditFieldRows[] {
+	if (edit.before && edit.after) {
+		return updateFieldRows(edit.before, edit.after);
+	}
+	return entryFieldRows(edit.after ?? edit.before ?? proposedRecord(edit));
+}
+
+function fieldRows(field: EditFieldRows): FieldRow[] {
+	if (field.change) {
+		return [
+			...field.change.removed.map((text): FieldRow => ({ text, color: "toolDiffRemoved", marker: "-" })),
+			...field.change.added.map((text): FieldRow => ({ text, color: "toolDiffAdded", marker: "+" })),
+		];
+	}
+	return field.value.map((text): FieldRow => ({ text, color: "customMessageText" }));
+}
+
+/**
+ * One refinement edit as a ` ╰─ ` label row plus readable key-value rows for
+ * the entry's fields, matching the agent-message layout language.
+ */
+class RefinementEditSection implements Component {
+	constructor(
+		private readonly label: string,
+		private readonly fields: EditFieldRows[] = [],
+	) {}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		if (width < 1) return [];
+		const lines: string[] = [];
+		for (const [index, line] of wrapTextWithAnsi(this.label, Math.max(1, width - LABEL_INDENT)).entries()) {
+			const prefix = index === 0 ? theme.fg("dim", " ╰─ ") : " ".repeat(LABEL_INDENT);
+			lines.push(`${prefix}${line}`);
+		}
+		for (const field of this.fields) {
+			if (width >= VALUE_COLUMN) {
+				this.renderWideField(field, width, lines);
+			} else {
+				this.renderNarrowField(field, width, lines);
+			}
+		}
+		return lines;
+	}
+
+	private renderWideField(field: EditFieldRows, width: number, lines: string[]): void {
+		const keyColumn =
+			" ".repeat(LABEL_INDENT) + theme.fg("muted", field.label) + " ".repeat(KEY_WIDTH - field.label.length);
+		const keyIndent = " ".repeat(LABEL_INDENT + KEY_WIDTH);
+		const valueWidth = Math.max(1, width - VALUE_COLUMN);
+		let keyShown = false;
+		for (const row of fieldRows(field)) {
+			for (const [index, segment] of wrapTextWithAnsi(row.text, valueWidth).entries()) {
+				const marker = index === 0 && row.marker ? theme.fg(row.color, `${row.marker} `) : "  ";
+				const prefix = keyShown ? keyIndent : keyColumn;
+				keyShown = true;
+				lines.push(`${prefix}${marker}${theme.fg(row.color, segment)}`);
+			}
+		}
+	}
+
+	// Terminals narrower than the value column fall back to stacked rows.
+	private renderNarrowField(field: EditFieldRows, width: number, lines: string[]): void {
+		const valueWidth = Math.max(1, width - LABEL_INDENT);
+		const indent = " ".repeat(LABEL_INDENT);
+		for (const line of wrapTextWithAnsi(theme.fg("muted", field.label), valueWidth)) {
+			lines.push(`${indent}${line}`);
+		}
+		for (const row of fieldRows(field)) {
+			const marker = row.marker ? `${row.marker} ` : "";
+			for (const line of wrapTextWithAnsi(theme.fg(row.color, `${marker}${row.text}`), valueWidth)) {
+				lines.push(`${indent}${line}`);
+			}
+		}
+	}
+}
+
+/** Durable refinement outcome with per-edit details available on demand. */
 export class RefinementOutcomeMessageComponent extends ExpandableEventMessage {
 	constructor(private readonly message: RefinementOutcomeMessage) {
 		super();
@@ -72,13 +205,19 @@ export class RefinementOutcomeMessageComponent extends ExpandableEventMessage {
 		const { summary, edits, scope } = this.message.details;
 		this.addChild(new Spacer(1));
 		this.addSummary(summary, `Refinement · ${editCount(edits)}`);
-		if (!this.expanded) return;
+		if (!this.expanded) {
+			for (const edit of edits) {
+				this.addChild(new RefinementEditSection(editLabel(edit, scope)));
+			}
+			return;
+		}
 
 		this.addChild(new Spacer(1));
-		for (const edit of edits) {
-			this.addChild(new Text(`${theme.fg("dim", "  ╰─ ")}${editLabel(edit, scope)}`, 0, 0));
-			const diff = editDiff(edit);
-			if (diff) this.addChild(new Text(renderDiff(diff), 4, 0));
+		for (const [index, edit] of edits.entries()) {
+			if (index > 0) {
+				this.addChild(new Spacer(1));
+			}
+			this.addChild(new RefinementEditSection(editLabel(edit, scope), editFieldRows(edit)));
 		}
 	}
 }
@@ -92,6 +231,6 @@ export class MalformedRefinementOutcomeMessageComponent extends ExpandableEventM
 	protected updateDisplay(): void {
 		this.clear();
 		this.addChild(new Spacer(1));
-		this.addChild(new Text(theme.fg("error", "[Malformed refinement outcome message]"), 0, 0));
+		this.addChild(new Text(theme.fg("error", "[Malformed refinement outcome message]"), 1, 0));
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/refinement-outcome-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/refinement-outcome-message.ts
@@ -196,13 +196,11 @@ export class RefinementOutcomeMessageComponent extends ExpandableEventMessage {
 		const outcome = refinementHeader(this.message);
 		const header = outcome.startsWith("Harness refined ·") ? "Harness refined" : outcome;
 		this.addChild(new Text(theme.fg("refinementHeader", `◆ ${header}`), 1, 0));
-		if (this.summaryExpanded || this.expanded) {
-			this.addSummary(
-				summary.trim() || "No summary was recorded for this harness change.",
-				undefined,
-				"refinementSummary",
-			);
-		}
+		this.addSummary(
+			summary.trim() || "No summary was recorded for this harness change.",
+			undefined,
+			"refinementSummary",
+		);
 		if (this.expanded) {
 			this.addChild(new Spacer(1));
 			this.addChild(

--- a/packages/coding-agent/src/modes/interactive/components/refinement-outcome-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/refinement-outcome-message.ts
@@ -1,7 +1,9 @@
-import { type Component, Spacer, Text, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { type Component, Spacer, Text } from "@earendil-works/pi-tui";
 import type { RefinementOutcomeMessage } from "../../../core/messages.js";
 import type { AppliedRefinementEdit, HarnessEntry } from "../../../core/refinement/refinement.js";
+import { generateDiffString } from "../../../core/tools/edit-diff.js";
 import { theme } from "../theme/theme.js";
+import { renderRichDiff } from "./diff.js";
 import { ExpandableEventMessage } from "./expandable-event-message.js";
 
 type EditFieldKey = (typeof EDIT_FIELDS)[number]["key"];
@@ -9,17 +11,12 @@ type EditFieldKey = (typeof EDIT_FIELDS)[number]["key"];
 /** Editable harness entry fields shown per edit, in display order. */
 const EDIT_FIELDS = [
 	{ key: "title", label: "Title" },
-	{ key: "content", label: "Content" },
+	{ key: "content", label: "Description" },
 	{ key: "path", label: "Path" },
 	{ key: "reference", label: "Reference" },
 	{ key: "arguments", label: "Arguments" },
 	{ key: "metadata", label: "Metadata" },
 ] as const;
-
-/** Column layout of one expanded edit section, measured from the chat edge. */
-const LABEL_INDENT = 4; // aligns field rows under the ` ╰─ ` label text
-const KEY_WIDTH = 9; // "Arguments"/"Reference"
-const VALUE_COLUMN = LABEL_INDENT + KEY_WIDTH + 2;
 
 interface EditFieldRows {
 	label: string;
@@ -27,14 +24,6 @@ interface EditFieldRows {
 	value: string[];
 	/** Changed fields render -/+ rows instead of a plain value. */
 	change?: { removed: string[]; added: string[] };
-}
-
-type FieldColor = "toolDiffRemoved" | "toolDiffAdded" | "customMessageText";
-
-interface FieldRow {
-	text: string;
-	color: FieldColor;
-	marker?: "-" | "+";
 }
 
 function editScope(edit: AppliedRefinementEdit, fallback: "local" | "global"): "local" | "global" {
@@ -51,11 +40,32 @@ function editLabel(edit: AppliedRefinementEdit, fallbackScope: "local" | "global
 	return `${theme.fg("success", verb)} ${scope} ${edit.kind} \`${edit.id}\``;
 }
 
-function editCount(edits: AppliedRefinementEdit[]): string {
-	const applied = edits.filter((edit) => edit.applied).length;
-	return edits.length === applied
-		? `${applied} edit${applied === 1 ? "" : "s"} applied`
-		: `${applied}/${edits.length} edits applied`;
+function refinementHeader(message: RefinementOutcomeMessage): string {
+	const { edits, rollbackOf } = message.details;
+	const applied = edits.filter((edit) => edit.applied);
+	const operation = rollbackOf ? "Harness rollback" : "Harness refinement";
+	if (edits.length === 0)
+		return `${rollbackOf ? "Harness rollback unchanged" : "Harness unchanged"} · no edits applied`;
+	if (applied.length === 0) return `${operation} failed · 0/${edits.length} edits applied`;
+	if (applied.length < edits.length) {
+		return `${rollbackOf ? "Harness partially rolled back" : "Harness partially refined"} · ${applied.length}/${edits.length} edits applied`;
+	}
+	if (rollbackOf)
+		return `Harness rollback completed · ${applied.length} edit${applied.length === 1 ? "" : "s"} applied`;
+	const first = applied[0]!;
+	if (applied.every((edit) => edit.kind === first.kind)) {
+		const kind =
+			first.kind === "memory"
+				? applied.length === 1
+					? "memory"
+					: "memories"
+				: `${first.kind}${applied.length === 1 ? "" : "s"}`;
+		const action = applied.every((edit) => edit.action === first.action)
+			? { create: "created", update: "updated", delete: "deleted" }[first.action]
+			: "changed";
+		return `Harness refined · ${applied.length} ${kind} ${action}`;
+	}
+	return `Harness refined · ${applied.length} edits applied`;
 }
 
 function fieldValueLines(value: unknown): string[] {
@@ -101,10 +111,6 @@ function updateFieldRows(before: HarnessEntry, after: HarnessEntry): EditFieldRo
 		if (removed.length === 0 && added.length === 0) {
 			continue;
 		}
-		if (removed.length === 0 || added.length === 0) {
-			rows.push({ label, value: removed.length > 0 ? removed : added });
-			continue;
-		}
 		if (removed.join("\n") === added.join("\n")) {
 			rows.push({ label, value: added });
 			continue;
@@ -115,26 +121,30 @@ function updateFieldRows(before: HarnessEntry, after: HarnessEntry): EditFieldRo
 }
 
 function editFieldRows(edit: AppliedRefinementEdit): EditFieldRows[] {
+	if (!edit.applied) {
+		const proposed = entryFieldRows(edit.after ?? proposedRecord(edit));
+		if (!edit.before) return proposed;
+		return [
+			...entryFieldRows(edit.before).map((field) => ({ ...field, label: `Before ${field.label}` })),
+			...proposed.map((field) => ({ ...field, label: `Proposed ${field.label}` })),
+		];
+	}
 	if (edit.before && edit.after) {
 		return updateFieldRows(edit.before, edit.after);
 	}
-	return entryFieldRows(edit.after ?? edit.before ?? proposedRecord(edit));
+	const fields = entryFieldRows(edit.after ?? edit.before ?? proposedRecord(edit));
+	if (edit.action === "update") return fields;
+	return fields.map((field) => ({
+		label: field.label,
+		value: [],
+		change: {
+			removed: edit.action === "delete" ? field.value : [],
+			added: edit.action === "create" ? field.value : [],
+		},
+	}));
 }
 
-function fieldRows(field: EditFieldRows): FieldRow[] {
-	if (field.change) {
-		return [
-			...field.change.removed.map((text): FieldRow => ({ text, color: "toolDiffRemoved", marker: "-" })),
-			...field.change.added.map((text): FieldRow => ({ text, color: "toolDiffAdded", marker: "+" })),
-		];
-	}
-	return field.value.map((text): FieldRow => ({ text, color: "customMessageText" }));
-}
-
-/**
- * One refinement edit as a ` ╰─ ` label row plus readable key-value rows for
- * the entry's fields, matching the agent-message layout language.
- */
+/** Expanded fields share the same line gutters and background blocks as file edits. */
 class RefinementEditSection implements Component {
 	constructor(
 		private readonly label: string,
@@ -145,50 +155,22 @@ class RefinementEditSection implements Component {
 
 	render(width: number): string[] {
 		if (width < 1) return [];
-		const lines: string[] = [];
-		for (const [index, line] of wrapTextWithAnsi(this.label, Math.max(1, width - LABEL_INDENT)).entries()) {
-			const prefix = index === 0 ? theme.fg("dim", " ╰─ ") : " ".repeat(LABEL_INDENT);
-			lines.push(`${prefix}${line}`);
-		}
+		const lines = new Text(this.label, 1, 0).render(width);
 		for (const field of this.fields) {
-			if (width >= VALUE_COLUMN) {
-				this.renderWideField(field, width, lines);
+			lines.push(...new Text(theme.fg("muted", field.label), 1, 0).render(width));
+			if (field.change) {
+				const { diff } = generateDiffString(
+					field.change.removed.join("\n"),
+					field.change.added.join("\n"),
+					Number.MAX_SAFE_INTEGER,
+				);
+				const inset = width > 1 ? " " : "";
+				for (const row of renderRichDiff(diff, width - inset.length)) lines.push(`${inset}${row}`);
 			} else {
-				this.renderNarrowField(field, width, lines);
+				for (const row of new Text(field.value.join("\n"), 1, 0).render(width)) lines.push(row);
 			}
 		}
 		return lines;
-	}
-
-	private renderWideField(field: EditFieldRows, width: number, lines: string[]): void {
-		const keyColumn =
-			" ".repeat(LABEL_INDENT) + theme.fg("muted", field.label) + " ".repeat(KEY_WIDTH - field.label.length);
-		const keyIndent = " ".repeat(LABEL_INDENT + KEY_WIDTH);
-		const valueWidth = Math.max(1, width - VALUE_COLUMN);
-		let keyShown = false;
-		for (const row of fieldRows(field)) {
-			for (const [index, segment] of wrapTextWithAnsi(row.text, valueWidth).entries()) {
-				const marker = index === 0 && row.marker ? theme.fg(row.color, `${row.marker} `) : "  ";
-				const prefix = keyShown ? keyIndent : keyColumn;
-				keyShown = true;
-				lines.push(`${prefix}${marker}${theme.fg(row.color, segment)}`);
-			}
-		}
-	}
-
-	// Terminals narrower than the value column fall back to stacked rows.
-	private renderNarrowField(field: EditFieldRows, width: number, lines: string[]): void {
-		const valueWidth = Math.max(1, width - LABEL_INDENT);
-		const indent = " ".repeat(LABEL_INDENT);
-		for (const line of wrapTextWithAnsi(theme.fg("muted", field.label), valueWidth)) {
-			lines.push(`${indent}${line}`);
-		}
-		for (const row of fieldRows(field)) {
-			const marker = row.marker ? `${row.marker} ` : "";
-			for (const line of wrapTextWithAnsi(theme.fg(row.color, `${marker}${row.text}`), valueWidth)) {
-				lines.push(`${indent}${line}`);
-			}
-		}
 	}
 }
 
@@ -202,23 +184,30 @@ export class RefinementOutcomeMessageComponent extends ExpandableEventMessage {
 	protected updateDisplay(): void {
 		this.clear();
 
-		const { summary, edits, scope } = this.message.details;
+		const { summary, edits, scope, rollbackOf, refinementId } = this.message.details;
 		this.addChild(new Spacer(1));
-		this.addSummary(summary, `Refinement · ${editCount(edits)}`);
-		if (!this.expanded) {
-			for (const edit of edits) {
-				this.addChild(new RefinementEditSection(editLabel(edit, scope)));
-			}
-			return;
-		}
+		this.addChild(new Text(theme.fg("accent", `◆ ${refinementHeader(this.message)}`), 1, 0));
+		this.addSummary(summary.trim() || "No summary was recorded for this harness change.");
+		if (this.expanded) {
+			this.addChild(new Spacer(1));
+			this.addChild(
+				new Text(
+					theme.fg(
+						"dim",
+						`Refinement ${refinementId} · ${scope}${rollbackOf ? ` · rollback of ${rollbackOf}` : ""}`,
+					),
+					1,
+					0,
+				),
+			);
 
-		this.addChild(new Spacer(1));
-		for (const [index, edit] of edits.entries()) {
-			if (index > 0) {
+			for (const edit of edits) {
 				this.addChild(new Spacer(1));
+				this.addChild(new RefinementEditSection(editLabel(edit, scope), editFieldRows(edit)));
+				if (edit.reason) this.addChild(new Text(theme.fg("muted", `Reason: ${edit.reason}`), 1, 0));
 			}
-			this.addChild(new RefinementEditSection(editLabel(edit, scope), editFieldRows(edit)));
 		}
+		this.addChild(new Spacer(1));
 	}
 }
 
@@ -232,5 +221,6 @@ export class MalformedRefinementOutcomeMessageComponent extends ExpandableEventM
 		this.clear();
 		this.addChild(new Spacer(1));
 		this.addChild(new Text(theme.fg("error", "[Malformed refinement outcome message]"), 1, 0));
+		this.addChild(new Spacer(1));
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/refinement-outcome-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/refinement-outcome-message.ts
@@ -1,11 +1,10 @@
-import { type Component, Spacer, Text, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { Spacer, Text } from "@earendil-works/pi-tui";
 import type { RefinementOutcomeMessage } from "../../../core/messages.js";
 import type { AppliedRefinementEdit, HarnessEntry } from "../../../core/refinement/refinement.js";
 import { generateDiffString } from "../../../core/tools/edit-diff.js";
 import { theme } from "../theme/theme.js";
 import { renderDiff } from "./diff.js";
-import { customMessageLabel, ExpandableCustomMessageBox } from "./expandable-custom-message.js";
-import { expandCollapseHint } from "./keybinding-hints.js";
+import { ExpandableEventMessage } from "./expandable-event-message.js";
 
 function editableEntry(entry: HarnessEntry): Record<string, unknown> {
 	return {
@@ -60,24 +59,8 @@ function editCount(edits: AppliedRefinementEdit[]): string {
 		: `${applied}/${edits.length} edits applied`;
 }
 
-/** Width-aware collapsed line: truncates the summary so the line never wraps. */
-class CollapsedOutcomeLine implements Component {
-	constructor(
-		private readonly summary: string,
-		private readonly suffix: string,
-	) {}
-
-	render(width: number): string[] {
-		const room = Math.max(20, width - visibleWidth(this.suffix) - 1);
-		const line = `${theme.fg("customMessageText", truncateToWidth(this.summary, room, "…"))} ${this.suffix}`;
-		return [truncateToWidth(line, Math.max(1, width), "")];
-	}
-
-	invalidate(): void {}
-}
-
-/** Durable refinement outcome card: per-edit rows with before/after diffs when expanded. */
-export class RefinementOutcomeMessageComponent extends ExpandableCustomMessageBox {
+/** Durable refinement outcome with per-edit before/after diffs available on demand. */
+export class RefinementOutcomeMessageComponent extends ExpandableEventMessage {
 	constructor(private readonly message: RefinementOutcomeMessage) {
 		super();
 		this.updateDisplay();
@@ -87,15 +70,11 @@ export class RefinementOutcomeMessageComponent extends ExpandableCustomMessageBo
 		this.clear();
 
 		const { summary, edits, scope } = this.message.details;
-		this.addChild(new Text(customMessageLabel("refinement"), 0, 0));
 		this.addChild(new Spacer(1));
-		if (!this.expanded) {
-			const suffix = `${theme.fg("customMessageText", `· ${editCount(edits)}`)} ${expandCollapseHint("app.tools.expand", false)}`;
-			this.addChild(new CollapsedOutcomeLine(summary, suffix));
-			return;
-		}
+		this.addSummary(summary, `Refinement · ${editCount(edits)}`);
+		if (!this.expanded) return;
 
-		this.addChild(new Text(theme.fg("customMessageText", `${summary} · ${editCount(edits)}`), 0, 0));
+		this.addChild(new Spacer(1));
 		for (const edit of edits) {
 			this.addChild(new Text(`${theme.fg("dim", "  ╰─ ")}${editLabel(edit, scope)}`, 0, 0));
 			const diff = editDiff(edit);
@@ -104,7 +83,7 @@ export class RefinementOutcomeMessageComponent extends ExpandableCustomMessageBo
 	}
 }
 
-export class MalformedRefinementOutcomeMessageComponent extends ExpandableCustomMessageBox {
+export class MalformedRefinementOutcomeMessageComponent extends ExpandableEventMessage {
 	constructor() {
 		super();
 		this.updateDisplay();
@@ -112,6 +91,7 @@ export class MalformedRefinementOutcomeMessageComponent extends ExpandableCustom
 
 	protected updateDisplay(): void {
 		this.clear();
+		this.addChild(new Spacer(1));
 		this.addChild(new Text(theme.fg("error", "[Malformed refinement outcome message]"), 0, 0));
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/theme/dark.json
+++ b/packages/coding-agent/src/modes/interactive/theme/dark.json
@@ -39,6 +39,8 @@
 		"customMessageBg": "customMsgBg",
 		"customMessageText": "",
 		"customMessageLabel": "#9575cd",
+		"refinementHeader": "#9575cd",
+		"refinementSummary": "#b7a1d6",
 		"toolPendingBg": "toolPendingBg",
 		"toolSuccessBg": "toolSuccessBg",
 		"toolErrorBg": "toolErrorBg",

--- a/packages/coding-agent/src/modes/interactive/theme/light.json
+++ b/packages/coding-agent/src/modes/interactive/theme/light.json
@@ -38,6 +38,8 @@
 		"customMessageBg": "customMsgBg",
 		"customMessageText": "",
 		"customMessageLabel": "#7e57c2",
+		"refinementHeader": "#7146ab",
+		"refinementSummary": "#8a70ad",
 		"toolPendingBg": "toolPendingBg",
 		"toolSuccessBg": "toolSuccessBg",
 		"toolErrorBg": "toolErrorBg",

--- a/packages/coding-agent/src/modes/interactive/theme/prime.json
+++ b/packages/coding-agent/src/modes/interactive/theme/prime.json
@@ -45,6 +45,8 @@
 		"customMessageBg": "customMsgBg",
 		"customMessageText": "",
 		"customMessageLabel": "warning",
+		"refinementHeader": "#9575cd",
+		"refinementSummary": "#b7a1d6",
 		"toolPendingBg": "toolPendingBg",
 		"toolSuccessBg": "toolSuccessBg",
 		"toolErrorBg": "toolErrorBg",

--- a/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
+++ b/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
@@ -33,7 +33,7 @@
 		},
 		"colors": {
 			"type": "object",
-			"description": "Theme color definitions (all required)",
+			"description": "Theme color definitions (refinement colors have purple defaults)",
 			"required": [
 				"accent",
 				"border",
@@ -159,6 +159,14 @@
 				"customMessageLabel": {
 					"$ref": "#/$defs/colorValue",
 					"description": "Custom message type label color"
+				},
+				"refinementHeader": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Harness refinement status (defaults to purple)"
+				},
+				"refinementSummary": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Harness refinement semantic summary (defaults to softer purple)"
 				},
 				"toolPendingBg": {
 					"$ref": "#/$defs/colorValue",

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -55,6 +55,8 @@ const ThemeJsonSchema = Type.Object({
 		customMessageBg: ColorValueSchema,
 		customMessageText: ColorValueSchema,
 		customMessageLabel: ColorValueSchema,
+		refinementHeader: Type.Optional(ColorValueSchema),
+		refinementSummary: Type.Optional(ColorValueSchema),
 		toolPendingBg: ColorValueSchema,
 		toolSuccessBg: ColorValueSchema,
 		toolErrorBg: ColorValueSchema,
@@ -139,6 +141,8 @@ export type ThemeColor =
 	| "userMessageText"
 	| "customMessageText"
 	| "customMessageLabel"
+	| "refinementHeader"
+	| "refinementSummary"
 	| "toolTitle"
 	| "toolOutput"
 	| "mdHeading"
@@ -184,6 +188,13 @@ export type ThemeBg =
 	| "toolPanelBg";
 
 type ColorMode = "truecolor" | "256color";
+type RefinementColor = "refinementHeader" | "refinementSummary";
+
+function refinementColors(light: boolean): Record<RefinementColor, string> {
+	return light
+		? { refinementHeader: "#7146ab", refinementSummary: "#8a70ad" }
+		: { refinementHeader: "#9575cd", refinementSummary: "#b7a1d6" };
+}
 
 const ADAPTIVE_LIGHT_BG_ACCENT: Rgb = { r: 0, g: 95, b: 135 };
 const SURFACE_MIN_LUMINANCE_DELTA = 12;
@@ -375,7 +386,8 @@ export class Theme {
 	private mode: ColorMode;
 
 	constructor(
-		fgColors: Record<ThemeColor, string | number>,
+		fgColors: Record<Exclude<ThemeColor, RefinementColor>, string | number> &
+			Partial<Record<RefinementColor, string | number>>,
 		bgColors: Record<ThemeBg, string | number>,
 		mode: ColorMode,
 		options: { name?: string; sourcePath?: string; sourceInfo?: SourceInfo } = {},
@@ -385,6 +397,9 @@ export class Theme {
 		this.sourceInfo = options.sourceInfo;
 		this.mode = mode;
 		this.fgColors = new Map();
+		for (const [key, value] of Object.entries(refinementColors(options.name === "light"))) {
+			this.fgColors.set(key as RefinementColor, fgAnsi(value, mode));
+		}
 		for (const [key, value] of Object.entries(fgColors) as [ThemeColor, string | number][]) {
 			this.fgColors.set(key, fgAnsi(value, mode));
 		}
@@ -757,7 +772,10 @@ function loadThemeJson(name: string): ThemeJson {
 
 function createTheme(themeJson: ThemeJson, mode?: ColorMode, sourcePath?: string): Theme {
 	const colorMode = mode ?? detectColorMode();
-	const resolvedColors = resolveThemeColors(themeJson.colors, themeJson.vars);
+	const resolvedColors = resolveThemeColors(
+		{ ...refinementColors(themeJson.name === "light"), ...themeJson.colors },
+		themeJson.vars,
+	);
 	const fgColors: Record<ThemeColor, string | number> = {} as Record<ThemeColor, string | number>;
 	const bgColors: Record<ThemeBg, string | number> = {} as Record<ThemeBg, string | number>;
 	const bgColorKeys: Set<string> = new Set([
@@ -1093,7 +1111,10 @@ export function getResolvedThemeColors(themeName?: string): Record<string, strin
 	const name = themeName ?? currentThemeName ?? getDefaultTheme();
 	const isLight = name === "light";
 	const themeJson = loadThemeJson(name);
-	const resolved = resolveThemeColors(themeJson.colors, themeJson.vars);
+	const resolved = resolveThemeColors(
+		{ ...refinementColors(themeJson.name === "light"), ...themeJson.colors },
+		themeJson.vars,
+	);
 
 	// Default text color for empty values (terminal uses default fg color)
 	const defaultText = isLight ? "#000000" : "#e5e5e7";

--- a/packages/coding-agent/test/compaction-message-components.test.ts
+++ b/packages/coding-agent/test/compaction-message-components.test.ts
@@ -1,0 +1,67 @@
+import { setKeybindings, visibleWidth } from "@earendil-works/pi-tui";
+import stripAnsi from "strip-ansi";
+import { beforeAll, describe, expect, test } from "vitest";
+import { KeybindingsManager } from "../src/core/keybindings.js";
+import { createCompactionOutcomeMessage, createCompactionSummaryMessage } from "../src/core/messages.js";
+import { CompactionOutcomeMessageComponent } from "../src/modes/interactive/components/compaction-outcome-message.js";
+import { CompactionSummaryMessageComponent } from "../src/modes/interactive/components/compaction-summary-message.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+describe("compact compaction messages", () => {
+	beforeAll(() => {
+		initTheme("dark");
+		setKeybindings(new KeybindingsManager());
+	});
+
+	test("shows the result and details hint without a separate banner or blank rows", () => {
+		const component = new CompactionSummaryMessageComponent(
+			createCompactionSummaryMessage("## Next steps\n\nFinish the authentication fixes.", 120480, "2026-09-09"),
+		);
+		const collapsed = component.render(80).map((line) => stripAnsi(line).trimEnd());
+
+		expect(collapsed).toEqual(["Compacted from 120,480 tokens", "Compaction (Ctrl+O to expand)"]);
+
+		component.setExpanded(true);
+		const expanded = stripAnsi(component.render(80).join("\n"));
+		expect(expanded).toContain("Next steps");
+		expect(expanded).toContain("Finish the authentication fixes.");
+		expect(expanded).toContain("Ctrl+O to collapse");
+
+		component.setExpanded(false);
+		expect(component.render(80).map((line) => stripAnsi(line).trimEnd())).toEqual(collapsed);
+	});
+
+	test("keeps long focus instructions bounded in the preview and complete in the expanded view", () => {
+		const focus =
+			"Keep the authentication investigation, the remaining rollout decisions, and the exact reproduction steps.\nPreserve the failing command and the environment details for the next turn.";
+		const component = new CompactionSummaryMessageComponent(
+			createCompactionSummaryMessage("Full retained summary.", 12345, "2026-09-09", focus),
+		);
+		const lines = component.render(80).map((line) => stripAnsi(line).trimEnd());
+		expect(lines).toHaveLength(3);
+		expect(lines[0]).toContain("Compacted from 12,345 tokens · focus:");
+		expect(lines[1]).toContain("…");
+		expect(lines[2]).toContain("Ctrl+O to expand");
+
+		for (const width of [12, 24, 40, 80]) {
+			for (const line of component.render(width)) {
+				expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+			}
+		}
+
+		component.setExpanded(true);
+		const expanded = stripAnsi(component.render(80).join("\n")).replace(/\s+/g, " ");
+		expect(expanded).toContain(focus.replace(/\s+/g, " "));
+		expect(expanded).toContain("Full retained summary.");
+	});
+
+	test.each(["skipped", "cancelled", "failed"] as const)("keeps the full %s explanation visible", (outcome) => {
+		const content = `Auto-compaction ${outcome}: the context could not be compacted because the summary request did not complete. The original conversation remains available.`;
+		const component = new CompactionOutcomeMessageComponent(
+			createCompactionOutcomeMessage(content, { outcome, reason: "threshold" }),
+		);
+		const lines = component.render(80).map((line) => stripAnsi(line).trimEnd());
+		expect(lines.join(" ").trim()).toBe(content);
+		expect(lines.filter((line) => line === "")).toHaveLength(1);
+	});
+});

--- a/packages/coding-agent/test/compaction-message-components.test.ts
+++ b/packages/coding-agent/test/compaction-message-components.test.ts
@@ -13,13 +13,13 @@ describe("compact compaction messages", () => {
 		setKeybindings(new KeybindingsManager());
 	});
 
-	test("shows the result and details hint without a separate banner or blank rows", () => {
+	test("shows the result and metadata without repeating the conversation detail shortcut", () => {
 		const component = new CompactionSummaryMessageComponent(
 			createCompactionSummaryMessage("## Next steps\n\nFinish the authentication fixes.", 120480, "2026-09-09"),
 		);
 		const collapsed = component.render(80).map((line) => stripAnsi(line).trimEnd());
 
-		expect(collapsed).toEqual([" Compacted from 120,480 tokens", " Compaction (Ctrl+O to expand)"]);
+		expect(collapsed).toEqual([" Compacted from 120,480 tokens", " Compaction"]);
 		for (const line of collapsed) {
 			expect(line.startsWith(" ")).toBe(true);
 		}
@@ -28,7 +28,7 @@ describe("compact compaction messages", () => {
 		const expanded = stripAnsi(component.render(80).join("\n"));
 		expect(expanded).toContain("Next steps");
 		expect(expanded).toContain("Finish the authentication fixes.");
-		expect(expanded).toContain("Ctrl+O to collapse");
+		expect(expanded).not.toContain("Ctrl+O");
 
 		component.setExpanded(false);
 		expect(component.render(80).map((line) => stripAnsi(line).trimEnd())).toEqual(collapsed);
@@ -47,7 +47,7 @@ describe("compact compaction messages", () => {
 			if (line.length > 0) expect(line.startsWith(" ")).toBe(true);
 		}
 		expect(lines[1]).toContain("…");
-		expect(lines[2]).toContain("Ctrl+O to expand");
+		expect(lines[2]).toBe(" Compaction");
 
 		for (const width of [12, 24, 40, 80]) {
 			for (const line of component.render(width)) {

--- a/packages/coding-agent/test/compaction-message-components.test.ts
+++ b/packages/coding-agent/test/compaction-message-components.test.ts
@@ -1,64 +1,122 @@
-import { setKeybindings, visibleWidth } from "@earendil-works/pi-tui";
+import { Container, setKeybindings, Text, visibleWidth } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
-import { beforeAll, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.js";
-import { createCompactionOutcomeMessage, createCompactionSummaryMessage } from "../src/core/messages.js";
+import { convertToLlm, createCompactionOutcomeMessage, createCompactionSummaryMessage } from "../src/core/messages.js";
 import { CompactionOutcomeMessageComponent } from "../src/modes/interactive/components/compaction-outcome-message.js";
 import { CompactionSummaryMessageComponent } from "../src/modes/interactive/components/compaction-summary-message.js";
-import { initTheme } from "../src/modes/interactive/theme/theme.js";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
+import { getMarkdownTheme, initTheme, theme } from "../src/modes/interactive/theme/theme.js";
 
 describe("compact compaction messages", () => {
-	beforeAll(() => {
+	beforeEach(() => {
 		initTheme("dark");
 		setKeybindings(new KeybindingsManager());
 	});
 
-	test("shows the result and metadata without repeating the conversation detail shortcut", () => {
+	test.each(["prime", "dark", "light"])("matches the refinement header and softer summary in the %s theme", (name) => {
+		initTheme(name);
+		const summary = "Finish the authentication fixes.";
 		const component = new CompactionSummaryMessageComponent(
-			createCompactionSummaryMessage("## Next steps\n\nFinish the authentication fixes.", 120480, "2026-09-09"),
+			createCompactionSummaryMessage(summary, 120480, "2026-09-09"),
 		);
-		const collapsed = component.render(80).map((line) => stripAnsi(line).trimEnd());
-
-		expect(collapsed).toEqual([" Compacted from 120,480 tokens", " Compaction"]);
-		for (const line of collapsed) {
-			expect(line.startsWith(" ")).toBe(true);
-		}
+		const collapsed = component.render(80);
+		expect(collapsed.map((line) => stripAnsi(line).trimEnd())).toEqual([
+			" ◆ Context compacted",
+			" Finish the authentication fixes.",
+		]);
+		expect(collapsed[0]).toContain(theme.fg("refinementHeader", "◆ Context compacted"));
+		expect(collapsed[1]).toBe(theme.fg("refinementSummary", ` ${summary}`));
+		expect(theme.getFgAnsi("refinementHeader")).not.toBe(theme.getFgAnsi("refinementSummary"));
 
 		component.setExpanded(true);
 		const expanded = stripAnsi(component.render(80).join("\n"));
-		expect(expanded).toContain("Next steps");
-		expect(expanded).toContain("Finish the authentication fixes.");
+		expect(expanded).toContain(summary);
+		expect(expanded).toContain("Compacted from 120,480 tokens");
 		expect(expanded).not.toContain("Ctrl+O");
-
 		component.setExpanded(false);
-		expect(component.render(80).map((line) => stripAnsi(line).trimEnd())).toEqual(collapsed);
+		expect(component.render(80)).toEqual(collapsed);
 	});
 
-	test("keeps long focus instructions bounded in the preview and complete in the expanded view", () => {
+	test("previews the stored summary instead of focus instructions and reveals all metadata on expansion", () => {
 		const focus =
-			"Keep the authentication investigation, the remaining rollout decisions, and the exact reproduction steps.\nPreserve the failing command and the environment details for the next turn.";
-		const component = new CompactionSummaryMessageComponent(
-			createCompactionSummaryMessage("Full retained summary.", 12345, "2026-09-09", focus),
-		);
+			"Keep the exact reproduction steps.\nPreserve the failing command and the environment details for the next turn.";
+		const summary = `${"Retained the authentication investigation and rollout decisions. ".repeat(8)}Final retained detail.`;
+		const message = createCompactionSummaryMessage(summary, 12345, "2026-09-09", focus);
+		const before = JSON.stringify(message);
+		const modelBefore = JSON.stringify(convertToLlm([message]));
+		const component = new CompactionSummaryMessageComponent(message);
 		const lines = component.render(80).map((line) => stripAnsi(line).trimEnd());
 		expect(lines).toHaveLength(3);
-		expect(lines[0]).toContain(" Compacted from 12,345 tokens · focus:");
-		for (const line of lines) {
-			if (line.length > 0) expect(line.startsWith(" ")).toBe(true);
-		}
-		expect(lines[1]).toContain("…");
-		expect(lines[2]).toBe(" Compaction");
+		expect(lines[0]).toBe(" ◆ Context compacted");
+		expect(lines[1]).toContain("Retained the authentication investigation");
+		expect(lines[2]).toContain("…");
+		expect(lines.join("\n")).not.toMatch(/focus:|12,345|Final retained detail/);
 
 		for (const width of [12, 24, 40, 80]) {
-			for (const line of component.render(width)) {
-				expect(visibleWidth(line)).toBeLessThanOrEqual(width);
-			}
+			for (const line of component.render(width)) expect(visibleWidth(line)).toBeLessThanOrEqual(width);
 		}
-
 		component.setExpanded(true);
 		const expanded = stripAnsi(component.render(80).join("\n")).replace(/\s+/g, " ");
+		expect(expanded).toContain(summary);
 		expect(expanded).toContain(focus.replace(/\s+/g, " "));
-		expect(expanded).toContain("Full retained summary.");
+		expect(expanded).toContain("Compacted from 12,345 tokens");
+		expect(JSON.stringify(message)).toBe(before);
+		expect(JSON.stringify(convertToLlm([message]))).toBe(modelBefore);
+	});
+
+	test("preserves full Markdown and the supplied Markdown theme in all output", () => {
+		const heading = vi.fn((text: string) => `heading:${text}`);
+		const component = new CompactionSummaryMessageComponent(
+			createCompactionSummaryMessage("## Next steps\n\nFinish the authentication fixes.", 100, "2026-09-09"),
+			{ ...getMarkdownTheme(), heading },
+		);
+		component.setExpanded(true);
+		expect(stripAnsi(component.render(80).join("\n"))).toContain("heading:Next steps");
+		expect(heading).toHaveBeenCalled();
+	});
+
+	test("retains one leading gap in live and reopened chats through every display stage", () => {
+		const message = createCompactionSummaryMessage("Retained the next task.", 100, "2026-09-09");
+		const createMode = (expanded: boolean) =>
+			Object.assign(Object.create(InteractiveMode.prototype), {
+				chatContainer: new Container(),
+				toolOutputExpanded: expanded,
+				editDiffsExpanded: false,
+				getMarkdownThemeWithSettings: getMarkdownTheme,
+				ui: { isFullscreen: () => true, requestRender: vi.fn() },
+			});
+		const append = (mode: ReturnType<typeof createMode>) => {
+			mode.chatContainer.addChild(new Text("Before compaction", 1, 0));
+			Reflect.get(InteractiveMode.prototype, "addMessageToChat").call(mode, message);
+		};
+		const live = createMode(false);
+		append(live);
+		for (const [expanded, details] of [
+			[false, false],
+			[false, true],
+			[true, true],
+			[false, false],
+		]) {
+			Object.assign(live, { toolOutputExpanded: expanded, editDiffsExpanded: details });
+			Reflect.get(InteractiveMode.prototype, "applyChatExpansion").call(live);
+			const reopened = createMode(expanded!);
+			append(reopened);
+			expect(live.chatContainer.render(80)).toEqual(reopened.chatContainer.render(80));
+			const lines = live.chatContainer.render(80).map((line: string) => stripAnsi(line).trimEnd());
+			expect(lines.slice(0, 3)).toEqual([" Before compaction", "", " ◆ Context compacted"]);
+			expect(lines.at(-1)).not.toBe("");
+			expect(lines.join("\n").includes("Compacted from")).toBe(expanded);
+			expect(lines.join("\n")).toContain("Retained the next task.");
+		}
+	});
+
+	test("labels missing summaries without inventing a result", () => {
+		const component = new CompactionSummaryMessageComponent(createCompactionSummaryMessage("  ", 100, "2026-09-09"));
+		for (const expanded of [false, true]) {
+			component.setExpanded(expanded);
+			expect(stripAnsi(component.render(80).join("\n"))).toContain("No summary was recorded for this compaction.");
+		}
 	});
 
 	test.each(["skipped", "cancelled", "failed"] as const)("keeps the full %s explanation visible", (outcome) => {

--- a/packages/coding-agent/test/compaction-message-components.test.ts
+++ b/packages/coding-agent/test/compaction-message-components.test.ts
@@ -19,7 +19,10 @@ describe("compact compaction messages", () => {
 		);
 		const collapsed = component.render(80).map((line) => stripAnsi(line).trimEnd());
 
-		expect(collapsed).toEqual(["Compacted from 120,480 tokens", "Compaction (Ctrl+O to expand)"]);
+		expect(collapsed).toEqual([" Compacted from 120,480 tokens", " Compaction (Ctrl+O to expand)"]);
+		for (const line of collapsed) {
+			expect(line.startsWith(" ")).toBe(true);
+		}
 
 		component.setExpanded(true);
 		const expanded = stripAnsi(component.render(80).join("\n"));
@@ -39,7 +42,10 @@ describe("compact compaction messages", () => {
 		);
 		const lines = component.render(80).map((line) => stripAnsi(line).trimEnd());
 		expect(lines).toHaveLength(3);
-		expect(lines[0]).toContain("Compacted from 12,345 tokens · focus:");
+		expect(lines[0]).toContain(" Compacted from 12,345 tokens · focus:");
+		for (const line of lines) {
+			if (line.length > 0) expect(line.startsWith(" ")).toBe(true);
+		}
 		expect(lines[1]).toContain("…");
 		expect(lines[2]).toContain("Ctrl+O to expand");
 
@@ -61,7 +67,15 @@ describe("compact compaction messages", () => {
 			createCompactionOutcomeMessage(content, { outcome, reason: "threshold" }),
 		);
 		const lines = component.render(80).map((line) => stripAnsi(line).trimEnd());
-		expect(lines.join(" ").trim()).toBe(content);
+		expect(
+			lines
+				.map((line) => line.trim())
+				.join(" ")
+				.trim(),
+		).toBe(content);
 		expect(lines.filter((line) => line === "")).toHaveLength(1);
+		for (const line of lines) {
+			if (line.length > 0) expect(line.startsWith(" ")).toBe(true);
+		}
 	});
 });

--- a/packages/coding-agent/test/compaction-message-components.test.ts
+++ b/packages/coding-agent/test/compaction-message-components.test.ts
@@ -81,6 +81,7 @@ describe("compact compaction messages", () => {
 		const createMode = (expanded: boolean) =>
 			Object.assign(Object.create(InteractiveMode.prototype), {
 				chatContainer: new Container(),
+				pendingBashComponents: [],
 				toolOutputExpanded: expanded,
 				editDiffsExpanded: false,
 				getMarkdownThemeWithSettings: getMarkdownTheme,

--- a/packages/coding-agent/test/refinement-outcome-message.test.ts
+++ b/packages/coding-agent/test/refinement-outcome-message.test.ts
@@ -11,6 +11,7 @@ import {
 import type { HarnessEntry, RefinementResult } from "../src/core/refinement/refinement.js";
 import { buildConversationComponents } from "../src/modes/interactive/components/conversation-components.js";
 import { RefinementOutcomeMessageComponent } from "../src/modes/interactive/components/refinement-outcome-message.js";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
 import { initTheme, theme } from "../src/modes/interactive/theme/theme.js";
 
 function entry(overrides: Partial<HarnessEntry> = {}): HarnessEntry {
@@ -85,15 +86,14 @@ describe("RefinementOutcomeMessageComponent", () => {
 
 	afterAll(() => vi.unstubAllEnvs());
 
-	test("shows a spaced accent harness header before its semantic summary", () => {
+	test("shows only the purple harness status in overview, then a softer summary and full diffs", () => {
 		const message = createRefinementOutcomeMessage(result());
 		const component = new RefinementOutcomeMessageComponent(message);
 
 		const collapsed = rendered(component);
 		const content = collapsed.split("\n").filter((line) => line.trim());
-		expect(content[0]?.trimEnd()).toBe(" ◆ Harness refined · 1 prompt created");
-		expect(content[1]).toBe(" Added local guidance to make conversational responses rhyme.");
-		expect(component.render(120)[1]).toContain(theme.fg("accent", "◆ Harness refined · 1 prompt created"));
+		expect(content.map((line) => line.trimEnd())).toEqual([" ◆ Harness refined"]);
+		expect(component.render(120)[1]).toContain(theme.fg("customMessageLabel", "◆ Harness refined"));
 		expect(collapsed.split("\n")[0].trim()).toBe("");
 		expect(collapsed.split("\n").at(-1)?.trim()).toBe("");
 		expect(collapsed).not.toContain("Ctrl+O");
@@ -104,6 +104,16 @@ describe("RefinementOutcomeMessageComponent", () => {
 		expect(collapsed).not.toContain("Rhyme response guidance");
 		expect(collapsed).not.toContain("prompts/rhyme-response-guidance.md");
 		expect(collapsed).not.toContain('"content"');
+
+		component.setEditDiffsExpanded(true);
+		const details = rendered(component);
+		expect(details).toContain("Added local guidance to make conversational responses rhyme.");
+		expect(component.render(120).join("\n")).toContain(
+			theme.fg("mdHeading", " Added local guidance to make conversational responses rhyme."),
+		);
+		expect(details).not.toContain("rhyme-response-guidance");
+		expect(details).not.toContain(" Description");
+		expect(details).not.toContain("1 prompt created");
 
 		component.setExpanded(true);
 		const expanded = rendered(component);
@@ -123,6 +133,8 @@ describe("RefinementOutcomeMessageComponent", () => {
 		expect(expanded).not.toContain("+1 {");
 
 		component.setExpanded(false);
+		expect(rendered(component)).toBe(details);
+		component.setEditDiffsExpanded(false);
 		expect(rendered(component)).toBe(collapsed);
 	});
 
@@ -132,10 +144,11 @@ describe("RefinementOutcomeMessageComponent", () => {
 			"Created local memory entries for the verifiers project context and running subagent tracking, plus a reusable subagent spec for parallel codebase exploration.";
 		const component = new RefinementOutcomeMessageComponent(createRefinementOutcomeMessage(long));
 
+		component.setEditDiffsExpanded(true);
 		const lines = component.render(80).map((line) => stripAnsi(line));
 		const content = lines.filter((line) => line.trim().length > 0);
 		expect(content).toHaveLength(3);
-		expect(content[0]).toContain("Harness refined · 1 prompt created");
+		expect(content[0].trim()).toBe("◆ Harness refined");
 		expect(content[1]).toContain("Created local memory entries for the verifiers project context");
 		expect(content[2]).toContain("…");
 		expectChatInset(lines);
@@ -274,8 +287,9 @@ describe("RefinementOutcomeMessageComponent", () => {
 		});
 		const original = JSON.stringify(message);
 		const component = new RefinementOutcomeMessageComponent(message);
-		expect(rendered(component)).toContain("◆ Harness refined · 1 memory updated");
+		expect(rendered(component).trim()).toBe("◆ Harness refined");
 		component.setExpanded(true);
+		expect(rendered(component)).toContain("1 memory updated");
 		const rows = component.render(80);
 		const output = rows.map(stripAnsi).join("\n");
 		expect(output).toMatch(/ Title +\n/);
@@ -313,6 +327,8 @@ describe("RefinementOutcomeMessageComponent", () => {
 				}),
 			);
 			expect(rendered(component)).toContain(expected);
+			expect(rendered(component)).not.toContain("No summary was recorded");
+			component.setEditDiffsExpanded(true);
 			expect(rendered(component)).toContain("No summary was recorded");
 			component.setExpanded(true);
 			if (rollbackOf) expect(rendered(component)).toContain(`rollback of ${rollbackOf}`);
@@ -323,18 +339,37 @@ describe("RefinementOutcomeMessageComponent", () => {
 		}
 	});
 
-	test("replays the durable outcome with the saved tool expansion state", () => {
+	test("matches live and replay refinement stages without changing saved messages", () => {
 		const message = createRefinementOutcomeMessage(result());
-		const [component] = buildConversationComponents([message], {
-			ui: {} as TUI,
-			cwd: "/tmp",
-			toolOptions: {},
-			getToolDefinition: () => undefined,
-			toolsExpanded: true,
+		const original = JSON.stringify(message);
+		const live = new RefinementOutcomeMessageComponent(message);
+		const mode = Object.assign(Object.create(InteractiveMode.prototype), {
+			chatContainer: { children: [live] },
+			ui: { isFullscreen: () => true, requestRender: vi.fn() },
 		});
-
-		expect(component).toBeInstanceOf(RefinementOutcomeMessageComponent);
-		expect(stripAnsi(component!.render(120).join("\n"))).toContain("+ Make conversational responses rhyme.");
+		for (const [toolsExpanded, editDiffsExpanded] of [
+			[false, false],
+			[false, true],
+			[true, true],
+			[false, false],
+		]) {
+			const [replay] = buildConversationComponents([message], {
+				ui: {} as TUI,
+				cwd: "/tmp",
+				toolOptions: {},
+				getToolDefinition: () => undefined,
+				toolsExpanded,
+				editDiffsExpanded,
+			});
+			Object.assign(mode, { toolOutputExpanded: toolsExpanded, editDiffsExpanded });
+			Reflect.get(InteractiveMode.prototype, "applyChatExpansion").call(mode);
+			expect(replay).toBeInstanceOf(RefinementOutcomeMessageComponent);
+			expect(live.render(120)).toEqual(replay!.render(120));
+			const output = rendered(live);
+			expect(output.includes(result().summary)).toBe(toolsExpanded || editDiffsExpanded);
+			expect(output.includes("+ Make conversational responses rhyme.")).toBe(toolsExpanded);
+		}
+		expect(JSON.stringify(message)).toBe(original);
 	});
 
 	test("uses a typed, presentation-only custom message", () => {

--- a/packages/coding-agent/test/refinement-outcome-message.test.ts
+++ b/packages/coding-agent/test/refinement-outcome-message.test.ts
@@ -98,16 +98,17 @@ describe("RefinementOutcomeMessageComponent", () => {
 
 	afterAll(() => vi.unstubAllEnvs());
 
-	test("shows only the purple harness status in overview, then a softer summary and full diffs", () => {
+	test("shows the purple harness status and softer summary in overview and details, then full diffs", () => {
 		const message = createRefinementOutcomeMessage(result());
 		const component = new RefinementOutcomeMessageComponent(message);
 
 		const collapsed = rendered(component);
 		const content = collapsed.split("\n").filter((line) => line.trim());
-		expect(content.map((line) => line.trimEnd())).toEqual([" ◆ Harness refined"]);
+		expect(content.map((line) => line.trimEnd())).toEqual([" ◆ Harness refined", ` ${result().summary}`]);
+		expect(component.render(120).join("\n")).toContain(theme.fg("refinementSummary", ` ${result().summary}`));
 		expect(component.render(120)[1]).toContain(theme.fg("refinementHeader", "◆ Harness refined"));
 		expect(collapsed.split("\n")[0].trim()).toBe("");
-		expect(collapsed.split("\n").at(-1)?.trim()).toBe("◆ Harness refined");
+		expect(collapsed.split("\n").at(-1)?.trim()).toBe(result().summary);
 		expect(collapsed).not.toContain("Ctrl+O");
 		expect(collapsed).not.toContain("[refinement]");
 		expect(collapsed).not.toContain("rhyme-response-guidance");
@@ -119,6 +120,7 @@ describe("RefinementOutcomeMessageComponent", () => {
 
 		component.setEditDiffsExpanded(true);
 		const details = rendered(component);
+		expect(details).toBe(collapsed);
 		expect(details).toContain("Added local guidance to make conversational responses rhyme.");
 		expect(component.render(120).join("\n")).toContain(
 			theme.fg("refinementSummary", " Added local guidance to make conversational responses rhyme."),
@@ -156,8 +158,10 @@ describe("RefinementOutcomeMessageComponent", () => {
 			"Created local memory entries for the verifiers project context and running subagent tracking, plus a reusable subagent spec for parallel codebase exploration.";
 		const component = new RefinementOutcomeMessageComponent(createRefinementOutcomeMessage(long));
 
+		const overview = component.render(80);
 		component.setEditDiffsExpanded(true);
-		const lines = component.render(80).map((line) => stripAnsi(line));
+		expect(component.render(80)).toEqual(overview);
+		const lines = overview.map((line) => stripAnsi(line));
 		const content = lines.filter((line) => line.trim().length > 0);
 		expect(content).toHaveLength(3);
 		expect(content[0].trim()).toBe("◆ Harness refined");
@@ -299,7 +303,7 @@ describe("RefinementOutcomeMessageComponent", () => {
 		});
 		const original = JSON.stringify(message);
 		const component = new RefinementOutcomeMessageComponent(message);
-		expect(rendered(component).trim()).toBe("◆ Harness refined");
+		expect(rendered(component)).toContain(message.details.summary);
 		component.setExpanded(true);
 		expect(rendered(component)).toContain("1 memory updated");
 		const rows = component.render(80);
@@ -339,7 +343,7 @@ describe("RefinementOutcomeMessageComponent", () => {
 				}),
 			);
 			expect(rendered(component)).toContain(expected);
-			expect(rendered(component)).not.toContain("No summary was recorded");
+			expect(rendered(component)).toContain("No summary was recorded");
 			component.setEditDiffsExpanded(true);
 			expect(rendered(component)).toContain("No summary was recorded");
 			component.setExpanded(true);
@@ -378,7 +382,7 @@ describe("RefinementOutcomeMessageComponent", () => {
 			expect(replay).toBeInstanceOf(RefinementOutcomeMessageComponent);
 			expect(live.render(120)).toEqual(replay!.render(120));
 			const output = rendered(live);
-			expect(output.includes(result().summary)).toBe(toolsExpanded || editDiffsExpanded);
+			expect(output).toContain(result().summary);
 			expect(output.includes("+ Make conversational responses rhyme.")).toBe(toolsExpanded);
 		}
 		expect(JSON.stringify(message)).toBe(original);

--- a/packages/coding-agent/test/refinement-outcome-message.test.ts
+++ b/packages/coding-agent/test/refinement-outcome-message.test.ts
@@ -1,6 +1,6 @@
 import { setKeybindings, type TUI, visibleWidth } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
-import { beforeAll, describe, expect, test } from "vitest";
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.js";
 import {
 	convertToLlm,
@@ -11,7 +11,7 @@ import {
 import type { HarnessEntry, RefinementResult } from "../src/core/refinement/refinement.js";
 import { buildConversationComponents } from "../src/modes/interactive/components/conversation-components.js";
 import { RefinementOutcomeMessageComponent } from "../src/modes/interactive/components/refinement-outcome-message.js";
-import { initTheme } from "../src/modes/interactive/theme/theme.js";
+import { initTheme, theme } from "../src/modes/interactive/theme/theme.js";
 
 function entry(overrides: Partial<HarnessEntry> = {}): HarnessEntry {
 	return {
@@ -78,21 +78,27 @@ function expectChatInset(lines: string[]): void {
 
 describe("RefinementOutcomeMessageComponent", () => {
 	beforeAll(() => {
+		vi.stubEnv("COLORTERM", "truecolor");
 		initTheme("dark");
 		setKeybindings(new KeybindingsManager());
 	});
 
-	test("shows the outcome before quiet metadata and expands through the shared tool toggle", () => {
+	afterAll(() => vi.unstubAllEnvs());
+
+	test("shows a spaced accent harness header before its semantic summary", () => {
 		const message = createRefinementOutcomeMessage(result());
 		const component = new RefinementOutcomeMessageComponent(message);
 
 		const collapsed = rendered(component);
 		const content = collapsed.split("\n").filter((line) => line.trim());
-		expect(content[0]).toBe(" Added local guidance to make conversational responses rhyme.");
-		expect(content[1]).toContain("Refinement · 1 edit applied");
-		expect(content[1]).toContain("Ctrl+O to expand");
+		expect(content[0]?.trimEnd()).toBe(" ◆ Harness refined · 1 prompt created");
+		expect(content[1]).toBe(" Added local guidance to make conversational responses rhyme.");
+		expect(component.render(120)[1]).toContain(theme.fg("accent", "◆ Harness refined · 1 prompt created"));
+		expect(collapsed.split("\n")[0].trim()).toBe("");
+		expect(collapsed.split("\n").at(-1)?.trim()).toBe("");
+		expect(collapsed).not.toContain("Ctrl+O");
 		expect(collapsed).not.toContain("[refinement]");
-		expect(collapsed).toContain("╰─ Created local prompt `rhyme-response-guidance`");
+		expect(collapsed).not.toContain("rhyme-response-guidance");
 		expectChatInset(collapsed.split("\n"));
 		// Collapsed rows stay compact: entry details only render when expanded.
 		expect(collapsed).not.toContain("Rhyme response guidance");
@@ -102,10 +108,13 @@ describe("RefinementOutcomeMessageComponent", () => {
 		component.setExpanded(true);
 		const expanded = rendered(component);
 		expect(expanded).toContain("Created local prompt `rhyme-response-guidance`");
-		expect(expanded).toContain("Title      Rhyme response guidance");
-		expect(expanded).toContain("Content    Make conversational responses rhyme.");
-		expect(expanded).toContain("Path       prompts/rhyme-response-guidance.md");
-		expect(expanded).toContain("Ctrl+O to collapse");
+		expect(expanded).toContain(" Title");
+		expect(expanded).toContain("+ Rhyme response guidance");
+		expect(expanded).toContain(" Description");
+		expect(expanded).toContain("+ Make conversational responses rhyme.");
+		expect(expanded).toContain(" Path");
+		expect(expanded).toContain("prompts/rhyme-response-guidance.md");
+		expect(expanded).not.toContain("Ctrl+O");
 		expectChatInset(expanded.split("\n"));
 		// Structured rows, not a JSON dump.
 		expect(expanded).not.toContain('"content":');
@@ -117,7 +126,7 @@ describe("RefinementOutcomeMessageComponent", () => {
 		expect(rendered(component)).toBe(collapsed);
 	});
 
-	test("gives long outcomes two preview lines without sacrificing the edit count and details hint", () => {
+	test("gives long semantic summaries two preview lines beneath the harness header", () => {
 		const long = result();
 		long.summary =
 			"Created local memory entries for the verifiers project context and running subagent tracking, plus a reusable subagent spec for parallel codebase exploration.";
@@ -125,12 +134,10 @@ describe("RefinementOutcomeMessageComponent", () => {
 
 		const lines = component.render(80).map((line) => stripAnsi(line));
 		const content = lines.filter((line) => line.trim().length > 0);
-		expect(content).toHaveLength(4);
-		expect(content[0]).toContain("Created local memory entries for the verifiers project context");
-		expect(content[1]).toContain("…");
-		expect(content[2]).toContain("1 edit applied");
-		expect(content[2]).toContain("Ctrl+O to expand");
-		expect(content[3]).toContain("╰─ Created local prompt `rhyme-response-guidance`");
+		expect(content).toHaveLength(3);
+		expect(content[0]).toContain("Harness refined · 1 prompt created");
+		expect(content[1]).toContain("Created local memory entries for the verifiers project context");
+		expect(content[2]).toContain("…");
 		expectChatInset(lines);
 		for (const line of lines) {
 			expect(visibleWidth(line)).toBeLessThanOrEqual(80);
@@ -164,11 +171,12 @@ describe("RefinementOutcomeMessageComponent", () => {
 		expectChatInset(output.split("\n"));
 
 		expect(output).toContain("Updated local prompt `tone-guidance`");
-		expect(output).toContain("Content  - Respond plainly.");
-		expect(output).toMatch(/ {13}\+ Respond in rhyme\./);
-		expect(output).toContain("Title      Tone guidance");
+		expect(output).toContain(" Description");
+		expect(output).toContain("  1 - Respond plainly.");
+		expect(output).toContain("  1 + Respond in rhyme.");
+		expect(output).toContain(" Tone guidance");
 		expect(output).toContain("Deleted local prompt `obsolete-guidance`");
-		expect(output).toContain("Content    Use prose.");
+		expect(output).toContain("  1 - Use prose.");
 		expect(output).not.toContain('"content":');
 	});
 
@@ -217,23 +225,23 @@ describe("RefinementOutcomeMessageComponent", () => {
 		const component = new RefinementOutcomeMessageComponent(message);
 
 		const collapsed = rendered(component);
-		expect(collapsed).toContain("Refinement · 2/3 edits applied");
-		expect(collapsed).toContain("╰─ Created local skill `linear`");
-		expect(collapsed).toContain("╰─ Updated local memory `osint-tips`");
-		expect(collapsed).toContain("╰─ Failed to delete local prompt `stale-note`: entry not found");
+		expect(collapsed).toContain("Harness partially refined · 2/3 edits applied");
+		expect(collapsed).not.toContain("`linear`");
+		expect(collapsed).not.toContain("`osint-tips`");
+		expect(collapsed).not.toContain("`stale-note`");
 		expectChatInset(collapsed.split("\n"));
 
 		component.setExpanded(true);
 		const expanded = rendered(component);
 		expectChatInset(expanded.split("\n"));
-		expect(expanded).toContain("Title      Linear issues");
-		expect(expanded).toContain("Content    Read and write Linear issues via MCP.");
-		expect(expanded).toContain('Reference  {"type":"python","import":"linear","callable":"run"}');
-		expect(expanded).toContain('Arguments  {"name":{"type":"string","required":true}}');
-		expect(expanded).toContain("Content  - Use blogs.");
-		expect(expanded).toMatch(/ {13}\+ Use blogs and acknowledgements\./);
+		expect(expanded).toContain("+ Linear issues");
+		expect(expanded).toContain("+ Read and write Linear issues via MCP.");
+		expect(expanded).toContain('+ {"type":"python","import":"linear","callable":"run"}');
+		expect(expanded).toContain('+ {"name":{"type":"string","required":true}}');
+		expect(expanded).toContain("  1 - Use blogs.");
+		expect(expanded).toContain("  1 + Use blogs and acknowledgements.");
 		expect(expanded).toContain("Failed to delete local prompt `stale-note`: entry not found");
-		expect(expanded).toContain("Title      Stale note");
+		expect(expanded).toContain(" Stale note");
 		// The raw JSON-diff blob is gone.
 		expect(expanded).not.toContain('"content":');
 		expect(expanded).not.toContain('"title":');
@@ -242,6 +250,75 @@ describe("RefinementOutcomeMessageComponent", () => {
 		for (const width of [80, 40, 24, 12]) {
 			for (const line of component.render(width)) {
 				expect(visibleWidth(stripAnsi(line))).toBeLessThanOrEqual(width);
+			}
+		}
+	});
+
+	test("shows memory action counts and file-style Title and Description backgrounds without changing the message", () => {
+		const before = entry({ kind: "memory", title: "Old title", content: "    preserve indentation\nOld guidance" });
+		const after = entry({ ...before, title: "New title", content: "    preserve indentation\nNew guidance" });
+		const message = createRefinementOutcomeMessage({
+			...result(),
+			summary: "Remembered the project's authentication conventions.",
+			appliedEdits: [
+				{
+					action: "update",
+					kind: "memory",
+					id: before.id,
+					before,
+					after,
+					applied: true,
+					reason: "Repeated user preference",
+				},
+			],
+		});
+		const original = JSON.stringify(message);
+		const component = new RefinementOutcomeMessageComponent(message);
+		expect(rendered(component)).toContain("◆ Harness refined · 1 memory updated");
+		component.setExpanded(true);
+		const rows = component.render(80);
+		const output = rows.map(stripAnsi).join("\n");
+		expect(output).toMatch(/ Title +\n/);
+		expect(output).toMatch(/ Description +\n/);
+		expect(output).toContain("     preserve indentation");
+		expect(output).toContain("Reason: Repeated user preference");
+		const removed = rows.find((row) => stripAnsi(row).includes("- Old guidance"))!;
+		const added = rows.find((row) => stripAnsi(row).includes("+ New guidance"))!;
+		expect(removed.startsWith(` ${theme.bg("toolDiffRemovedBg", "").slice(0, -5)}`)).toBe(true);
+		expect(added.startsWith(` ${theme.bg("toolDiffAddedBg", "").slice(0, -5)}`)).toBe(true);
+		expect(visibleWidth(removed)).toBe(80);
+		expect(visibleWidth(added)).toBe(80);
+		expect(output).not.toContain("Content");
+		for (const width of [12, 24, 40, 80]) {
+			for (const row of component.render(width)) expect(visibleWidth(row)).toBeLessThanOrEqual(width);
+		}
+		expect(JSON.stringify(message)).toBe(original);
+	});
+
+	test("labels no-change, failed, partial, and rollback outcomes honestly and preserves failure details", () => {
+		const failed = { ...result().appliedEdits[0]!, applied: false, error: "Permission denied" };
+		for (const [edits, rollbackOf, expected] of [
+			[[], undefined, "Harness unchanged · no edits applied"],
+			[[failed], undefined, "Harness refinement failed · 0/1 edits applied"],
+			[[failed], "old-refinement", "Harness rollback failed · 0/1 edits applied"],
+			[[...result().appliedEdits, failed], "old-refinement", "Harness partially rolled back · 1/2 edits applied"],
+			[result().appliedEdits, "old-refinement", "Harness rollback completed · 1 edit applied"],
+		] as const) {
+			const component = new RefinementOutcomeMessageComponent(
+				createRefinementOutcomeMessage({
+					...result(),
+					summary: "",
+					appliedEdits: [...edits],
+					rollbackOf,
+				}),
+			);
+			expect(rendered(component)).toContain(expected);
+			expect(rendered(component)).toContain("No summary was recorded");
+			component.setExpanded(true);
+			if (rollbackOf) expect(rendered(component)).toContain(`rollback of ${rollbackOf}`);
+			if (edits.some((edit) => !edit.applied)) expect(rendered(component)).toContain("Permission denied");
+			if (edits.every((edit) => !edit.applied)) {
+				expect(component.render(120).join("\n")).not.toContain(theme.bg("toolDiffAddedBg", "").slice(0, -5));
 			}
 		}
 	});
@@ -257,7 +334,7 @@ describe("RefinementOutcomeMessageComponent", () => {
 		});
 
 		expect(component).toBeInstanceOf(RefinementOutcomeMessageComponent);
-		expect(stripAnsi(component!.render(120).join("\n"))).toContain("Content    Make conversational responses rhyme.");
+		expect(stripAnsi(component!.render(120).join("\n"))).toContain("+ Make conversational responses rhyme.");
 	});
 
 	test("uses a typed, presentation-only custom message", () => {

--- a/packages/coding-agent/test/refinement-outcome-message.test.ts
+++ b/packages/coding-agent/test/refinement-outcome-message.test.ts
@@ -1,6 +1,12 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { setKeybindings, type TUI, visibleWidth } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import { getThemesDir } from "../src/config.js";
+import type { AgentSessionMessage } from "../src/core/agent-messages.js";
 import { KeybindingsManager } from "../src/core/keybindings.js";
 import {
 	convertToLlm,
@@ -12,7 +18,13 @@ import type { HarnessEntry, RefinementResult } from "../src/core/refinement/refi
 import { buildConversationComponents } from "../src/modes/interactive/components/conversation-components.js";
 import { RefinementOutcomeMessageComponent } from "../src/modes/interactive/components/refinement-outcome-message.js";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
-import { initTheme, theme } from "../src/modes/interactive/theme/theme.js";
+import {
+	initTheme,
+	loadThemeFromPath,
+	preloadThemeValidator,
+	setThemeInstance,
+	theme,
+} from "../src/modes/interactive/theme/theme.js";
 
 function entry(overrides: Partial<HarnessEntry> = {}): HarnessEntry {
 	return {
@@ -93,9 +105,9 @@ describe("RefinementOutcomeMessageComponent", () => {
 		const collapsed = rendered(component);
 		const content = collapsed.split("\n").filter((line) => line.trim());
 		expect(content.map((line) => line.trimEnd())).toEqual([" ◆ Harness refined"]);
-		expect(component.render(120)[1]).toContain(theme.fg("customMessageLabel", "◆ Harness refined"));
+		expect(component.render(120)[1]).toContain(theme.fg("refinementHeader", "◆ Harness refined"));
 		expect(collapsed.split("\n")[0].trim()).toBe("");
-		expect(collapsed.split("\n").at(-1)?.trim()).toBe("");
+		expect(collapsed.split("\n").at(-1)?.trim()).toBe("◆ Harness refined");
 		expect(collapsed).not.toContain("Ctrl+O");
 		expect(collapsed).not.toContain("[refinement]");
 		expect(collapsed).not.toContain("rhyme-response-guidance");
@@ -109,7 +121,7 @@ describe("RefinementOutcomeMessageComponent", () => {
 		const details = rendered(component);
 		expect(details).toContain("Added local guidance to make conversational responses rhyme.");
 		expect(component.render(120).join("\n")).toContain(
-			theme.fg("mdHeading", " Added local guidance to make conversational responses rhyme."),
+			theme.fg("refinementSummary", " Added local guidance to make conversational responses rhyme."),
 		);
 		expect(details).not.toContain("rhyme-response-guidance");
 		expect(details).not.toContain(" Description");
@@ -370,6 +382,116 @@ describe("RefinementOutcomeMessageComponent", () => {
 			expect(output.includes("+ Make conversational responses rhyme.")).toBe(toolsExpanded);
 		}
 		expect(JSON.stringify(message)).toBe(original);
+	});
+
+	test("uses purple refinement colors in every built-in theme and both terminal color modes", () => {
+		try {
+			for (const name of ["prime", "dark", "light"]) {
+				for (const mode of ["truecolor", "256color"] as const) {
+					setThemeInstance(loadThemeFromPath(join(getThemesDir(), `${name}.json`), mode));
+					const component = new RefinementOutcomeMessageComponent(createRefinementOutcomeMessage(result()));
+					const expectedHeader = name === "light" ? "113;70;171" : "149;117;205";
+					const expectedSummary = name === "light" ? "138;112;173" : "183;161;214";
+					if (mode === "truecolor") {
+						expect(component.render(120).join("\n")).toContain(`\x1b[38;2;${expectedHeader}m◆ Harness refined`);
+					} else {
+						expect(theme.getFgAnsi("refinementHeader")).toMatch(/^\x1b\[38;5;\d+m$/);
+					}
+					expect(theme.getFgAnsi("refinementHeader")).not.toBe(theme.getFgAnsi("warning"));
+					expect(theme.getFgAnsi("refinementSummary")).not.toBe(theme.getFgAnsi("refinementHeader"));
+					component.setEditDiffsExpanded(true);
+					if (mode === "truecolor")
+						expect(component.render(120).join("\n")).toContain(
+							`\x1b[38;2;${expectedSummary}m Added local guidance`,
+						);
+				}
+			}
+		} finally {
+			initTheme("dark");
+		}
+	});
+
+	test("gives existing custom themes purple defaults rather than inheriting their warning label", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "refinement-theme-"));
+		try {
+			await preloadThemeValidator();
+			const json = JSON.parse(readFileSync(join(getThemesDir(), "prime.json"), "utf8"));
+			delete json.colors.refinementHeader;
+			delete json.colors.refinementSummary;
+			json.name = "existing-custom";
+			const path = join(directory, "custom.json");
+			writeFileSync(path, JSON.stringify(json));
+			const custom = loadThemeFromPath(path, "truecolor");
+			expect(custom.getFgAnsi("refinementHeader")).toBe("\x1b[38;2;149;117;205m");
+			expect(custom.getFgAnsi("refinementSummary")).toBe("\x1b[38;2;183;161;214m");
+			expect(custom.getFgAnsi("customMessageLabel")).toBe(custom.getFgAnsi("warning"));
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	test("leaves one blank row before following prose through empty and agent-message neighbors in every stage", () => {
+		const assistant = (text: string): AssistantMessage => ({
+			role: "assistant",
+			content: [{ type: "text", text }],
+			api: "openai-responses",
+			provider: "openai",
+			model: "test",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: 0,
+		});
+		const agent: AgentSessionMessage = {
+			role: "custom",
+			customType: "agent_message",
+			content: "Worker finished",
+			display: true,
+			timestamp: 0,
+			details: {
+				id: "worker",
+				message: "Worker finished",
+				from: { sessionId: "worker" },
+				fromRelationship: "child",
+			},
+		};
+		for (const neighbor of [[], [assistant("")], [agent], [agent, assistant("")]]) {
+			for (const [toolsExpanded, editDiffsExpanded] of [
+				[false, false],
+				[false, true],
+				[true, true],
+			]) {
+				const components = buildConversationComponents(
+					[
+						assistant("Before notice"),
+						createRefinementOutcomeMessage(result()),
+						...neighbor,
+						assistant("Following prose"),
+					],
+					{
+						ui: {} as TUI,
+						cwd: "/tmp",
+						toolOptions: {},
+						getToolDefinition: () => undefined,
+						toolsExpanded,
+						editDiffsExpanded,
+					},
+				);
+				const rows = components.flatMap((component) => component.render(120)).map((row) => stripAnsi(row).trim());
+				const following = rows.indexOf("Following prose");
+				expect(rows[following - 1]).toBe("");
+				expect(rows[following - 2]).not.toBe("");
+				const header = rows.indexOf("◆ Harness refined");
+				expect(rows[header - 1]).toBe("");
+				expect(rows[header - 2]).toBe("Before notice");
+			}
+		}
 	});
 
 	test("uses a typed, presentation-only custom message", () => {

--- a/packages/coding-agent/test/refinement-outcome-message.test.ts
+++ b/packages/coding-agent/test/refinement-outcome-message.test.ts
@@ -74,12 +74,15 @@ describe("RefinementOutcomeMessageComponent", () => {
 		setKeybindings(new KeybindingsManager());
 	});
 
-	test("collapses to a labeled one-liner and expands through the shared tool toggle", () => {
+	test("shows the outcome before quiet metadata and expands through the shared tool toggle", () => {
 		const message = createRefinementOutcomeMessage(result());
 		const component = new RefinementOutcomeMessageComponent(message);
 
 		const collapsed = rendered(component);
-		expect(collapsed).toContain("[refinement]");
+		const content = collapsed.split("\n").filter((line) => line.trim());
+		expect(content[0]).toBe("Added local guidance to make conversational responses rhyme.");
+		expect(content[1]).toContain("Refinement · 1 edit applied");
+		expect(collapsed).not.toContain("[refinement]");
 		expect(collapsed).toContain("Added local guidance to make conversational responses rhyme.");
 		expect(collapsed).toContain("1 edit applied");
 		expect(collapsed).toContain("Ctrl+O to expand");
@@ -91,9 +94,13 @@ describe("RefinementOutcomeMessageComponent", () => {
 		expect(expanded).toContain("Created local prompt `rhyme-response-guidance`");
 		expect(expanded).toContain('"content": "Make conversational responses rhyme."');
 		expect(expanded).toContain('"path": "prompts/rhyme-response-guidance.md"');
+		expect(expanded).toContain("Ctrl+O to collapse");
+
+		component.setExpanded(false);
+		expect(rendered(component)).toBe(collapsed);
 	});
 
-	test("truncates the collapsed summary so the line never wraps", () => {
+	test("gives long outcomes two preview lines without sacrificing the edit count and details hint", () => {
 		const long = result();
 		long.summary =
 			"Created local memory entries for the verifiers project context and running subagent tracking, plus a reusable subagent spec for parallel codebase exploration.";
@@ -101,10 +108,11 @@ describe("RefinementOutcomeMessageComponent", () => {
 
 		const lines = component.render(80).map((line) => stripAnsi(line));
 		const content = lines.filter((line) => line.trim().length > 0);
-		expect(content).toHaveLength(2);
+		expect(content).toHaveLength(3);
+		expect(content[0]).toContain("Created local memory entries for the verifiers project context");
 		expect(content[1]).toContain("…");
-		expect(content[1]).toContain("1 edit applied");
-		expect(content[1]).toContain("Ctrl+O to expand");
+		expect(content[2]).toContain("1 edit applied");
+		expect(content[2]).toContain("Ctrl+O to expand");
 		for (const line of lines) {
 			expect(visibleWidth(line)).toBeLessThanOrEqual(80);
 		}
@@ -114,6 +122,9 @@ describe("RefinementOutcomeMessageComponent", () => {
 				expect(visibleWidth(stripAnsi(line))).toBeLessThanOrEqual(width);
 			}
 		}
+
+		component.setExpanded(true);
+		expect(rendered(component).replace(/\s+/g, " ")).toContain(long.summary);
 	});
 
 	test("renders exact before and after payloads for updates and deletes", () => {

--- a/packages/coding-agent/test/refinement-outcome-message.test.ts
+++ b/packages/coding-agent/test/refinement-outcome-message.test.ts
@@ -68,6 +68,14 @@ function rendered(component: RefinementOutcomeMessageComponent): string {
 	return stripAnsi(component.render(120).join("\n"));
 }
 
+function expectChatInset(lines: string[]): void {
+	for (const line of lines) {
+		if (line.trim().length > 0) {
+			expect(line.startsWith(" "), `missing left inset: ${JSON.stringify(line)}`).toBe(true);
+		}
+	}
+}
+
 describe("RefinementOutcomeMessageComponent", () => {
 	beforeAll(() => {
 		initTheme("dark");
@@ -80,21 +88,30 @@ describe("RefinementOutcomeMessageComponent", () => {
 
 		const collapsed = rendered(component);
 		const content = collapsed.split("\n").filter((line) => line.trim());
-		expect(content[0]).toBe("Added local guidance to make conversational responses rhyme.");
+		expect(content[0]).toBe(" Added local guidance to make conversational responses rhyme.");
 		expect(content[1]).toContain("Refinement · 1 edit applied");
+		expect(content[1]).toContain("Ctrl+O to expand");
 		expect(collapsed).not.toContain("[refinement]");
-		expect(collapsed).toContain("Added local guidance to make conversational responses rhyme.");
-		expect(collapsed).toContain("1 edit applied");
-		expect(collapsed).toContain("Ctrl+O to expand");
-		expect(collapsed).not.toContain("Created local prompt");
-		expect(collapsed).not.toContain('Make conversational responses rhyme."');
+		expect(collapsed).toContain("╰─ Created local prompt `rhyme-response-guidance`");
+		expectChatInset(collapsed.split("\n"));
+		// Collapsed rows stay compact: entry details only render when expanded.
+		expect(collapsed).not.toContain("Rhyme response guidance");
+		expect(collapsed).not.toContain("prompts/rhyme-response-guidance.md");
+		expect(collapsed).not.toContain('"content"');
 
 		component.setExpanded(true);
 		const expanded = rendered(component);
 		expect(expanded).toContain("Created local prompt `rhyme-response-guidance`");
-		expect(expanded).toContain('"content": "Make conversational responses rhyme."');
-		expect(expanded).toContain('"path": "prompts/rhyme-response-guidance.md"');
+		expect(expanded).toContain("Title      Rhyme response guidance");
+		expect(expanded).toContain("Content    Make conversational responses rhyme.");
+		expect(expanded).toContain("Path       prompts/rhyme-response-guidance.md");
 		expect(expanded).toContain("Ctrl+O to collapse");
+		expectChatInset(expanded.split("\n"));
+		// Structured rows, not a JSON dump.
+		expect(expanded).not.toContain('"content":');
+		expect(expanded).not.toContain('"title":');
+		expect(expanded).not.toContain('"path":');
+		expect(expanded).not.toContain("+1 {");
 
 		component.setExpanded(false);
 		expect(rendered(component)).toBe(collapsed);
@@ -108,11 +125,13 @@ describe("RefinementOutcomeMessageComponent", () => {
 
 		const lines = component.render(80).map((line) => stripAnsi(line));
 		const content = lines.filter((line) => line.trim().length > 0);
-		expect(content).toHaveLength(3);
+		expect(content).toHaveLength(4);
 		expect(content[0]).toContain("Created local memory entries for the verifiers project context");
 		expect(content[1]).toContain("…");
 		expect(content[2]).toContain("1 edit applied");
 		expect(content[2]).toContain("Ctrl+O to expand");
+		expect(content[3]).toContain("╰─ Created local prompt `rhyme-response-guidance`");
+		expectChatInset(lines);
 		for (const line of lines) {
 			expect(visibleWidth(line)).toBeLessThanOrEqual(80);
 		}
@@ -127,11 +146,11 @@ describe("RefinementOutcomeMessageComponent", () => {
 		expect(rendered(component).replace(/\s+/g, " ")).toContain(long.summary);
 	});
 
-	test("renders exact before and after payloads for updates and deletes", () => {
+	test("renders structured before and after rows for updates and deletes", () => {
 		const base = result();
-		const before = entry({ id: "tone-guidance", content: "Respond plainly." });
-		const after = entry({ id: "tone-guidance", content: "Respond in rhyme.", version: 2 });
-		const deleted = entry({ id: "obsolete-guidance", content: "Use prose." });
+		const before = entry({ id: "tone-guidance", title: "Tone guidance", content: "Respond plainly." });
+		const after = entry({ id: "tone-guidance", title: "Tone guidance", content: "Respond in rhyme.", version: 2 });
+		const deleted = entry({ id: "obsolete-guidance", title: "Obsolete guidance", content: "Use prose." });
 		const message = createRefinementOutcomeMessage({
 			...base,
 			appliedEdits: [
@@ -142,12 +161,89 @@ describe("RefinementOutcomeMessageComponent", () => {
 		const component = new RefinementOutcomeMessageComponent(message);
 		component.setExpanded(true);
 		const output = rendered(component);
+		expectChatInset(output.split("\n"));
 
 		expect(output).toContain("Updated local prompt `tone-guidance`");
+		expect(output).toContain("Content  - Respond plainly.");
+		expect(output).toMatch(/ {13}\+ Respond in rhyme\./);
+		expect(output).toContain("Title      Tone guidance");
 		expect(output).toContain("Deleted local prompt `obsolete-guidance`");
-		expect(output).toContain('"content": "Respond plainly."');
-		expect(output).toContain('"content": "Respond in rhyme."');
-		expect(output).toContain('"content": "Use prose."');
+		expect(output).toContain("Content    Use prose.");
+		expect(output).not.toContain('"content":');
+	});
+
+	test("renders create, update, and failed edits as structured sections with the chat inset", () => {
+		const created = entry({
+			id: "linear",
+			kind: "skill",
+			title: "Linear issues",
+			content: "Read and write Linear issues via MCP.",
+			path: "skills/linear/SKILL.md",
+			reference: { type: "python", import: "linear", callable: "run" },
+			arguments: { name: { type: "string", required: true } },
+		});
+		const before = entry({ id: "osint-tips", kind: "memory", title: "OSINT tips", content: "Use blogs." });
+		const after = entry({
+			id: "osint-tips",
+			kind: "memory",
+			title: "OSINT tips",
+			content: "Use blogs and acknowledgements.",
+		});
+		const message = createRefinementOutcomeMessage({
+			...result(),
+			appliedEdits: [
+				{
+					action: "create",
+					kind: "skill",
+					id: created.id,
+					title: created.title,
+					content: created.content,
+					path: created.path,
+					after: created,
+					applied: true,
+				},
+				{ action: "update", kind: "memory", id: before.id, before, after, applied: true },
+				{
+					action: "delete",
+					kind: "prompt",
+					id: "stale-note",
+					title: "Stale note",
+					content: "Old session note.",
+					applied: false,
+					error: "entry not found",
+				},
+			],
+		});
+		const component = new RefinementOutcomeMessageComponent(message);
+
+		const collapsed = rendered(component);
+		expect(collapsed).toContain("Refinement · 2/3 edits applied");
+		expect(collapsed).toContain("╰─ Created local skill `linear`");
+		expect(collapsed).toContain("╰─ Updated local memory `osint-tips`");
+		expect(collapsed).toContain("╰─ Failed to delete local prompt `stale-note`: entry not found");
+		expectChatInset(collapsed.split("\n"));
+
+		component.setExpanded(true);
+		const expanded = rendered(component);
+		expectChatInset(expanded.split("\n"));
+		expect(expanded).toContain("Title      Linear issues");
+		expect(expanded).toContain("Content    Read and write Linear issues via MCP.");
+		expect(expanded).toContain('Reference  {"type":"python","import":"linear","callable":"run"}');
+		expect(expanded).toContain('Arguments  {"name":{"type":"string","required":true}}');
+		expect(expanded).toContain("Content  - Use blogs.");
+		expect(expanded).toMatch(/ {13}\+ Use blogs and acknowledgements\./);
+		expect(expanded).toContain("Failed to delete local prompt `stale-note`: entry not found");
+		expect(expanded).toContain("Title      Stale note");
+		// The raw JSON-diff blob is gone.
+		expect(expanded).not.toContain('"content":');
+		expect(expanded).not.toContain('"title":');
+		expect(expanded).not.toContain("+1 {");
+
+		for (const width of [80, 40, 24, 12]) {
+			for (const line of component.render(width)) {
+				expect(visibleWidth(stripAnsi(line))).toBeLessThanOrEqual(width);
+			}
+		}
 	});
 
 	test("replays the durable outcome with the saved tool expansion state", () => {
@@ -161,9 +257,7 @@ describe("RefinementOutcomeMessageComponent", () => {
 		});
 
 		expect(component).toBeInstanceOf(RefinementOutcomeMessageComponent);
-		expect(stripAnsi(component!.render(120).join("\n"))).toContain(
-			'"content": "Make conversational responses rhyme."',
-		);
+		expect(stripAnsi(component!.render(120).join("\n"))).toContain("Content    Make conversational responses rhyme.");
 	});
 
 	test("uses a typed, presentation-only custom message", () => {


### PR DESCRIPTION
Refinement notices show a spaced purple `Harness refined` status with the existing semantic summary in softer purple in both overview and details. All output reveals the full summary, change counts, and edit details. Partial, failed, unchanged, and rollback outcomes keep accurate labels. Dedicated optional theme colors provide purple defaults in Prime, dark, light, and existing custom themes. Live rendering and replay use the same display states; the unified Ctrl+O cycle is provided by #2193.

Full refinements retain entry IDs, scope, rollback identity, reasons, and all editable fields. Title and Description sections use the same red/green background rows and line gutters as file diffs, aligned to the chat inset. Unchanged values and failed proposals remain plain text. Refinement spacing uses one separator before following prose, including empty and agent-message neighbors. Successful compaction now uses the same purple diamond header, labeled `Context compacted`, with a softer-purple preview of the stored summary in collapsed and details modes. All output shows the full Markdown summary plus token-count and focus metadata. Failed, skipped, and cancelled compactions keep their full explanations. Neither notice repeats the conversation-detail shortcut.

Validation: focused refinement and compaction tests and `npm run check` pass, covering matching collapsed/details previews, full-output summaries and diffs, live/reopened rendering, composed spacing, built-in and custom themes, narrow widths, failure/rollback labels, and unchanged message data. Presentation only; no model calls, prompt, storage, or protocol changes.

Fixes [ENG-6114](https://linear.app/primeintellect/issue/ENG-6114/make-refinement-and-compaction-notices-compact-and-readable).
Design: [Prime Agent UI/UX Improvements](https://app.notion.com/p/3d672940136f817b99a3d97c7d5fa048).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Redesign refinement and compaction notices with expandable structured diffs
> - Adds `ExpandableEventMessage` base component in [expandable-event-message.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2179/files#diff-40d151dee201213cd4222fa37437fcd0db1e966dd73d6a8c284fa9155e13aab7) with shared expand/collapse state, width-aware two-line collapsed summaries, and full expanded text.
> - Refinement outcomes in [refinement-outcome-message.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2179/files#diff-f692015058a4a066abb55d47530f40b40e65b771e0606299852273ebbf671bd5) now classify results into outcome-specific headers (unchanged, failed, partial, rollback, create, update, delete, mixed) and render labeled field diffs with colored gutter blocks instead of raw JSON dumps.
> - Compaction summaries in [compaction-summary-message.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2179/files#diff-a101ec2686a7361ee5e2a4e13c33eb1e31d3ac54199071062f7c74f6860476b8) show a purple header with a two-line collapsed preview, expanding to full Markdown and token/focus metadata.
> - Compaction outcome messages in [compaction-outcome-message.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2179/files#diff-2c9399384f6df81a97eff029c93f50a52e4356aa0c57dce7328fd4338e840b25) drop the user-message background panel and use indented foreground or error text.
> - Theme system adds optional `refinementHeader` and `refinementSummary` colors to dark, light, and prime themes in [theme.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2179/files#diff-cfeb6df930e2178ee2bad20d06795540093a317adcd9ed03e9b70bf39c667c53) with purple fallback defaults.
> - Behavioral Change: custom themes lacking `refinementHeader`/`refinementSummary` receive purple defaults instead of inheriting their existing warning color; serialized messages and model-facing representations are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13e43c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive TUI presentation and theme tokens only; message payloads and LLM conversion are unchanged per tests.
> 
> **Overview**
> **Refinement and successful compaction notices** are redesigned for a compact chat-first layout: a spaced **◆ Harness refined** / **◆ Context compacted** line in purple, with the semantic summary in a softer purple in both overview and “details” stages. Expand still reveals edit lists, token/focus metadata, and full Markdown summaries without repeating Ctrl+O hints or boxed custom-message backgrounds.
> 
> A new **`ExpandableEventMessage`** base drives collapsed two-line previews (width-safe wrapping) and expanded bodies. **Refinement outcomes** replace whole-entry JSON diffs with labeled fields (**Title**, **Description**, etc.); changed text uses the same red/green **`renderRichDiff`** rows as file edits, with honest headers for partial, failed, unchanged, and rollback cases. **`setEditDiffsExpanded`** aligns refinement summary behavior with the shared tool expansion cycle.
> 
> **Themes** add optional **`refinementHeader`** / **`refinementSummary`** (purple defaults merged for built-in and legacy custom themes). Failed/skipped compaction outcomes stay fully visible as indented text with a single leading gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13e43c221465f13999f51cc46d7b6cc5088388e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->