### PR TITLE
fix(coding-agent): absorb kernel pipe errors instead of crashing the worker

### DIFF
--- a/packages/coding-agent/.changes/fix-kernel-pipe-write-errors.md
+++ b/packages/coding-agent/.changes/fix-kernel-pipe-write-errors.md
@@ -1,0 +1,1 @@
+- Fixed a kernel pipe write error (write EPIPE) crashing the whole session worker: pipe errors are now recorded as kernel diagnostics while the pending write rejects cleanly.

--- a/packages/coding-agent/src/core/kernel/repl-manager.ts
+++ b/packages/coding-agent/src/core/kernel/repl-manager.ts
@@ -432,6 +432,19 @@ export class ReplKernelManager {
 				this.appendKernelDiagnostic(`kernel stderr log close failed: ${errorMessage(error)}`);
 			}
 		});
+		// A pipe write into a dead kernel surfaces as an 'error' event on the
+		// stream (write EPIPE); without a listener Node rethrows it and takes
+		// down the whole worker. The pending writeLine rejection and the child
+		// 'exit' handler below own the fallout, so this only records the
+		// diagnosis.
+		child.stdin?.on("error", (error) => {
+			if (this.child !== child) return;
+			this.appendKernelDiagnostic(`kernel stdin error: ${errorMessage(error)}`);
+		});
+		child.stdout?.on("error", (error) => {
+			if (this.child !== child) return;
+			this.appendKernelDiagnostic(`kernel stdout error: ${errorMessage(error)}`);
+		});
 		child.once("exit", () => {
 			// One turn for the poll phase to deliver the bytes the kernel wrote
 			// before dying (the pipe buffer bounds them), then destroy: EOF may

--- a/packages/coding-agent/test/repl-kernel-pipe-errors.test.ts
+++ b/packages/coding-agent/test/repl-kernel-pipe-errors.test.ts
@@ -1,0 +1,62 @@
+import { type ChildProcess, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ReplKernelManager } from "../src/core/kernel/index.js";
+
+function resolveReplPython(): string | null {
+	const candidates = [
+		process.env.PRIME_AGENT_KERNEL_PYTHON,
+		resolve(__dirname, "..", "..", "..", "prime-agent-runtime", ".venv", "bin", "python"),
+		join(homedir(), ".prime", "agent", "kernel-venv", "bin", "python"),
+	].filter((p): p is string => Boolean(p));
+	for (const python of candidates) {
+		if (!existsSync(python)) continue;
+		const check = spawnSync(python, ["-c", "import rlm.repl, dill"], { encoding: "utf8" });
+		if (check.status === 0) return python;
+	}
+	return null;
+}
+
+const python = resolveReplPython();
+const describeIf = python ? describe : describe.skip;
+
+describeIf("ReplKernelManager pipe errors (real runtime)", () => {
+	let dir = "";
+	let manager: ReplKernelManager | undefined;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "prime-agent-repl-pipe-"));
+	});
+
+	afterEach(async () => {
+		await manager?.shutdown({ snapshot: true, drainHostRequests: true });
+		manager = undefined;
+		if (dir) {
+			rmSync(dir, { recursive: true, force: true });
+			dir = "";
+		}
+	});
+
+	it("absorbs kernel pipe write errors instead of crashing the host process", async () => {
+		manager = new ReplKernelManager({ python: python as string, cwd: dir });
+		const first = await manager.execute("x = 1");
+		expect(first.status).toBe("ok");
+
+		const child = (manager as unknown as { child?: ChildProcess }).child;
+		expect(child?.stdin).toBeDefined();
+		expect(child?.stdout).toBeDefined();
+		// A write racing the kernel's death lands as an 'error' event on the pipe;
+		// without a listener Node would crash the worker (observed in production as
+		// "uncaught exception: Error: write EPIPE").
+		expect(() => child?.stdin?.emit("error", new Error("write EPIPE"))).not.toThrow();
+		expect(() => child?.stdout?.emit("error", new Error("read ECONNRESET"))).not.toThrow();
+
+		// The kernel is still healthy: further cells keep executing and shutdown
+		// (afterEach) still completes.
+		const second = await manager.execute("x + 1");
+		expect(second.status).toBe("ok");
+		expect(second.result).toBe("2");
+	}, 30_000);
+});

