### PR TITLE
use a compact butterfly in chat and agents view

### DIFF
--- a/packages/coding-agent/.changes/ui-compact-header.md
+++ b/packages/coding-agent/.changes/ui-compact-header.md
@@ -1,2 +1,2 @@
-- Replaced chat and agents splash logos with a compact "prime agent" heading and metadata that stays visible in narrow terminals.
+- Replaced chat and agents splash logos with a compact PRIME wordmark beside runtime metadata, with a "prime agent" text heading in narrow terminals.
 - Removed duplicate prompt suggestions from chat and agents headers.

--- a/packages/coding-agent/.changes/ui-compact-header.md
+++ b/packages/coding-agent/.changes/ui-compact-header.md
@@ -1,2 +1,2 @@
-- Replaced chat and agents splash logos with a compact PRIME wordmark beside runtime metadata, with a "prime agent" text heading in narrow terminals.
+- Replaced chat and agents splash logos with a compact butterfly beside runtime metadata, with a "prime agent" text heading in narrow terminals.
 - Removed duplicate prompt suggestions from chat and agents headers.

--- a/packages/coding-agent/.changes/ui-compact-header.md
+++ b/packages/coding-agent/.changes/ui-compact-header.md
@@ -1,4 +1,4 @@
 - Replaced chat and agents splash logos with a compact solid butterfly beside runtime metadata, with a "prime agent" text heading in narrow terminals.
 - Removed duplicate prompt suggestions from chat and agents headers.
 - Centered runtime metadata vertically beside the compact butterfly and removed the header model line because session rows already show the model.
-- Ordered the centered header metadata so contextual lines like the agents count sit above the working directory.
+- Ordered the centered header metadata so contextual lines like the agents count sit above the working directory, and labeled the working directory line with a dim `cwd` prefix and muted path matching the agents count styling.

--- a/packages/coding-agent/.changes/ui-compact-header.md
+++ b/packages/coding-agent/.changes/ui-compact-header.md
@@ -1,2 +1,3 @@
 - Replaced chat and agents splash logos with a compact solid butterfly beside runtime metadata, with a "prime agent" text heading in narrow terminals.
 - Removed duplicate prompt suggestions from chat and agents headers.
+- Centered runtime metadata vertically beside the compact butterfly and removed the header model line because session rows already show the model.

--- a/packages/coding-agent/.changes/ui-compact-header.md
+++ b/packages/coding-agent/.changes/ui-compact-header.md
@@ -2,3 +2,4 @@
 - Removed duplicate prompt suggestions from chat and agents headers.
 - Centered runtime metadata vertically beside the compact butterfly and removed the header model line because session rows already show the model.
 - Ordered the centered header metadata so contextual lines like the agents count sit above the working directory, and labeled the working directory line with a dim `cwd` prefix and muted path matching the agents count styling.
+- Restored the model line in the chat splash header while keeping the agents-view splash without a model line.

--- a/packages/coding-agent/.changes/ui-compact-header.md
+++ b/packages/coding-agent/.changes/ui-compact-header.md
@@ -1,2 +1,2 @@
-- Changed chat and agents headers to use a compact butterfly mark and concise metadata that stays visible in narrow terminals.
+- Replaced chat and agents splash logos with a compact "prime agent" heading and metadata that stays visible in narrow terminals.
 - Removed duplicate prompt suggestions from chat and agents headers.

--- a/packages/coding-agent/.changes/ui-compact-header.md
+++ b/packages/coding-agent/.changes/ui-compact-header.md
@@ -1,0 +1,2 @@
+- Changed chat and agents headers to use a compact butterfly mark and concise metadata that stays visible in narrow terminals.
+- Removed duplicate prompt suggestions from chat and agents headers.

--- a/packages/coding-agent/.changes/ui-compact-header.md
+++ b/packages/coding-agent/.changes/ui-compact-header.md
@@ -1,2 +1,2 @@
-- Replaced chat and agents splash logos with a compact Braille butterfly beside runtime metadata, with a "prime agent" text heading in narrow terminals.
+- Replaced chat and agents splash logos with a compact solid butterfly beside runtime metadata, with a "prime agent" text heading in narrow terminals.
 - Removed duplicate prompt suggestions from chat and agents headers.

--- a/packages/coding-agent/.changes/ui-compact-header.md
+++ b/packages/coding-agent/.changes/ui-compact-header.md
@@ -1,3 +1,4 @@
 - Replaced chat and agents splash logos with a compact solid butterfly beside runtime metadata, with a "prime agent" text heading in narrow terminals.
 - Removed duplicate prompt suggestions from chat and agents headers.
 - Centered runtime metadata vertically beside the compact butterfly and removed the header model line because session rows already show the model.
+- Ordered the centered header metadata so contextual lines like the agents count sit above the working directory.

--- a/packages/coding-agent/.changes/ui-compact-header.md
+++ b/packages/coding-agent/.changes/ui-compact-header.md
@@ -1,2 +1,2 @@
-- Replaced chat and agents splash logos with a compact butterfly beside runtime metadata, with a "prime agent" text heading in narrow terminals.
+- Replaced chat and agents splash logos with a compact Braille butterfly beside runtime metadata, with a "prime agent" text heading in narrow terminals.
 - Removed duplicate prompt suggestions from chat and agents headers.

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -841,23 +841,17 @@ export class AgentsViewMode implements Component, Focusable {
 				this.editor.invalidate();
 			},
 		};
