### PR TITLE
fail kernel bootstrap fast when the bundled runtime source is missing

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -685,6 +685,7 @@ prime-agent --thinking high "Solve this complex problem"
 | `PRIME_AGENT_TRACES_API_KEY` | Prime API key used only for opt-in trace sharing |
 | `PRIME_AGENT_TRACES_BASE_URL` | Override the Prime Agent trace upload API base URL |
 | `PRIME_AGENT_KERNEL_PYTHON` | Use an existing Python environment with `prime-agent-runtime` instead of auto-bootstrapping `~/.prime/agent/kernel-venv` |
+| `PRIME_AGENT_RUNTIME_SOURCE` | Install `prime-agent-runtime` into the kernel venv from this source checkout instead of the copy bundled with Prime Agent |
 | `VISUAL`, `EDITOR` | External editor for Ctrl+G |
 
 The remaining `PI_*` variables in this table are compatibility names still read by the current runtime. They do not change the application name, command, or default `~/.prime/agent` configuration path.

--- a/packages/coding-agent/docs/rlm-runtime.md
+++ b/packages/coding-agent/docs/rlm-runtime.md
@@ -237,6 +237,7 @@ Provider credentials are resolved by the TypeScript host. The bounded model cata
 | Failure | Behavior |
 |---|---|
 | Managed runtime is missing | Kernel bootstrap rebuilds it; a custom `PRIME_AGENT_KERNEL_PYTHON` without a current `prime-agent-runtime` is rejected at kernel startup. |
+| Bundled runtime source is missing | Kernel bootstrap fails immediately, names the paths it searched, and leaves the existing venv untouched. This happens when the Prime Agent install a running process started from is deleted or moved (for example a removed worktree); restart from an intact install or set `PRIME_AGENT_RUNTIME_SOURCE`. |
 | Depth limit reached | The host rejects the spawn request; the error reply raises in Python. |
 | Unsupported options | Host rejects the request. |
 | Requested model unavailable | Spawn fails instead of substituting another model. |

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -363,6 +363,7 @@ prime-agent --tools ipython -p "Review the code"
 | `PRIME_AGENT_TRACES_API_KEY` | Prime API key used only for opt-in trace sharing |
 | `PRIME_AGENT_TRACES_BASE_URL` | Override the Prime Agent trace upload API base URL |
 | `PRIME_AGENT_KERNEL_PYTHON` | Use an existing Python environment with `prime-agent-runtime` instead of bootstrapping `~/.prime/agent/kernel-venv` |
+| `PRIME_AGENT_RUNTIME_SOURCE` | Install `prime-agent-runtime` into the kernel venv from this source checkout instead of the copy bundled with Prime Agent |
 | `VISUAL`, `EDITOR` | External editor for Ctrl+G |
 
 The remaining `PI_*` variables are compatibility names still read by the current runtime. They do not change the application name, command, or default `~/.prime/agent` configuration path.

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -14,7 +14,9 @@ import type { PythonSkillRuntimeInfo } from "../skills.js";
 
 const BOOTSTRAP_SCHEMA = 9;
 const PYTHON_VERSION = "3.11";
-const RUNTIME_REQUIREMENT = "prime-agent-runtime";
+const RUNTIME_PACKAGE_NAME = "prime-agent-runtime";
+// Bounded tail of a failed helper command's stderr kept for its error message.
+const RUN_STDERR_TAIL_CHARS = 8_000;
 // Serializes the kernel's user namespace so it can be revived across session
 // resume. Internal-only; intentionally not surfaced to the model as an import.
 const STATE_SNAPSHOT_REQUIREMENT = "dill";