--- a/packages/coding-agent/test/repl-kernel-shutdown.test.ts
+++ b/packages/coding-agent/test/repl-kernel-shutdown.test.ts
@@ -17,7 +17,11 @@ type ShutdownInternals = {
 		signalCode: NodeJS.Signals | null;
 		kill: (signal?: NodeJS.Signals | number) => boolean;
 		pid?: number;
-		stdin: { destroyed: boolean; destroy: () => void };
+		stdin: {
+			destroyed: boolean;
+			destroy: () => void;
+			on: (event: string, listener: (...args: unknown[]) => void) => void;
+		};
 		stdout?: { destroy: () => void; on: (event: string, listener: (...args: unknown[]) => void) => void };
 		stderr?: {
 			destroy: () => void;
@@ -46,7 +50,7 @@ function configuredManager(
 		signalCode: null,
 		kill: vi.fn(() => true),
 		pid: undefined,
-		stdin: { destroyed: false, destroy: vi.fn() },
+		stdin: { destroyed: false, destroy: vi.fn(), on: vi.fn() },
 		stdout: { destroy: vi.fn(), on: vi.fn() },
 		stderr: { destroy: vi.fn(), on: vi.fn(), once: vi.fn() },
 	});


### PR DESCRIPTION
Fixes [ENG-6079](https://linear.app/primeintellect/issue/ENG-6079/kernel-pipe-write-error-crashes-the-session-worker)

## Summary
A write racing the kernel process's death lands as an 'error' event on the kernel stdin pipe. Production crash (2026-09-10): `uncaught exception: Error: write EPIPE` out of `ReplKernelManager.writeLine` took down a whole session worker and its active sessions. The write callback already rejects the pending `writeLine` promise and every caller handles that rejection, but the pipe had no 'error' listener, so Node rethrew the event and killed the worker process.

Attach 'error' listeners on the kernel child's stdin and stdout pipes that record a kernel diagnostic; the pending write rejection and the child 'exit' handler own the fallout.

## Validation
- New regression test with a real kernel: emitting the pipe errors must not throw, the kernel keeps executing cells, and shutdown stays clean. It fails on the previous code at the emit site (the pre-fix crash was the thrown event).
- The repl-kernel suite (execute, abort, protocol corruption, mcp shutdown, parent watchdog, pipe errors) passes; `tsgo --noEmit` and `biome check` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes failure handling on kernel IPC pipes; stream errors no longer crash the worker and rely on diagnostics plus existing write/exit paths instead.
> 
> **Overview**
> Fixes a production crash where a **write EPIPE** on the kernel child’s stdin (when a write races process death) became an uncaught stream `error` and took down the whole session worker.
> 
> **ReplKernelManager** now attaches `error` listeners on the spawned kernel’s **stdin** and **stdout** pipes. Events for a stale child are ignored; for the current child they are logged via **kernel diagnostics** only—pending **writeLine** rejection and the existing **exit** handler still own recovery, so the worker stays up.
> 
> Adds a **real-kernel regression test** that simulates pipe errors and checks execution and shutdown still succeed. Shutdown unit test mocks gain **`stdin.on`** so **wireChild** wiring matches production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 463fac7e9543168be6cf183366776649972eb46f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix kernel pipe errors terminating the `ReplKernelManager` worker
> - Registers `error` listeners on the kernel child's `stdin` and `stdout` in `ReplKernelManager.wireChild`, recording stream errors as kernel diagnostics instead of letting them surface as unhandled EventEmitter errors
> - Stale child-process events are ignored so only the current child's stream errors are handled
> - Adds an integration test that emits synthetic `stdin`/`stdout` error events during a live session and confirms subsequent cell execution still succeeds
> - Risk: pending writes to a failed stream still reject, so callers in [repl-manager.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2213/files#diff-787a4ef333fe6eca0d80d5f5a8a4f93970d4f0716e6e43a446241a1dcf488097) that do not catch write rejections may see unhandled promise rejections from the same paths as before
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 463fac7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->