### PR TITLE
fix(coding-agent): bound heartbeat listing and skip client-owned launches

### DIFF
--- a/packages/coding-agent/.changes/fix-heartbeat-list-launch-wait.md
+++ b/packages/coding-agent/.changes/fix-heartbeat-list-launch-wait.md
@@ -1,0 +1,2 @@
+- Bounded the global `heartbeats_list` startup wait and stopped waiting on client-owned launches, so private session startups no longer stall the catalog past the caller's request timeout.
+- Bounded the session-scoped `heartbeats_list` forward so a stuck worker fails inside the caller's request budget instead of hanging until the client transport timeout.

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -194,6 +194,14 @@ const SUPERVISOR_SERVER_CAPABILITIES: readonly DaemonServerCapability[] = [
 ];
 const PEER_TRANSPORT_GRANT_TTL_MS = 10_000;
 const WORKER_REQUEST_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+// The daemon client's default request budget is 30s and each ready-worker heartbeat
+// forward gets 5s, so waiting longer than this on in-flight launches would only
+// surface as a client transport timeout instead of a bounded per-worker state error.
+export const HEARTBEAT_LIST_LAUNCH_WAIT_MS = 15_000;
+// Session-scoped listing must fail inside the client's request budget too; the
+// worker request default (24h) would turn a stuck worker into a client transport
+// timeout instead of a daemon-side failure.
+export const HEARTBEAT_LIST_FORWARD_TIMEOUT_MS = 25_000;
 const INPUT_PAUSE_CLEANUP_TIMEOUT_MS = 5_000;
 const UPDATE_RESTART_MUTATION_DRAIN_TIMEOUT_MS = 80_000;
 const UPDATE_RESTART_WORKER_REQUEST_TIMEOUT_MS = 90_000;
