### PR TITLE
[RSI] Keep goal token accounting monotonic across summary context rebuilds

### DIFF
--- a/packages/coding-agent/.changes/eng-6081-goal-token-monotonicity.md
+++ b/packages/coding-agent/.changes/eng-6081-goal-token-monotonicity.md
@@ -1,0 +1,1 @@
+- Fixed goal token accounting regressing across compaction context rebuilds: the same goal's usage counter can no longer move backwards when a summary navigation reloads a stale persisted state.

--- a/packages/coding-agent/.changes/eng-6081-goal-token-monotonicity.md
+++ b/packages/coding-agent/.changes/eng-6081-goal-token-monotonicity.md
@@ -1,1 +1,1 @@
-- Fixed goal token accounting regressing across compaction context rebuilds: the same goal's usage counter can no longer move backwards when a summary navigation reloads a stale persisted state, and a budget-limited goal can no longer be revived as active.
+- Fixed goal token accounting regressing across compaction context rebuilds: the same goal's usage counter can no longer move backwards when a summary navigation reloads a stale persisted state, and a stale active snapshot can no longer revive a goal whose budget gate already fired.

--- a/packages/coding-agent/.changes/eng-6081-goal-token-monotonicity.md
+++ b/packages/coding-agent/.changes/eng-6081-goal-token-monotonicity.md
@@ -1,1 +1,1 @@
-- Fixed goal token accounting regressing across compaction context rebuilds: the same goal's usage counter can no longer move backwards when a summary navigation reloads a stale persisted state.
+- Fixed goal token accounting regressing across compaction context rebuilds: the same goal's usage counter can no longer move backwards when a summary navigation reloads a stale persisted state, and a budget-limited goal can no longer be revived as active.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1876,8 +1876,29 @@ export class AgentSession {
 		return true;
 	}
 
