### PR TITLE
test(coding-agent): isolate harness-digest compaction test from the real global store

### DIFF
--- a/packages/coding-agent/.changes/fix-compaction-test-env-isolation.md
+++ b/packages/coding-agent/.changes/fix-compaction-test-env-isolation.md
@@ -1,0 +1,1 @@
+- Fixed the harness-digest compaction characterization test failing on machines with a populated real global harness store: the test now isolates PRIME_AGENT_CODING_AGENT_DIR to an empty temp dir so the digest reflects only the test's own entry.

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -1,4 +1,6 @@
-import { appendFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { AgentContinueError, type AgentMessage, type ShouldStopAfterTurnContext } from "@earendil-works/pi-agent-core";
 import {
 	type AssistantMessage,
@@ -7,7 +9,8 @@ import {
 	type ToolResultMessage,
 	type Usage,
 } from "@earendil-works/pi-ai";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { ENV_AGENT_DIR } from "../../src/config.js";
 import { convertToLlm } from "../../src/core/messages.js";
 import { getLocalHarnessStateDir, loadHarnessState, saveHarnessState } from "../../src/core/refinement/index.js";
 import { SessionManager } from "../../src/core/session-manager.js";
@@ -199,6 +202,20 @@ describe("AgentSession compaction characterization", () => {
 	});
 
 	it("prepends the harness digest to the compaction head message on initial and update-merge compactions", async () => {
+		// Empty global store: the digest must reflect only the local test entry
+		// (a populated real global store would truncate the local entry out of the digest).
+		const previousAgentDir = process.env[ENV_AGENT_DIR];
+		const agentDir = join(
+			tmpdir(),
+			`pi-compaction-digest-agent-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		mkdirSync(agentDir, { recursive: true });
+		process.env[ENV_AGENT_DIR] = agentDir;
+		onTestFinished(() => {
+			if (previousAgentDir === undefined) delete process.env[ENV_AGENT_DIR];
+			else process.env[ENV_AGENT_DIR] = previousAgentDir;
+			rmSync(agentDir, { recursive: true, force: true });
+		});
 		const harness = await createHarness({
 			settings: { compaction: { keepRecentTokens: 1 } },
 			persistSession: true,


### PR DESCRIPTION
## Summary

`test/suite/agent-session-compaction.test.ts` > "prepends the harness digest to the compaction head message…" asserts the digest contains the test's local harness entry, but the digest merges the **global** harness store (`~/.prime/agent/harness/harness_state.json`). On any machine with a populated real store, the test's single entry is crowded out by the truncation limit ("+N more memory entries") and the assertion fails. On a clean CI machine it passes, which is why this is invisible upstream.

Fix: point `PRIME_AGENT_CODING_AGENT_DIR` at an empty temp dir for the duration of the test (restored via `onTestFinished`), so the digest deterministically reflects only the test's own entry. This mirrors the existing isolation pattern already used in `agent-session-prompt.test.ts`.

No assertions were weakened; the digest, ordering, and update-merge assertions all run unchanged against a deterministic store.

No-Ticket: test-only fix found via downstream merge testing; no Linear ticket.

## Test plan

- `npx vitest --run test/suite/agent-session-compaction.test.ts` from `packages/coding-agent`: 39 passed (39), three consecutive runs, on a machine whose real global store holds 476 harness entries (previously 1 failed / 38 passed)
- Repo pre-commit checks pass


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate harness-digest compaction test from real global store
> The compaction characterization test in [agent-session-compaction.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2205/files#diff-0848ef0191d07318bcac49b250616ad8fce4e1210426c2b9898e7d6fd9d35633) now sets `PRIME_AGENT_CODING_AGENT_DIR` to a unique temporary directory before creating the persisted harness, and restores the prior value (removing the temp dir) on cleanup. This ensures the harness digest is computed only from test-created entries rather than entries in the machine's real global store.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd19159.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->