### PR TITLE
chore(catalog): refresh OpenRouter models

### DIFF
--- a/catalog/models.v1.json
+++ b/catalog/models.v1.json
@@ -15025,6 +15025,38 @@
 			"maxTokens": 384000
 		},
 		{
+			"id": "deepseek/deepseek-v4.1-flash",
+			"name": "DeepSeek: DeepSeek V4.1 Flash",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"compat": {
+				"requiresReasoningContentOnAssistantMessages": true,
+				"thinkingFormat": "deepseek"
+			},
+			"reasoning": true,
+			"thinkingLevelMap": {
+				"minimal": null,
+				"low": null,
+				"medium": null,
+				"high": "high",
+				"xhigh": "max",
+				"max": null
+			},
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0.006,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 384000
+		},
+		{
 			"id": "dots-studio/dots-3-note-preview:free",
 			"name": "Dots Studio: Dots3-Note Preview (free)",
 			"api": "openai-completions",
@@ -15749,6 +15781,33 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 50000
+		},
+		{
+			"id": "inception/mercury-2.5",
+			"name": "Inception: Mercury 2.5",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"thinkingLevelMap": {
+				"minimal": null,
+				"low": "low",
+				"medium": "medium",
+				"high": "high",
+				"xhigh": null,
+				"max": null
+			},
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.04,
+				"output": 0.15,
+				"cacheRead": 0.004,
+				"cacheWrite": 0
+			},
+			"contextWindow": 260000,
+			"maxTokens": 65536
 		},
 		{
 			"id": "inception/mercury-2.5-preview",
@@ -17110,6 +17169,62 @@
 				"input": 0.25,
 				"output": 1,
 				"cacheRead": 0.024999999999999998,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 235929
+		},
+		{
+			"id": "nex-agi/nex-n2.5-mini:free",
+			"name": "Nex AGI: Nex-N2.5-Mini (free)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"thinkingLevelMap": {
+				"minimal": null,
+				"low": null,
+				"medium": "medium",
+				"high": "high",
+				"xhigh": null,
+				"max": null
+			},
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 235929
+		},
+		{
+			"id": "nex-agi/nex-n2.5-pro:free",
+			"name": "Nex AGI: Nex-N2.5-Pro (free)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"thinkingLevelMap": {
+				"minimal": null,
+				"low": null,
+				"medium": "medium",
+				"high": "high",
+				"xhigh": null,
+				"max": null
+			},
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,


### PR DESCRIPTION
Adds the four tool-capable OpenRouter models that appeared after the catalog snapshot in #2138:

- `deepseek/deepseek-v4.1-flash`
- `inception/mercury-2.5`
- `nex-agi/nex-n2.5-mini:free`
- `nex-agi/nex-n2.5-pro:free`

This is catalog data only. It does not add another refresh path or change runtime behavior.

Validation:
- `npx tsx packages/ai/scripts/validate-model-catalog.ts`
- `cd packages/ai && npx vitest --run test/model-catalog.test.ts`
- `cd packages/coding-agent && npx vitest --run test/suite/regressions/5982-bundled-model-catalog.test.ts`
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add DeepSeek V4.1 Flash, Inception Mercury 2.5, and Nex AGI N2.5 models to OpenRouter catalog
> - Adds `deepseek/deepseek-v4.1-flash` with text and image input, reasoning support, 1,048,576-token context, and 384,000-token max output
> - Adds `inception/mercury-2.5` with text input, reasoning support, 260,000-token context, and 65,536-token max output
> - Adds free `nex-agi/nex-n2.5-mini:free` and `nex-agi/nex-n2.5-pro:free` with text and image input, reasoning support, 262,144-token context, and 235,929-token max output
> - All new entries use the OpenAI completions API and include pricing metadata (zero-cost for the Nex AGI free variants)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2235eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->