### PR TITLE
kernel: alias <skill>.<skill> to run when the submodule shadows it

### DIFF
--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -123,6 +123,11 @@ def _prime_agent_wrap_skill_module(module):
     doc = getattr(run, "__doc__", None)
     if doc:
         wrapped.__doc__ = doc
+    # Packages laid out as <skill>/<skill>.py expose the submodule under the
+    # skill name, so <skill>.<skill>(...) raised "'module' object is not callable".
+    short_name = module.__name__.rsplit(".", 1)[-1]
+    if not callable(getattr(wrapped, short_name, None)):
+        setattr(wrapped, short_name, run)
     _prime_agent_sys.modules[module.__name__] = wrapped
     return wrapped
 

--- a/packages/coding-agent/test/kernel-attach-image-skill.test.ts
+++ b/packages/coding-agent/test/kernel-attach-image-skill.test.ts
@@ -57,6 +57,25 @@ describe("attach-image skill over the kernel host bridge", () => {
 		expect(blocks).toEqual([{ type: "image", data: PNG_BASE64, mimeType: "image/png" }]);
 	});
 
+	it("accepts the attach_image.attach_image(...) spelling instead of returning the submodule", async () => {
+		const imagePath = join(tempDir, "sample.png");
+		writeFileSync(imagePath, Buffer.from(PNG_BASE64, "base64"));
+
+		provisioner = new IpythonKernelProvisioner(tempDir, {
+			pythonSkills: [bundledAttachImageSkill()],
+			hostHandlers: {
+				"model.info": async () => ({ id: "anthropic/claude-haiku-4.5", input: ["text", "image"] }),
+			},
+		});
+
+		const manager = await provisioner.ensure();
+		const result = await manager.execute(`print(await attach_image.attach_image(${JSON.stringify(imagePath)}))`);
+
+		expect(result.status).toBe("ok");
+		expect(result.stdout.trim()).toContain("Loaded 1 image(s) into context");
+		expect(result.attachments).toHaveLength(1);
+	});
+
 	it("compresses large attached images before storing them in the tool result", { retry: 1 }, async () => {
 		const imagePath = join(tempDir, "large.png");
 


### PR DESCRIPTION
## Context

No-Ticket: external bug fix, no Linear access.

Bundled Python skills laid out as `<skill>/<skill>.py` (`attach_image`, `websearch`) expose the submodule under the skill name. `attach_image.attach_image` is therefore a module, and `await attach_image.attach_image(path)` raises `TypeError: 'module' object is not callable`.

Models try that spelling first in practice. In one user's logs, 8 of 8 sessions since 2026-09-01 that attached an image hit the TypeError, then retried with `await attach_image(path)`. That is one wasted failed tool step per image.

## Changes

- `_prime_agent_wrap_skill_module` now sets `<module>.<short_name> = run` on the wrapped module when that attribute is not already callable. `await attach_image(...)` and `await attach_image.run(...)` are unchanged; `await attach_image.attach_image(...)` now works too.
- Kernel test: `attach_image.attach_image(path)` loads the image. Fails without the alias (TypeError), passes with it.

## Validation

- `npx vitest --run test/kernel-attach-image-skill.test.ts`: 10 passed.
- Same test file with `src/core/tools/ipython.ts` stashed: new test fails with the TypeError, confirming it covers the bug.
- `biome check --error-on-warnings` on the two touched files: clean.
- `tsgo --noEmit`: only pre-existing `@smithy/*` errors in `amazon-bedrock.ts` / `6006-bundled-bedrock.test.ts`, unrelated to this change.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Alias `<skill>.<skill>` to `run` for shadowed skill submodules
> - Updates the `_prime_agent_wrap_skill_module` wrapper in [ipython.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2221/files#diff-812e64dd0562a31155c537ae8f665280f5201d993eea105d5066d0e7d02ee36d) to expose a module's `run` function under its short name when the wrapper does not already provide a callable attribute. This allows package layouts like `<skill>/<skill>.py` to support `<skill>.<skill>(...)` calls.
> - Adds an integration test in [kernel-attach-image-skill.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2221/files#diff-cc0c1c0cb0982883d0cf5f47e26e26512f3f336f30f517337e661054e0ef7234) verifying that `attach_image.attach_image(...)` executes successfully and produces an image attachment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6480c72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->