### PR TITLE
feat(coding-agent): add /traces subcommand autocomplete

### DIFF
--- a/packages/coding-agent/.changes/traces-argument-autocomplete.md
+++ b/packages/coding-agent/.changes/traces-argument-autocomplete.md
@@ -1,0 +1,1 @@
+- Added subcommand autocomplete to /traces, suggesting status, on, off, preview, upload, upload-current, upload-all, and login after the command.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -571,6 +571,17 @@ const HEARTBEAT_ARGUMENT_COMPLETIONS: AutocompleteItem[] = [
 	},
 ];
 
+const TRACES_ARGUMENT_COMPLETIONS: AutocompleteItem[] = [
+	{ value: "status", label: "status", description: "Show trace sharing status" },
+	{ value: "on", label: "on", description: "Enable automatic trace uploads" },
+	{ value: "off", label: "off", description: "Disable automatic trace uploads" },
+	{ value: "preview", label: "preview", description: "Preview the current session trace" },
+	{ value: "upload", label: "upload", description: "Alias of upload-current" },
+	{ value: "upload-current", label: "upload-current", description: "Upload the current session trace" },
+	{ value: "upload-all", label: "upload-all", description: "Upload all persisted traces" },
+	{ value: "login", label: "login", description: "Configure the Prime API key for trace uploads" },
+];
+
 const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);
 
 // Cap on retained pasted-image bytes (base64). Images are resized below the
@@ -1360,6 +1371,12 @@ export class InteractiveMode {
 		if (heartbeatCommand) {
 			heartbeatCommand.getArgumentCompletions = (prefix: string): AutocompleteItem[] | null =>
 				this.getHeartbeatArgumentCompletions(prefix);
+		}
+
+		const tracesCommand = slashCommands.find((command) => command.name === "traces");
+		if (tracesCommand) {
+			tracesCommand.getArgumentCompletions = (prefix: string): AutocompleteItem[] | null =>
+				this.getTracesArgumentCompletions(prefix);
 		}
 
 		const connectionCommands = this.connectionCommands;
@@ -8010,6 +8027,14 @@ export class InteractiveMode {
 					(item) => item.value.toLowerCase().startsWith(term) || item.label.toLowerCase().startsWith(term),
 				)
 			: HEARTBEAT_ARGUMENT_COMPLETIONS;
+		return filtered.length === 0 ? null : filtered;
+	}
+
+	private getTracesArgumentCompletions(prefix: string): AutocompleteItem[] | null {
+		const term = prefix.trim().toLowerCase();
+		const filtered = term
+			? TRACES_ARGUMENT_COMPLETIONS.filter((item) => item.value.toLowerCase().startsWith(term))
+			: TRACES_ARGUMENT_COMPLETIONS;
 		return filtered.length === 0 ? null : filtered;
 	}
 

--- a/packages/coding-agent/test/interactive-mode-traces-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-traces-command.test.ts
@@ -1,3 +1,4 @@
+import type { AutocompleteItem } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentTraceUploadAllResult, AgentTraceUploadResult } from "../src/core/agent-traces.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
@@ -24,6 +25,7 @@ interface TracesCommandContext {
 
 interface TracesCommandPrototype {
 	handleTracesCommand(this: TracesCommandContext, text: string): Promise<void>;
+	getTracesArgumentCompletions(prefix: string): AutocompleteItem[] | null;
 }
 
 const prototype = InteractiveMode.prototype as unknown as TracesCommandPrototype;
@@ -141,5 +143,49 @@ describe("InteractiveMode /traces", () => {
 		expect(context.showStatus).toHaveBeenCalledWith("Trace upload cancelled.");
 		expect(context.showStatus).not.toHaveBeenCalledWith(expect.stringContaining("Uploaded 0 of 2"));
 		expect(context.traceUploadAllAbortController).toBeUndefined();
+	});
+
+	describe("argument autocomplete", () => {
+		it("lists every subcommand for an empty prefix", () => {
+			const items = prototype.getTracesArgumentCompletions("");
+
+			expect(items?.map((item) => item.value)).toEqual([
+				"status",
+				"on",
+				"off",
+				"preview",
+				"upload",
+				"upload-current",
+				"upload-all",
+				"login",
+			]);
+			const statusItem = items?.find((item) => item.value === "status");
+			expect(statusItem?.label).toBe("status");
+			expect(statusItem?.description).toBe("Show trace sharing status");
+		});
+
+		it("filters subcommands by prefix", () => {
+			const items = prototype.getTracesArgumentCompletions("up");
+
+			expect(items?.map((item) => item.value)).toEqual(["upload", "upload-current", "upload-all"]);
+		});
+
+		it("matches a single subcommand exactly", () => {
+			const items = prototype.getTracesArgumentCompletions("status");
+
+			expect(items?.map((item) => item.value)).toEqual(["status"]);
+		});
+
+		it("filters case-insensitively", () => {
+			const items = prototype.getTracesArgumentCompletions("LOGIN");
+
+			expect(items?.map((item) => item.value)).toEqual(["login"]);
+		});
+
+		it("returns null for an unknown prefix", () => {
+			const items = prototype.getTracesArgumentCompletions("xyz");
+
+			expect(items).toBeNull();
+		});
 	});
 });


### PR DESCRIPTION
## Context

No-Ticket: small UX improvement requested directly.

`/traces` accepts fixed subcommands (`status|on|off|preview|upload|upload-current|upload-all|login`), but the editor showed no suggestions after the command. Other value-completed commands (`/model`, `/effort`, `/heartbeat`) already expose `getArgumentCompletions` on their `SlashCommand` entries; this wires the same mechanism up for `/traces`.

## Changes

- Added `TRACES_ARGUMENT_COMPLETIONS` and `getTracesArgumentCompletions(prefix)` to `InteractiveMode`, filtering the fixed subcommand list case-insensitively by prefix.
- Attached `getArgumentCompletions` to the `traces` command in `createBaseAutocompleteProvider()`.
- Added argument-autocomplete tests to the existing `interactive-mode-traces-command.test.ts` and a changelog fragment.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/interactive-mode-traces-command.test.ts` — 12 tests pass (7 existing + 5 new).
- Drove the real provider from `createBaseAutocompleteProvider()`: `/traces st` suggests `status`, `/traces ` lists all 8 subcommands, `/export st` (no completer) returns null.
- `npm run check` passes (biome, tsgo, linear-ticket, installer, browser-smoke).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive UX only—no changes to trace upload, auth, or command execution behavior.
> 
> **Overview**
> Adds interactive autocomplete for **`/traces`** so users get the same subcommand hints as on **`/model`**, **`/effort`**, and **`/heartbeat`**.
> 
> A fixed list of eight subcommands (`status`, `on`, `off`, `preview`, `upload`, `upload-current`, `upload-all`, `login`) is registered on the traces slash command via **`getArgumentCompletions`**, with case-insensitive prefix filtering. Tests cover full listing, filtering, exact match, and unknown prefixes; a changelog fragment documents the UX change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a195d758a70fbd6f6ff9c19f0611ee1fba6431e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `/traces` subcommand autocomplete in `InteractiveMode`
> Registers an argument-completion callback on the `traces` slash command that filters eight named subcommands (`status`, `on`, `off`, `preview`, `upload`, `upload-current`, `upload-all`, `login`) by case-insensitive prefix. Empty or whitespace prefixes return all items; unknown prefixes return `null`. Tests cover list contents, prefix filtering, exact and case-insensitive matching, and no-match behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a195d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->