### PR TITLE
fix(coding-agent): keep restored transcripts visible when render steps fail (ENG-4742)

### DIFF
--- a/packages/coding-agent/.changes/eng-4742-transcript-survives-render-failures.md
+++ b/packages/coding-agent/.changes/eng-4742-transcript-survives-render-failures.md
@@ -1,0 +1,2 @@
+- Fixed re-opened sessions rendering an empty transcript until the next message when a transient control-plane failure interrupted the initial render.
+- Fixed one unrenderable message aborting the whole transcript rebuild during a session resync.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -578,6 +578,9 @@ const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);
 // evicted past the cap to keep a long session bounded.
 const MAX_PASTED_IMAGE_BYTES = 64 * 1024 * 1024;
 const INITIAL_TRANSCRIPT_RENDER_MESSAGE_LIMIT = 400;
+// Coalesce at most this many heartbeats_changed refreshes into one refresh
+// promise; sustained churn must not hold rebindCurrentSession in a drain loop.
+const HEARTBEAT_REFRESH_DRAIN_LIMIT = 25;
 
 function initialRenderMessages(messages: AgentMessage[]): AgentMessage[] {
 	if (messages.length <= INITIAL_TRANSCRIPT_RENDER_MESSAGE_LIMIT) {
@@ -2580,12 +2583,16 @@ export class InteractiveMode {
 		}
 		const connection = this.agentConnection;
 		const refresh = (async () => {
-			do {
+			// Bound the drain loop: sustained heartbeats_changed churn must not
+			// starve an awaiting rebind (and its transcript render) indefinitely.
+			for (let drain = 0; drain <= HEARTBEAT_REFRESH_DRAIN_LIMIT; drain++) {
 				this.heartbeatRefreshRequested = false;
 				const heartbeats = await connection.listHeartbeats();
 				if (this.agentConnection !== connection) return;
 				this.applyHeartbeatCatalog(heartbeats);
-			} while (this.heartbeatRefreshRequested);
+				if (!this.heartbeatRefreshRequested) return;
+			}
+			// A further heartbeats_changed event starts the next refresh.
 		})().finally(() => {
 			if (this.heartbeatRefreshPromise === refresh) {
 				this.heartbeatRefreshPromise = undefined;
@@ -2840,14 +2847,28 @@ export class InteractiveMode {
 			await this.bindCurrentSessionExtensions();
 		} else {
 			setRegisteredThemes(this.uiServices.getThemes());
-			await this.refreshConnectionCatalog();
+			// Best-effort: the catalog enriches the composer (commands, models,
+			// resources). A transient control-plane failure must not abort the
+			// rebind and leave the transcript unrendered.
+			try {
+				await this.refreshConnectionCatalog();
+			} catch {
+				// Keep the previous catalog; reconnects re-fetch it.
+			}
 			this.setupAutocompleteProvider();
 			this.showLoadedResources({ force: false, showDiagnosticsWhenQuiet: true });
 		}
 		this.subscribeToAgent();
 		await this.subscribeToRosterBar();
 		// A session_action_update in the unsubscribed gap above is lost; re-sync the queue post-subscription.
-		this.patchConnectionState({ sessionActions: (await this.agentConnection.getState()).sessionActions });
+		// Best-effort: a transient control-plane failure must not abort the
+		// rebind and leave the transcript unrendered.
+		try {
+			this.patchConnectionState({ sessionActions: (await this.agentConnection.getState()).sessionActions });
+		} catch {
+			// Keep the attached snapshot's session actions; the next connection
+			// state update re-syncs them.
+		}
 		this.refreshQueueSelectionFromState();
 		this.updatePendingMessagesDisplay();
 		await this.refreshHeartbeatCatalog().catch(() => undefined);
@@ -6407,7 +6428,14 @@ export class InteractiveMode {
 				}
 			}
 		}
-		await this.preloadToolDefinitions(toolNames);
+		// Tool definitions only enrich rendering: components fall back to
+		// cached or missing definitions. A transient control-plane failure here
+		// must not abort the render (a resync render aborts into an empty chat).
+		try {
+			await this.preloadToolDefinitions(toolNames);
+		} catch (error) {
+			this.showWarning(`Could not load tool definitions: ${error instanceof Error ? error.message : String(error)}`);
+		}
 
 		if (options.clearChat) {
 			this.chatContainer.clear();
@@ -6441,61 +6469,79 @@ export class InteractiveMode {
 		}
 
 		for (const message of messagesToRender) {
-			// Assistant messages need special handling for tool calls
-			if (message.role === "assistant") {
-				this.addMessageToChat(message);
-				// Render tool call components
-				for (const content of message.content) {
-					if (content.type === "toolCall") {
-						const spacing = createConversationSpacing(this.chatContainer.children);
-						const component = new ToolExecutionComponent(
-							content.name,
-							content.id,
-							content.arguments,
-							{
-								showImages: this.settingsManager.getShowImages(),
-								includeImageDimensions: false,
-								shouldAddLeadingSpace: () => spacing.shouldAddLeadingSpace(true),
-							},
-							this.getCachedToolDefinition(content.name),
-							this.ui,
-							this.getCurrentCwd(),
-						);
-						component.setExpanded(this.toolOutputExpanded);
-						component.setEditDiffsExpanded(this.editDiffsExpanded);
-						selectLatestToolExpandHint(this.chatContainer.children, component);
-						this.chatContainer.addChild(component);
-						this.registerIpythonToolComponent(content.name, content.id, component);
+			// One unrenderable message must not abort the whole transcript:
+			// the chat container may already be cleared for this render.
+			try {
+				// Assistant messages need special handling for tool calls
+				if (message.role === "assistant") {
+					this.addMessageToChat(message);
+					// Render tool call components
+					for (const content of message.content) {
+						if (content.type === "toolCall") {
+							const spacing = createConversationSpacing(this.chatContainer.children);
+							const component = new ToolExecutionComponent(
+								content.name,
+								content.id,
+								content.arguments,
+								{
+									showImages: this.settingsManager.getShowImages(),
+									includeImageDimensions: false,
+									shouldAddLeadingSpace: () => spacing.shouldAddLeadingSpace(true),
+								},
+								this.getCachedToolDefinition(content.name),
+								this.ui,
+								this.getCurrentCwd(),
+							);
+							component.setExpanded(this.toolOutputExpanded);
+							component.setEditDiffsExpanded(this.editDiffsExpanded);
+							selectLatestToolExpandHint(this.chatContainer.children, component);
+							this.chatContainer.addChild(component);
+							this.registerIpythonToolComponent(content.name, content.id, component);
 
-						if (message.stopReason === "aborted" || message.stopReason === "error") {
-							let errorMessage: string;
-							if (message.stopReason === "aborted") {
-								const retryAttempt = this.getRetryAttempt();
-								errorMessage =
-									retryAttempt > 0
-										? `Aborted after ${retryAttempt} retry attempt${retryAttempt > 1 ? "s" : ""}`
-										: message.errorMessage && message.errorMessage !== "Request was aborted"
-											? message.errorMessage
-											: "Operation aborted";
+							if (message.stopReason === "aborted" || message.stopReason === "error") {
+								let errorMessage: string;
+								if (message.stopReason === "aborted") {
+									const retryAttempt = this.getRetryAttempt();
+									errorMessage =
+										retryAttempt > 0
+											? `Aborted after ${retryAttempt} retry attempt${retryAttempt > 1 ? "s" : ""}`
+											: message.errorMessage && message.errorMessage !== "Request was aborted"
+												? message.errorMessage
+												: "Operation aborted";
+								} else {
+									errorMessage = message.errorMessage || "Error";
+								}
+								component.updateResult({ content: [{ type: "text", text: errorMessage }], isError: true });
 							} else {
-								errorMessage = message.errorMessage || "Error";
+								renderedPendingTools.set(content.id, component);
 							}
-							component.updateResult({ content: [{ type: "text", text: errorMessage }], isError: true });
-						} else {
-							renderedPendingTools.set(content.id, component);
 						}
 					}
+				} else if (message.role === "toolResult") {
+					// Match tool results to pending tool components
+					const component = renderedPendingTools.get(message.toolCallId);
+					if (component) {
+						component.updateResult(message);
+						renderedPendingTools.delete(message.toolCallId);
+					}
+				} else {
+					// All other messages use standard rendering
+					this.addMessageToChat(message, renderOptions);
 				}
-			} else if (message.role === "toolResult") {
-				// Match tool results to pending tool components
-				const component = renderedPendingTools.get(message.toolCallId);
-				if (component) {
-					component.updateResult(message);
-					renderedPendingTools.delete(message.toolCallId);
-				}
-			} else {
-				// All other messages use standard rendering
-				this.addMessageToChat(message, renderOptions);
+			} catch (error) {
+				// Render an inline placeholder instead of losing the transcript.
+				this.chatContainer.addChild(
+					new Text(
+						theme.fg(
+							"warning",
+							`Failed to render a ${message.role} message: ${
+								error instanceof Error ? error.message : String(error)
+							}`,
+						),
+						1,
+						0,
+					),
+				);
 			}
 		}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2592,10 +2592,15 @@ export class InteractiveMode {
 				this.applyHeartbeatCatalog(heartbeats);
 				if (!this.heartbeatRefreshRequested) return;
 			}
-			// A further heartbeats_changed event starts the next refresh.
 		})().finally(() => {
 			if (this.heartbeatRefreshPromise === refresh) {
 				this.heartbeatRefreshPromise = undefined;
+				// The drain bound was hit with a newer heartbeats_changed
+				// pending: schedule the follow-up refresh so the catalog
+				// converges instead of staying stale until the next event.
+				if (this.heartbeatRefreshRequested) {
+					void this.refreshHeartbeatCatalog().catch(() => undefined);
+				}
 			}
 		});
 		this.heartbeatRefreshPromise = refresh;
@@ -6431,14 +6436,22 @@ export class InteractiveMode {
 		// Tool definitions only enrich rendering: components fall back to
 		// cached or missing definitions. A transient control-plane failure here
 		// must not abort the render (a resync render aborts into an empty chat).
+		let toolDefinitionWarning: string | undefined;
 		try {
 			await this.preloadToolDefinitions(toolNames);
 		} catch (error) {
-			this.showWarning(`Could not load tool definitions: ${error instanceof Error ? error.message : String(error)}`);
+			toolDefinitionWarning = `Could not load tool definitions: ${
+				error instanceof Error ? error.message : String(error)
+			}`;
 		}
 
 		if (options.clearChat) {
 			this.chatContainer.clear();
+		}
+
+		// Shown after clearChat so rebuild/resync renders keep the warning.
+		if (toolDefinitionWarning) {
+			this.showWarning(toolDefinitionWarning);
 		}
 
 		if (options.updateFooter) {
@@ -6521,8 +6534,10 @@ export class InteractiveMode {
 					// Match tool results to pending tool components
 					const component = renderedPendingTools.get(message.toolCallId);
 					if (component) {
-						component.updateResult(message);
+						// Delete first: a throwing updateResult must not leave the
+						// completed result reported as still pending.
 						renderedPendingTools.delete(message.toolCallId);
+						component.updateResult(message);
 					}
 				} else {
 					// All other messages use standard rendering

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -224,6 +224,7 @@ type RenderSessionContextHarness = {
 	getRetryAttempt: () => number;
 	ui: { requestRender: () => void };
 	addMessageToChat: (message: AgentMessage, options?: { populateHistory?: boolean }) => void;
+	showWarning: (warningMessage: string) => void;
 	connectionState?: AgentConnectionState;
 };
 
@@ -272,6 +273,7 @@ function createRenderSessionContextHarness(overrides: Partial<RenderSessionConte
 		getRetryAttempt: () => 0,
 		ui: { requestRender: vi.fn() },
 		addMessageToChat,
+		showWarning: vi.fn(),
 		...overrides,
 	};
 	Object.setPrototypeOf(harness, InteractiveMode.prototype);
@@ -482,6 +484,43 @@ describe("InteractiveMode.renderSessionContext", () => {
 		expect(addMessageToChat.mock.calls[0]?.[0]).toMatchObject({ content: "message 0" });
 		expect(renderAll(chatContainer)).not.toContain("old transcript");
 		expect(renderAll(chatContainer)).not.toContain("for faster open");
+	});
+
+	test("still renders the transcript when tool definition preloading fails", async () => {
+		const showWarning = vi.fn();
+		const { harness, chatContainer, addMessageToChat } = createRenderSessionContextHarness({
+			preloadToolDefinitions: vi.fn(async () => {
+				throw new Error("daemon transport unavailable");
+			}),
+			showWarning,
+		});
+		const messages = [userMessage("message 0", 0), userMessage("message 1", 1)];
+
+		await renderMessages(harness, messages, { clearChat: true });
+
+		expect(showWarning).toHaveBeenCalledWith(expect.stringContaining("daemon transport unavailable"));
+		expect(addMessageToChat).toHaveBeenCalledTimes(2);
+		expect(chatContainer.children).toHaveLength(2);
+	});
+
+	test("keeps rendering later messages when one message fails to render", async () => {
+		const chatContainer = new Container();
+		const addMessageToChat = vi.fn((message: AgentMessage) => {
+			if (message.role === "user" && message.content === "broken") {
+				throw new Error("render boom");
+			}
+			chatContainer.addChild({ render: () => ["assistant"], invalidate: () => {} });
+		});
+		const { harness } = createRenderSessionContextHarness({ chatContainer, addMessageToChat });
+
+		await renderMessages(harness, [userMessage("first", 0), userMessage("broken", 1), userMessage("last", 2)], {
+			clearChat: true,
+		});
+
+		expect(addMessageToChat).toHaveBeenCalledTimes(3);
+		// Two rendered messages plus the inline failure placeholder.
+		expect(chatContainer.children).toHaveLength(3);
+		expect(renderAll(chatContainer)).toContain("Failed to render a user message");
 	});
 
 	test("populates editor history from the full transcript when initial rendering is capped", async () => {


### PR DESCRIPTION
## Problem

Re-opening a daemon session (`--resume`, the agents-view picker, or `prime-agent attach <agent>`) can show only the recap and footer with an **empty transcript**. The prior conversation history stays invisible until the user sends a message, which looks like session-history loss even though the persisted session is intact.

## Root cause

The transcript render chain has several awaits that run either before the transcript is first rendered (`init`) or after the chat container has already been cleared (`session_replaced` / resync renders). A transient control-plane failure in any of them aborted the render and left the chat empty:

- `renderSessionContext` awaited `preloadToolDefinitions` without a guard. A `get_tool_definition` transport failure (e.g. `DaemonControlPlaneTransportError` while the daemon connection is unavailable) aborted the whole render after `clearChat`. Production `client-errors.log` shows repeated crashes in exactly this path:
  `getToolDefinition -> preloadToolDefinitions -> renderSessionContext -> renderInitialMessages`.
- In `rebindCurrentSession`, the post-subscribe `getState()` session-actions patch and the connection-catalog refresh (`getState`, `getModelCatalog`, `getResourceSnapshot`) could abort the rebind before `renderInitialMessages` ran.
- One message that threw during rendering aborted the rest of the loop after `clearChat`.
- The `heartbeats_changed` drain loop in `refreshHeartbeatCatalog` is unbounded; sustained heartbeat churn could keep an awaiting rebind (and its transcript render) starved indefinitely.

Sending a message recovered the view because the run's events (or the next resync snapshot) re-entered the render chain after the transient failure had passed.

## Fix

`packages/coding-agent/src/modes/interactive/interactive-mode.ts`:

- `renderSessionContext`: tool-definition preload is best-effort. A failure shows a warning and rendering continues; components already tolerate missing definitions.
- `renderSessionContext`: per-message isolation. An unrenderable message produces an inline placeholder line and the rest of the transcript still renders.
- `rebindCurrentSession`: the `sessionActions` `getState()` patch and the connection-catalog refresh are best-effort; the next connection state update / reconnect re-syncs them.
- `refreshHeartbeatCatalog`: the drain loop is bounded to 25 refreshes; any further `heartbeats_changed` event starts a new refresh.

## Testing

- New regression tests in `test/interactive-mode-status.test.ts` cover both `renderSessionContext` failure modes (preload failure; one broken message). Both fail on main and pass with this change.
- `npm run check` (biome, tsgo, ticket/installer/browser-smoke gates) passes.
- End-to-end: source TUI `--resume` of a 73-message fixture session against a scratch daemon renders the full transcript with no errors.

Fixes ENG-4742. Also matches the symptom reported in ENG-4211.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error handling on session rebind and full transcript rebuild paths; behavior is more resilient but heartbeat refresh may complete in multiple promises instead of one unbounded drain.
> 
> **Overview**
> Fixes **empty transcripts** when re-opening a session if a transient control-plane error or a single bad message interrupted rendering after the chat was cleared.
> 
> **`renderSessionContext`** now treats tool-definition preload as best-effort (warning + continue) and wraps each message in its own try/catch so one failure becomes an inline placeholder instead of aborting the rebuild. Pending tool results are removed from the pending map **before** `updateResult` so a throwing update does not leave stale pending state.
> 
> **`rebindCurrentSession`** wraps connection-catalog refresh and the post-subscribe `getState()` session-actions patch in try/catch so those failures no longer block transcript render; prior snapshots stay until the next sync.
> 
> **`refreshHeartbeatCatalog`** caps coalesced drain at 25 iterations per promise and schedules a follow-up refresh if more `heartbeats_changed` events are still queued, so heartbeat churn cannot starve an awaiting rebind indefinitely.
> 
> Regression tests cover preload failure and a mid-transcript render throw.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 094a2128e09451574d715d526ddfe9dedf888a10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep restored transcripts visible when render steps fail in `InteractiveMode`
> - Makes tool-definition preloading and individual message rendering best-effort in `InteractiveMode.renderSessionContext`; failed messages get an inline warning placeholder and rendering continues with later messages.
> - Wraps catalog refresh and post-subscription state fetch in independent try/catch in `InteractiveMode.rebindCurrentSession` so transient failures no longer abort the rebind.
> - Bounds the heartbeat catalog refresh drain loop with `HEARTBEAT_REFRESH_DRAIN_LIMIT` (26 passes) in `InteractiveMode.refreshHeartbeatCatalog`; a pending request beyond the limit schedules a follow-up refresh instead of looping indefinitely.
> - Risk: failed messages now display an inline placeholder instead of aborting the entire transcript render; reviewers should check `renderSessionContext` in [interactive-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2214/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316) to confirm the placeholder is acceptable for users.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 094a212.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->