-		this.splash = new BrandSplashHeader(
-			VERSION,
-			() => this.getSplashModelId(),
-			() => this.getSplashCwd(),
-			undefined,
-			{
-				topPadding: true,
-				getExtraMetadata: () => {
-					const root = this.scopeRootSummary;
-					return [
-						{ label: "agents", value: this.getAgentCountsText() },
-						{ label: "scope", value: root ? getAgentsViewSessionTitle(root) : "global" },
-						{ label: "depth", value: String(getAgentsViewDepth(root)) },
-					];
-				},
+		this.splash = new BrandSplashHeader(VERSION, () => this.getSplashCwd(), undefined, {
+			topPadding: true,
+			getExtraMetadata: () => {
+				const root = this.scopeRootSummary;
+				return [
+					{ label: "agents", value: this.getAgentCountsText() },
+					{ label: "scope", value: root ? getAgentsViewSessionTitle(root) : "global" },
+					{ label: "depth", value: String(getAgentsViewDepth(root)) },
+				];
 			},
-		);
+		});
 	}
 
 	async run(): Promise<AgentsViewRunResult> {
@@ -2720,10 +2714,6 @@ export class AgentsViewMode implements Component, Focusable {
 		const rows = this.ui.terminal.rows;
 		const dockHeight = clippedFullscreenDockHeight(this.renderDock(width).length, rows);
 		return Math.max(0, rows - dockHeight);
-	}
-
-	private getSplashModelId(): string | undefined {
-		return this.rows[this.selectedIndex]?.summary.model?.id ?? this.options.startupModelId;
 	}
 
 	private getSplashCwd(): string {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -480,8 +480,8 @@ export class BrandSplashHeader implements Component {
 		const title = theme.fg("text", titleText);
 		const metaLines = [
 			...(visibleWidth(`${titleText} v${this.version}`) <= metaWidth ? [`${title} ${version}`] : [title, version]),
-			theme.fg("dim", truncatePathMiddle(formatSplashCwd(this.getCwd()), metaWidth)),
 			...extraMetadata.map(({ label, value }) => `${theme.fg("dim", `${label} `)}${theme.fg("muted", value)}`),
+			theme.fg("dim", truncatePathMiddle(formatSplashCwd(this.getCwd()), metaWidth)),
 		];
 		const lines = this.options.topPadding ? [""] : [];
 		const rowCount = Math.max(showLogo ? this.logoRaw.length : 0, metaLines.length);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -478,10 +478,11 @@ export class BrandSplashHeader implements Component {
 		const version = theme.fg("muted", `v${this.version}`);
 		const titleText = "prime agent";
 		const title = theme.fg("text", titleText);
+		const cwdLabel = "cwd ";
 		const metaLines = [
 			...(visibleWidth(`${titleText} v${this.version}`) <= metaWidth ? [`${title} ${version}`] : [title, version]),
 			...extraMetadata.map(({ label, value }) => `${theme.fg("dim", `${label} `)}${theme.fg("muted", value)}`),
-			theme.fg("dim", truncatePathMiddle(formatSplashCwd(this.getCwd()), metaWidth)),
+			`${theme.fg("dim", cwdLabel)}${theme.fg("muted", truncatePathMiddle(formatSplashCwd(this.getCwd()), Math.max(1, metaWidth - visibleWidth(cwdLabel))))}`,
 		];
 		const lines = this.options.topPadding ? [""] : [];
 		const rowCount = Math.max(showLogo ? this.logoRaw.length : 0, metaLines.length);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -456,7 +456,6 @@ export class BrandSplashHeader implements Component {
 
 	constructor(
 		private readonly version: string,
-		private readonly getModelId: () => string | undefined,
 		private readonly getCwd: () => string,
 		private readonly verboseInstructions?: string,
 		private readonly options: BrandSplashHeaderOptions = {},
@@ -481,18 +480,20 @@ export class BrandSplashHeader implements Component {
 		const title = theme.fg("text", titleText);
 		const metaLines = [
 			...(visibleWidth(`${titleText} v${this.version}`) <= metaWidth ? [`${title} ${version}`] : [title, version]),
-			theme.fg("muted", truncateToWidth(this.getModelId() ?? "—", metaWidth)),
 			theme.fg("dim", truncatePathMiddle(formatSplashCwd(this.getCwd()), metaWidth)),
 			...extraMetadata.map(({ label, value }) => `${theme.fg("dim", `${label} `)}${theme.fg("muted", value)}`),
 		];
 		const lines = this.options.topPadding ? [""] : [];
 		const rowCount = Math.max(showLogo ? this.logoRaw.length : 0, metaLines.length);
+		const metaStartIndex = showLogo ? Math.floor((rowCount - metaLines.length) / 2) : 0;
 		for (let index = 0; index < rowCount; index++) {
 			const logoLine = showLogo ? (this.logoRaw[index] ?? "") : "";
 			const logo = showLogo
 				? theme.fg("text", logoLine) + " ".repeat(this.logoCanvasWidth - visibleWidth(logoLine) + this.gutter)
 				: "";
-			const content = truncateToWidth(logo + (metaLines[index] ?? ""), contentWidth);
+			const metaIndex = index - metaStartIndex;
+			const metaLine = metaIndex >= 0 && metaIndex < metaLines.length ? metaLines[metaIndex] : "";
+			const content = truncateToWidth(logo + metaLine, contentWidth);
 			lines.push(
 				" ".repeat(paddingX) + content + " ".repeat(Math.max(0, safeWidth - paddingX - visibleWidth(content))),
 			);
@@ -1449,15 +1450,9 @@ export class InteractiveMode {
 						rawKeyHint("drop files", "to attach"),
 					].join("\n")
 				: undefined;
-			this.builtInHeader = new BrandSplashHeader(
-				this.version,
-				() => this.getCurrentModelId(),
-				() => this.getCurrentCwd(),
-				verboseInstructions,
-				{
-					topPadding: true,
-				},
-			);
+			this.builtInHeader = new BrandSplashHeader(this.version, () => this.getCurrentCwd(), verboseInstructions, {
+				topPadding: true,
+			});
 			this.headerContainer.addChild(this.builtInHeader);
 			this.headerContainer.addChild(new Spacer(1));
 		} else {
@@ -2764,10 +2759,6 @@ export class InteractiveMode {
 
 	private getCurrentModel(): AgentConnectionModel | undefined {
 		return this.connectionState?.model;
-	}
-
-	private getCurrentModelId(): string | undefined {
-		return this.getCurrentModel()?.id;
 	}
 
 	private isAgentStreaming(): boolean {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -446,6 +446,7 @@ export interface BrandSplashMetadataLine {
 export interface BrandSplashHeaderOptions {
 	logo?: string;
 	topPadding?: boolean;
+	getModelId?: () => string | undefined;
 	getExtraMetadata?: () => readonly BrandSplashMetadataLine[];
 }
 
@@ -478,9 +479,21 @@ export class BrandSplashHeader implements Component {
 		const version = theme.fg("muted", `v${this.version}`);
 		const titleText = "prime agent";
 		const title = theme.fg("text", titleText);
+		const modelLabel = "model ";
 		const cwdLabel = "cwd ";
 		const metaLines = [
 			...(visibleWidth(`${titleText} v${this.version}`) <= metaWidth ? [`${title} ${version}`] : [title, version]),
+			...(this.options.getModelId
+				? [
+						`${theme.fg("dim", modelLabel)}${theme.fg(
+							"muted",
+							truncateToWidth(
+								this.options.getModelId() ?? "—",
+								Math.max(1, metaWidth - visibleWidth(modelLabel)),
+							),
+						)}`,
+					]
+				: []),
 			...extraMetadata.map(({ label, value }) => `${theme.fg("dim", `${label} `)}${theme.fg("muted", value)}`),
 			`${theme.fg("dim", cwdLabel)}${theme.fg("muted", truncatePathMiddle(formatSplashCwd(this.getCwd()), Math.max(1, metaWidth - visibleWidth(cwdLabel))))}`,
 		];
@@ -1453,6 +1466,7 @@ export class InteractiveMode {
 				: undefined;
 			this.builtInHeader = new BrandSplashHeader(this.version, () => this.getCurrentCwd(), verboseInstructions, {
 				topPadding: true,
+				getModelId: () => this.getCurrentModelId(),
 			});
 			this.headerContainer.addChild(this.builtInHeader);
 			this.headerContainer.addChild(new Spacer(1));
@@ -2760,6 +2774,10 @@ export class InteractiveMode {
 
 	private getCurrentModel(): AgentConnectionModel | undefined {
 		return this.connectionState?.model;
+	}
+
+	private getCurrentModelId(): string | undefined {
+		return this.getCurrentModel()?.id;
 	}
 
 	private isAgentStreaming(): boolean {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -135,6 +135,7 @@ import {
 	type TelemetryOnboardingOutcome,
 } from "../../core/telemetry.js";
 import { type TruncationResult, truncateTail } from "../../core/tools/truncate.js";
+import { PRIME_WORDMARK } from "../../themes/prime-wordmark.js";
 import { getChangelogPath, parseChangelog } from "../../utils/changelog.js";
 import { spawnHidden, spawnSyncHidden } from "../../utils/child-process.js";
 import { copyToClipboard } from "../../utils/clipboard.js";
@@ -451,7 +452,7 @@ export interface BrandSplashHeaderOptions {
 export class BrandSplashHeader implements Component {
 	private readonly logoRaw: string[];
 	private readonly logoCanvasWidth: number;
-	private readonly gutter = 2;
+	private readonly gutter = 3;
 
 	constructor(
 		private readonly version: string,
@@ -460,7 +461,7 @@ export class BrandSplashHeader implements Component {
 		private readonly verboseInstructions?: string,
 		private readonly options: BrandSplashHeaderOptions = {},
 	) {
-		this.logoRaw = options.logo?.split("\n") ?? [];
+		this.logoRaw = (options.logo ?? PRIME_WORDMARK).split("\n");
 		this.logoCanvasWidth = this.logoRaw.reduce((max, line) => Math.max(max, visibleWidth(line)), 0);
 	}
 
@@ -476,7 +477,7 @@ export class BrandSplashHeader implements Component {
 		const metaWidth = showLogo ? contentWidth - this.logoCanvasWidth - this.gutter : contentWidth;
 		const extraMetadata = this.options.getExtraMetadata?.() ?? [];
 		const version = theme.fg("muted", `v${this.version}`);
-		const titleText = "prime agent";
+		const titleText = showLogo && this.options.logo === undefined ? "agent" : "prime agent";
 		const title = theme.fg("text", titleText);
 		const metaLines = [
 			...(visibleWidth(`${titleText} v${this.version}`) <= metaWidth ? [`${title} ${version}`] : [title, version]),
@@ -1417,7 +1418,7 @@ export class InteractiveMode {
 
 		this.ui.addChild(this.headerContainer);
 
-		// Compact text header with runtime metadata.
+		// Compact wordmark beside runtime metadata.
 		// The model/cwd are read through live getters, so they fill in once the
 		// connection state loads (rebindCurrentSession below). Onboarding, when
 		// required, renders as a full-screen overlay on top of this header.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -135,7 +135,6 @@ import {
 	type TelemetryOnboardingOutcome,
 } from "../../core/telemetry.js";
 import { type TruncationResult, truncateTail } from "../../core/tools/truncate.js";
-import { PRIME_BUTTERFLY_LOGO_COMPACT } from "../../themes/prime-logo.js";
 import { getChangelogPath, parseChangelog } from "../../utils/changelog.js";
 import { spawnHidden, spawnSyncHidden } from "../../utils/child-process.js";
 import { copyToClipboard } from "../../utils/clipboard.js";
@@ -461,7 +460,7 @@ export class BrandSplashHeader implements Component {
 		private readonly verboseInstructions?: string,
 		private readonly options: BrandSplashHeaderOptions = {},
 	) {
-		this.logoRaw = (options.logo ?? PRIME_BUTTERFLY_LOGO_COMPACT).split("\n");
+		this.logoRaw = options.logo?.split("\n") ?? [];
 		this.logoCanvasWidth = this.logoRaw.reduce((max, line) => Math.max(max, visibleWidth(line)), 0);
 	}
 
@@ -477,9 +476,10 @@ export class BrandSplashHeader implements Component {
 		const metaWidth = showLogo ? contentWidth - this.logoCanvasWidth - this.gutter : contentWidth;
 		const extraMetadata = this.options.getExtraMetadata?.() ?? [];
 		const version = theme.fg("muted", `v${this.version}`);
-		const title = theme.bold(theme.fg("text", APP_TITLE));
+		const titleText = "prime agent";
+		const title = theme.fg("text", titleText);
 		const metaLines = [
-			visibleWidth(`${APP_TITLE} v${this.version}`) <= metaWidth ? `${title} ${version}` : version,
+			...(visibleWidth(`${titleText} v${this.version}`) <= metaWidth ? [`${title} ${version}`] : [title, version]),
 			theme.fg("muted", truncateToWidth(this.getModelId() ?? "—", metaWidth)),
 			theme.fg("dim", truncatePathMiddle(formatSplashCwd(this.getCwd()), metaWidth)),
 			...extraMetadata.map(({ label, value }) => `${theme.fg("dim", `${label} `)}${theme.fg("muted", value)}`),
@@ -1417,12 +1417,12 @@ export class InteractiveMode {
 
 		this.ui.addChild(this.headerContainer);
 
-		// Brand splash: side-panel layout with structured runtime metadata on the right.
+		// Compact text header with runtime metadata.
 		// The model/cwd are read through live getters, so they fill in once the
 		// connection state loads (rebindCurrentSession below). Onboarding, when
 		// required, renders as a full-screen overlay on top of this header.
 		if (this.options.verbose || !this.settingsManager.getQuietStartup()) {
-			// Verbose: include the full keybinding cheatsheet under the brand mark.
+			// Verbose: include the full keybinding cheatsheet below the header.
 			const hint = (keybinding: AppKeybinding, description: string) => keyHint(keybinding, description);
 			const verboseInstructions = this.options.verbose
 				? [

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -135,7 +135,7 @@ import {
 	type TelemetryOnboardingOutcome,
 } from "../../core/telemetry.js";
 import { type TruncationResult, truncateTail } from "../../core/tools/truncate.js";
-import { PRIME_WORDMARK } from "../../themes/prime-wordmark.js";
+import { PRIME_COMPACT_BUTTERFLY_LOGO } from "../../themes/prime-logo.js";
 import { getChangelogPath, parseChangelog } from "../../utils/changelog.js";
 import { spawnHidden, spawnSyncHidden } from "../../utils/child-process.js";
 import { copyToClipboard } from "../../utils/clipboard.js";
@@ -461,7 +461,7 @@ export class BrandSplashHeader implements Component {
 		private readonly verboseInstructions?: string,
 		private readonly options: BrandSplashHeaderOptions = {},
 	) {
-		this.logoRaw = (options.logo ?? PRIME_WORDMARK).split("\n");
+		this.logoRaw = (options.logo ?? PRIME_COMPACT_BUTTERFLY_LOGO).split("\n");
 		this.logoCanvasWidth = this.logoRaw.reduce((max, line) => Math.max(max, visibleWidth(line)), 0);
 	}
 
@@ -477,7 +477,7 @@ export class BrandSplashHeader implements Component {
 		const metaWidth = showLogo ? contentWidth - this.logoCanvasWidth - this.gutter : contentWidth;
 		const extraMetadata = this.options.getExtraMetadata?.() ?? [];
 		const version = theme.fg("muted", `v${this.version}`);
-		const titleText = showLogo && this.options.logo === undefined ? "agent" : "prime agent";
+		const titleText = "prime agent";
 		const title = theme.fg("text", titleText);
 		const metaLines = [
 			...(visibleWidth(`${titleText} v${this.version}`) <= metaWidth ? [`${title} ${version}`] : [title, version]),
@@ -1418,7 +1418,7 @@ export class InteractiveMode {
 
 		this.ui.addChild(this.headerContainer);
 
-		// Compact wordmark beside runtime metadata.
+		// Compact butterfly beside runtime metadata.
 		// The model/cwd are read through live getters, so they fill in once the
 		// connection state loads (rebindCurrentSession below). Onboarding, when
 		// required, renders as a full-screen overlay on top of this header.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -135,7 +135,7 @@ import {
 	type TelemetryOnboardingOutcome,
 } from "../../core/telemetry.js";
 import { type TruncationResult, truncateTail } from "../../core/tools/truncate.js";
-import { PRIME_BUTTERFLY_LOGO } from "../../themes/prime-logo.js";
+import { PRIME_BUTTERFLY_LOGO_COMPACT } from "../../themes/prime-logo.js";
 import { getChangelogPath, parseChangelog } from "../../utils/changelog.js";
 import { spawnHidden, spawnSyncHidden } from "../../utils/child-process.js";
 import { copyToClipboard } from "../../utils/clipboard.js";
@@ -447,15 +447,12 @@ export interface BrandSplashHeaderOptions {
 	logo?: string;
 	topPadding?: boolean;
 	getExtraMetadata?: () => readonly BrandSplashMetadataLine[];
-	getHideStartHint?: () => boolean;
-	getStartHint?: () => string;
 }
 
 export class BrandSplashHeader implements Component {
 	private readonly logoRaw: string[];
 	private readonly logoCanvasWidth: number;
-	private readonly gutter = 4;
-	private readonly labelWidth = 9;
+	private readonly gutter = 2;
 
 	constructor(
 		private readonly version: string,
@@ -464,7 +461,7 @@ export class BrandSplashHeader implements Component {
 		private readonly verboseInstructions?: string,
 		private readonly options: BrandSplashHeaderOptions = {},
 	) {
-		this.logoRaw = (options.logo ?? PRIME_BUTTERFLY_LOGO).split("\n");
+		this.logoRaw = (options.logo ?? PRIME_BUTTERFLY_LOGO_COMPACT).split("\n");
 		this.logoCanvasWidth = this.logoRaw.reduce((max, line) => Math.max(max, visibleWidth(line)), 0);
 	}
 
@@ -476,41 +473,29 @@ export class BrandSplashHeader implements Component {
 		const safeWidth = Math.max(1, width);
 		const paddingX = safeWidth > 1 ? 1 : 0;
 		const contentWidth = Math.max(1, safeWidth - paddingX * 2);
-		const metaWidth = contentWidth - this.logoCanvasWidth - this.gutter;
-		const showMeta = metaWidth >= this.labelWidth + 8;
-		const valueWidth = Math.max(1, metaWidth - this.labelWidth);
-		const labelled = (label: string, value: string) => {
-			const displayValue =
-				label === "cwd" ? truncatePathMiddle(value, valueWidth) : truncateToWidth(value, valueWidth);
-			return theme.fg("dim", label.padEnd(this.labelWidth)) + theme.fg("muted", displayValue);
-		};
+		const showLogo = this.logoCanvasWidth > 0 && contentWidth - this.logoCanvasWidth - this.gutter >= 24;
+		const metaWidth = showLogo ? contentWidth - this.logoCanvasWidth - this.gutter : contentWidth;
 		const extraMetadata = this.options.getExtraMetadata?.() ?? [];
-		const hideStartHint = this.options.getHideStartHint?.() ?? false;
-		const startHint = this.options.getStartHint?.() ?? "type to search sessions";
-		const metaLines = showMeta
-			? [
-					labelled("version", `v${this.version}`),
-					labelled("model", this.getModelId() ?? "—"),
-					labelled("cwd", formatSplashCwd(this.getCwd())),
-					...extraMetadata.map((line) => labelled(line.label, line.value)),
-					...(hideStartHint ? [] : ["", theme.fg("dim", startHint)]),
-				]
-			: [];
-		const metaStart = Math.max(0, Math.floor((this.logoRaw.length - metaLines.length) / 2));
+		const version = theme.fg("muted", `v${this.version}`);
+		const title = theme.bold(theme.fg("text", APP_TITLE));
+		const metaLines = [
+			visibleWidth(`${APP_TITLE} v${this.version}`) <= metaWidth ? `${title} ${version}` : version,
+			theme.fg("muted", truncateToWidth(this.getModelId() ?? "—", metaWidth)),
+			theme.fg("dim", truncatePathMiddle(formatSplashCwd(this.getCwd()), metaWidth)),
+			...extraMetadata.map(({ label, value }) => `${theme.fg("dim", `${label} `)}${theme.fg("muted", value)}`),
+		];
 		const lines = this.options.topPadding ? [""] : [];
-		lines.push(
-			...this.logoRaw.map((line, index) => {
-				const colored = theme.fg("text", line);
-				const meta = index >= metaStart && index < metaStart + metaLines.length ? metaLines[index - metaStart] : "";
-				const padding = showMeta
-					? " ".repeat(Math.max(0, this.logoCanvasWidth - visibleWidth(line) + this.gutter))
-					: "";
-				const content = truncateToWidth(colored + padding + meta, contentWidth, "");
-				return (
-					" ".repeat(paddingX) + content + " ".repeat(Math.max(0, safeWidth - paddingX - visibleWidth(content)))
-				);
-			}),
-		);
+		const rowCount = Math.max(showLogo ? this.logoRaw.length : 0, metaLines.length);
+		for (let index = 0; index < rowCount; index++) {
+			const logoLine = showLogo ? (this.logoRaw[index] ?? "") : "";
+			const logo = showLogo
+				? theme.fg("text", logoLine) + " ".repeat(this.logoCanvasWidth - visibleWidth(logoLine) + this.gutter)
+				: "";
+			const content = truncateToWidth(logo + (metaLines[index] ?? ""), contentWidth);
+			lines.push(
+				" ".repeat(paddingX) + content + " ".repeat(Math.max(0, safeWidth - paddingX - visibleWidth(content))),
+			);
+		}
 
 		if (this.verboseInstructions) {
 			lines.push(" ".repeat(safeWidth));
@@ -1470,8 +1455,6 @@ export class InteractiveMode {
 				verboseInstructions,
 				{
 					topPadding: true,
-					getHideStartHint: () => !this.isNewChat(),
-					getStartHint: () => this.startHint,
 				},
 			);
 			this.headerContainer.addChild(this.builtInHeader);

--- a/packages/coding-agent/src/themes/prime-logo.ts
+++ b/packages/coding-agent/src/themes/prime-logo.ts
@@ -16,3 +16,11 @@ export const PRIME_BUTTERFLY_LOGO = `                          ▄▄███�
  █████    ▀█▄▄▄█████▀
 ███████▄  ████████▀
 ▀███▀▀    █████▀`;
+
+/** Compact 6-row × 20-column butterfly, rendered from the brand SVG at width 20. */
+export const PRIME_COMPACT_BUTTERFLY_LOGO = `   ▄▄          ▄▄██▀
+   ███▄     ▄████▀
+  ██ ██▄ ▄██▀▄█▀
+ ▀█  █████▀██▀
+▄███ ▀▀█▄▄███
+████▀ ████▀▀`;

--- a/packages/coding-agent/src/themes/prime-logo.ts
+++ b/packages/coding-agent/src/themes/prime-logo.ts
@@ -16,3 +16,9 @@ export const PRIME_BUTTERFLY_LOGO = `                          ▄▄███�
  █████    ▀█▄▄▄█████▀
 ███████▄  ████████▀
 ▀███▀▀    █████▀`;
+
+/** Four rows × 12 cols for compact chat and session headers. */
+export const PRIME_BUTTERFLY_LOGO_COMPACT = `  ▄▄    ▄▄█▀
+ ███▄▄▄██▀
+ █ █████
+██▀ ██▀`;

--- a/packages/coding-agent/src/themes/prime-logo.ts
+++ b/packages/coding-agent/src/themes/prime-logo.ts
@@ -17,10 +17,11 @@ export const PRIME_BUTTERFLY_LOGO = `                          ▄▄███�
 ███████▄  ████████▀
 ▀███▀▀    █████▀`;
 
-/** Compact 6-row × 20-column butterfly, rendered from the brand SVG at width 20. */
-export const PRIME_COMPACT_BUTTERFLY_LOGO = `   ▄▄          ▄▄██▀
-   ███▄     ▄████▀
-  ██ ██▄ ▄██▀▄█▀
- ▀█  █████▀██▀
-▄███ ▀▀█▄▄███
-████▀ ████▀▀`;
+/** Compact 7-row × 18-column butterfly, rendered from the brand SVG with Braille cells. */
+export const PRIME_COMPACT_BUTTERFLY_LOGO = `                ⣀⣀
+  ⢠⣤⣤⡀      ⢀⣤⣾⣿⠟⠁
+  ⣼⡿⢻⣿⡄  ⢀⣤⡾⢋⣾⠟⠁
+ ⢰⡿⠁⢼⣿⣿⣤⣾⡿⠋⠰⠶⠂
+⢀⣴⣷ ⠘⢻⠿⠛⣁⣤⣾⡗
+⣾⣿⣿⠷ ⢠⣾⣿⣿⠿⠋
+⠈⠉    ⠉⠉`;

--- a/packages/coding-agent/src/themes/prime-logo.ts
+++ b/packages/coding-agent/src/themes/prime-logo.ts
@@ -16,9 +16,3 @@ export const PRIME_BUTTERFLY_LOGO = `                          ▄▄███�
  █████    ▀█▄▄▄█████▀
 ███████▄  ████████▀
 ▀███▀▀    █████▀`;
-
-/** Four rows × 12 cols for compact chat and session headers. */
-export const PRIME_BUTTERFLY_LOGO_COMPACT = `  ▄▄    ▄▄█▀
- ███▄▄▄██▀
- █ █████
-██▀ ██▀`;

--- a/packages/coding-agent/src/themes/prime-logo.ts
+++ b/packages/coding-agent/src/themes/prime-logo.ts
@@ -17,11 +17,11 @@ export const PRIME_BUTTERFLY_LOGO = `                          ▄▄███�
 ███████▄  ████████▀
 ▀███▀▀    █████▀`;
 
-/** Compact 7-row × 18-column butterfly, rendered from the brand SVG with Braille cells. */
-export const PRIME_COMPACT_BUTTERFLY_LOGO = `                ⣀⣀
-  ⢠⣤⣤⡀      ⢀⣤⣾⣿⠟⠁
-  ⣼⡿⢻⣿⡄  ⢀⣤⡾⢋⣾⠟⠁
- ⢰⡿⠁⢼⣿⣿⣤⣾⡿⠋⠰⠶⠂
-⢀⣴⣷ ⠘⢻⠿⠛⣁⣤⣾⡗
-⣾⣿⣿⠷ ⢠⣾⣿⣿⠿⠋
-⠈⠉    ⠉⠉`;
+/** Compact 7-row × 22-column butterfly, rendered from the brand SVG with solid quadrant cells. */
+export const PRIME_COMPACT_BUTTERFLY_LOGO = `                 ▗▄▄█▀
+   ███▄       ▗▄███▀
+  ▗█▛▐█▙   ▗▄█▀▗█▀
+ ▗█▛ ▟██▙▄██▛ ▟▛
+ ▗▟▌ ▐███▛▘▗▄█▖
+▟███▄  ▄▄▟███▀
+▜█▛▀▘  ▜█▛▀▘`;

--- a/packages/coding-agent/src/themes/prime-wordmark.ts
+++ b/packages/coding-agent/src/themes/prime-wordmark.ts
@@ -1,5 +1,0 @@
-/** Compact terminal wordmark: 4 rows × 29 columns. */
-export const PRIME_WORDMARK = `█▀▀▀▄ █▀▀▀▄ ▀▀█▀▀ █▄ ▄█ █▀▀▀▀
-█▄▄▄▀ █▄▄▄▀   █   █ ▀ █ █▄▄▄
-█     █ ▀▄    █   █   █ █
-▀     ▀   ▀ ▀▀▀▀▀ ▀   ▀ ▀▀▀▀▀`;

--- a/packages/coding-agent/src/themes/prime-wordmark.ts
+++ b/packages/coding-agent/src/themes/prime-wordmark.ts
@@ -1,0 +1,5 @@
+/** Compact terminal wordmark: 4 rows × 29 columns. */
+export const PRIME_WORDMARK = `█▀▀▀▄ █▀▀▀▄ ▀▀█▀▀ █▄ ▄█ █▀▀▀▀
+█▄▄▄▀ █▄▄▄▀   █   █ ▀ █ █▄▄▄
+█     █ ▀▄    █   █   █ █
+▀     ▀   ▀ ▀▀▀▀▀ ▀   ▀ ▀▀▀▀▀`;

--- a/packages/coding-agent/test/interactive-mode-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup.test.ts
@@ -35,7 +35,7 @@ describe("InteractiveMode startup hints", () => {
 		return mode;
 	}
 
-	it("shows a compact wordmark beside metadata without a repeated input hint", () => {
+	it("shows a compact butterfly beside metadata without a repeated input hint", () => {
 		const header = new BrandSplashHeader(
 			"0.0.0",
 			() => "test-model",
@@ -51,9 +51,8 @@ describe("InteractiveMode startup hints", () => {
 		const output = stripAnsi(lines.join("\n"));
 
 		expect(lines[0]).toBe("");
-		expect(lines.length).toBeLessThanOrEqual(5);
-		expect(output).toContain("agent v0.0.0");
-		expect(output).not.toContain("prime agent");
+		expect(lines.length).toBeLessThanOrEqual(7);
+		expect(output).toContain("prime agent v0.0.0");
 		expect(output).toMatch(/[▀▄█]/);
 		expect(output).toContain("test-model");
 		expect(output).toContain("/tmp/project");
@@ -76,11 +75,11 @@ describe("InteractiveMode startup hints", () => {
 			() => "/tmp/project",
 		);
 
-		for (const width of [1, 2, 12, 14, 20, 24, 39, 40, 57, 58, 80]) {
+		for (const width of [1, 2, 12, 14, 20, 24, 39, 40, 48, 49, 80]) {
 			const lines = header.render(width);
 			const output = stripAnsi(lines.join("\n"));
 			expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
-			if (width < 58) {
+			if (width < 49) {
 				expect(output).not.toMatch(/[▀▄█]/);
 				if (width >= 14) expect(output).toContain("prime agent");
 			} else {

--- a/packages/coding-agent/test/interactive-mode-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup.test.ts
@@ -1,6 +1,7 @@
-import { Container, setKeybindings } from "@earendil-works/pi-tui";
+import { Container, setKeybindings, visibleWidth } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { APP_TITLE } from "../src/config.js";
 import { KeybindingsManager } from "../src/core/keybindings.js";
 import {
 	BrandSplashHeader,
@@ -35,7 +36,7 @@ describe("InteractiveMode startup hints", () => {
 		return mode;
 	}
 
-	it("keeps a blank row above the shared splash and limits its metadata", () => {
+	it("keeps the shared splash compact without repeating the input hint", () => {
 		const header = new BrandSplashHeader(
 			"0.0.0",
 			() => "test-model",
@@ -43,7 +44,6 @@ describe("InteractiveMode startup hints", () => {
 			undefined,
 			{
 				topPadding: true,
-				getStartHint: () => 'Try "refactor @<filepath>"',
 			},
 		);
 
@@ -51,13 +51,12 @@ describe("InteractiveMode startup hints", () => {
 		const output = stripAnsi(lines.join("\n"));
 
 		expect(lines[0]).toBe("");
-		expect(output).toContain("version  v0.0.0");
-		expect(output).toContain("model    test-model");
-		expect(output).toContain("cwd      /tmp/project");
-		expect(output).toContain('Try "refactor @<filepath>"');
-		expect(output).not.toContain("input");
-		expect(output).not.toContain("files");
-		expect(output).not.toContain("help");
+		expect(lines.length).toBeLessThanOrEqual(5);
+		expect(output).toContain(`${APP_TITLE} v0.0.0`);
+		expect(output).toContain("test-model");
+		expect(output).toContain("/tmp/project");
+		expect(output).not.toContain("Try ");
+		expect(output).not.toContain("type to search sessions");
 
 		const unpadded = new BrandSplashHeader(
 			"0.0.0",
@@ -65,6 +64,56 @@ describe("InteractiveMode startup hints", () => {
 			() => "/tmp/project",
 		);
 		expect(unpadded.render(120)[0]).not.toBe("");
+	});
+
+	it("keeps metadata visible in narrow terminals and bounds every rendered row", () => {
+		const header = new BrandSplashHeader(
+			"0.0.0",
+			() => "test-model",
+			() => "/tmp/project",
+		);
+
+		for (const width of [1, 2, 12, 24, 39, 40, 80]) {
+			const lines = header.render(width);
+			expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+			if (width >= 24) {
+				const output = stripAnsi(lines.join("\n"));
+				expect(output).toContain("v0.0.0");
+				expect(output).toContain("test-model");
+				expect(output).toContain("/tmp/project");
+			}
+		}
+	});
+
+	it("renders live metadata and extra rows even when the custom mark is shorter", () => {
+		let model = "first-model";
+		let cwd = "/tmp/first";
+		const header = new BrandSplashHeader(
+			"0.0.0",
+			() => model,
+			() => cwd,
+			"custom shortcut instructions",
+			{
+				logo: "<>\n><",
+				getExtraMetadata: () => [
+					{ label: "agents", value: "2 running" },
+					{ label: "scope", value: "current project" },
+				],
+			},
+		);
+
+		const initial = stripAnsi(header.render(80).join("\n"));
+		expect(initial).toContain("<>");
+		expect(initial).toContain("agents 2 running");
+		expect(initial).toContain("scope current project");
+		expect(initial).toContain("custom shortcut instructions");
+
+		model = "second-model";
+		cwd = "/tmp/second";
+		const updated = stripAnsi(header.render(80).join("\n"));
+		expect(updated).toContain("second-model");
+		expect(updated).toContain("/tmp/second");
+		expect(updated).not.toContain("first-model");
 	});
 
 	it("randomly selects from five concise filepath prompts", () => {

--- a/packages/coding-agent/test/interactive-mode-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup.test.ts
@@ -1,7 +1,6 @@
 import { Container, setKeybindings, visibleWidth } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { APP_TITLE } from "../src/config.js";
 import { KeybindingsManager } from "../src/core/keybindings.js";
 import {
 	BrandSplashHeader,
@@ -36,7 +35,7 @@ describe("InteractiveMode startup hints", () => {
 		return mode;
 	}
 
-	it("keeps the shared splash compact without repeating the input hint", () => {
+	it("shows a compact text header without a logo or repeated input hint", () => {
 		const header = new BrandSplashHeader(
 			"0.0.0",
 			() => "test-model",
@@ -51,8 +50,9 @@ describe("InteractiveMode startup hints", () => {
 		const output = stripAnsi(lines.join("\n"));
 
 		expect(lines[0]).toBe("");
-		expect(lines.length).toBeLessThanOrEqual(5);
-		expect(output).toContain(`${APP_TITLE} v0.0.0`);
+		expect(lines.length).toBeLessThanOrEqual(4);
+		expect(output).toContain("prime agent v0.0.0");
+		expect(output).not.toMatch(/[▀▄█]/);
 		expect(output).toContain("test-model");
 		expect(output).toContain("/tmp/project");
 		expect(output).not.toContain("Try ");
@@ -73,11 +73,12 @@ describe("InteractiveMode startup hints", () => {
 			() => "/tmp/project",
 		);
 
-		for (const width of [1, 2, 12, 24, 39, 40, 80]) {
+		for (const width of [1, 2, 12, 14, 20, 24, 39, 40, 80]) {
 			const lines = header.render(width);
 			expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
-			if (width >= 24) {
+			if (width >= 14) {
 				const output = stripAnsi(lines.join("\n"));
+				expect(output).toContain("prime agent");
 				expect(output).toContain("v0.0.0");
 				expect(output).toContain("test-model");
 				expect(output).toContain("/tmp/project");
@@ -85,7 +86,7 @@ describe("InteractiveMode startup hints", () => {
 		}
 	});
 
-	it("renders live metadata and extra rows even when the custom mark is shorter", () => {
+	it("renders live agents metadata, custom marks, and verbose instructions", () => {
 		let model = "first-model";
 		let cwd = "/tmp/first";
 		const header = new BrandSplashHeader(

--- a/packages/coding-agent/test/interactive-mode-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup.test.ts
@@ -53,7 +53,7 @@ describe("InteractiveMode startup hints", () => {
 		expect(lines[0]).toBe("");
 		expect(lines.length).toBeLessThanOrEqual(8);
 		expect(output).toContain("prime agent v0.0.0");
-		expect(output).toMatch(/[\u2801-\u28ff]/u);
+		expect(output).toMatch(/[▗▙▛▜]/u);
 		expect(output).toContain("test-model");
 		expect(output).toContain("/tmp/project");
 		expect(stripAnsi(lines[4])).toContain("agents 2 running");
@@ -75,15 +75,15 @@ describe("InteractiveMode startup hints", () => {
 			() => "/tmp/project",
 		);
 
-		for (const width of [1, 2, 12, 14, 20, 24, 39, 40, 46, 47, 80]) {
+		for (const width of [1, 2, 12, 14, 20, 24, 39, 40, 50, 51, 80]) {
 			const lines = header.render(width);
 			const output = stripAnsi(lines.join("\n"));
 			expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
-			if (width < 47) {
-				expect(output).not.toMatch(/[\u2801-\u28ff]/u);
+			if (width < 51) {
+				expect(output).not.toMatch(/[▗▙▛▜]/u);
 				if (width >= 14) expect(output).toContain("prime agent");
 			} else {
-				expect(output).toMatch(/[\u2801-\u28ff]/u);
+				expect(output).toMatch(/[▗▙▛▜]/u);
 				expect(output).toContain("agent v0.0.0");
 			}
 			if (width >= 14) {

--- a/packages/coding-agent/test/interactive-mode-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup.test.ts
@@ -49,7 +49,7 @@ describe("InteractiveMode startup hints", () => {
 		expect(output).toContain("prime agent v0.0.0");
 		expect(output).toMatch(/[▗▙▛▜]/u);
 		expect(stripAnsi(lines[4])).toContain("agents 2 running");
-		expect(stripAnsi(lines[5])).toContain("/tmp/project");
+		expect(stripAnsi(lines[5])).toContain("cwd /tmp/project");
 		expect(output).not.toContain("Try ");
 		expect(output).not.toContain("type to search sessions");
 
@@ -73,7 +73,9 @@ describe("InteractiveMode startup hints", () => {
 			}
 			if (width >= 14) {
 				expect(output).toContain("v0.0.0");
-				expect(output).toContain("/tmp/project");
+			}
+			if (width >= 18) {
+				expect(output).toContain("cwd /tmp/project");
 			}
 		}
 	});

--- a/packages/coding-agent/test/interactive-mode-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup.test.ts
@@ -36,16 +36,10 @@ describe("InteractiveMode startup hints", () => {
 	}
 
 	it("shows a compact butterfly beside metadata without a repeated input hint", () => {
-		const header = new BrandSplashHeader(
-			"0.0.0",
-			() => "test-model",
-			() => "/tmp/project",
-			undefined,
-			{
-				topPadding: true,
-				getExtraMetadata: () => [{ label: "agents", value: "2 running" }],
-			},
-		);
+		const header = new BrandSplashHeader("0.0.0", () => "/tmp/project", undefined, {
+			topPadding: true,
+			getExtraMetadata: () => [{ label: "agents", value: "2 running" }],
+		});
 
 		const lines = header.render(120);
 		const output = stripAnsi(lines.join("\n"));
@@ -54,26 +48,17 @@ describe("InteractiveMode startup hints", () => {
 		expect(lines.length).toBeLessThanOrEqual(8);
 		expect(output).toContain("prime agent v0.0.0");
 		expect(output).toMatch(/[▗▙▛▜]/u);
-		expect(output).toContain("test-model");
 		expect(output).toContain("/tmp/project");
-		expect(stripAnsi(lines[4])).toContain("agents 2 running");
+		expect(stripAnsi(lines[5])).toContain("agents 2 running");
 		expect(output).not.toContain("Try ");
 		expect(output).not.toContain("type to search sessions");
 
-		const unpadded = new BrandSplashHeader(
-			"0.0.0",
-			() => "test-model",
-			() => "/tmp/project",
-		);
+		const unpadded = new BrandSplashHeader("0.0.0", () => "/tmp/project");
 		expect(unpadded.render(120)[0]).not.toBe("");
 	});
 
 	it("keeps metadata visible in narrow terminals and bounds every rendered row", () => {
-		const header = new BrandSplashHeader(
-			"0.0.0",
-			() => "test-model",
-			() => "/tmp/project",
-		);
+		const header = new BrandSplashHeader("0.0.0", () => "/tmp/project");
 
 		for (const width of [1, 2, 12, 14, 20, 24, 39, 40, 50, 51, 80]) {
 			const lines = header.render(width);
@@ -88,28 +73,20 @@ describe("InteractiveMode startup hints", () => {
 			}
 			if (width >= 14) {
 				expect(output).toContain("v0.0.0");
-				expect(output).toContain("test-model");
 				expect(output).toContain("/tmp/project");
 			}
 		}
 	});
 
 	it("renders live agents metadata, custom marks, and verbose instructions", () => {
-		let model = "first-model";
 		let cwd = "/tmp/first";
-		const header = new BrandSplashHeader(
-			"0.0.0",
-			() => model,
-			() => cwd,
-			"custom shortcut instructions",
-			{
-				logo: "<>\n><",
-				getExtraMetadata: () => [
-					{ label: "agents", value: "2 running" },
-					{ label: "scope", value: "current project" },
-				],
-			},
-		);
+		const header = new BrandSplashHeader("0.0.0", () => cwd, "custom shortcut instructions", {
+			logo: "<>\n><",
+			getExtraMetadata: () => [
+				{ label: "agents", value: "2 running" },
+				{ label: "scope", value: "current project" },
+			],
+		});
 
 		const initial = stripAnsi(header.render(80).join("\n"));
 		expect(initial).toContain("<>");
@@ -118,12 +95,9 @@ describe("InteractiveMode startup hints", () => {
 		expect(initial).toContain("scope current project");
 		expect(initial).toContain("custom shortcut instructions");
 
-		model = "second-model";
 		cwd = "/tmp/second";
 		const updated = stripAnsi(header.render(80).join("\n"));
-		expect(updated).toContain("second-model");
 		expect(updated).toContain("/tmp/second");
-		expect(updated).not.toContain("first-model");
 	});
 
 	it("randomly selects from five concise filepath prompts", () => {

--- a/packages/coding-agent/test/interactive-mode-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup.test.ts
@@ -50,11 +50,37 @@ describe("InteractiveMode startup hints", () => {
 		expect(output).toMatch(/[▗▙▛▜]/u);
 		expect(stripAnsi(lines[4])).toContain("agents 2 running");
 		expect(stripAnsi(lines[5])).toContain("cwd /tmp/project");
+		expect(output).not.toContain("model ");
 		expect(output).not.toContain("Try ");
 		expect(output).not.toContain("type to search sessions");
 
 		const unpadded = new BrandSplashHeader("0.0.0", () => "/tmp/project");
 		expect(unpadded.render(120)[0]).not.toBe("");
+	});
+
+	it("renders the model line in the chat splash without effort metadata", () => {
+		let modelId: string | undefined = "first-model";
+		const header = new BrandSplashHeader("0.0.0", () => "/tmp/project", undefined, {
+			topPadding: true,
+			getModelId: () => modelId,
+		});
+
+		const lines = header.render(120);
+		const output = stripAnsi(lines.join("\n"));
+
+		expect(output).toContain("prime agent v0.0.0");
+		expect(stripAnsi(lines[3])).toContain("prime agent v0.0.0");
+		expect(stripAnsi(lines[4])).toContain("model first-model");
+		expect(stripAnsi(lines[5])).toContain("cwd /tmp/project");
+		expect(output).not.toContain("•");
+
+		modelId = "second-model";
+		const updated = stripAnsi(header.render(120).join("\n"));
+		expect(updated).toContain("model second-model");
+		expect(updated).not.toContain("first-model");
+
+		modelId = undefined;
+		expect(stripAnsi(header.render(120).join("\n"))).toContain("model —");
 	});
 
 	it("keeps metadata visible in narrow terminals and bounds every rendered row", () => {

--- a/packages/coding-agent/test/interactive-mode-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup.test.ts
@@ -48,8 +48,8 @@ describe("InteractiveMode startup hints", () => {
 		expect(lines.length).toBeLessThanOrEqual(8);
 		expect(output).toContain("prime agent v0.0.0");
 		expect(output).toMatch(/[▗▙▛▜]/u);
-		expect(output).toContain("/tmp/project");
-		expect(stripAnsi(lines[5])).toContain("agents 2 running");
+		expect(stripAnsi(lines[4])).toContain("agents 2 running");
+		expect(stripAnsi(lines[5])).toContain("/tmp/project");
 		expect(output).not.toContain("Try ");
 		expect(output).not.toContain("type to search sessions");
 

--- a/packages/coding-agent/test/interactive-mode-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup.test.ts
@@ -35,7 +35,7 @@ describe("InteractiveMode startup hints", () => {
 		return mode;
 	}
 
-	it("shows a compact text header without a logo or repeated input hint", () => {
+	it("shows a compact wordmark beside metadata without a repeated input hint", () => {
 		const header = new BrandSplashHeader(
 			"0.0.0",
 			() => "test-model",
@@ -43,6 +43,7 @@ describe("InteractiveMode startup hints", () => {
 			undefined,
 			{
 				topPadding: true,
+				getExtraMetadata: () => [{ label: "agents", value: "2 running" }],
 			},
 		);
 
@@ -50,11 +51,13 @@ describe("InteractiveMode startup hints", () => {
 		const output = stripAnsi(lines.join("\n"));
 
 		expect(lines[0]).toBe("");
-		expect(lines.length).toBeLessThanOrEqual(4);
-		expect(output).toContain("prime agent v0.0.0");
-		expect(output).not.toMatch(/[▀▄█]/);
+		expect(lines.length).toBeLessThanOrEqual(5);
+		expect(output).toContain("agent v0.0.0");
+		expect(output).not.toContain("prime agent");
+		expect(output).toMatch(/[▀▄█]/);
 		expect(output).toContain("test-model");
 		expect(output).toContain("/tmp/project");
+		expect(stripAnsi(lines[4])).toContain("agents 2 running");
 		expect(output).not.toContain("Try ");
 		expect(output).not.toContain("type to search sessions");
 
@@ -73,12 +76,18 @@ describe("InteractiveMode startup hints", () => {
 			() => "/tmp/project",
 		);
 
-		for (const width of [1, 2, 12, 14, 20, 24, 39, 40, 80]) {
+		for (const width of [1, 2, 12, 14, 20, 24, 39, 40, 57, 58, 80]) {
 			const lines = header.render(width);
+			const output = stripAnsi(lines.join("\n"));
 			expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+			if (width < 58) {
+				expect(output).not.toMatch(/[▀▄█]/);
+				if (width >= 14) expect(output).toContain("prime agent");
+			} else {
+				expect(output).toMatch(/[▀▄█]/);
+				expect(output).toContain("agent v0.0.0");
+			}
 			if (width >= 14) {
-				const output = stripAnsi(lines.join("\n"));
-				expect(output).toContain("prime agent");
 				expect(output).toContain("v0.0.0");
 				expect(output).toContain("test-model");
 				expect(output).toContain("/tmp/project");
@@ -105,6 +114,7 @@ describe("InteractiveMode startup hints", () => {
 
 		const initial = stripAnsi(header.render(80).join("\n"));
 		expect(initial).toContain("<>");
+		expect(initial).toContain("prime agent v0.0.0");
 		expect(initial).toContain("agents 2 running");
 		expect(initial).toContain("scope current project");
 		expect(initial).toContain("custom shortcut instructions");

--- a/packages/coding-agent/test/interactive-mode-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup.test.ts
@@ -51,9 +51,9 @@ describe("InteractiveMode startup hints", () => {
 		const output = stripAnsi(lines.join("\n"));
 
 		expect(lines[0]).toBe("");
-		expect(lines.length).toBeLessThanOrEqual(7);
+		expect(lines.length).toBeLessThanOrEqual(8);
 		expect(output).toContain("prime agent v0.0.0");
-		expect(output).toMatch(/[▀▄█]/);
+		expect(output).toMatch(/[\u2801-\u28ff]/u);
 		expect(output).toContain("test-model");
 		expect(output).toContain("/tmp/project");
 		expect(stripAnsi(lines[4])).toContain("agents 2 running");
@@ -75,15 +75,15 @@ describe("InteractiveMode startup hints", () => {
 			() => "/tmp/project",
 		);
 
-		for (const width of [1, 2, 12, 14, 20, 24, 39, 40, 48, 49, 80]) {
+		for (const width of [1, 2, 12, 14, 20, 24, 39, 40, 46, 47, 80]) {
 			const lines = header.render(width);
 			const output = stripAnsi(lines.join("\n"));
 			expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
-			if (width < 49) {
-				expect(output).not.toMatch(/[▀▄█]/);
+			if (width < 47) {
+				expect(output).not.toMatch(/[\u2801-\u28ff]/u);
 				if (width >= 14) expect(output).toContain("prime agent");
 			} else {
-				expect(output).toMatch(/[▀▄█]/);
+				expect(output).toMatch(/[\u2801-\u28ff]/u);
 				expect(output).toContain("agent v0.0.0");
 			}
 			if (width >= 14) {

--- a/scripts/render-logo.py
+++ b/scripts/render-logo.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Render the Prime butterfly SVG to ASCII via half-block encoding.
+"""Render the Prime butterfly SVG as terminal-safe text art.
 
 Usage:
-  uv run scripts/render-logo.py [--width 60] [--threshold 96] [--svg path]
+  uv run scripts/render-logo.py [--width 60] [--threshold 96] [--style blocks] [--svg path]
 
 Outputs the rendered art to stdout.
 
@@ -29,7 +29,45 @@ def render(svg_path: Path, width: int, threshold: int, style: str) -> str:
     import cairosvg
     from PIL import Image
 
-    if style == "dots":
+    if style == "braille":
+        # A Braille cell is a 2 x 4 pixel grid. Terminal cells are typically twice as
+        # tall as they are wide, so those subpixels are approximately square and the
+        # SVG keeps its intended aspect without further vertical scaling.
+        png_bytes = cairosvg.svg2png(url=str(svg_path), output_width=width * 2)
+        img = Image.open(io.BytesIO(png_bytes)).convert("RGBA")
+        bg = Image.new("RGBA", img.size, (0, 0, 0, 255))
+        bg.paste(img, (0, 0), img)
+        img = bg.convert("L")
+        w, h = img.size
+        padded_w = w + (-w % 2)
+        padded_h = h + (-h % 4)
+        if (padded_w != w) or (padded_h != h):
+            padded = Image.new("L", (padded_w, padded_h), 0)
+            padded.paste(img, (0, 0))
+            img = padded
+            w, h = img.size
+        px = img.load()
+        dot_bits = (
+            (0, 0, 0),
+            (0, 1, 1),
+            (0, 2, 2),
+            (1, 0, 3),
+            (1, 1, 4),
+            (1, 2, 5),
+            (0, 3, 6),
+            (1, 3, 7),
+        )
+        rows = []
+        for y in range(0, h, 4):
+            row: list[str] = []
+            for x in range(0, w, 2):
+                mask = 0
+                for dx, dy, bit in dot_bits:
+                    if px[x + dx, y + dy] > threshold:
+                        mask |= 1 << bit
+                row.append(chr(0x2800 + mask) if mask else " ")
+            rows.append("".join(row).rstrip())
+    elif style == "dots":
         # 1 pixel = 1 character cell. Compensate for terminal cells being ~2x taller than wide
         # so the rendered shape keeps the original proportions.
         # Use ▪ (BLACK SMALL SQUARE) so adjacent cells read as a tightly packed dot matrix —
@@ -95,9 +133,9 @@ def main() -> int:
     )
     parser.add_argument(
         "--style",
-        choices=("blocks", "dots"),
+        choices=("blocks", "braille", "dots"),
         default="blocks",
-        help="blocks = half-block ▀▄█; dots = mid-dot · matrix (default: blocks)",
+        help="blocks = half-block ▀▄█; braille = 2x4 Unicode dots; dots = square dot matrix (default: blocks)",
     )
     args = parser.parse_args()
 

--- a/scripts/render-logo.py
+++ b/scripts/render-logo.py
@@ -29,7 +29,37 @@ def render(svg_path: Path, width: int, threshold: int, style: str) -> str:
     import cairosvg
     from PIL import Image
 
-    if style == "braille":
+    if style == "quadrants":
+        # Quadrant block characters encode a solid 2x2 grid. Halving the SVG's
+        # raster height compensates for terminal cells being roughly twice as tall
+        # as they are wide while retaining twice the horizontal edge resolution.
+        png_bytes = cairosvg.svg2png(url=str(svg_path), output_width=width * 2)
+        img = Image.open(io.BytesIO(png_bytes)).convert("RGBA")
+        bg = Image.new("RGBA", img.size, (0, 0, 0, 255))
+        bg.paste(img, (0, 0), img)
+        img = bg.convert("L").resize((width * 2, max(2, round(img.size[1] / 2))), Image.LANCZOS)
+        w, h = img.size
+        padded_h = h + (-h % 2)
+        if padded_h != h:
+            padded = Image.new("L", (w, padded_h), 0)
+            padded.paste(img, (0, 0))
+            img = padded
+            h = padded_h
+        px = img.load()
+        glyphs = (" ", "▘", "▝", "▀", "▖", "▌", "▞", "▛", "▗", "▚", "▐", "▜", "▄", "▙", "▟", "█")
+        rows = []
+        for y in range(0, h, 2):
+            row = ""
+            for x in range(0, w, 2):
+                mask = (
+                    (1 if px[x, y] > threshold else 0)
+                    | (2 if px[x + 1, y] > threshold else 0)
+                    | (4 if px[x, y + 1] > threshold else 0)
+                    | (8 if px[x + 1, y + 1] > threshold else 0)
+                )
+                row += glyphs[mask]
+            rows.append(row.rstrip())
+    elif style == "braille":
         # A Braille cell is a 2 x 4 pixel grid. Terminal cells are typically twice as
         # tall as they are wide, so those subpixels are approximately square and the
         # SVG keeps its intended aspect without further vertical scaling.
@@ -133,9 +163,9 @@ def main() -> int:
     )
     parser.add_argument(
         "--style",
-        choices=("blocks", "braille", "dots"),
+		choices=("blocks", "braille", "dots", "quadrants"),
         default="blocks",
-        help="blocks = half-block ▀▄█; braille = 2x4 Unicode dots; dots = square dot matrix (default: blocks)",
+		help="blocks = half-block; braille = 2x4 dots; dots = square matrix; quadrants = solid 2x2 cells",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
- replace large chat and agents splashes with a compact butterfly rendered from the original logo, alongside muted runtime details.
- center the runtime metadata vertically beside the butterfly and drop the header model line since session rows already show the model.
- order the centered metadata so contextual lines like the agents count sit above the working directory, rendered as a dim `cwd` label with a muted path.
- remove duplicate input hints and keep metadata readable in narrow terminals.
- validated with focused startup tests and npm run check.

no-ticket: ui proposals tracked in https://app.notion.com/p/3d672940136f817b99a3d97c7d5fa048


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use compact butterfly logo in `BrandSplashHeader` for chat and agents views
> - Adds `PRIME_COMPACT_BUTTERFLY_LOGO` constant and makes it the default logo for `BrandSplashHeader`, replacing the full butterfly art
> - Reworks `BrandSplashHeader.render` to optionally render a model row, center metadata beside the logo, truncate model and cwd to available width, and fall back to metadata-only output in narrow terminals instead of dropping metadata
> - Chat (interactive) mode passes a live model callback so the header shows the current model; agents view no longer supplies a model callback, so its header omits the model line
> - Removes the repeated startup prompt hint and duplicate prompt suggestions from the header
> - Extends `scripts/render-logo.py` with quadrant-block and Braille text-art rendering styles
> - Behavioral Change: `BrandSplashHeader` constructor signature changes from positional model callback to cwd callback; callers in `agents-view-mode.ts` and `interactive-mode.ts` are updated. In narrow terminals the logo is omitted rather than metadata.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d445289.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal UI and header rendering only; behavior changes are covered by startup tests with no auth or data-path impact.
> 
> **Overview**
> Replaces the large butterfly splash in **chat** and **agents view** with **`PRIME_COMPACT_BUTTERFLY_LOGO`**, laid out beside vertically centered runtime text (**"prime agent"**, version, optional **model**, extra lines, then **`cwd`** with dim labels).
> 
> **`BrandSplashHeader`** no longer takes a required model getter or **`getStartHint` / `getHideStartHint`**; model appears only when callers pass **`getModelId`** (interactive chat does; agents view does not). Header **start-hint / duplicate prompt rows** are removed. On **narrow terminals** the logo is omitted while title and metadata stay within width.
> 
> Adds logo generation styles **`quadrants`** and **`braille`** in **`render-logo.py`**, plus expanded startup tests for layout and wrapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4452895f10028c8c2ccb9438eba4ae55684cdda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



