### PR TITLE
4. modularize session shell execution

### DIFF
--- a/packages/coding-agent/src/README.md
+++ b/packages/coding-agent/src/README.md
@@ -54,12 +54,29 @@ Preserve these distinctions when extending the scheduler:
 
 The abortable promise helper moved unchanged to `utils/wait-for-abort.ts`, shared by commit acquisition and existing session checkpoint waits.
 
-The next extraction should move action preparation and dispatch into a separate owner while preserving their delivery, rollback, and cross-feature ordering rules.
+Action preparation and dispatch still need a separate owner that preserves their delivery, rollback, and cross-feature ordering rules.
+
+## Session shell commands
+
+`session/bash.ts` owns shell-command execution, abort controllers, the user-command slot, abort requests during extension dispatch, and deferred transcript output. Its host supplies current shell settings and working directory, extension interception, event delivery, transcript append, and session scheduling notifications. These callbacks read the current runtime so rebuilding extensions or changing settings does not retain stale dependencies.
+
+`AgentSession` keeps its public shell methods and the cross-feature decision about when to flush deferred output. It also appends messages to agent state before persistence and schedules queued input after the agent becomes idle. The shell owner does not receive the session, kernel, agent loop, or storage manager.
+
+Execution and recording callbacks preserve dispatch through the public session methods, including wrappers installed by callers. They delegate to the shell owner's corresponding operations; they do not duplicate shell state.
+
+- User commands reserve the slot before awaiting extensions. Direct executions may overlap and each remains independently abortable.
+- Release the user slot and notify waiters before publishing `bash_end`; queued work resumes afterward.
+- Extension-provided results take precedence over an abort received during interception. Otherwise, that abort prevents process execution.
+- Transient commands publish their lifecycle events but never enter pending output, transcript storage, or model context. Context-excluded commands remain persisted.
+- Output produced during streaming waits for the same existing prompt-preparation flush points, preserving tool-call/result ordering.
+- Shell event shapes, command options, error behavior, and persisted `bashExecution` messages stay unchanged.
 
 ## Validation
 
 Controller tests live in `test/goals/`. Session integration coverage remains in `test/suite/agent-session-goal.test.ts`, `test/suite/agent-session-compaction-continuation.test.ts`, and `test/goal-continuation-quiescence.test.ts`.
 
 Scheduler and commit-fence tests live in `test/session/`. Existing queue, action-contract, action-race, and compaction suites cover the integration with `AgentSession`, including pause, cancellation, restart, branch navigation, and goal continuation.
+
+Shell-owner tests also live in `test/session/`. Session bash/persistence, prompt, queue, and side-question regression suites retain end-to-end coverage of scheduling and transcript behavior using the faux provider and controlled shell operations.
 
 Run the focused files from the coding-agent package root with the repository's prescribed Vitest command, then run `npm run check` from the repository root. Use faux providers for session tests.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -38,6 +38,12 @@ import { parseGoalSlashCommand } from "../goals/commands.js";
 import { GoalController } from "../goals/controller.js";
 import { createGoalPersistence } from "../goals/persistence.js";
 import { theme } from "../modes/interactive/theme/theme.js";
+import {
+	type ExecuteBashOptions,
+	type RunUserBashOptions,
+	SessionBash,
+	type SessionBashEvent,
+} from "../session/bash.js";
 import { SessionCommitFence, type SessionCommitLease } from "../session/commit-fence.js";
 import { SessionInputScheduler } from "../session/input-scheduler.js";
 import { stripFrontmatter } from "../utils/frontmatter.js";
@@ -97,7 +103,7 @@ import {
 	refreshAutonomousQualityGates,
 	setAutonomousEnabled,
 } from "./autonomous.js";