@@ -361,6 +363,7 @@ function ensureKernelPythonKey(pythonSkills: readonly BootstrapPythonSkill[]): s
 	return [
 		process.env.PRIME_AGENT_KERNEL_PYTHON ?? "",
 		process.env.PRIME_AGENT_KERNEL_VENV ?? "",
+		process.env.PRIME_AGENT_RUNTIME_SOURCE ?? "",
 		process.env.HOME ?? "",
 		process.env.XDG_DATA_HOME ?? "",
 		JSON.stringify(pythonSkills),
@@ -411,19 +414,28 @@ function run(command: string, args: string[], options: { stdio?: "ignore" | "inh
 		// CPython must read UTF-8 .pth files even under a Windows legacy code page.
 		const env = { ...process.env, ...(process.platform === "win32" ? { PYTHONUTF8: "1" } : {}) };
 		const batch = isBatchShim(command) ? buildBatchShimInvocation(command, args, env) : undefined;
+		// stderr is captured rather than discarded so a failing uv/python invocation
+		// reports its actual complaint instead of a bare exit code.
 		const child = spawnHidden(batch ? (process.env.ComSpec ?? "cmd.exe") : command, batch?.args ?? args, {
 			env: batch?.env ?? env,
-			stdio: options.stdio ?? "ignore",
+			stdio: options.stdio === "inherit" ? "inherit" : ["ignore", "ignore", "pipe"],
 			...(batch ? { windowsVerbatimArguments: true } : {}),
 		});
+		let stderrTail = "";
+		child.stderr?.setEncoding("utf8");
+		child.stderr?.on("data", (chunk: string) => {
+			stderrTail = (stderrTail + chunk).slice(-RUN_STDERR_TAIL_CHARS);
+		});
 		child.on("error", reject);
-		child.on("exit", (code, signal) => {
+		// "close" rather than "exit": the captured stderr is complete once stdio has closed.
+		child.on("close", (code, signal) => {
 			if (code === 0) {
 				resolve();
 				return;
 			}
 			const reason = signal ? `signal ${signal}` : `exit code ${code}`;
-			reject(new Error(`${command} ${args.join(" ")} failed with ${reason}`));
+			const detail = stderrTail.trim();
+			reject(new Error(`${command} ${args.join(" ")} failed with ${reason}${detail ? `\n${detail}` : ""}`));
 		});
 	});
 }
@@ -685,6 +697,10 @@ async function writeBootstrapVersion(
 }
 
 function runtimeCandidateDirs(): string[] {
+	// An explicit override is the only candidate: it names a prime-agent-runtime
+	// checkout to install instead of the copy that ships with this prime-agent.
+	const override = process.env.PRIME_AGENT_RUNTIME_SOURCE;
+	if (override) return [path.resolve(expandHome(override))];
 	const moduleDir = path.dirname(fileURLToPath(import.meta.url));
 	// dist/prime-agent-runtime is listed first deliberately: it is the only path stable
 	// across every shipped layout (dist/, dist/bundle/, bun), where import.meta.url-relative
@@ -707,19 +723,37 @@ async function resolveRuntimeSourceDir(): Promise<string | null> {
 	return null;
 }
 
-// Identity of the runtime to be installed. For a local source checkout this is a
-// content hash of every rlm/*.py file plus pyproject.toml, so any runtime code or
-// dependency change invalidates an existing venv automatically. Falls back to the
-// bare package name when the runtime resolves to a registry install (no local source).
-export async function resolveRuntimeIdentity(): Promise<string> {
+// The runtime is always installed from a local source directory: prime-agent-runtime
+// is not published to a package index, so there is no registry fallback. When no
+// candidate exists, the install this process runs from has been deleted or moved out
+// from under it (or PRIME_AGENT_RUNTIME_SOURCE is wrong). The only safe move is to
+// fail before touching the shared kernel venv, which other live kernels depend on.
+async function requireRuntimeSourceDir(): Promise<string> {
 	const sourceDir = await resolveRuntimeSourceDir();
-	if (!sourceDir) return RUNTIME_REQUIREMENT;
-	return hashRuntimeSource(sourceDir);
+	if (sourceDir) return sourceDir;
+	throw missingRuntimeSourceError(runtimeCandidateDirs());
 }
 
-// Throws if the local source can't be read. A failure here must surface rather than
-// fall back to RUNTIME_REQUIREMENT: that constant is the registry-install identity, and
-// recording it for a local checkout would permanently mask later source changes.
+function missingRuntimeSourceError(candidates: string[]): Error {
+	return new Error(
+		`Failed to set up the Python kernel runtime: the ${RUNTIME_PACKAGE_NAME} source that ships with this prime-agent install is missing ` +
+			`(looked in: ${candidates.join(", ")}). ` +
+			"The install this process was started from was probably deleted, moved, or replaced while prime-agent was running. " +
+			"The existing kernel venv was left untouched. Restart prime-agent from an intact install, " +
+			`point PRIME_AGENT_RUNTIME_SOURCE at a ${RUNTIME_PACKAGE_NAME} checkout, ` +
+			`or set PRIME_AGENT_KERNEL_PYTHON to a Python with a current ${RUNTIME_PACKAGE_NAME} and default Python packages installed.`,
+	);
+}
+
+// Identity of the runtime to be installed: a content hash of every rlm/*.py file plus
+// pyproject.toml, so any runtime code or dependency change invalidates an existing venv
+// automatically. Throws when no runtime source is available (see requireRuntimeSourceDir).
+export async function resolveRuntimeIdentity(): Promise<string> {
+	return hashRuntimeSource(await requireRuntimeSourceDir());
+}
+
+// Throws if the local source can't be read. A failure here must surface: recording a
+// placeholder identity for a checkout would permanently mask later source changes.
 async function hashRuntimeSource(sourceDir: string): Promise<string> {
 	const rlmDir = path.join(sourceDir, "src", "rlm");
 	const files: string[] = [path.join(sourceDir, "pyproject.toml")];
@@ -752,15 +786,14 @@ export function kernelVenvPython(venv: string, platform: NodeJS.Platform = proce
 
 async function bootstrapVenv(
 	venv: string,
+	runtimeSourceDir: string,
+	runtimeIdentity: string,
 	pythonSkills: readonly BootstrapPythonSkill[],
 	options: EnsureKernelPythonOptions,
 ): Promise<void> {
 	await mkdir(path.dirname(venv), { recursive: true });
 	const uv = await ensureUv(options);
 	const python = kernelVenvPython(venv);
-	const sourceDir = await resolveRuntimeSourceDir();
-	const runtimeRequirement = sourceDir ?? RUNTIME_REQUIREMENT;
-	const runtimeIdentity = await resolveRuntimeIdentity();
 
 	await run(uv, ["python", "install", PYTHON_VERSION]);
 	await run(uv, ["venv", venv, "--python", PYTHON_VERSION, "--seed"]);
@@ -769,7 +802,7 @@ async function bootstrapVenv(
 		"install",
 		"--python",
 		python,
-		runtimeRequirement,
+		runtimeSourceDir,
 		STATE_SNAPSHOT_REQUIREMENT,
 		...DEFAULT_RLM_EXTRA_UV_ARGS,
 	]);
@@ -919,9 +952,12 @@ async function ensureKernelPythonUncached(
 		throw new Error(`PRIME_AGENT_KERNEL_PYTHON points to a Python missing ${missing.join(" and ")}: ${python}`);
 	}
 
+	// Resolve the runtime source before looking at the venv: with no source there is
+	// nothing to (re)install, so a stale-looking venv must not be torn down.
+	const runtimeSourceDir = await requireRuntimeSourceDir();
+	const runtimeIdentity = await hashRuntimeSource(runtimeSourceDir);
 	const venv = await resolveWritableKernelVenvDir();
 	const python = kernelVenvPython(venv);
-	const runtimeIdentity = await resolveRuntimeIdentity();
 	if (await kernelReady(python, venv, runtimeIdentity, pythonSkills)) return python;
 
 	const releaseLock = await acquireBootstrapLock(venv);
@@ -939,7 +975,7 @@ async function ensureKernelPythonUncached(
 			await rm(venv, { recursive: true, force: true });
 		}
 
-		await bootstrapVenv(venv, pythonSkills, options);
+		await bootstrapVenv(venv, runtimeSourceDir, runtimeIdentity, pythonSkills, options);
 	} catch (error) {
 		throw formatBootstrapFailure(error);
 	} finally {

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -135,6 +135,7 @@ function installFakeUv(): string {
 			'if [ "$1" = "pip" ]; then',
 			'  for arg in "$@"; do',
 			'    if [ "$UV_FAIL_ARG" != "" ] && [ "$arg" = "$UV_FAIL_ARG" ]; then',
+			'      echo "fake uv: refusing to install $arg" >&2',
 			"      exit 1",
 			"    fi",
 			"  done",
@@ -156,6 +157,7 @@ describe("kernel bootstrap", () => {
 		process.env.PATH = originalEnv.PATH ?? "";
 		delete process.env.PRIME_AGENT_KERNEL_PYTHON;
 		delete process.env.PRIME_AGENT_KERNEL_VENV;
+		delete process.env.PRIME_AGENT_RUNTIME_SOURCE;
 		delete process.env.XDG_DATA_HOME;
 	});
 
@@ -200,6 +202,73 @@ describe("kernel bootstrap", () => {
 			pythonSkills: [],
 		});
 		expect(version.runtime).toMatch(/^sha256:/);
+	});
+
+	it("installs the runtime from PRIME_AGENT_RUNTIME_SOURCE when set", async () => {
+		const logPath = installFakeUv();
+		const venv = join(tempDir, "kernel-venv");
+		const runtimeSource = join(tempDir, "runtime-src");
+		mkdirSync(join(runtimeSource, "src", "rlm"), { recursive: true });
+		writeFileSync(
+			join(runtimeSource, "pyproject.toml"),
+			'[project]\nname = "prime-agent-runtime"\nversion = "0.0.0"\n',
+		);
+		writeFileSync(join(runtimeSource, "src", "rlm", "__init__.py"), "spawn = None\n");
+		process.env.PRIME_AGENT_KERNEL_VENV = venv;
+		process.env.PRIME_AGENT_RUNTIME_SOURCE = runtimeSource;
+
+		await expect(ensureKernelPython()).resolves.toBe(join(venv, "bin", "python"));
+
+		expect(readFileSync(logPath, "utf8")).toContain(
+			`pip install --python ${join(venv, "bin", "python")} ${runtimeSource} dill`,
+		);
+		const version = JSON.parse(readFileSync(join(venv, ".bootstrap-version"), "utf8"));
+		expect(version.runtime).toBe(await resolveRuntimeIdentity());
+		expect(version.runtime).toMatch(/^sha256:/);
+		expect(version.runtime).not.toBe(runtimeIdentity);
+	});
+
+	it("fails without tearing down a stale venv when the runtime source is missing", async () => {
+		const logPath = installFakeUv();
+		const venv = join(tempDir, "kernel-venv");
+		const python = join(venv, "bin", "python");
+		mkdirSync(join(venv, "bin"), { recursive: true });
+		writeFakePython(python, ["rlm", ...DEFAULT_RLM_EXTRA_IMPORT_NAMES]);
+		// A stale identity would normally trigger rm -rf + rebuild of the shared venv.
+		const staleVersion = `${JSON.stringify({
+			schema: 9,
+			runtime: "sha256:stale",
+			snapshot: "dill",
+			extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
+			pythonSkills: [],
+		})}\n`;
+		writeFileSync(join(venv, ".bootstrap-version"), staleVersion);
+		process.env.PRIME_AGENT_KERNEL_VENV = venv;
+		const missingSource = join(tempDir, "missing-runtime");
+		process.env.PRIME_AGENT_RUNTIME_SOURCE = missingSource;
+
+		const error = await ensureKernelPython().catch((caught: unknown) => caught);
+
+		expect(error).toBeInstanceOf(Error);
+		const message = (error as Error).message;
+		expect(message).toMatch(/prime-agent-runtime source .* is missing/);
+		expect(message).toContain(missingSource);
+		expect(message).toContain("left untouched");
+		expect(message).not.toContain("First-time setup needs internet");
+		expect(readFileSync(join(venv, ".bootstrap-version"), "utf8")).toBe(staleVersion);
+		expect(existsSync(python)).toBe(true);
+		expect(existsSync(logPath)).toBe(false);
+	});
+
+	it("includes the failing command's stderr in the bootstrap error", async () => {
+		installFakeUv();
+		const venv = join(tempDir, "kernel-venv");
+		process.env.PRIME_AGENT_KERNEL_VENV = venv;
+		process.env.UV_FAIL_ARG = "dill";
+
+		await expect(ensureKernelPython()).rejects.toThrow(
+			/failed with exit code 1\nfake uv: refusing to install dill\nFirst-time setup needs internet/,
+		);
 	});
 
 	it("routes bootstrap progress through the provided callback", async () => {

--- a/packages/coding-agent/test/kernel-windows-process.test.ts
+++ b/packages/coding-agent/test/kernel-windows-process.test.ts
@@ -39,7 +39,7 @@ describe("Windows kernel subprocesses", () => {
 		await expect(ensureKernelPython()).rejects.toThrow("PRIME_AGENT_KERNEL_PYTHON");
 		expect(spawn.mock.calls[0]?.[2]).toMatchObject({
 			windowsHide: true,
-			stdio: "ignore",
+			stdio: ["ignore", "ignore", "pipe"],
 			env: { PYTHONUTF8: "1" },
 		});
 		expect(process.env.PYTHONUTF8).toBe("0");
@@ -65,7 +65,11 @@ describe("Windows kernel subprocesses", () => {
 		await expect(ensureKernelPython({ onProgress: () => {} })).rejects.toThrow("spawn refused by test");
 		const call = spawn.mock.calls.at(-1);
 		expect(call?.[0]).toBe(process.env.ComSpec ?? "cmd.exe");
-		expect(call?.[2]).toMatchObject({ windowsHide: true, windowsVerbatimArguments: true, stdio: "ignore" });
+		expect(call?.[2]).toMatchObject({
+			windowsHide: true,
+			windowsVerbatimArguments: true,
+			stdio: ["ignore", "ignore", "pipe"],
+		});
 		expect(Object.values(call?.[2]?.env ?? {})).toContain(uv);
 	});
 


### PR DESCRIPTION
- a session that outlived its deleted worktree could no longer find the bundled runtime source, fell back to installing an unpublished package name, and wiped the shared kernel venv that every other session was using before the reinstall failed with a bare exit code.
- bootstrap now resolves the runtime source before looking at the venv and fails with a clear message naming the searched paths and the recovery steps, leaving the existing venv untouched; the registry fallback is gone since the runtime is always installed from a local checkout.
- uv and python helper failures now carry the tail of their stderr, and a new runtime source override lets you install from an explicit checkout and doubles as the test seam for the missing-source path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared kernel venv bootstrap ordering and install path resolution; incorrect behavior could still break multi-session Python kernel setup, though the intent is to reduce collateral damage when installs go missing.
> 
> **Overview**
> **Kernel bootstrap no longer destroys the shared venv when the bundled `prime-agent-runtime` checkout is gone** (e.g. a long-lived session after its worktree was removed). Bootstrap **resolves the runtime source directory before** comparing or rebuilding `~/.prime/agent/kernel-venv`, and **drops the old registry-name fallback**—installs always come from a local path with a content hash identity.
> 
> When no source is found, bootstrap **fails immediately** with searched paths, recovery hints (`PRIME_AGENT_RUNTIME_SOURCE`, restart from a valid install, or `PRIME_AGENT_KERNEL_PYTHON`), and an explicit note that the **existing venv was left untouched**.
> 
> **`PRIME_AGENT_RUNTIME_SOURCE`** lets devs point bootstrap at a specific runtime checkout (also wired into the bootstrap cache key). **`uv`/`python` helper failures** now append a bounded **stderr tail** instead of only an exit code.
> 
> Docs add the env var and a new RLM failure-mode row; tests cover override install, missing-source safety, and stderr propagation (Windows spawn expectations updated for stderr piping).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 147fc295215d8adcf6f5f5797a5d8cae7a6ec56c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail kernel bootstrap fast when bundled runtime source is missing
> - Kernel bootstrap now resolves and hashes the local runtime source before touching the shared venv. If no source is found, it throws a structured error listing searched paths and leaves the existing venv untouched.
> - Adds `PRIME_AGENT_RUNTIME_SOURCE` env var so callers can point bootstrap at a specific runtime checkout; when set, it is the sole candidate and the cache key changes accordingly.
> - Removes the registry-package fallback from `bootstrapVenv`; installs always use the resolved local source directory.
> - Subprocess helper `run` now captures stderr (up to a fixed tail) and appends it to failure errors instead of reporting only the exit code.
> - Risk: `resolveRuntimeIdentity` no longer returns a package-name fallback identity — any out-of-tree caller relying on that fallback will now fail when the local source is absent. Bootstrap subprocess spawn options changed to pipe stderr, so tests asserting stdio config in [kernel-windows-process.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2203/files#diff-db1356e4f0322906d7eea82aba4053a2bb4193e6879a3bd43a0bbd34deb494ee) were updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 147fc29. 4 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->