### PR TITLE
colour benchmark changes below the noise threshold

### DIFF
--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -100,10 +100,12 @@ subsystem measurements alongside the normal installed CLI benchmarks, not end-to
 
 The comment has four columns: metric, main, PR, and signed change with the percentage in parentheses.
 A single summary counts regressions, improvements, metrics with no clear change, and incomplete or
-unavailable comparisons. Improvements are green with `↓`, regressions red with `↑`, and changes within
-the noise threshold remain neutral with `≈`. The entire change value, including the arrow, delta, and
-percentage, goes from muted to vivid as the absolute percentage grows, reaching maximum intensity at
-100%. An undefined percentage uses the muted shade. Colors use GitHub's native MathJax rendering;
+unavailable comparisons. Every nonzero change is green for a decrease or red for an increase, including
+changes within the noise threshold, which retain `≈` and count as no clear change in the summary.
+Changes exceeding the threshold use `↓` for improvements and `↑` for regressions. The entire change
+value, including the symbol, delta, and percentage, goes from muted to vivid as the absolute percentage
+grows, reaching maximum intensity at 100%. An undefined percentage uses the muted shade. Exact zero,
+incomplete, and unavailable changes remain neutral. Colors use GitHub's native MathJax rendering;
 no external badge service is required. Successful/attempted counts and spread appear in the collapsed
 methodology.
 Arrows require a change larger than the metric's absolute floor, relative floor,