-import { type BashResult, executeBashWithOperations } from "./bash-executor.js";
+import type { BashResult } from "./bash-executor.js";
 import {
 	COMPACT_SKILL_NAME,
 	type CompactionResult,
@@ -168,7 +174,6 @@ import {
 	ASYNC_BASH_COMPLETION_CUSTOM_TYPE,
 	ASYNC_BASH_COMPLETION_PREVIEW_LABEL,
 	type AsyncBashCompletionDetails,
-	type BashExecutionMessage,
 	type CompactionOutcome,
 	type CompactionOutcomeReason,
 	type CustomMessage,
@@ -305,7 +310,6 @@ import { createSyntheticSourceInfo, type SourceInfo } from "./source-info.js";
 import { type BuildSystemPromptOptions, buildSystemPrompt } from "./system-prompt.js";
 import { THINKING_LEVELS } from "./thinking-levels.js";
 import { acpMcpToolNames, createAcpMcpToolDefinitions } from "./tools/acp-mcp.js";
-import { type BashOperations, createLocalBashOperations } from "./tools/bash.js";
 import { createAllToolDefinitions } from "./tools/index.js";
 import { IpythonKernelProvisioner } from "./tools/ipython.js";
 import { createToolDefinitionFromAgentTool } from "./tools/tool-definition-wrapper.js";
@@ -398,36 +402,11 @@ export type AgentSessionEvent =
 	| { type: "rlm_child_update"; child: RlmChildAgentSnapshot }
 	| { type: "recap_update"; recap: string | undefined }
 	| { type: "goal_update"; goal: GoalState }
-	| {
-			type: "bash_start";
-			command: string;
-			excludeFromContext: boolean;
-			transient?: boolean;
-			runId?: string;
-	  }
-	| { type: "bash_output"; chunk: string }
-	| {
-			type: "bash_end";
-			exitCode: number | undefined;
-			cancelled: boolean;
-			truncated: boolean;
-			fullOutputPath?: string;
-			errorMessage?: string;
-			transient?: boolean;
-			runId?: string;
-	  }
+	| SessionBashEvent
 	| { type: "refine_complete"; result: RefinementResult }
 	| { type: "refine_failed"; error: string };
 
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
-
-type UserBashEndDetails = {
-	exitCode: number | undefined;
-	cancelled: boolean;
-	truncated: boolean;
-	fullOutputPath?: string;
-	errorMessage?: string;
-};
 
 export class CompactionSkippedError extends Error {}
 
@@ -1136,10 +1115,22 @@ export class AgentSession {
 	/** Fresh/empty contexts defer digest injection to the first committed turn so untouched sessions stay empty. */
 	private _harnessDigestPending = false;
 
-	private _bashAbortControllers = new Set<AbortController>();
-	private _userBashRunning = false;
-	private _userBashAbortRequested = false;
-	private _pendingBashMessages: BashExecutionMessage[] = [];
+	private readonly _bash = new SessionBash({
+		getCwd: () => this.sessionManager.getCwd(),
+		getShellCommandPrefix: () => this.settingsManager.getShellCommandPrefix(),
+		getShellPath: () => this.settingsManager.getShellPath(),
+		isStreaming: () => this.isStreaming,
+		intercept: (event) => this._extensionRunner.emitUserBash(event),
+		emit: (event) => this._emit(event),
+		appendMessage: (message) => {
+			this.agent.state.messages.push(message);
+			this.sessionManager.appendMessage(message);
+		},
+		onStateChange: () => this._notifySessionInputCheckpointChange(),
+		onUserBashEnd: () => this._drainQueuedMessagesAfterBash(),
+		executeBash: (command, onChunk, options) => this.executeBash(command, onChunk, options),
+		recordBashResult: (command, result, options) => this.recordBashResult(command, result, options),
+	});
 
 	private _extensionRunner!: ExtensionRunner;
 	private _execEnvProvider?: () => Record<string, string | undefined> | undefined;
@@ -11197,99 +11188,14 @@ export class AgentSession {
 		this.settingsManager.setRetryEnabled(enabled);
 	}
 
-	/**
-	 * Execute a bash command.
-	 * Adds result to agent context and session.
-	 * @param command The bash command to execute
-	 * @param onChunk Optional streaming callback for output
-	 * @param options.excludeFromContext If true, command output won't be sent to LLM (!! prefix)
-	 * @param options.operations Custom BashOperations for remote execution
-	 */
-	async executeBash(
-		command: string,
-		onChunk?: (chunk: string) => void,
-		options?: {
-			excludeFromContext?: boolean;
-			operations?: BashOperations;
-			transient?: boolean;
-		},
-	): Promise<BashResult> {
-		// Each invocation owns its controller so abortBash reaches every in-flight command.
-		const abortController = new AbortController();
-		this._bashAbortControllers.add(abortController);
-
-		const prefix = this.settingsManager.getShellCommandPrefix();
-		const shellPath = this.settingsManager.getShellPath();
-		const resolvedCommand = prefix ? `${prefix}\n${command}` : command;
-
-		try {
-			const result = await executeBashWithOperations(
-				resolvedCommand,
-				this.sessionManager.getCwd(),
-				options?.operations ?? createLocalBashOperations({ shellPath }),
-				{
-					onChunk,
-					signal: abortController.signal,
-				},
-			);
-
-			if (!options?.transient) {
-				this.recordBashResult(command, result, options);
-			}
-			return result;
-		} finally {
-			this._bashAbortControllers.delete(abortController);
-			this._notifySessionInputCheckpointChange();
-		}
+	/** Execute a shell command and record its result unless transient. */
+	executeBash(command: string, onChunk?: (chunk: string) => void, options?: ExecuteBashOptions): Promise<BashResult> {
+		return this._bash.executeBash(command, onChunk, options);
 	}
 
-	/**
-	 * Run a user-initiated bash command (! / !! prefix), emitting bash_start,
-	 * bash_output, and bash_end session events so any attached client can render
-	 * streaming output. Extensions can intercept execution via the user_bash event.
-	 * Execution failures are reported through bash_end rather than a rejected promise;
-	 * only the already-running guard and extension dispatch errors reject.
-	 * @param command The bash command to execute
-	 * @param options.excludeFromContext If true, command output won't be sent to LLM (!! prefix)
-	 */
-	async runUserBash(
-		command: string,
-		options?: {
-			excludeFromContext?: boolean;
-			transient?: boolean;
-			runId?: string;
-		},
-	): Promise<void> {
-		if (this.isBashRunning) {
-			throw new Error("A bash command is already running");
-		}
-		// Claim the bash slot synchronously: isBashRunning is otherwise false until
-		// executeBash installs its abort controller, which would let a second command
-		// slip through during the user_bash extension dispatch below.
-		this._userBashRunning = true;
-		this._userBashAbortRequested = false;
-		// Echoed on bash_start/bash_end so the requesting client can tell its own
-		// run apart from other clients' runs broadcast on the same session.
-		const identity = {
-			...(options?.transient ? { transient: true } : {}),
-			...(options?.runId !== undefined ? { runId: options.runId } : {}),
-		};
-		let end: UserBashEndDetails;
-		try {
-			end = await this.runUserBashLocked(
-				command,
-				options?.excludeFromContext ?? false,
-				options?.transient ?? false,
-				identity,
-			);
-		} finally {
-			this._userBashRunning = false;
-			this._notifySessionInputCheckpointChange();
-		}
-		// Emitted after the slot is released so clients never observe a bash_end
-		// while the session still rejects new commands as already running.
-		this._emit({ type: "bash_end", ...end, ...identity });
-		void this._drainQueuedMessagesAfterBash().catch(() => undefined);
+	/** Run ! / !! input with extension interception and bash lifecycle events. */
+	runUserBash(command: string, options?: RunUserBashOptions): Promise<void> {
+		return this._bash.runUserBash(command, options);
 	}
 
 	private async _drainQueuedMessagesAfterBash(): Promise<void> {
@@ -11297,150 +11203,25 @@ export class AgentSession {
 		this._scheduleSessionInputPump();
 	}
 
-	private async runUserBashLocked(
-		command: string,
-		excludeFromContext: boolean,
-		transient: boolean,
-		identity: { transient?: boolean; runId?: string },
-	): Promise<UserBashEndDetails> {
-		const eventResult = await this._extensionRunner.emitUserBash({
-			type: "user_bash",
-			command,
-			excludeFromContext,
-			cwd: this.sessionManager.getCwd(),
-		});
-
-		// Transient runs (side-conversation bash) live only in their pane: they
-		// are never recorded, so reloads and rebuilds cannot resurface them.
-		const record = transient
-			? () => {}
-			: (result: BashResult) => this.recordBashResult(command, result, { excludeFromContext });
-
-		this._emit({
-			type: "bash_start",
-			command,
-			excludeFromContext,
-			...identity,
-		});
-		try {
-			// If an extension returned a full result, surface it without executing
-			if (eventResult?.result) {
-				const result = eventResult.result;
-				if (result.output) {
-					this._emit({ type: "bash_output", chunk: result.output });
-				}
-				record(result);
-				return {
-					exitCode: result.exitCode,
-					cancelled: result.cancelled,
-					truncated: result.truncated,
-					fullOutputPath: result.fullOutputPath,
-				};
-			}
-
-			// An abort that arrived before the process spawned (during extension
-			// dispatch) has no abort controller to act on; honor it here instead.
-			if (this._userBashAbortRequested) {
-				record({
-					output: "",
-					exitCode: undefined,
-					cancelled: true,
-					truncated: false,
-				});
-				return { exitCode: undefined, cancelled: true, truncated: false };
-			}
-
-			const result = await this.executeBash(command, (chunk) => this._emit({ type: "bash_output", chunk }), {
-				excludeFromContext,
-				operations: eventResult?.operations,
-				transient,
-			});
-			return {
-				exitCode: result.exitCode,
-				cancelled: result.cancelled,
-				truncated: result.truncated,
-				fullOutputPath: result.fullOutputPath,
-			};
-		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : String(error);
-			// Persist the failure like every other outcome so replayed transcripts
-			// and the LLM context reflect that the command did not run.
-			record({
-				output: `bash failed: ${errorMessage}`,
-				exitCode: undefined,
-				cancelled: false,
-				truncated: false,
-			});
-			return {
-				exitCode: undefined,
-				cancelled: false,
-				truncated: false,
-				errorMessage,
-			};
-		}
-	}
-
 	recordBashResult(command: string, result: BashResult, options?: { excludeFromContext?: boolean }): void {
-		const bashMessage: BashExecutionMessage = {
-			role: "bashExecution",
-			command,
-			output: result.output,
-			exitCode: result.exitCode,
-			cancelled: result.cancelled,
-			truncated: result.truncated,
-			fullOutputPath: result.fullOutputPath,
-			timestamp: Date.now(),
-			excludeFromContext: options?.excludeFromContext,
-		};
-
-		// If agent is streaming, defer adding to avoid breaking tool_use/tool_result ordering
-		if (this.isStreaming) {
-			this._pendingBashMessages.push(bashMessage);
-		} else {
-			this.agent.state.messages.push(bashMessage);
-
-			this.sessionManager.appendMessage(bashMessage);
-		}
+		this._bash.recordBashResult(command, result, options);
 	}
 
-	/**
-	 * Cancel running bash command.
-	 */
+	/** Cancel every in-flight shell command, including pending extension dispatch. */
 	abortBash(): void {
-		// A user bash command may not have spawned yet (extension dispatch in
-		// progress); flag the request so runUserBash cancels before executing.
-		// runUserBash clears the flag at each start, so a stale flag is harmless.
-		if (this._userBashRunning) {
-			this._userBashAbortRequested = true;
-		}
-		for (const controller of this._bashAbortControllers) {
-			controller.abort();
-		}
+		this._bash.abortBash();
 	}
 
 	get isBashRunning(): boolean {
-		return this._bashAbortControllers.size > 0 || this._userBashRunning;
+		return this._bash.isBashRunning;
 	}
 
-	/** Whether there are pending bash messages waiting to be flushed */
 	get hasPendingBashMessages(): boolean {
-		return this._pendingBashMessages.length > 0;
+		return this._bash.hasPendingBashMessages;
 	}
 
-	/**
-	 * Flush pending bash messages to agent state and session.
-	 * Called after agent turn completes to maintain proper message ordering.
-	 */
 	private _flushPendingBashMessages(): void {
-		if (this._pendingBashMessages.length === 0) return;
-
-		for (const bashMessage of this._pendingBashMessages) {
-			this.agent.state.messages.push(bashMessage);
-
-			this.sessionManager.appendMessage(bashMessage);
-		}
-
-		this._pendingBashMessages = [];
+		this._bash.flushPendingMessages();
 	}
 
 	getRlmMaxDepthStatus(): RlmMaxDepthStatus {

--- a/packages/coding-agent/src/session/bash.ts
+++ b/packages/coding-agent/src/session/bash.ts
@@ -1,0 +1,288 @@
+import { type BashResult, executeBashWithOperations } from "../core/bash-executor.js";
+import type { UserBashEvent, UserBashEventResult } from "../core/extensions/types.js";
+import type { BashExecutionMessage } from "../core/messages.js";
+import { type BashOperations, createLocalBashOperations } from "../core/tools/bash.js";
+
+export interface ExecuteBashOptions {
+	excludeFromContext?: boolean;
+	operations?: BashOperations;
+	transient?: boolean;
+}
+
+export interface RunUserBashOptions {
+	excludeFromContext?: boolean;
+	transient?: boolean;
+	runId?: string;
+}
+
+type UserBashEndDetails = {
+	exitCode: number | undefined;
+	cancelled: boolean;
+	truncated: boolean;
+	fullOutputPath?: string;
+	errorMessage?: string;
+};
+
+export type SessionBashEvent =
+	| {
+			type: "bash_start";
+			command: string;
+			excludeFromContext: boolean;
+			transient?: boolean;
+			runId?: string;
+	  }
+	| { type: "bash_output"; chunk: string }
+	| ({ type: "bash_end"; transient?: boolean; runId?: string } & UserBashEndDetails);
+
+export interface SessionBashHost {
+	getCwd(): string;
+	getShellCommandPrefix(): string | undefined;
+	getShellPath(): string | undefined;
+	isStreaming(): boolean;
+	intercept(event: UserBashEvent): Promise<UserBashEventResult | undefined>;
+	emit(event: SessionBashEvent): void;
+	appendMessage(message: BashExecutionMessage): void;
+	onStateChange(): void;
+	onUserBashEnd(): Promise<void>;
+	executeBash(command: string, onChunk?: (chunk: string) => void, options?: ExecuteBashOptions): Promise<BashResult>;
+	recordBashResult(command: string, result: BashResult, options?: { excludeFromContext?: boolean }): void;
+}
+
+export class SessionBash {
+	private _bashAbortControllers = new Set<AbortController>();
+	private _userBashRunning = false;
+	private _userBashAbortRequested = false;
+	private _pendingBashMessages: BashExecutionMessage[] = [];
+
+	constructor(private readonly _host: SessionBashHost) {}
+
+	/**
+	 * Execute a bash command.
+	 * Adds result to agent context and session.
+	 * @param command The bash command to execute
+	 * @param onChunk Optional streaming callback for output
+	 * @param options.excludeFromContext If true, command output won't be sent to LLM (!! prefix)
+	 * @param options.operations Custom BashOperations for remote execution
+	 */
+	async executeBash(
+		command: string,
+		onChunk?: (chunk: string) => void,
+		options?: ExecuteBashOptions,
+	): Promise<BashResult> {
+		// Each invocation owns its controller so abortBash reaches every in-flight command.
+		const abortController = new AbortController();
+		this._bashAbortControllers.add(abortController);
+
+		const prefix = this._host.getShellCommandPrefix();
+		const shellPath = this._host.getShellPath();
+		const resolvedCommand = prefix ? `${prefix}\n${command}` : command;
+
+		try {
+			const result = await executeBashWithOperations(
+				resolvedCommand,
+				this._host.getCwd(),
+				options?.operations ?? createLocalBashOperations({ shellPath }),
+				{
+					onChunk,
+					signal: abortController.signal,
+				},
+			);
+
+			if (!options?.transient) {
+				this._host.recordBashResult(command, result, options);
+			}
+			return result;
+		} finally {
+			this._bashAbortControllers.delete(abortController);
+			this._host.onStateChange();
+		}
+	}
+
+	/**
+	 * Run a user-initiated bash command (! / !! prefix), emitting bash_start,
+	 * bash_output, and bash_end session events so any attached client can render
+	 * streaming output. Extensions can intercept execution via the user_bash event.
+	 * Execution failures are reported through bash_end rather than a rejected promise;
+	 * only the already-running guard and extension dispatch errors reject.
+	 * @param command The bash command to execute
+	 * @param options.excludeFromContext If true, command output won't be sent to LLM (!! prefix)
+	 */
+	async runUserBash(command: string, options?: RunUserBashOptions): Promise<void> {
+		if (this.isBashRunning) {
+			throw new Error("A bash command is already running");
+		}
+		// Claim the bash slot synchronously: isBashRunning is otherwise false until
+		// executeBash installs its abort controller, which would let a second command
+		// slip through during the user_bash extension dispatch below.
+		this._userBashRunning = true;
+		this._userBashAbortRequested = false;
+		// Echoed on bash_start/bash_end so the requesting client can tell its own
+		// run apart from other clients' runs broadcast on the same session.
+		const identity = {
+			...(options?.transient ? { transient: true } : {}),
+			...(options?.runId !== undefined ? { runId: options.runId } : {}),
+		};
+		let end: UserBashEndDetails;
+		try {
+			end = await this.runUserBashLocked(
+				command,
+				options?.excludeFromContext ?? false,
+				options?.transient ?? false,
+				identity,
+			);
+		} finally {
+			this._userBashRunning = false;
+			this._host.onStateChange();
+		}
+		// Emitted after the slot is released so clients never observe a bash_end
+		// while the session still rejects new commands as already running.
+		this._host.emit({ type: "bash_end", ...end, ...identity });
+		void this._host.onUserBashEnd().catch(() => undefined);
+	}
+
+	private async runUserBashLocked(
+		command: string,
+		excludeFromContext: boolean,
+		transient: boolean,
+		identity: { transient?: boolean; runId?: string },
+	): Promise<UserBashEndDetails> {
+		const eventResult = await this._host.intercept({
+			type: "user_bash",
+			command,
+			excludeFromContext,
+			cwd: this._host.getCwd(),
+		});
+
+		// Transient runs (side-conversation bash) live only in their pane: they
+		// are never recorded, so reloads and rebuilds cannot resurface them.
+		const record = transient
+			? () => {}
+			: (result: BashResult) => this._host.recordBashResult(command, result, { excludeFromContext });
+
+		this._host.emit({
+			type: "bash_start",
+			command,
+			excludeFromContext,
+			...identity,
+		});
+		try {
+			// If an extension returned a full result, surface it without executing
+			if (eventResult?.result) {
+				const result = eventResult.result;
+				if (result.output) {
+					this._host.emit({ type: "bash_output", chunk: result.output });
+				}
+				record(result);
+				return {
+					exitCode: result.exitCode,
+					cancelled: result.cancelled,
+					truncated: result.truncated,
+					fullOutputPath: result.fullOutputPath,
+				};
+			}
+
+			// An abort that arrived before the process spawned (during extension
+			// dispatch) has no abort controller to act on; honor it here instead.
+			if (this._userBashAbortRequested) {
+				record({
+					output: "",
+					exitCode: undefined,
+					cancelled: true,
+					truncated: false,
+				});
+				return { exitCode: undefined, cancelled: true, truncated: false };
+			}
+
+			const result = await this._host.executeBash(
+				command,
+				(chunk) => this._host.emit({ type: "bash_output", chunk }),
+				{
+					excludeFromContext,
+					operations: eventResult?.operations,
+					transient,
+				},
+			);
+			return {
+				exitCode: result.exitCode,
+				cancelled: result.cancelled,
+				truncated: result.truncated,
+				fullOutputPath: result.fullOutputPath,
+			};
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			// Persist the failure like every other outcome so replayed transcripts
+			// and the LLM context reflect that the command did not run.
+			record({
+				output: `bash failed: ${errorMessage}`,
+				exitCode: undefined,
+				cancelled: false,
+				truncated: false,
+			});
+			return {
+				exitCode: undefined,
+				cancelled: false,
+				truncated: false,
+				errorMessage,
+			};
+		}
+	}
+
+	recordBashResult(command: string, result: BashResult, options?: { excludeFromContext?: boolean }): void {
+		const bashMessage: BashExecutionMessage = {
+			role: "bashExecution",
+			command,
+			output: result.output,
+			exitCode: result.exitCode,
+			cancelled: result.cancelled,
+			truncated: result.truncated,
+			fullOutputPath: result.fullOutputPath,
+			timestamp: Date.now(),
+			excludeFromContext: options?.excludeFromContext,
+		};
+
+		// If agent is streaming, defer adding to avoid breaking tool_use/tool_result ordering
+		if (this._host.isStreaming()) {
+			this._pendingBashMessages.push(bashMessage);
+		} else {
+			this._host.appendMessage(bashMessage);
+		}
+	}
+
+	/**
+	 * Cancel running bash command.
+	 */
+	abortBash(): void {
+		// A user bash command may not have spawned yet (extension dispatch in
+		// progress); flag the request so runUserBash cancels before executing.
+		// runUserBash clears the flag at each start, so a stale flag is harmless.
+		if (this._userBashRunning) {
+			this._userBashAbortRequested = true;
+		}
+		for (const controller of this._bashAbortControllers) {
+			controller.abort();
+		}
+	}
+
+	get isBashRunning(): boolean {
+		return this._bashAbortControllers.size > 0 || this._userBashRunning;
+	}
+
+	/** Whether there are pending bash messages waiting to be flushed */
+	get hasPendingBashMessages(): boolean {
+		return this._pendingBashMessages.length > 0;
+	}
+
+	/**
+	 * Flush pending bash messages to agent state and session.
+	 * Called after agent turn completes to maintain proper message ordering.
+	 */
+	flushPendingMessages(): void {
+		if (this._pendingBashMessages.length === 0) return;
+
+		for (const bashMessage of this._pendingBashMessages) {
+			this._host.appendMessage(bashMessage);
+		}
+
+		this._pendingBashMessages = [];
+	}
+}

--- a/packages/coding-agent/test/session/bash.test.ts
+++ b/packages/coding-agent/test/session/bash.test.ts
@@ -1,0 +1,206 @@
+import { Buffer } from "node:buffer";
+import { describe, expect, it, vi } from "vitest";
+import type { BashResult } from "../../src/core/bash-executor.js";
+import type { BashExecutionMessage } from "../../src/core/messages.js";
+import { SessionBash, type SessionBashEvent, type SessionBashHost } from "../../src/session/bash.js";
+
+function deferred() {
+	let resolve = () => {};
+	const promise = new Promise<void>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+function result(output = "done"): BashResult {
+	return { output, exitCode: 0, cancelled: false, truncated: false };
+}
+
+function createShell(overrides: Partial<SessionBashHost> = {}) {
+	const events: SessionBashEvent[] = [];
+	const messages: BashExecutionMessage[] = [];
+	const onStateChange = vi.fn();
+	const onUserBashEnd = vi.fn(async () => {});
+	const host: SessionBashHost = {
+		getCwd: () => "/workspace",
+		getShellCommandPrefix: () => undefined,
+		getShellPath: () => undefined,
+		isStreaming: () => false,
+		intercept: async () => undefined,
+		emit: (event) => events.push(event),
+		appendMessage: (message) => messages.push(message),
+		onStateChange,
+		onUserBashEnd,
+		executeBash: (command, onChunk, options) => shell.executeBash(command, onChunk, options),
+		recordBashResult: (command, outcome, options) => shell.recordBashResult(command, outcome, options),
+		...overrides,
+	};
+	const shell = new SessionBash(host);
+	return { shell, events, messages, onStateChange, onUserBashEnd };
+}
+
+describe("SessionBash", () => {
+	it("reads current shell settings and cwd while recording the original command", async () => {
+		let cwd = "/first";
+		let prefix = "set -e";
+		const { shell, messages } = createShell({ getCwd: () => cwd, getShellCommandPrefix: () => prefix });
+		const calls: string[][] = [];
+		const chunks: string[] = [];
+		const options = {
+			excludeFromContext: true,
+			operations: {
+				exec: vi.fn(async (command, directory, execution) => {
+					calls.push([command, directory]);
+					execution.onData(Buffer.from("output"));
+					return { exitCode: 0 };
+				}),
+			},
+		} satisfies Parameters<SessionBash["executeBash"]>[2];
+		await shell.executeBash("first", (chunk) => chunks.push(chunk), options);
+		cwd = "/second";
+		prefix = "";
+		await shell.executeBash("second", undefined, options);
+		expect(calls).toEqual([
+			["set -e\nfirst", "/first"],
+			["second", "/second"],
+		]);
+		expect(chunks).toEqual(["output"]);
+		expect(messages.map((message) => [message.command, message.excludeFromContext])).toEqual([
+			["first", true],
+			["second", true],
+		]);
+	});
+
+	it("holds the user slot during interception and honours abort before execution", async () => {
+		const gate = deferred();
+		const exec = vi.fn(async () => ({ exitCode: 0 }));
+		const { shell, events, messages } = createShell({
+			intercept: async () => {
+				await gate.promise;
+				return { operations: { exec } };
+			},
+		});
+		const run = shell.runUserBash("cancel me", { runId: "first" });
+		expect(shell.isBashRunning).toBe(true);
+		await expect(shell.runUserBash("second")).rejects.toThrow("already running");
+		shell.abortBash();
+		gate.resolve();
+		await run;
+		expect(exec).not.toHaveBeenCalled();
+		expect(messages).toMatchObject([{ command: "cancel me", cancelled: true, output: "" }]);
+		expect(events).toEqual([
+			{ type: "bash_start", command: "cancel me", excludeFromContext: false, runId: "first" },
+			{ type: "bash_end", exitCode: undefined, cancelled: true, truncated: false, runId: "first" },
+		]);
+		expect(shell.isBashRunning).toBe(false);
+	});
+
+	it("keeps an extension replacement result authoritative when abort arrives during interception", async () => {
+		const gate = deferred();
+		const exec = vi.fn(async () => ({ exitCode: 1 }));
+		const replacement = { ...result("replacement"), truncated: true, fullOutputPath: "/output/complete" };
+		const { shell, events, messages } = createShell({
+			intercept: async () => {
+				await gate.promise;
+				return { result: replacement, operations: { exec } };
+			},
+		});
+		const run = shell.runUserBash("intercepted");
+		shell.abortBash();
+		gate.resolve();
+		await run;
+		expect(exec).not.toHaveBeenCalled();
+		expect(messages).toMatchObject([replacement]);
+		expect(events.at(-1)).toMatchObject({
+			type: "bash_end",
+			cancelled: false,
+			truncated: true,
+			fullOutputPath: "/output/complete",
+		});
+	});
+
+	it("releases the slot on interception failure without fabricating execution events", async () => {
+		let fail = true;
+		const { shell, events, messages, onStateChange, onUserBashEnd } = createShell({
+			intercept: async () => {
+				if (fail) throw new Error("dispatch failed");
+				return { result: result() };
+			},
+		});
+		await expect(shell.runUserBash("first")).rejects.toThrow("dispatch failed");
+		expect(shell.isBashRunning).toBe(false);
+		expect(onStateChange).toHaveBeenCalledOnce();
+		expect(onUserBashEnd).not.toHaveBeenCalled();
+		expect(events).toEqual([]);
+		expect(messages).toEqual([]);
+		fail = false;
+		await shell.runUserBash("second");
+		expect(messages).toHaveLength(1);
+	});
+
+	it.each(["execution", "replacement", "failure"] as const)(
+		"keeps transient %s output out of pending messages and persistence",
+		async (mode) => {
+			const { shell, events, messages } = createShell({
+				isStreaming: () => true,
+				intercept: async () =>
+					mode === "replacement"
+						? { result: result() }
+						: {
+								operations: {
+									exec: async (_command, _cwd, options) => {
+										if (mode === "failure") throw new Error("failed");
+										options.onData(Buffer.from("transient"));
+										return { exitCode: 0 };
+									},
+								},
+							},
+			});
+			await shell.runUserBash("side command", { transient: true, runId: "side" });
+			expect(events[0]).toMatchObject({ type: "bash_start", transient: true, runId: "side" });
+			expect(events.at(-1)).toMatchObject({ type: "bash_end", transient: true, runId: "side" });
+			expect(messages).toEqual([]);
+			expect(shell.hasPendingBashMessages).toBe(false);
+			shell.flushPendingMessages();
+			expect(messages).toEqual([]);
+		},
+	);
+
+	it("flushes deferred output in order only at the explicit flush boundary", () => {
+		let streaming = true;
+		const { shell, messages } = createShell({ isStreaming: () => streaming });
+		shell.recordBashResult("first", result("one"));
+		shell.recordBashResult("second", result("two"), { excludeFromContext: true });
+		streaming = false;
+		expect(messages).toEqual([]);
+		expect(shell.hasPendingBashMessages).toBe(true);
+		shell.flushPendingMessages();
+		shell.flushPendingMessages();
+		expect(messages.map((message) => message.command)).toEqual(["first", "second"]);
+		expect(messages[1]?.excludeFromContext).toBe(true);
+		expect(shell.hasPendingBashMessages).toBe(false);
+	});
+
+	it("allows a completion subscriber to synchronously start another user command", async () => {
+		const events: SessionBashEvent[] = [];
+		let secondRun: Promise<void> | undefined;
+		const { shell, messages } = createShell({
+			intercept: async (event) => ({ result: result(event.command) }),
+			emit: (event) => {
+				events.push(event);
+				if (event.type === "bash_end" && event.runId === "first") {
+					expect(shell.isBashRunning).toBe(false);
+					secondRun = shell.runUserBash("second", { runId: "second" });
+				}
+			},
+		});
+		await shell.runUserBash("first", { runId: "first" });
+		await secondRun;
+		expect(messages.map((message) => message.command)).toEqual(["first", "second"]);
+		expect(events.filter((event) => event.type === "bash_end").map((event) => event.runId)).toEqual([
+			"first",
+			"second",
+		]);
+		expect(shell.isBashRunning).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -1067,7 +1067,6 @@ stale post-hook extension instructions`,
 		});
 		const sessionInternals = harness.session as unknown as {
 			_refineInFlight?: Promise<void>;
-			_userBashRunning?: boolean;
 		};
 		sessionInternals._refineInFlight = refineGate;
 
@@ -1076,12 +1075,26 @@ stale post-hook extension instructions`,
 			{ expandPromptTemplates: false, queueIfBusy: true },
 		);
 		await vi.waitFor(() => expect(harness.session.getPendingNextTurnMessageSnapshots()).toEqual([]));
-		sessionInternals._userBashRunning = true;
+		const bashGate = createDeferred();
+		const bashRun = harness.session.executeBash("hold handoff", undefined, {
+			transient: true,
+			operations: {
+				exec: async () => {
+					await bashGate.promise;
+					return { exitCode: 0 };
+				},
+			},
+		});
+		expect(harness.session.isBashRunning).toBe(true);
 		sessionInternals._refineInFlight = undefined;
 		releaseRefine?.();
 
-		await expect(accepted).rejects.toThrow("Agent became busy before prompt delivery");
-		sessionInternals._userBashRunning = false;
+		try {
+			await expect(accepted).rejects.toThrow("Agent became busy before prompt delivery");
+		} finally {
+			bashGate.resolve();
+			await bashRun;
+		}
 
 		let sawRestoredContext = false;
 		harness.setResponses([


### PR DESCRIPTION
- move shell execution, cancellation, lifecycle events, and deferred output into one session feature owner.
- preserve public dispatch and transcript ordering; all 282 focused tests and repository checks pass, with live validation pending.
- stacked on #2187; continues [eng-5938](https://linear.app/primeintellect/issue/ENG-5938/extract-session-input-goal-continuation-and-context-controllers) with unchanged shell events and persistence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shell execution, abort timing, extension precedence, and deferred transcript ordering are scheduling-sensitive; behavior is intended to be unchanged but the logic moved behind new host wiring.
> 
> **Overview**
> Extracts session shell behavior from **`AgentSession`** into a dedicated **`SessionBash`** owner in `session/bash.ts`, continuing the session modularization pattern used for scheduling and commit fencing.
> 
> **`AgentSession`** now constructs **`SessionBash`** with host callbacks (cwd/shell settings, extension `user_bash` interception, event emit, transcript append, input checkpoint notifications, and chained `executeBash` / `recordBashResult` so public method wrappers still apply). Public APIs (`executeBash`, `runUserBash`, `abortBash`, pending flush, `isBashRunning`) delegate without changing event shapes or `bashExecution` persistence. Bash lifecycle events are typed via **`SessionBashEvent`** on the session event union.
> 
> Adds focused **`SessionBash`** unit tests and documents shell ownership in **`README.md`**. One integration test now holds a real in-flight **`executeBash`** instead of toggling private bash flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d79a0a31d00c04f142a5b2e3bdb1410a28c8177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract shell execution logic from `AgentSession` into `SessionBash` class
> - Moves bash state (abort-controller tracking, user-command slot, deferred messages) and behavior (execution, user-command interception, lifecycle events, recording, cancellation) from `AgentSession` into a new `SessionBash` owner class in [bash.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2189/files#diff-035722399ed33f37105a723fb6659ae38be4940f7533b1127f55105ba16a562e)
> - `SessionBash` depends on a `SessionBashHost` callback interface rather than receiving `AgentSession`, `Agent`, kernel, or storage-manager objects, keeping the boundary decoupled
> - `AgentSession` retains public wrapper methods (`executeBash`, `runUserBash`, `recordBashResult`, `abortBash`) and getters (`isBashRunning`, `hasPendingBashMessages`) that delegate to `SessionBash`
> - Extracts `ExecuteBashOptions`, `RunUserBashOptions`, and `SessionBashEvent` types into [bash.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2189/files#diff-035722399ed33f37105a723fb6659ae38be4940f7533b1127f55105ba16a562e); updates [agent-session.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2189/files#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448ae) to use the exported `SessionBashEvent` union
> - Adds focused unit tests for `SessionBash` in [bash.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2189/files#diff-1213b82722395ad3fc11f41c6859eef04c1f024fbc10adcca456399a687e3c1f) and updates the prompt handoff race test in [agent-session-prompt.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2189/files#diff-9a8dd710562f43458302c5fe8d1a5f9923041fb99f9584188f1014c903070e26) to use a real transient `executeBash` instead of mutating removed private fields
> - Behavioral Change: `AgentSession.runUserBashLocked` and its private bash fields are removed; any out-of-tree code referencing these private members will break
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d79a0a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->