@@ -714,6 +722,13 @@ export class DaemonSupervisor {
 	private readonly workers = new Map<string, ResidentWorker>();
 	private workerStopCounts?: Map<ResidentWorker, number>;
 	private readonly openingWorkers = new Map<string, Promise<ResidentWorker>>();
+	/**
+	 * Openings that can register catalog-visible workers (`ownerClientId === undefined`).
+	 * Client-owned launches stay in `openingWorkers` for create dedupe but can never
+	 * join the public heartbeat catalog (`isVisibleWorker`), so catalog listing
+	 * never waits on them.
+	 */
+	private readonly catalogOpeningWorkers = new Map<string, Promise<ResidentWorker>>();
 	/** Public admission ids are scoped to the socket that registered them. */
 	private readonly promptAdmissions = new Map<DaemonSocketClient, Map<string, SupervisorPromptAdmission>>();
 	private readonly sessionInputPauses = new Map<string, SupervisorSessionInputPause>();
@@ -2287,13 +2302,21 @@ export class DaemonSupervisor {
 			case "heartbeats_list": {
 				if (command.activeSessionId) {
 					const match = await this.findWorkerForClient(client, command.activeSessionId);
-					return this.forwardToWorker(match.worker, command);
+					return this.forwardToWorker(match.worker, command, HEARTBEAT_LIST_FORWARD_TIMEOUT_MS);
 				}
-				const openings = [...this.openingWorkers.values()];
+				const openings = [...this.catalogOpeningWorkers.values()];
 				const selectedWorkers = new Set(this.workers.values());
-				for (const result of await Promise.allSettled(openings)) {
-					if (result.status === "fulfilled") selectedWorkers.add(result.value);
+				for (const opening of openings) {
+					opening.then(
+						(worker) => selectedWorkers.add(worker),
+						() => undefined,
+					);
 				}
+				// Slow launches must not outrun the caller's request budget: after
+				// HEARTBEAT_LIST_LAUNCH_WAIT_MS the catalog proceeds with whatever
+				// registered, and still-opening workers surface through the per-worker
+				// state error below.
+				await Promise.race([Promise.allSettled(openings), unrefDelay(HEARTBEAT_LIST_LAUNCH_WAIT_MS)]);
 				const workers = [...this.workers.values()].filter(
 					(worker) =>
 						selectedWorkers.has(worker) && this.isLiveWorker(worker) && worker.descriptor.lifecycle !== "failed",
@@ -2911,11 +2934,17 @@ export class DaemonSupervisor {
 			});
 		})();
 		this.openingWorkers.set(key, opening);
+		if (ownerClientId === undefined) {
+			this.catalogOpeningWorkers.set(key, opening);
+		}
 		try {
 			return await opening;
 		} finally {
 			if (this.openingWorkers.get(key) === opening) {
 				this.openingWorkers.delete(key);
+			}
+			if (this.catalogOpeningWorkers.get(key) === opening) {
+				this.catalogOpeningWorkers.delete(key);
 			}
 		}
 	}
@@ -6893,6 +6922,7 @@ export class DaemonSupervisor {
 		}
 		this.workers.clear();
 		this.openingWorkers.clear();
+		this.catalogOpeningWorkers.clear();
 		await this.runCleanupStep("daemon catalog", () => this.catalog.stop());
 		await this.runCleanupStep("daemon server", () => serverClosed);
 		await this.runCleanupStep("daemon socket", () => this.cleanupSocket());

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2302,7 +2302,19 @@ export class DaemonSupervisor {
 			case "heartbeats_list": {
 				if (command.activeSessionId) {
 					const match = await this.findWorkerForClient(client, command.activeSessionId);
-					return this.forwardToWorker(match.worker, command, HEARTBEAT_LIST_FORWARD_TIMEOUT_MS);
+					// The forward may first join an in-flight recovery whose budget far exceeds
+					// the client's request timeout, so bound the whole operation: a stuck or
+					// still-recovering worker fails daemon-side inside the caller's budget
+					// instead of surfacing as a client transport timeout.
+					const forward = this.forwardToWorker(match.worker, command, HEARTBEAT_LIST_FORWARD_TIMEOUT_MS);
+					const forwardDeadline = unrefDelay(HEARTBEAT_LIST_FORWARD_TIMEOUT_MS).then(() => {
+						throw new Error(
+							`Timed out waiting for session worker to list heartbeats within ${HEARTBEAT_LIST_FORWARD_TIMEOUT_MS}ms`,
+						);
+					});
+					return Promise.race([forward, forwardDeadline]).catch((error: unknown) =>
+						failure(command.id, command.type, error, serializeDaemonError(error)),
+					);
 				}
 				const openings = [...this.catalogOpeningWorkers.values()];
 				const selectedWorkers = new Set(this.workers.values());
@@ -2314,9 +2326,12 @@ export class DaemonSupervisor {
 				}
 				// Slow launches must not outrun the caller's request budget: after
 				// HEARTBEAT_LIST_LAUNCH_WAIT_MS the catalog proceeds with whatever
-				// registered, and still-opening workers surface through the per-worker
-				// state error below.
+				// registered, and workers that are still starting surface through the
+				// per-worker state error below instead of being omitted.
 				await Promise.race([Promise.allSettled(openings), unrefDelay(HEARTBEAT_LIST_LAUNCH_WAIT_MS)]);
+				for (const worker of this.workers.values()) {
+					selectedWorkers.add(worker);
+				}
 				const workers = [...this.workers.values()].filter(
 					(worker) =>
 						selectedWorkers.has(worker) && this.isLiveWorker(worker) && worker.descriptor.lifecycle !== "failed",

--- a/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
@@ -130,6 +130,57 @@ describe("daemon supervisor heartbeat aggregation", () => {
 		}
 	});
 
+	it("reports a still-starting worker after the launch wait instead of omitting it", async () => {
+		vi.useFakeTimers();
+		try {
+			const supervisor = createSupervisorHarness();
+			supervisor.workers.set("public", worker("ready"));
+			supervisor.openingWorkers.set("slow", new Promise<unknown>(() => {}));
+			supervisor.catalogOpeningWorkers.set("slow", new Promise<unknown>(() => {}));
+			supervisor.forwardToWorker = vi.fn(async (_worker, command) =>
+				success(command.id, command.type, { heartbeats: [{ job: { id: "heartbeat-1" } }] }),
+			);
+
+			const pending = supervisor.handleCommand({} as DaemonSocketClient, {
+				id: "list-1",
+				type: "heartbeats_list",
+			});
+			await vi.advanceTimersByTimeAsync(0);
+			// The slow launch registers mid-wait but never becomes ready.
+			supervisor.workers.set("slow", worker("starting"));
+
+			await vi.advanceTimersByTimeAsync(HEARTBEAT_LIST_LAUNCH_WAIT_MS);
+			await expect(pending).resolves.toMatchObject({
+				success: false,
+				error: "Cannot list heartbeats while session worker is starting",
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("fails the session-scoped list when the forward outlives its budget", async () => {
+		vi.useFakeTimers();
+		try {
+			const supervisor = createSupervisorHarness();
+			supervisor.findWorkerForClient = vi.fn(async () => ({ worker: worker("ready") }));
+			supervisor.forwardToWorker = vi.fn(() => new Promise<DaemonResponse>(() => {}));
+
+			const pending = supervisor.handleCommand({} as DaemonSocketClient, {
+				id: "list-1",
+				type: "heartbeats_list",
+				activeSessionId: "session-1",
+			});
+			await vi.advanceTimersByTimeAsync(HEARTBEAT_LIST_FORWARD_TIMEOUT_MS);
+			await expect(pending).resolves.toMatchObject({
+				success: false,
+				error: expect.stringContaining("Timed out waiting for session worker to list heartbeats"),
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("bounds the session-scoped list forward inside the client request budget", async () => {
 		const supervisor = createSupervisorHarness();
 		const target = worker("ready");

--- a/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
@@ -4,11 +4,17 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
 import { type DaemonCommand, type DaemonResponse, failure, success } from "../src/modes/daemon/daemon-protocol.js";
-import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
+import {
+	DaemonSupervisor,
+	HEARTBEAT_LIST_FORWARD_TIMEOUT_MS,
+	HEARTBEAT_LIST_LAUNCH_WAIT_MS,
+} from "../src/modes/daemon/daemon-supervisor.js";
 
 interface SupervisorHarness {
 	workers: Map<string, unknown>;
 	openingWorkers: Map<string, Promise<unknown>>;
+	catalogOpeningWorkers: Map<string, Promise<unknown>>;
+	findWorkerForClient(client: DaemonSocketClient, selector: string): Promise<{ worker: unknown }>;
 	forwardToWorker(worker: unknown, command: DaemonCommand, timeoutMs?: number): Promise<DaemonResponse>;
 	handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<DaemonResponse | undefined>;
 	handleWorkerFrame(worker: unknown, frame: unknown): void;
@@ -44,12 +50,11 @@ describe("daemon supervisor heartbeat aggregation", () => {
 		const target = worker("starting");
 		if (registered) supervisor.workers.set("target", target);
 		let finishStartup = () => {};
-		supervisor.openingWorkers.set(
-			"target",
-			new Promise<unknown>((resolve) => {
-				finishStartup = () => resolve(target);
-			}),
-		);
+		const opening = new Promise<unknown>((resolve) => {
+			finishStartup = () => resolve(target);
+		});
+		supervisor.openingWorkers.set("target", opening);
+		supervisor.catalogOpeningWorkers.set("target", opening);
 		supervisor.forwardToWorker = vi.fn(async (_worker, command) =>
 			success(command.id, command.type, { heartbeats: [{ job: { id: "heartbeat-1" } }] }),
 		);
@@ -65,6 +70,86 @@ describe("daemon supervisor heartbeat aggregation", () => {
 			data: { heartbeats: [{ job: { id: "heartbeat-1" } }] },
 		});
 		expect(supervisor.forwardToWorker).toHaveBeenCalledOnce();
+	});
+
+	it("skips client-owned launches without waiting on them", async () => {
+		const supervisor = createSupervisorHarness();
+		supervisor.workers.set("public", worker("ready"));
+		// A client-owned create can never join the public catalog (isVisibleWorker),
+		// so a launch that never settles must not gate the global list.
+		supervisor.openingWorkers.set("private", new Promise<unknown>(() => {}));
+		supervisor.forwardToWorker = vi.fn(async (_worker, command) =>
+			success(command.id, command.type, { heartbeats: [{ job: { id: "heartbeat-1" } }] }),
+		);
+
+		const watchdog = new Promise<never>((_, reject) => {
+			const timer = globalThis.setTimeout(
+				() => reject(new Error("heartbeats_list waited on a client-owned launch")),
+				1_000,
+			);
+			timer.unref?.();
+		});
+		const response = await Promise.race([
+			supervisor.handleCommand({} as DaemonSocketClient, { id: "list-1", type: "heartbeats_list" }),
+			watchdog,
+		]);
+
+		expect(response).toMatchObject({
+			success: true,
+			data: { heartbeats: [{ job: { id: "heartbeat-1" } }] },
+		});
+		expect(supervisor.forwardToWorker).toHaveBeenCalledOnce();
+	});
+
+	it("stops waiting on slow catalog launches after the launch wait budget", async () => {
+		vi.useFakeTimers();
+		try {
+			const supervisor = createSupervisorHarness();
+			supervisor.workers.set("public", worker("ready"));
+			supervisor.openingWorkers.set("slow", new Promise<unknown>(() => {}));
+			supervisor.catalogOpeningWorkers.set("slow", new Promise<unknown>(() => {}));
+			supervisor.forwardToWorker = vi.fn(async (_worker, command) =>
+				success(command.id, command.type, { heartbeats: [{ job: { id: "heartbeat-1" } }] }),
+			);
+
+			const pending = supervisor.handleCommand({} as DaemonSocketClient, {
+				id: "list-1",
+				type: "heartbeats_list",
+			});
+			await vi.advanceTimersByTimeAsync(0);
+			expect(supervisor.forwardToWorker).not.toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(HEARTBEAT_LIST_LAUNCH_WAIT_MS);
+			await expect(pending).resolves.toMatchObject({
+				success: true,
+				data: { heartbeats: [{ job: { id: "heartbeat-1" } }] },
+			});
+			expect(supervisor.forwardToWorker).toHaveBeenCalledOnce();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("bounds the session-scoped list forward inside the client request budget", async () => {
+		const supervisor = createSupervisorHarness();
+		const target = worker("ready");
+		supervisor.findWorkerForClient = vi.fn(async () => ({ worker: target }));
+		supervisor.forwardToWorker = vi.fn(async (_worker, command) =>
+			success(command.id, command.type, { heartbeats: [{ job: { id: "heartbeat-1" } }] }),
+		);
+
+		const response = await supervisor.handleCommand({} as DaemonSocketClient, {
+			id: "list-1",
+			type: "heartbeats_list",
+			activeSessionId: "session-1",
+		});
+
+		expect(response).toMatchObject({ success: true });
+		expect(supervisor.forwardToWorker).toHaveBeenCalledWith(
+			target,
+			expect.objectContaining({ type: "heartbeats_list" }),
+			HEARTBEAT_LIST_FORWARD_TIMEOUT_MS,
+		);
 	});
 
 	it("uses the last complete worker snapshot during recovery", async () => {


### PR DESCRIPTION
Fixes [ENG-6078](https://linear.app/primeintellect/issue/ENG-6078/keep-heartbeat-catalog-listing-responsive-during-worker-startup)

## Summary
Stacked on #2125. Addresses the review concern there: the global `heartbeats_list` must not depend on launches that can never join the public catalog, and it must stay inside the caller's request budget.

- Track catalog-eligible openings separately at the launch site (`ownerClientId === undefined`). Client-owned launches stay in `openingWorkers` for create dedupe, and the heartbeat catalog never waits on them.
- Bound the launch wait (`HEARTBEAT_LIST_LAUNCH_WAIT_MS` = 15s). Settled launches accumulate into the selection as they complete; a hung launch surfaces through the existing per-worker state error instead of outrunning the caller's 30s request timeout.
- Bound the session-scoped list forward (`HEARTBEAT_LIST_FORWARD_TIMEOUT_MS` = 25s) so a stuck worker fails inside the client budget instead of riding the 24h worker request default.

## Validation
- New regression tests: client-owned launches are not awaited (fails against the previous wait on `openingWorkers`), the launch wait stops at the budget and lists what registered, and the session-scoped forward receives the bounded timeout.
- All eleven heartbeat tests pass; `tsgo --noEmit` and `biome check` pass on the touched files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon `heartbeats_list` timing and error behavior under startup/recovery; low blast radius but callers may see earlier partial lists or new timeout errors instead of long hangs.
> 
> **Overview**
> Fixes global and session-scoped **`heartbeats_list`** hanging past the client’s ~30s request budget during slow or private worker startup.
> 
> **Global catalog listing** now waits only on **`catalogOpeningWorkers`** (supervisor-owned launches with `ownerClientId === undefined`). Client-owned creates still dedupe via **`openingWorkers`** but no longer block the public list. The wait is capped at **`HEARTBEAT_LIST_LAUNCH_WAIT_MS` (15s)**; after that the daemon lists whatever workers registered, and still-starting workers fail with the existing per-worker state error instead of being dropped silently.
> 
> **Session-scoped listing** wraps the worker forward in **`Promise.race`** with **`HEARTBEAT_LIST_FORWARD_TIMEOUT_MS` (25s)** so stuck recovery/forward paths return a daemon-side timeout instead of riding the 24h worker default until the client transport times out.
> 
> Regression tests cover client-owned launch exclusion, launch-wait budget, starting-worker errors after the budget, and bounded session forward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89dbbc9bb2b83545fc175c9410e3d55cfc05a7d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound heartbeat listing waits and skip client-owned launches in `DaemonSupervisor`
> - Adds separate timeout constants for catalog-visible launch waits and session-scoped heartbeat forwarding in [daemon-supervisor.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2212/files#diff-18f2d5ec391785bebc6ddf3c1bd3b795e4ed6e02d0aa3852f5bf247d61d012f8)
> - Introduces a `catalogOpeningWorkers` registry that tracks only unowned, catalog-visible worker openings, so global heartbeat listing no longer waits on client-owned launches
> - Global listing stops waiting after the launch budget, includes workers registered during the wait, and reports still-starting workers rather than omitting them
> - Session-scoped listing races worker forwarding against an unref'd daemon timer and returns a failure response on timeout instead of waiting for the client transport timeout
> - Risk: `handleCommand` for `heartbeats_list` now returns daemon failures on forwarding timeouts rather than relying on client-side timeouts; callers expecting indefinite waits will see earlier failures
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89dbbc9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->