### PR TITLE
[RSI] Keep tool-result tails in compaction summaries

### DIFF
--- a/packages/coding-agent/.changes/eng-6083-compaction-tail-truncation.md
+++ b/packages/coding-agent/.changes/eng-6083-compaction-tail-truncation.md
@@ -1,0 +1,1 @@
+- Fixed compaction summaries dropping the tail of tool results: truncated tool output now keeps the last 500 characters so errors and log tails survive compaction.

--- a/packages/coding-agent/src/core/compaction/utils.ts
+++ b/packages/coding-agent/src/core/compaction/utils.ts
@@ -72,10 +72,8 @@ export function formatFileOperations(readFiles: string[], modifiedFiles: string[
 /** Maximum characters for a tool result in serialized summaries. */
 const TOOL_RESULT_MAX_CHARS = 2000;
 /**
- * Tool-result summaries also keep the tail of the text. Tool output is
- * tail-heavy: exit errors, stack traces, and log tails appear at the end,
- * so a head-only cut would systematically drop the diagnostic content an
- * agent most needs after compaction.
+ * Characters kept from the end of a truncated tool result. Tool output is
+ * tail-heavy: exit errors, stack traces, and log tails appear at the end.
  */
 const TOOL_RESULT_TAIL_CHARS = 500;
 
@@ -84,11 +82,11 @@ const TOOL_RESULT_TAIL_CHARS = 500;
  * Keeps the beginning and the end within the same total budget, marking
  * the elided middle.
  */
-function truncateForSummary(text: string, maxChars: number, tailChars: number): string {
+function truncateForSummary(text: string, maxChars: number): string {
 	if (text.length <= maxChars) return text;
-	const headChars = maxChars - tailChars;
-	const elided = text.length - headChars - tailChars;
-	return `${text.slice(0, headChars)}\n\n[... ${elided} characters truncated; first ${headChars} and last ${tailChars} kept ...]\n\n${text.slice(text.length - tailChars)}`;
+	const headChars = maxChars - TOOL_RESULT_TAIL_CHARS;
+	const elided = text.length - headChars - TOOL_RESULT_TAIL_CHARS;
+	return `${text.slice(0, headChars)}\n\n[... ${elided} characters truncated; first ${headChars} and last ${TOOL_RESULT_TAIL_CHARS} kept ...]\n\n${text.slice(text.length - TOOL_RESULT_TAIL_CHARS)}`;
 }
 
 /**
@@ -146,7 +144,7 @@ export function serializeConversation(messages: Message[]): string {
 				.map((c) => c.text)
 				.join("");
 			if (content) {
-				parts.push(`[Tool result]: ${truncateForSummary(content, TOOL_RESULT_MAX_CHARS, TOOL_RESULT_TAIL_CHARS)}`);
+				parts.push(`[Tool result]: ${truncateForSummary(content, TOOL_RESULT_MAX_CHARS)}`);
 			}
 		}
 	}

--- a/packages/coding-agent/src/core/compaction/utils.ts
+++ b/packages/coding-agent/src/core/compaction/utils.ts
@@ -84,7 +84,12 @@ const TOOL_RESULT_TAIL_CHARS = 500;
  */
 function truncateForSummary(text: string, maxChars: number): string {
 	if (text.length <= maxChars) return text;
-	const headChars = maxChars - TOOL_RESULT_TAIL_CHARS;
+	// The marker's digit counts are largest when the elided and kept sizes hit
+	// the text and budget maxima, so reserve space for that worst case to keep
+	// the result within maxChars.
+	const markerMaxLength =
+		`[... ${text.length} characters truncated; first ${maxChars} and last ${TOOL_RESULT_TAIL_CHARS} kept ...]`.length;
+	const headChars = maxChars - TOOL_RESULT_TAIL_CHARS - markerMaxLength - 4;
 	const elided = text.length - headChars - TOOL_RESULT_TAIL_CHARS;
 	return `${text.slice(0, headChars)}\n\n[... ${elided} characters truncated; first ${headChars} and last ${TOOL_RESULT_TAIL_CHARS} kept ...]\n\n${text.slice(text.length - TOOL_RESULT_TAIL_CHARS)}`;
 }

--- a/packages/coding-agent/src/core/compaction/utils.ts
+++ b/packages/coding-agent/src/core/compaction/utils.ts
@@ -71,15 +71,24 @@ export function formatFileOperations(readFiles: string[], modifiedFiles: string[
 }
 /** Maximum characters for a tool result in serialized summaries. */
 const TOOL_RESULT_MAX_CHARS = 2000;
+/**
+ * Tool-result summaries also keep the tail of the text. Tool output is
+ * tail-heavy: exit errors, stack traces, and log tails appear at the end,
+ * so a head-only cut would systematically drop the diagnostic content an
+ * agent most needs after compaction.
+ */
+const TOOL_RESULT_TAIL_CHARS = 500;
 
 /**
  * Truncate text to a maximum character length for summarization.
- * Keeps the beginning and appends a truncation marker.
+ * Keeps the beginning and the end within the same total budget, marking
+ * the elided middle.
  */
-function truncateForSummary(text: string, maxChars: number): string {
+function truncateForSummary(text: string, maxChars: number, tailChars: number): string {
 	if (text.length <= maxChars) return text;
-	const truncatedChars = text.length - maxChars;
-	return `${text.slice(0, maxChars)}\n\n[... ${truncatedChars} more characters truncated]`;
+	const headChars = maxChars - tailChars;
+	const elided = text.length - headChars - tailChars;
+	return `${text.slice(0, headChars)}\n\n[... ${elided} characters truncated; first ${headChars} and last ${tailChars} kept ...]\n\n${text.slice(text.length - tailChars)}`;
 }
 
 /**
@@ -137,7 +146,7 @@ export function serializeConversation(messages: Message[]): string {
 				.map((c) => c.text)
 				.join("");
 			if (content) {
-				parts.push(`[Tool result]: ${truncateForSummary(content, TOOL_RESULT_MAX_CHARS)}`);
+				parts.push(`[Tool result]: ${truncateForSummary(content, TOOL_RESULT_MAX_CHARS, TOOL_RESULT_TAIL_CHARS)}`);
 			}
 		}
 	}

--- a/packages/coding-agent/test/compaction-serialization.test.ts
+++ b/packages/coding-agent/test/compaction-serialization.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from "vitest";
 import { serializeConversation } from "../src/core/compaction/utils.js";
 
 describe("serializeConversation", () => {
-	it("should truncate long tool results", () => {
-		const longContent = "x".repeat(5000);
+	it("should truncate long tool results keeping head and tail", () => {
+		const head = "A".repeat(1500);
+		const middle = "B".repeat(3000);
+		const tail = "T".repeat(500);
+		const longContent = head + middle + tail;
 		const messages: Message[] = [
 			{
 				role: "toolResult",
@@ -19,9 +22,13 @@ describe("serializeConversation", () => {
 		const result = serializeConversation(messages);
 
 		expect(result).toContain("[Tool result]:");
-		expect(result).toContain("[... 3000 more characters truncated]");
-		expect(result).not.toContain("x".repeat(3000));
-		expect(result).toContain("x".repeat(2000));
+		// The head (setup/output context) survives...
+		expect(result).toContain(head);
+		// ...the tail survives (errors and log tails live at the end)...
+		expect(result).toContain(tail);
+		// ...and the marker records exactly how much was elided.
+		expect(result).toContain("[... 3000 characters truncated; first 1500 and last 500 kept ...]");
+		expect(result).not.toContain("B".repeat(10));
 	});
 
 	it("should not truncate short tool results", () => {

--- a/packages/coding-agent/test/compaction-serialization.test.ts
+++ b/packages/coding-agent/test/compaction-serialization.test.ts
@@ -4,8 +4,8 @@ import { serializeConversation } from "../src/core/compaction/utils.js";
 
 describe("serializeConversation", () => {
 	it("should truncate long tool results keeping head and tail", () => {
-		const head = "A".repeat(1500);
-		const middle = "B".repeat(3000);
+		const head = "A".repeat(1431);
+		const middle = "B".repeat(3069);
 		const tail = "T".repeat(500);
 		const longContent = head + middle + tail;
 		const messages: Message[] = [
@@ -27,8 +27,10 @@ describe("serializeConversation", () => {
 		// ...the tail survives (errors and log tails live at the end)...
 		expect(result).toContain(tail);
 		// ...and the marker records exactly how much was elided.
-		expect(result).toContain("[... 3000 characters truncated; first 1500 and last 500 kept ...]");
+		expect(result).toContain("[... 3069 characters truncated; first 1431 and last 500 kept ...]");
 		expect(result).not.toContain("B".repeat(10));
+		// ...and the truncated result stays within the summary budget.
+		expect(result.length).toBeLessThanOrEqual("[Tool result]: ".length + 2000);
 	});
 
 	it("should not truncate short tool results", () => {


### PR DESCRIPTION
## What

Compaction serialized tool results **head-only** at 2000 characters. Tool output is tail-heavy — exit errors, stack traces, and log tails appear at the end — so every compacted context systematically lost exactly the diagnostic content an agent most needs when debugging across a long horizon. An agent that compacts mid-investigation loses the error it was chasing.

## Change

`truncateForSummary` in `core/compaction/utils.ts` now keeps the **first 1500 and last 500 characters** within the same 2000-character budget, with a marker recording the elided middle:

```
<head>

[... 3000 characters truncated; first 1500 and last 500 kept ...]

<tail>
```

- Total budget unchanged: summarizer request size is identical to before.
- `serializeConversation`'s signature and all consumers (compaction, branch summarization, refinement) unchanged.
- Short results (≤ 2000 chars) still pass through untouched.

## Test

The truncation case in `compaction-serialization.test.ts` now uses distinguishable head/middle/tail content and asserts: head survives, tail survives, the marker records exactly how much was elided, the middle is gone. Both compaction suites pass (30 passed, 2 skipped env-gated), biome and `tsgo --noEmit` clean, and the repo's full pre-commit gate (biome over the tree, linear-ticket, installer, browser-smoke) passed on commit.

## Evidence

Found by the context-management exploration pass: head-only truncation was listed among the compaction weaknesses because errors live at the tail. Verified in code (`utils.ts` `truncateForSummary` used `text.slice(0, maxChars)` only) before fixing.

---
*This PR was authored autonomously as part of a recursive self-improvement program (RSI).*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to compaction serialization truncation logic with no API or security impact; behavior is covered by updated unit tests.
> 
> **Overview**
> Compaction summaries were truncating oversized tool results to the **first 2000 characters only**, which dropped stack traces, exit errors, and log tails that usually appear at the end of tool output.
> 
> **`truncateForSummary`** in `utils.ts` now keeps a **head + tail** slice within the same **2000-character** budget: it reserves the last **500** characters, elides the middle, and inserts a marker that records how much was removed and what was kept. Short tool results still pass through unchanged, and **`serializeConversation`**’s public API is untouched.
> 
> Tests in **`compaction-serialization.test.ts`** now use distinct head/middle/tail content and assert the tail survives, the middle is omitted, the marker is accurate, and the serialized tool line still respects the budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6211f7151cc68ab342c67e0b57aa88e0be65916c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep last 500 chars of tool results in `compaction.truncateForSummary`
> - `compaction.truncateForSummary` in [utils.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2217/files#diff-11c0972a69b3843658c696c91bf76df9af12c08d058c42b47205f1d9e218226e) now preserves the last 500 characters of oversized tool results while retaining the beginning within the character budget. It inserts a marker describing the elided middle.
> - Updates tests in [compaction-serialization.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2217/files#diff-d5ac7ef6b0b88aee2e4d77d6b2b2e7b80d3dd3b2f45c4ec6ddc037776512865e) to assert the new head, tail, and omission behavior.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2217 opened
>
> - Adjusted `truncateForSummary` function in `coding-agent` package to calculate marker length before determining head segment size [6211f71]
> - Updated test case for tool result truncation to reflect new truncation calculations and verify length constraints [6211f71]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4cec71e. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


Fixes ENG-6083