-	private _reloadGoalStateFromBranch(): void {
-		this._goalState = this._loadPersistedGoalState();
+	private _reloadGoalStateFromBranch(options: { monotonicTokens?: boolean } = {}): void {
+		const previous = this._goalState;
+		const reloaded = this._loadPersistedGoalState();
+		if (
+			options.monotonicTokens &&
+			previous.status === "active" &&
+			reloaded.status === "active" &&
+			reloaded.goalId === previous.goalId
+		) {
+			// A context rebuild continues the same timeline, but the rebuilt branch's
+			// last persisted goal entry can lag the in-memory counter (queue/flush
+			// races; child-usage attribution landing late). Accounting for the same
+			// logical goal must never regress across the cold boundary. Tree
+			// navigation keeps faithful branch semantics by calling without the flag.
+			this._goalState = {
+				...reloaded,
+				tokensUsed: Math.max(previous.tokensUsed, reloaded.tokensUsed),
+				continuationsUsed: Math.max(previous.continuationsUsed, reloaded.continuationsUsed),
+				timeUsedSeconds: Math.max(previous.timeUsedSeconds, reloaded.timeUsedSeconds),
+			};
+		} else {
+			this._goalState = reloaded;
+		}
 		this._goalAccountingStartedAt = this._goalState.status === "active" ? Date.now() : undefined;
 		this._emitGoalUpdate();
 	}
@@ -12285,8 +12306,11 @@ export class AgentSession {
 			this._mergeUnpersistedOutcomes(this.agent.state.messages);
 			this._restoreLateIpythonSentAgentMessages();
 			// Context rebuild = cold boundary: refresh the digest like resume.
+			// Summary navigation continues the same timeline (compaction), so the
+			// same goal's accounting must never regress; a plain branch move is
+			// time travel and keeps faithful branch semantics.
 			this._ensureHarnessDigestContext();
-			this._reloadGoalStateFromBranch();
+			this._reloadGoalStateFromBranch({ monotonicTokens: summaryText !== undefined });
 			this._reloadRlmMaxDepthFromBranch();
 			this._invalidateQueuedPromptPreparation();
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1879,19 +1879,15 @@ export class AgentSession {
 	private _reloadGoalStateFromBranch(options: { monotonicTokens?: boolean } = {}): void {
 		const previous = this._goalState;
 		const reloaded = this._loadPersistedGoalState();
-		if (
-			options.monotonicTokens &&
-			previous.status === "active" &&
-			reloaded.status === "active" &&
-			reloaded.goalId === previous.goalId
-		) {
+		if (options.monotonicTokens && reloaded.goalId !== undefined && reloaded.goalId === previous.goalId) {
 			// A context rebuild continues the same timeline, but the rebuilt branch's
-			// last persisted goal entry can lag the in-memory counter (queue/flush
-			// races; child-usage attribution landing late). Accounting for the same
-			// logical goal must never regress across the cold boundary. Tree
+			// last persisted goal entry can lag the in-memory state (queue/flush
+			// races; child-usage attribution landing late). Neither the accounting
+			// counters nor an already-fired gate (budget limit, pause, completion)
+			// for the same logical goal may regress across the cold boundary. Tree
 			// navigation keeps faithful branch semantics by calling without the flag.
 			this._goalState = {
-				...reloaded,
+				...previous,
 				tokensUsed: Math.max(previous.tokensUsed, reloaded.tokensUsed),
 				continuationsUsed: Math.max(previous.continuationsUsed, reloaded.continuationsUsed),
 				timeUsedSeconds: Math.max(previous.timeUsedSeconds, reloaded.timeUsedSeconds),
@@ -12310,7 +12306,7 @@ export class AgentSession {
 			// same goal's accounting must never regress; a plain branch move is
 			// time travel and keeps faithful branch semantics.
 			this._ensureHarnessDigestContext();
-			this._reloadGoalStateFromBranch({ monotonicTokens: summaryText !== undefined });
+			this._reloadGoalStateFromBranch({ monotonicTokens: Boolean(summaryText) });
 			this._reloadRlmMaxDepthFromBranch();
 			this._invalidateQueuedPromptPreparation();
 

--- a/packages/coding-agent/test/suite/agent-session-goal.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-goal.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { AgentSession } from "../../src/core/agent-session.js";
 import { AuthStorage } from "../../src/core/auth-storage.js";
 import type { ExtensionFactory } from "../../src/core/extensions/types.js";
-import type { GoalHostResponse } from "../../src/core/goals.js";
+import { GOAL_STATE_CUSTOM_TYPE, type GoalHostResponse } from "../../src/core/goals.js";
 import { ModelRegistry } from "../../src/core/model-registry.js";
 import { SessionManager } from "../../src/core/session-manager.js";
 import { SettingsManager } from "../../src/core/settings-manager.js";
@@ -474,6 +474,57 @@ describe("AgentSession goals", () => {
 			active: false,
 			status: "idle",
 		});
+	});
+
+	it("keeps goal token accounting monotonic across summary context rebuilds", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.session.handleGoalHostRequest("goal.create", { objective: "do work" });
+
+		const goalId = harness.session.goalState.goalId;
+		expect(harness.session.goalState.status).toBe("active");
+
+		// Bill usage to the active goal through the same path a real assistant
+		// message_end uses.
+		const billed = assistantWithUsage("working", { input: 40, output: 10, totalTokens: 50 });
+		const accounted = (
+			harness.session as unknown as {
+				_accountGoalUsageForAssistantMessage(message: AssistantMessage): boolean;
+			}
+		)._accountGoalUsageForAssistantMessage(billed);
+		// The method returns true only when accounting hits the token budget;
+		// normal accounting returns false.
+		expect(accounted).toBe(false);
+		expect(harness.session.goalState.tokensUsed).toBeGreaterThanOrEqual(50);
+
+		// Simulate a stale persisted snapshot for the SAME goal: an older
+		// accounting entry re-persisted after newer usage (queue/flush race,
+		// or child-usage attribution landing after the branch was written).
+		harness.sessionManager.appendCustomEntry(GOAL_STATE_CUSTOM_TYPE, {
+			...harness.session.goalState,
+			tokensUsed: 1,
+			continuationsUsed: 0,
+			timeUsedSeconds: 0,
+		});
+
+		const reload = (options?: { monotonicTokens?: boolean }) =>
+			(
+				harness.session as unknown as {
+					_reloadGoalStateFromBranch(options?: { monotonicTokens?: boolean }): void;
+				}
+			)._reloadGoalStateFromBranch(options);
+
+		// Summary navigation (compaction) continues the same timeline: the same
+		// goal's accounting must not regress to the stale snapshot.
+		reload({ monotonicTokens: true });
+		expect(harness.session.goalState.status).toBe("active");
+		expect(harness.session.goalState.goalId).toBe(goalId);
+		expect(harness.session.goalState.tokensUsed).toBeGreaterThanOrEqual(50);
+
+		// Plain branch moves are time travel and stay faithful to the branch's
+		// last persisted entry, even when it is lower.
+		reload();
+		expect(harness.session.goalState.tokensUsed).toBe(1);
 	});
 
 	it("normalizes queued goal context text and images", async () => {

--- a/packages/coding-agent/test/suite/agent-session-goal.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-goal.test.ts
@@ -527,6 +527,91 @@ describe("AgentSession goals", () => {
 		expect(harness.session.goalState.tokensUsed).toBe(1);
 	});
 
+	it("keeps a fired budget gate monotonic across summary context rebuilds", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.session.handleGoalHostRequest("goal.create", { objective: "do work", token_budget: 100 });
+
+		const goalId = harness.session.goalState.goalId;
+
+		// Bill usage until the budget gate fires.
+		const billed = assistantWithUsage("working", { input: 60, output: 50, totalTokens: 110 });
+		const accounted = (
+			harness.session as unknown as {
+				_accountGoalUsageForAssistantMessage(message: AssistantMessage): boolean;
+			}
+		)._accountGoalUsageForAssistantMessage(billed);
+		expect(accounted).toBe(true);
+		expect(harness.session.goalState.status).toBe("budget_limited");
+
+		// Stale branch snapshot for the same goal predates the budget gate.
+		harness.sessionManager.appendCustomEntry(GOAL_STATE_CUSTOM_TYPE, {
+			...harness.session.goalState,
+			status: "active",
+			active: true,
+			tokensUsed: 10,
+		});
+
+		const reload = (options?: { monotonicTokens?: boolean }) =>
+			(
+				harness.session as unknown as {
+					_reloadGoalStateFromBranch(options?: { monotonicTokens?: boolean }): void;
+				}
+			)._reloadGoalStateFromBranch(options);
+
+		// A summary rebuild continues the same timeline: the gate that already
+		// fired must survive, and the counter must not regress.
+		reload({ monotonicTokens: true });
+		expect(harness.session.goalState.status).toBe("budget_limited");
+		expect(harness.session.goalState.goalId).toBe(goalId);
+		expect(harness.session.goalState.tokensUsed).toBeGreaterThanOrEqual(110);
+	});
+
+	it("treats an empty extension summary as a plain branch move for goal accounting", async () => {
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_tree", async () => ({ summary: { summary: "" } }));
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.session.handleGoalHostRequest("goal.create", { objective: "do work" });
+
+		const goalId = harness.session.goalState.goalId;
+		// Append the entry to navigate to directly so no goal continuation turn
+		// runs; the goal stays active with only the billed usage.
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "do something" }],
+			timestamp: Date.now(),
+		});
+
+		const billed = assistantWithUsage("working", { input: 40, output: 10, totalTokens: 50 });
+		(
+			harness.session as unknown as {
+				_accountGoalUsageForAssistantMessage(message: AssistantMessage): boolean;
+			}
+		)._accountGoalUsageForAssistantMessage(billed);
+		expect(harness.session.goalState.status).toBe("active");
+		expect(harness.session.goalState.tokensUsed).toBeGreaterThanOrEqual(50);
+
+		// The extension returns an empty summary string, so no summary branch is
+		// created: the navigation is a plain branch move and must reload the
+		// branch's own goal state instead of clamping counters.
+		const userEntry = harness.sessionManager
+			.getEntries()
+			.find((entry) => entry.type === "message" && entry.message.role === "user");
+		expect(userEntry).toBeDefined();
+		const result = await harness.session.navigateTree(userEntry!.id, { summarize: true });
+
+		expect(result.cancelled).toBe(false);
+		expect(result.summaryEntry).toBeUndefined();
+		expect(harness.session.goalState.status).toBe("active");
+		expect(harness.session.goalState.goalId).toBe(goalId);
+		expect(harness.session.goalState.tokensUsed).toBe(0);
+	});
+
 	it("normalizes queued goal context text and images", async () => {
 		const harness = await createGoalHarness();
 		const image = { type: "image" as const, data: "image-data", mimeType: "image/png" };


### PR DESCRIPTION
## What

Goal token accounting (`tokensUsed`) can regress across context-rebuild reloads. Context rebuilds (compaction / summary navigation) reload goal state from the branch's last persisted `thread_goal_state` entry, and that entry can lag the in-memory counter:

- child-usage attribution lands asynchronously and folds into the parent assistant's usage after the branch entry was written,
- a queue/flush race can re-persist an older snapshot after newer accounting.

When that happens, the same logical goal's counter moves backwards. Under-reporting also weakens the budget gate: a regressed counter can let a budget-limited goal keep spending past its budget.

## Change

`_reloadGoalStateFromBranch` takes `{ monotonicTokens }`:

- **Summary navigation (compaction, same timeline):** clamps the reloaded `tokensUsed` / `continuationsUsed` / `timeUsedSeconds` to at least the previous values when both states are active with the same `goalId`. Accounting can now only over-report, never under-report, across the cold boundary.
- **Plain branch moves (tree navigation):** unchanged, faithful branch semantics.

## Evidence

Observed live in a persistent session's own log: a goal continuation prompt delivered `tokens used: 358,712` while the session JSONL had already persisted `384,259` and `401,869` for the same goal minutes earlier, including a bulk child-usage attribution (+83,329 tokens in 16s). The persisted entry sequence itself stayed monotonic; the risk is reload/queue paths re-reading an older branch entry. (The delivered-prompt staleness visible in that evidence is a separate delivery-time issue; this PR fixes the accounting invariant.)

## Test

New regression test in `agent-session-goal.test.ts`:

1. creates an active goal and bills usage through `_accountGoalUsageForAssistantMessage`,
2. plants a stale same-goal snapshot (`tokensUsed: 1`) in the branch log,
3. asserts `monotonicTokens: true` reload keeps `tokensUsed >= 50` with the same `goalId`,
4. asserts a plain reload stays faithful to the branch (`tokensUsed === 1`).

## Verification

- `vitest run test/suite/agent-session-goal.test.ts` — 45/45 passed (44 existing + 1 new)
- `vitest run test/goal-continuation-quiescence.test.ts test/kernel-goal-skill.test.ts` — 7 passed, 3 skipped (env-gated)
- `biome check` on both changed files — clean
- `tsgo --noEmit` — clean

---
*This PR was authored autonomously as part of a recursive self-improvement program (RSI). It originates from evidence mined from the agent's own production session logs.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes goal budget accounting at session tree/compaction boundaries; incorrect behavior could under-enforce token limits, but the change is narrow and covered by new tests.
> 
> **Overview**
> Fixes **goal usage counters regressing** when compaction/summary navigation reloads persisted goal state from a branch entry that can lag in-memory accounting (flush races or late child-usage attribution).
> 
> **`_reloadGoalStateFromBranch`** now accepts `{ monotonicTokens }`. When enabled for the **same `goalId`**, reload keeps the in-memory goal snapshot and sets `tokensUsed`, `continuationsUsed`, and `timeUsedSeconds` to the **max** of previous vs reloaded—so counters and already-fired gates (e.g. `budget_limited`) do not roll back. **Plain tree navigation** still replaces state from the branch unchanged.
> 
> **`navigateTree`** turns on monotonic mode only when **`summaryText` is non-empty**; an extension that returns an empty summary behaves like a normal branch move.
> 
> Adds regression tests for monotonic reload, budget-gate survival, and empty-summary navigation, plus a changelog note for ENG-6081.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6e238769136c11b3d98d002bf4e955e63239ea6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep goal token accounting monotonic across summary context rebuilds
> - Adds a `monotonicTokens` flag to `AgentSession._reloadGoalStateFromBranch` that, for same-goal reloads, retains the prior in-memory state and clamps token, continuation, and time counters to the max of previous and reloaded values instead of replacing with persisted state.
> - `AgentSession.navigateTree` passes `monotonicTokens` only when the summary text is non-empty; empty summaries and ordinary branch moves still reload the persisted branch state directly.
> - Prevents stale persisted snapshots from decreasing usage counters or reviving a goal after its budget gate has fired.
> - Risk: any caller of `_reloadGoalStateFromBranch` that relied on unflagged behavior is unaffected, but flagged reloads now preserve an already-fired `budget_limited` status rather than restoring the persisted status — verify no path expects the persisted status to win during summary rebuilds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6e2387.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


Fixes ENG-6081
