### PR TITLE
Count running/idle subagents across the whole subtree in the bar

### DIFF
--- a/packages/coding-agent/.changes/subagents-bar-subtree-counts.md
+++ b/packages/coding-agent/.changes/subagents-bar-subtree-counts.md
@@ -1,0 +1,1 @@
+- Changed the subagents bar to count running, idle, and inactive agents across the whole subagent subtree instead of only direct children.

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -635,18 +635,7 @@ function getParentKeys(summary: SessionSummary): string[] {
 	].filter((key): key is string => key !== undefined);
 }
 
-/** Direct-child linkage over getParentKeys, shared by the view tree and the chat subagents bar. */
-export function isDirectAgentChild(
-	child: SessionSummary,
-	parent: { activeSessionId?: string | undefined; sessionId?: string | undefined; sessionFile?: string | undefined },
-): boolean {
-	const parentKeys = new Set(getParentKeys(child));
-	if (parent.activeSessionId !== undefined && parentKeys.has(`active:${parent.activeSessionId}`)) return true;
-	if (parent.sessionId !== undefined && parentKeys.has(`session:${parent.sessionId}`)) return true;
-	return parent.sessionFile !== undefined && parentKeys.has(fileIdentity(parent.sessionFile));
-}
-
-// The parent side of isDirectAgentChild: the keys by which a session is referenced as a parent.
+// The parent side of getParentKeys: the keys by which a session is referenced as a parent.
 function parentIdentityKeys(summary: {
 	activeSessionId?: string | undefined;
 	sessionId?: string | undefined;

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -646,6 +646,50 @@ export function isDirectAgentChild(
 	return parent.sessionFile !== undefined && parentKeys.has(fileIdentity(parent.sessionFile));
 }
 
+// The parent side of isDirectAgentChild: the keys by which a session is referenced as a parent.
+function parentIdentityKeys(summary: {
+	activeSessionId?: string | undefined;
+	sessionId?: string | undefined;
+	sessionFile?: string | undefined;
+}): string[] {
+	return [
+		summary.activeSessionId !== undefined ? `active:${summary.activeSessionId}` : undefined,
+		summary.sessionId !== undefined ? `session:${summary.sessionId}` : undefined,
+		summary.sessionFile !== undefined ? fileIdentity(summary.sessionFile) : undefined,
+	].filter((key): key is string => key !== undefined);
+}
+
+/**
+ * Every subagent summary descending from the parent session, breadth-first over the shared parent
+ * linkage. Rows of any lifecycle link so live descendants stay reachable; callers decide what counts.
+ */
+export function collectSubagentDescendantSummaries(
+	summaries: Iterable<SessionSummary>,
+	parent: { activeSessionId?: string | undefined; sessionId?: string | undefined; sessionFile?: string | undefined },
+): SessionSummary[] {
+	const rowsByParentKey = new Map<string, SessionSummary[]>();
+	for (const summary of summaries) {
+		if (summary.runtimeKind !== "subagent") continue;
+		for (const key of getParentKeys(summary)) {
+			const siblings = rowsByParentKey.get(key) ?? [];
+			siblings.push(summary);
+			rowsByParentKey.set(key, siblings);
+		}
+	}
+	const descendants: SessionSummary[] = [];
+	const linked = new Set<SessionSummary>();
+	const keyQueue = [...parentIdentityKeys(parent)];
+	for (let index = 0; index < keyQueue.length; index++) {
+		for (const row of rowsByParentKey.get(keyQueue[index]!) ?? []) {
+			if (linked.has(row)) continue;
+			linked.add(row);
+			descendants.push(row);
+			keyQueue.push(...parentIdentityKeys(row));
+		}
+	}
+	return descendants;
+}
+
 export function getAgentsViewSummaryIdentity(summary: SessionSummary): string {
 	if (summary.runtimeKind === "subagent" && summary.rlmChildId) {
 		return `agent:${rosterAgentIdForSummary(summary)}`;

--- a/packages/coding-agent/src/modes/interactive/components/subagent-summary-line.ts
+++ b/packages/coding-agent/src/modes/interactive/components/subagent-summary-line.ts
@@ -1,6 +1,6 @@
 import { type Component, type Focusable, getKeybindings, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { AgentConnectionRlmChildAgentSnapshot } from "../../agent-connection/index.js";
-import { isDirectAgentChild } from "../../agents-view/agents-view-state.js";
+import { collectSubagentDescendantSummaries } from "../../agents-view/agents-view-state.js";
 import { type AgentRosterStatus, classifyAgentStatus } from "../../daemon/agent-roster.js";
 import { classifySessionRosterStatus, type SessionSummary } from "../../daemon/daemon-session-list.js";
 import { theme } from "../theme/theme.js";
@@ -24,15 +24,26 @@ export function classifySubagentSnapshotStatus(child: AgentConnectionRlmChildAge
 	});
 }
 
-export function countDirectSubagentStatuses(
+/** Status counts over every snapshot descending from `parentId`; the recursive roster carries the whole subtree. */
+export function countSubtreeSubagentStatuses(
 	children: Iterable<AgentConnectionRlmChildAgentSnapshot>,
 	parentId: string | undefined,
 ): SubagentSummaryCounts {
 	const counts: SubagentSummaryCounts = { total: 0, running: 0, idle: 0, inactive: 0 };
-	for (const child of children) {
-		if (child.parentId !== parentId || child.status === "cancelled") continue;
-		counts.total += 1;
-		counts[classifySubagentSnapshotStatus(child)] += 1;
+	const knownNodes = new Set<string | undefined>([parentId]);
+	const pending = [...children].filter((child) => child.status !== "cancelled");
+	let matched = true;
+	while (matched) {
+		matched = false;
+		for (let index = pending.length - 1; index >= 0; index--) {
+			const child = pending[index]!;
+			if (!knownNodes.has(child.parentId)) continue;
+			pending.splice(index, 1);
+			matched = true;
+			counts.total += 1;
+			counts[classifySubagentSnapshotStatus(child)] += 1;
+			knownNodes.add(child.id);
+		}
 	}
 	return counts;
 }
@@ -42,9 +53,9 @@ export function countRosterSubagentStatuses(
 	parent: { activeSessionId?: string | undefined; sessionId?: string | undefined; sessionFile?: string | undefined },
 ): SubagentSummaryCounts {
 	const counts: SubagentSummaryCounts = { total: 0, running: 0, idle: 0, inactive: 0 };
-	for (const child of summaries) {
-		if (child.runtimeKind !== "subagent" || child.lifecycle !== "live") continue;
-		if (!isDirectAgentChild(child, parent)) continue;
+	// The daemon roster spans every tree: count live rows in this session's subtree, at any depth.
+	for (const child of collectSubagentDescendantSummaries(summaries, parent)) {
+		if (child.lifecycle !== "live") continue;
 		counts.total += 1;
 		counts[child.rosterStatus ?? classifySessionRosterStatus(child)] += 1;
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -228,8 +228,8 @@ import {
 } from "./components/slash-command-message.js";
 import { SlashCommandResultMessageComponent } from "./components/slash-command-result-message.js";
 import {
-	countDirectSubagentStatuses,
 	countRosterSubagentStatuses,
+	countSubtreeSubagentStatuses,
 	SubagentSummaryLine,
 } from "./components/subagent-summary-line.js";
 import { ThinkingSelectorComponent } from "./components/thinking-selector.js";
@@ -6054,7 +6054,7 @@ export class InteractiveMode {
 						sessionId: this.connectionState?.sessionId,
 						sessionFile: this.connectionState?.sessionFile,
 					})
-				: countDirectSubagentStatuses(this.subagentSnapshots.values(), this.rlmNodeId),
+				: countSubtreeSubagentStatuses(this.subagentSnapshots.values(), this.rlmNodeId),
 		);
 		if (!this.subagentSummaryLine.isSelectable() && this.subagentSummaryLine.focused) this.focusEditor();
 	}

--- a/packages/coding-agent/test/subagent-summary-line.test.ts
+++ b/packages/coding-agent/test/subagent-summary-line.test.ts
@@ -6,8 +6,8 @@ import type { AgentConnectionRlmChildAgentSnapshot } from "../src/modes/agent-co
 import { isDirectAgentChild } from "../src/modes/agents-view/agents-view-state.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import {
-	countDirectSubagentStatuses,
 	countRosterSubagentStatuses,
+	countSubtreeSubagentStatuses,
 	SubagentSummaryLine,
 } from "../src/modes/interactive/components/subagent-summary-line.js";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
@@ -79,7 +79,7 @@ describe("SubagentSummaryLine", () => {
 		}
 	});
 
-	it("counts only direct children using running, idle, and inactive status projections", () => {
+	it("counts the whole snapshot subtree using running, idle, and inactive status projections", () => {
 		const children = [
 			child("running", "running"),
 			child("queued", "queued"),
@@ -91,12 +91,14 @@ describe("SubagentSummaryLine", () => {
 			child("inactive-error", "error"),
 			child("cancelled", "cancelled"),
 			child("grandchild", "running", { parentId: "running" }),
+			child("great-grandchild", "done", { activeSessionId: "gg-session", parentId: "grandchild" }),
+			child("foreign", "running", { parentId: "stranger" }),
 		];
 
-		expect(countDirectSubagentStatuses(children, undefined)).toEqual({
-			total: 8,
-			running: 3,
-			idle: 3,
+		expect(countSubtreeSubagentStatuses(children, undefined)).toEqual({
+			total: 10,
+			running: 4,
+			idle: 4,
 			inactive: 2,
 		});
 	});
@@ -269,7 +271,7 @@ describe("SubagentSummaryLine", () => {
 		expect(stripAnsi(line.render(100).join("\n"))).toContain("● 0 running   ◐ 0 idle   ○ 1 inactive");
 	});
 
-	it("counts parentSessionId-only roster children exactly like the agents view", () => {
+	it("counts the whole roster subtree, not just direct children", () => {
 		const rosterChild = {
 			id: "c1",
 			sessionId: "c1",
@@ -279,10 +281,61 @@ describe("SubagentSummaryLine", () => {
 			parentSessionId: "root-session",
 			rosterStatus: "idle",
 		} as SessionSummary;
+		const grandchild = {
+			id: "gc1",
+			sessionId: "gc1",
+			activeSessionId: "gc1-active",
+			lifecycle: "live",
+			runtimeKind: "subagent",
+			rlmChildId: "gc1",
+			parentSessionId: "c1",
+			rosterStatus: "running",
+		} as SessionSummary;
+		const greatGrandchild = {
+			id: "gg1",
+			sessionId: "gg1",
+			lifecycle: "live",
+			runtimeKind: "subagent",
+			rlmChildId: "gg1",
+			parentActiveSessionId: "gc1-active",
+			rosterStatus: "running",
+		} as SessionSummary;
+		const archivedChild = {
+			id: "ac1",
+			sessionId: "ac1",
+			lifecycle: "archived",
+			runtimeKind: "subagent",
+			rlmChildId: "ac1",
+			parentSessionId: "root-session",
+			rosterStatus: "inactive",
+		} as SessionSummary;
+		const archivedGrandchild = {
+			id: "ag1",
+			sessionId: "ag1",
+			lifecycle: "live",
+			runtimeKind: "subagent",
+			rlmChildId: "ag1",
+			parentSessionId: "ac1",
+			rosterStatus: "running",
+		} as SessionSummary;
+		const foreign = {
+			id: "f1",
+			sessionId: "f1",
+			lifecycle: "live",
+			runtimeKind: "subagent",
+			rlmChildId: "f1",
+			parentSessionId: "other-root",
+			rosterStatus: "running",
+		} as SessionSummary;
 		expect(isDirectAgentChild(rosterChild, { sessionId: "root-session" })).toBe(true);
-		expect(countRosterSubagentStatuses([rosterChild], { sessionId: "root-session" })).toEqual({
-			total: 1,
-			running: 0,
+		expect(
+			countRosterSubagentStatuses(
+				[rosterChild, grandchild, greatGrandchild, archivedChild, archivedGrandchild, foreign],
+				{ sessionId: "root-session" },
+			),
+		).toEqual({
+			total: 4,
+			running: 3,
 			idle: 1,
 			inactive: 0,
 		});

--- a/packages/coding-agent/test/subagent-summary-line.test.ts
+++ b/packages/coding-agent/test/subagent-summary-line.test.ts
@@ -3,7 +3,6 @@ import stripAnsi from "strip-ansi";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.js";
 import type { AgentConnectionRlmChildAgentSnapshot } from "../src/modes/agent-connection/types.js";
-import { isDirectAgentChild } from "../src/modes/agents-view/agents-view-state.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import {
 	countRosterSubagentStatuses,
@@ -327,7 +326,6 @@ describe("SubagentSummaryLine", () => {
 			parentSessionId: "other-root",
 			rosterStatus: "running",
 		} as SessionSummary;
-		expect(isDirectAgentChild(rosterChild, { sessionId: "root-session" })).toBe(true);
 		expect(
 			countRosterSubagentStatuses(
 				[rosterChild, grandchild, greatGrandchild, archivedChild, archivedGrandchild, foreign],


### PR DESCRIPTION
No-Ticket: display-only interactive-bar counting fix, no tracked workstream

## Summary
- The interactive subagents bar counted only direct children, so running grandchildren were invisible (e.g. a coordinator idling while its child's child works).
- Both counting paths now cover the whole subtree:
  - snapshot path: `countSubtreeSubagentStatuses` walks the recursive child roster over `parentId`, seeded with the session's `rlmNodeId`
  - roster path: new `collectSubagentDescendantSummaries` in `agents-view-state.ts` BFSes the shared parent linkage; rows are indexed by parent key once, so linkage cost matches the old depth-1 scan
- Non-live roster rows link their live descendants but do not count; `SubagentSummaryCounts`, status classification, and selectability are unchanged.

## Verification
- `test/subagent-summary-line.test.ts`: grandchild/great-grandchild/foreign fixtures on both paths
- `agents-view-roster`, `agents-view-state`, `agents-view-mode`, `interactive-heartbeat-management`, 502 regression: pass
- `npm run check` clean


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only counting in the interactive UI; no auth, persistence, or agent execution logic changes.
> 
> **Overview**
> The interactive **subagents** bar previously counted only **direct** children, so nested agents (e.g. a running grandchild under an idle coordinator) did not show up in the running/idle/inactive totals.
> 
> **Roster path:** `countRosterSubagentStatuses` now walks every live subagent in the current session’s tree via new `collectSubagentDescendantSummaries` (BFS over the same parent keys as the agents view). Archived rows can still link descendants but are not counted.
> 
> **Snapshot path:** `countDirectSubagentStatuses` is replaced by `countSubtreeSubagentStatuses`, which expands from the session’s `rlmNodeId` through `parentId` links; `interactive-mode` uses this when the daemon roster is unavailable. Cancelled snapshots are excluded from counts.
> 
> Tests in `subagent-summary-line.test.ts` cover multi-level and foreign-branch fixtures on both paths. Rendering, status classification, and bar selectability are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5938a3e7cbd546c2e545a025b248645ef93eae9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Count running/idle subagents across full subtree in the agents bar
> - Adds `collectSubagentDescendantSummaries` in [agents-view-state.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2218/files#diff-2e58b45b4d539a55b0a23f04ab90b169c6783299ca57cf9ce39557d901dcd3a1), a breadth-first traversal that returns every reachable subagent summary in the selected session's subtree, matched via active session IDs, session IDs, or session files.
> - Replaces the direct-child counters in [subagent-summary-line.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2218/files#diff-b8fd94fae8d7032bc4ed0f3d11fb3fff8c17dc31ad4eda340ad199b71388fb43): `countSubtreeSubagentStatuses` now iterates non-cancelled snapshots at any depth, and `countRosterSubagentStatuses` uses the new collector while keeping its live-lifecycle filter.
> - Updates the snapshot fallback call site in [interactive-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2218/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316) to use the subtree counter.
> - Behavioral Change: subagent bar counts now include descendants at all depths rather than only direct children. Snapshot counts exclude cancelled snapshots and their descendants; roster counts still exclude non-live rows.
> >
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2218 opened
>
> - Removed the `isDirectAgentChild` utility function from the `agents-view-state` module and updated a preceding comment to reference `getParentKeys` instead [c5938a3]
> - Removed test assertions that verified direct parent-child relationships using the deleted `isDirectAgentChild` function [c5938a3]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
> >
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 662ba50. 4 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
> >
> ### 🗂️ Filtered Issues
> <details>
> <summary>packages/coding-agent/src/modes/interactive/components/subagent-summary-line.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
> >
> - [line 34](https://github.com/PrimeIntellect-ai/prime-agent/blob/662ba50179ea4ca25864bccce225a555726da701/packages/coding-agent/src/modes/interactive/components/subagent-summary-line.ts#L34): `pending` removes every `cancelled` snapshot before traversal, so a live descendant whose `parentId` is a cancelled intermediate is never reached or counted. The snapshot producer explicitly emits a cancelled retained parent while still appending `child.getRlmChildSnapshots()` for its descendants (for example after a cleanup failure), making a running grandchild disappear from the bar even though it remains in the recursive roster. Cancelled rows should be excluded from the counts but still add their `id` to the traversal frontier. <b>[ Failed validation ]</b>
> </details>
> >
> >
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
