### PR TITLE
fix(coding-agent): observe draft-discard closeSession failures; honor pendingAttaches

### DIFF
--- a/packages/coding-agent/.changes/1922-nonworker-draft-discard.md
+++ b/packages/coding-agent/.changes/1922-nonworker-draft-discard.md
@@ -1,0 +1,1 @@
+- Fixed non-worker draft discard dropping closeSession failures and discarding drafts with an in-flight attach ([#1922](https://github.com/PrimeIntellect-ai/prime-agent/issues/1922))

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -6315,17 +6315,25 @@ export class AgentDaemon {
 			// runs, in which case the draft is no longer abandoned and must be kept.
 			queueMicrotask(() => {
 				if (this.sessions.has(state.activeSessionId) && this.isDiscardableDraft(state)) {
-					void this.closeSession(state, "killed");
+					this.discardAbandonedDraft(state);
 				}
 			});
 		}
+	}
+
+	private discardAbandonedDraft(state: ActiveSessionState): void {
+		void this.closeSession(state, "killed").catch((error) => {
+			this.log(
+				`failed to discard abandoned draft ${state.activeSessionId}: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		});
 	}
 
 	private isDiscardableDraft(state: ActiveSessionState): boolean {
 		if (this.options.worker) {
 			return false;
 		}
-		if (state.clients.size > 0) {
+		if (state.clients.size > 0 || state.pendingAttaches > 0) {
 			return false;
 		}
 		if (state.runtime.metadata.kind === "subagent") {
@@ -6883,7 +6891,7 @@ export class AgentDaemon {
 				(eventType === "turn_end" || eventType === "compaction_end" || eventType === "bash_end") &&
 				this.isDiscardableDraft(state)
 			) {
-				void this.closeSession(state, "killed");
+				this.discardAbandonedDraft(state);
 			}
 			if (RECOVERY_CHECKPOINT_EVENTS.has(eventType)) {
 				this.recordWorkerRecoveryState(state, eventType);

--- a/packages/coding-agent/test/suite/regressions/1922-nonworker-draft-discard.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1922-nonworker-draft-discard.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import type { Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ActiveSessionState, DaemonSocketClient } from "../../../src/modes/daemon/active-session-state.js";
+import { AgentDaemon } from "../../../src/modes/daemon/daemon-mode.js";
+
+const tempDirectories: string[] = [];
+
+afterEach(() => {
+	for (const directory of tempDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+function tempDirectory(): string {
+	const directory = mkdtempSync(join(tmpdir(), "eng-1922-"));
+	tempDirectories.push(directory);
+	return directory;
+}
+
+function socketClient(id: string, activeSessionId: string): { client: DaemonSocketClient; socket: PassThrough } {
+	const socket = new PassThrough();
+	return {
+		socket,
+		client: {
+			id,
+			socket: socket as unknown as Socket,
+			transport: "private-framed",
+			attachedActiveSessionIds: new Set([activeSessionId]),
+			catchupActiveSessionIds: new Set<string>(),
+			detachInput: () => {},
+			supportsExtensionUi: false,
+			capabilities: new Set(),
+		} as unknown as DaemonSocketClient,
+	};
+}
+
+function discardableState(activeSessionId: string): ActiveSessionState {
+	return {
+		activeSessionId,
+		clients: new Set(),
+		pendingAttaches: 0,
+		lastEventSequence: 0,
+		extensionUiRequests: new Map(),
+		runtime: {
+			metadata: { kind: "top-level" },
+			session: {
+				messages: [],
+				isBashRunning: false,
+				isSessionActive: false,
+				hasRunningRlmChildren: () => false,
+				sessionManager: { hasUserContent: () => false },
+			},
+		},
+	} as unknown as ActiveSessionState;
+}
+
+type DaemonInternals = {
+	sessions: Map<string, ActiveSessionState>;
+	detachClientFromSession(client: DaemonSocketClient, state: ActiveSessionState): void;
+	isDiscardableDraft(state: ActiveSessionState): boolean;
+	closeSession(state: ActiveSessionState, reason: "killed"): Promise<void>;
+	write(client: DaemonSocketClient, message: unknown): boolean;
+	log(message: string): void;
+};
+
+function createDaemon(root: string): { daemon: AgentDaemon; internals: DaemonInternals } {
+	const daemon = new AgentDaemon(join(root, "daemon.sock"), {
+		defaultSessionConfig: { agentDir: root, cwd: root },
+		createRuntime: async () => {
+			throw new Error("unexpected runtime creation");
+		},
+	});
+	const internals = daemon as unknown as DaemonInternals;
+	internals.write = vi.fn(() => true);
+	internals.log = vi.fn();
+	return { daemon, internals };
+}
+
+async function flushAsyncWork(): Promise<void> {
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	await new Promise<void>((resolve) => setTimeout(resolve, 10));
+}
+
+describe("regression #1922: non-worker draft discard", () => {
+	it("keeps a discardable draft while an attach is in flight", () => {
+		const root = tempDirectory();
+		const { internals } = createDaemon(root);
+		const state = discardableState("active-1922-attach");
+		expect(internals.isDiscardableDraft(state)).toBe(true);
+		state.pendingAttaches = 1;
+		expect(internals.isDiscardableDraft(state)).toBe(false);
+	});
+
+	it("observes closeSession failures when discarding an abandoned draft", async () => {
+		const root = tempDirectory();
+		const { internals } = createDaemon(root);
+		const activeSessionId = "active-1922-detach";
+		const { client, socket } = socketClient("client-1922", activeSessionId);
+		const state = discardableState(activeSessionId);
+		state.clients.add(client);
+		internals.sessions.set(activeSessionId, state);
+		const closeSession = vi.fn(async () => {
+			throw new Error("close failed");
+		});
+		internals.closeSession = closeSession as never;
+		const log = internals.log as unknown as ReturnType<typeof vi.fn>;
+		try {
+			internals.detachClientFromSession(client, state);
+			await flushAsyncWork();
+			expect(closeSession).toHaveBeenCalledTimes(1);
+			expect(log).toHaveBeenCalledWith(expect.stringContaining(activeSessionId));
+		} finally {
+			socket.destroy();
+		}
+	});
+});


### PR DESCRIPTION
Fixes #1922.

Two latent bugs in the non-worker draft-discard path, both still present on main:

- Both discard sites called `void this.closeSession(state, "killed")` without observing the promise. The daemon's `unhandledRejection` handler exits the process, so a failure during best-effort teardown killed the daemon instead of failing the discard. Both sites now go through a `discardAbandonedDraft` helper that catches and logs the failure, matching the other best-effort teardown calls in the file.
- `isDiscardableDraft` checked only `clients.size`, but `attach` increments `pendingAttaches` before the client joins `clients`. A `turn_end`/`compaction_end`/`bash_end` in that window discarded a draft with an in-flight attach, which then failed its liveness check. `pendingAttaches > 0` now counts as attached.

Worker mode still returns false; no roster/worker changes.

Test plan:
- New `test/suite/regressions/1922-nonworker-draft-discard.test.ts`: fails 2/2 before the fix, passes after.
- `test/daemon-mode.test.ts`: 203 passed.
- Neighbor daemon tests (`4601-worker-snapshot-cache`, `daemon-peer-transport`): 20 passed.
- `npm run check` (biome, tsgo, installer, browser-smoke): clean.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix non-worker draft discard to observe `closeSession` failures and respect `pendingAttaches`
> - Adds `discardAbandonedDraft` helper in [daemon-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2195/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450) that catches and logs `closeSession` rejections instead of leaving them as unhandled promise rejections.
> - Updates `isDiscardableDraft` to reject drafts with nonzero `pendingAttaches`, preventing discard while an attach is in flight.
> - Routes both the `session-detach` handler and the `session-event` handler cleanup through the new helper.
> - Adds regression tests in [1922-nonworker-draft-discard.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2195/files#diff-d223fe0920a0ab90dee413b9183599db54cf0d4b4a1644896f2f3252941b563c) covering the attach-guard and close-failure logging paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a024927.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->