--- a/scripts/benchmarks/report.py
+++ b/scripts/benchmarks/report.py
@@ -178,14 +178,18 @@ def comparison(
     change = f"{number(delta, definition, True)} {definition.unit} ({percentage})"
     if len(left) != expected or len(right) != expected:
         return Comparison(main_text, head_text, f"{change}; incomplete", "incomplete")
-    threshold = max(definition.absolute, main * definition.relative, spread(left), spread(right))
-    if abs(delta) <= threshold:
+    if delta == 0:
         return Comparison(main_text, head_text, f"≈ {change}", "no clear change")
-    signal = "↑" if delta > 0 else "↓"
+    threshold = max(definition.absolute, main * definition.relative, spread(left), spread(right))
+    signal = "≈"
+    outcome: Literal["regressed", "improved", "no clear change"] = "no clear change"
+    if abs(delta) > threshold:
+        signal = "↑" if delta > 0 else "↓"
+        outcome = "regressed" if delta > 0 else "improved"
     color = change_color(relative_change, regressed=delta > 0)
     text = f"{signal} {change}".replace("%", r"\%")
     colored = rf"$`\textcolor{{{color}}}{{\textsf{{{text}}}}}`$"
-    return Comparison(main_text, head_text, colored, "regressed" if delta > 0 else "improved")
+    return Comparison(main_text, head_text, colored, outcome)
 
 
 def comparisons(report: Report) -> dict[Metric, Comparison]:

--- a/scripts/benchmarks/tests/test_benchmarks.py
+++ b/scripts/benchmarks/tests/test_benchmarks.py
@@ -128,6 +128,18 @@ class ReportTests(unittest.TestCase):
         self.assertEqual(slower.change, r"$`\textcolor{#b9625f}{\textsf{↑ +500.0 ms (+25.00\%)}}`$")
         self.assertEqual(faster.change, r"$`\textcolor{#548565}{\textsf{↓ -500.0 ms (-25.00\%)}}`$")
 
+    def test_small_changes_are_colored_without_changing_the_overall_assessment(self):
+        report = fixture()
+        report.status = "partial"
+        report.main.metrics["cold"] = observations(*([3.0] * 10))
+        report.pr_head.metrics["cold"] = observations(*([3.03] * 10))
+        report.main.metrics["warm"] = observations(*([2.0] * 10))
+        report.pr_head.metrics["warm"] = observations(*([1.98] * 10))
+        text = render(report)
+        self.assertIn("**Overall: 0 regressed · 0 improved · 2 no clear change · 15 unavailable.**", text)
+        self.assertIn(r"$`\textcolor{#ab6a65}{\textsf{≈ +30.0 ms (+1.00\%)}}`$", text)
+        self.assertIn(r"$`\textcolor{#65816d}{\textsf{≈ -20.0 ms (-1.00\%)}}`$", text)
+
     def test_larger_percentages_are_more_vivid_and_intensity_is_capped(self):
         def color(baseline, head):
             result = comparison(METRICS[3], observations(baseline), observations(head), 1)
@@ -168,9 +180,15 @@ class ReportTests(unittest.TestCase):
         cells = comparison(METRICS[3], observations(0), observations(65537), 1)
         self.assertIn("(N/A)", cells.change)
         self.assertEqual(cells.outcome, "regressed")
-        unchanged = comparison(METRICS[3], observations(10_000_000), observations(10_001_000), 1)
-        self.assertEqual(unchanged.outcome, "no clear change")
-        self.assertEqual(unchanged.change, "≈ +0.001 MB (+0.01%)")
+        small = comparison(METRICS[3], observations(10_000_000), observations(10_001_000), 1)
+        self.assertEqual(small.outcome, "no clear change")
+        self.assertEqual(small.change, r"$`\textcolor{#aa6a65}{\textsf{≈ +0.001 MB (+0.01\%)}}`$")
+        for baseline in (0, 10_000_000):
+            with self.subTest(baseline=baseline):
+                unchanged = comparison(METRICS[3], observations(baseline), observations(baseline), 1)
+                self.assertEqual(unchanged.outcome, "no clear change")
+                self.assertNotIn("textcolor", unchanged.change)
+                self.assertTrue(unchanged.change.startswith("≈ +0.00 MB"))
 
     def test_compact_tables_summarize_outcomes_without_treating_missing_samples_as_unchanged(self):
         report = fixture()


### PR DESCRIPTION
- fixes [eng-6043](https://linear.app/primeintellect/issue/ENG-6043): small measured deltas now receive muted red or green, with stronger colours for larger percentages.
- preserves the noise threshold for arrows and overall assessments; exact zero and incomplete results remain neutral.
- verified with 30 benchmark tests, repository checks, and github’s comment preview.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reporting-only change in the benchmark harness; noise thresholds and outcome aggregation are unchanged.
> 
> **Overview**
> PR benchmark comments now **show direction for small deltas** while **keeping the noise gate for arrows and headline counts**.
> 
> In `comparison`, changes below the existing absolute/relative/spread threshold still count as **no clear change** and keep the **`≈` prefix**, but **nonzero** deltas are rendered with **muted red or green** MathJax text whose intensity scales with percentage. **`↑`/`↓` and improved/regressed outcomes** apply only when the delta exceeds the threshold; **exact zero**, incomplete, and unavailable rows stay **uncolored**.
> 
> The benchmarks **README** documents this split (color vs arrows vs summary). **Tests** cover sub-threshold coloring in full renders, colored small bundle deltas, and neutral exact-zero cells.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f69921cba8f216b1a2dfd31593f3ede3020152d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Color nonzero benchmark changes below the noise threshold in `report.py`
> Updates the benchmark comparison helper in [report.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/2191/files#diff-1df3740e246b391a773feeba76ec266d05cdfffcda183e24ed73f4b232673696) so that nonzero complete changes are always passed through color rendering, regardless of whether they exceed the threshold. The threshold now controls only the displayed symbol (`≈` vs directional arrow) and the outcome classification (no clear change vs regressed/improved). Exact-zero, incomplete, and unavailable comparisons remain uncolored. Tests in [test_benchmarks.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/2191/files#diff-efabd214c1e844b58d8afe164d41cdd63f0576eefb98f305986e7221d63b9259) and docs in [README.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/2191/files#diff-c6e63a1388428a1019d32c9c1bcbb0eb6b079dbca07dd0100081278cc7f85215) are updated to match.
> - Behavioral Change: within-threshold nonzero changes now render with direction-specific color markup where they were previously uncolored; exact-zero changes remain uncolored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f69921c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->