### PR TITLE
[RSI] Typed fan-in for subagent results (rlm.collect)

### DIFF
--- a/packages/coding-agent/.changes/eng-6088-rlm-collect-typed-fanin.md
+++ b/packages/coding-agent/.changes/eng-6088-rlm-collect-typed-fanin.md
@@ -1,0 +1,1 @@
+- Added `rlm.collect`, a typed non-steering fan-in for subagent results: it awaits direct children's runs with a bounded timeout and returns per-child result envelopes (status, settled, answer preview, error, duration, tool count) without growing the parent's message queue.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10219,27 +10219,28 @@ export class AgentSession {
 	 * deleted.
 	 */
 	async collectRlmChildren(targets: string[], timeoutMs: number): Promise<RlmCollectResult> {
-		const runs = new Map<string, RlmChildRun>();
+		const candidates = new Map<string, RlmChildRun>();
 		for (const run of this._activeRlmChildRuns.values()) {
-			runs.set(run.id, run);
+			candidates.set(run.id, run);
 		}
 		// Terminal cleanup moves settled runs out of _activeRlmChildRuns while their
 		// envelope stays retained in _rlmChildSessions until deleted; collect must see
 		// both or a completed child can no longer be re-collected.
 		for (const [childId, retained] of this._rlmChildSessions) {
-			if (retained.run && !runs.has(childId)) {
-				runs.set(childId, retained.run);
+			if (retained.run && !candidates.has(childId)) {
+				candidates.set(childId, retained.run);
 			}
 		}
+		const runs = new Map<string, RlmChildRun>();
 		if (targets.length === 0) {
-			for (const [childId, run] of runs) {
-				if (run.detachedDeletion || this._deletingRlmChildren.has(run.id)) {
-					runs.delete(childId);
+			for (const [childId, run] of candidates) {
+				if (!run.detachedDeletion && !this._deletingRlmChildren.has(run.id)) {
+					runs.set(childId, run);
 				}
 			}
 		} else {
 			for (const target of targets) {
-				const matches = [...runs.values()].filter(
+				const matches = [...candidates.values()].filter(
 					(run) =>
 						!run.detachedDeletion &&
 						!this._deletingRlmChildren.has(run.id) &&

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -238,6 +238,7 @@ import {
 	type CreateRlmSubagentRuntimeOptions,
 	createAsyncBashCompletionHostHandler,
 	createDefaultRlmSubagentSessionName,
+	createRlmCollectHostHandler,
 	createRlmCreateSessionHostHandler,
 	createRlmDeleteSubagentHostHandler,
 	createRlmFindModelsHostHandler,
@@ -247,6 +248,8 @@ import {
 	normalizeRequestedRlmSubagentModel,
 	normalizeRequestedRlmSubagentSessionName,
 	normalizeRequestedRlmSubagentThinkingLevel,
+	type RlmCollectResult,
+	type RlmCollectResultEntry,
 	type RlmCreateSessionResult,
 	type RlmDeleteSubagentResult,
 	type RlmFindModelsResult,
@@ -9711,6 +9714,9 @@ export class AgentSession {
 			}),
 			"rlm.find_models": createRlmFindModelsHostHandler((query, limit) => this.findRlmModels(query, limit)),
 			"rlm.list_subagents": createRlmListSubagentsHostHandler(() => this.listRlmSubagents()),
+			"rlm.collect": createRlmCollectHostHandler((targets, timeoutMs) =>
+				this.collectRlmChildren(targets, timeoutMs),
+			),
 			"rlm.delete_subagent": createRlmDeleteSubagentHostHandler((target) => this.deleteRlmSubagent(target)),
 			"model.info": async () => ({
 				id: this.model?.id ?? null,
@@ -10202,6 +10208,92 @@ export class AgentSession {
 			});
 		}
 		return { subagents };
+	}
+
+	/**
+	 * Typed fan-in for direct RLM children: wait (bounded) for the selected
+	 * runs to settle and return result envelopes. Never steers the parent and
+	 * never rejects on timeout — a timeout returns the current snapshots so
+	 * the caller can end its turn, poll, or retry. `targets` are child ids or
+	 * session names; an empty list means every direct child that is not being
+	 * deleted.
+	 */
+	async collectRlmChildren(targets: string[], timeoutMs: number): Promise<RlmCollectResult> {
+		const runs = new Map<string, RlmChildRun>();
+		if (targets.length === 0) {
+			for (const run of this._activeRlmChildRuns.values()) {
+				if (!run.detachedDeletion && !this._deletingRlmChildren.has(run.id)) {
+					runs.set(run.id, run);
+				}
+			}
+		} else {
+			for (const target of targets) {
+				const matches = [...this._activeRlmChildRuns.values()].filter(
+					(run) =>
+						!run.detachedDeletion &&
+						!this._deletingRlmChildren.has(run.id) &&
+						this._rlmChildRunMatchesTarget(run, target),
+				);
+				if (matches.length === 0) {
+					throw new Error(`No direct RLM child matches "${target}" in the current parent session`);
+				}
+				if (matches.length > 1) {
+					throw new Error(`RLM child selector "${target}" is ambiguous in the current parent session`);
+				}
+				runs.set(matches[0].id, matches[0]);
+			}
+		}
+		if (timeoutMs > 0) {
+			const deadline = Date.now() + timeoutMs;
+			await Promise.all(
+				[...runs.values()].map((run) => {
+					if (run.settled) return undefined;
+					const remainingMs = deadline - Date.now();
+					if (remainingMs <= 0) return undefined;
+					let timer: NodeJS.Timeout | undefined;
+					const timeout = new Promise<void>((resolve) => {
+						timer = setTimeout(resolve, remainingMs);
+						timer.unref?.();
+					});
+					return Promise.race([
+						// A settled failure is terminal state, not a collect error.
+						run.settlement.promise.then(
+							() => undefined,
+							() => undefined,
+						),
+						timeout,
+					]).finally(() => {
+						clearTimeout(timer);
+					});
+				}),
+			);
+		}
+		return { results: [...runs.values()].map((run) => this._rlmCollectEntryForRun(run)) };
+	}
+
+	private _rlmChildRunMatchesTarget(run: RlmChildRun, target: string): boolean {
+		return (
+			run.id === target ||
+			run.sessionName === target ||
+			run.session?.sessionId === target ||
+			run.session?.sessionName === target
+		);
+	}
+
+	private _rlmCollectEntryForRun(run: RlmChildRun): RlmCollectResultEntry {
+		const snapshot = this._rlmChildSnapshotForRun(run);
+		return {
+			rlm_child_id: snapshot.id,
+			session_name: snapshot.sessionName,
+			session_dir: snapshot.sessionDir,
+			status: snapshot.status,
+			settled: run.settled,
+			answer_preview: snapshot.answerPreview,
+			error: snapshot.error,
+			duration_ms: snapshot.durationMs,
+			tool_use_count: snapshot.toolUseCount,
+			replied_since_task: snapshot.repliedSinceTask,
+		};
 	}
 
 	private _rlmSubagentMatchesTarget(entry: RlmSubagentRegistryEntry, target: string): boolean {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10220,15 +10220,26 @@ export class AgentSession {
 	 */
 	async collectRlmChildren(targets: string[], timeoutMs: number): Promise<RlmCollectResult> {
 		const runs = new Map<string, RlmChildRun>();
+		for (const run of this._activeRlmChildRuns.values()) {
+			runs.set(run.id, run);
+		}
+		// Terminal cleanup moves settled runs out of _activeRlmChildRuns while their
+		// envelope stays retained in _rlmChildSessions until deleted; collect must see
+		// both or a completed child can no longer be re-collected.
+		for (const [childId, retained] of this._rlmChildSessions) {
+			if (retained.run && !runs.has(childId)) {
+				runs.set(childId, retained.run);
+			}
+		}
 		if (targets.length === 0) {
-			for (const run of this._activeRlmChildRuns.values()) {
-				if (!run.detachedDeletion && !this._deletingRlmChildren.has(run.id)) {
-					runs.set(run.id, run);
+			for (const [childId, run] of runs) {
+				if (run.detachedDeletion || this._deletingRlmChildren.has(run.id)) {
+					runs.delete(childId);
 				}
 			}
 		} else {
 			for (const target of targets) {
-				const matches = [...this._activeRlmChildRuns.values()].filter(
+				const matches = [...runs.values()].filter(
 					(run) =>
 						!run.detachedDeletion &&
 						!this._deletingRlmChildren.has(run.id) &&
@@ -10272,11 +10283,12 @@ export class AgentSession {
 	}
 
 	private _rlmChildRunMatchesTarget(run: RlmChildRun, target: string): boolean {
+		const session = run.session ?? this._rlmChildSessions.get(run.id)?.session;
 		return (
 			run.id === target ||
 			run.sessionName === target ||
-			run.session?.sessionId === target ||
-			run.session?.sessionName === target
+			session?.sessionId === target ||
+			session?.sessionName === target
 		);
 	}
 

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -222,7 +222,8 @@ export function buildSubagentGuidance(
 		lines.push("Use `agent_observe` for bounded transcript inspection.");
 	}
 	lines.push(
-		"Have children write files and read those files for fan-in.",
+		"Fan-in results with `await rlm.collect(targets, timeout_ms=0)`: it returns typed snapshots of direct children (status, answer preview, error) without steering anyone; an explicit timeout blocks only that call until the children settle or the deadline passes.",
+		"Large child outputs belong in files that you read selectively; `collect` snapshots are previews, not full results.",
 		"Delegate parallel context-heavy research or independent implementation; do a single known lookup, edit, or command inline.",
 	);
 	if (options.includeRefineExamples ?? true) {

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -309,8 +309,13 @@ export function createRlmCollectHostHandler(handler: RlmCollectHandler): HostReq
 			const { results } = await handler(targets, 0);
 			return { results };
 		}
-		if (typeof rawTimeout !== "number" || !Number.isSafeInteger(rawTimeout) || rawTimeout < 0) {
-			throw new Error("rlm.collect timeout_ms must be a non-negative integer");
+		if (
+			typeof rawTimeout !== "number" ||
+			!Number.isSafeInteger(rawTimeout) ||
+			rawTimeout < 0 ||
+			rawTimeout > 2_147_483_647
+		) {
+			throw new Error("rlm.collect timeout_ms must be a non-negative integer up to 2147483647");
 		}
 		const { results } = await handler(targets, rawTimeout);
 		return { results };

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -1,6 +1,6 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model, ServiceTier } from "@earendil-works/pi-ai";
-import type { AgentSession } from "./agent-session.js";
+import type { AgentSession, RlmChildAgentStatus } from "./agent-session.js";
 import type { ToolDefinition } from "./extensions/index.js";
 import type { HostRequestHandler } from "./kernel/index.js";
 import { THINKING_LEVELS } from "./thinking-levels.js";
@@ -62,6 +62,27 @@ export interface RlmModelMatch {
 export interface RlmFindModelsResult {
 	models: RlmModelMatch[];
 }
+
+export interface RlmCollectResultEntry {
+	rlm_child_id: string;
+	session_name: string | undefined;
+	session_dir: string;
+	/** Raw run status: queued | running | done | error | cancelled. */
+	status: RlmChildAgentStatus;
+	/** True once the run reached a terminal state (settlement resolved or rejected). */
+	settled: boolean;
+	answer_preview: string | undefined;
+	error: string | undefined;
+	duration_ms: number | undefined;
+	tool_use_count: number | undefined;
+	replied_since_task: boolean | undefined;
+}
+
+export interface RlmCollectResult {
+	results: RlmCollectResultEntry[];
+}
+
+export type RlmCollectHandler = (targets: string[], timeoutMs: number) => Promise<RlmCollectResult>;
 
 export type RlmRunHandler = (request: RlmRunRequest) => Promise<Record<string, unknown>>;
 type RlmCreateSessionHandler = (request: RlmCreateSessionRequest) => Promise<RlmCreateSessionResult>;
@@ -262,6 +283,37 @@ export function createRlmDeleteSubagentHostHandler(handler: RlmDeleteSubagentHan
 		}
 		const { subagent, outcome } = await handler(payload.target.trim());
 		return outcome === undefined ? { subagent } : { subagent, outcome };
+	};
+}
+
+/**
+ * Typed fan-in for subagent results: `rlm.collect` waits (bounded) for the
+ * selected direct children's runs to settle and returns result envelopes.
+ * Never steers the parent: a timeout returns the current snapshots instead of
+ * rejecting, so the caller can poll, end the turn, or retry.
+ */
+export function createRlmCollectHostHandler(handler: RlmCollectHandler): HostRequestHandler {
+	return async (payload) => {
+		const rawTargets = payload.targets;
+		if (rawTargets !== undefined && rawTargets !== null && !Array.isArray(rawTargets)) {
+			throw new Error("rlm.collect targets must be an array of child ids or names");
+		}
+		const targets = (rawTargets ?? []).map((target) => {
+			if (typeof target !== "string" || !target.trim()) {
+				throw new Error("rlm.collect targets must be non-empty strings");
+			}
+			return target.trim();
+		});
+		const rawTimeout = payload.timeout_ms;
+		if (rawTimeout === undefined || rawTimeout === null) {
+			const { results } = await handler(targets, 0);
+			return { results };
+		}
+		if (typeof rawTimeout !== "number" || !Number.isSafeInteger(rawTimeout) || rawTimeout < 0) {
+			throw new Error("rlm.collect timeout_ms must be a non-negative integer");
+		}
+		const { results } = await handler(targets, rawTimeout);
+		return { results };
 	};
 }
 

--- a/packages/coding-agent/test/rlm-collect.test.ts
+++ b/packages/coding-agent/test/rlm-collect.test.ts
@@ -121,6 +121,28 @@ describe("rlm.collect typed fan-in", () => {
 		expect(results.results.every((entry) => entry.settled && entry.status === "done")).toBe(true);
 	});
 
+	it("re-collects a settled child after terminal cleanup", async () => {
+		session = makeSession();
+		const handle = await session.runRlmChild("compute the answer", { name: "worker-a" });
+		// Wait for settlement: the terminal path removes the settled run from
+		// _activeRlmChildRuns while its envelope stays retained until deleted.
+		const settled = await session.collectRlmChildren([handle.rlm_child_id], 10_000);
+		expect(settled.results[0]?.settled).toBe(true);
+
+		const byId = await session.collectRlmChildren([handle.rlm_child_id], 0);
+		expect(byId.results).toHaveLength(1);
+		expect(byId.results[0]?.rlm_child_id).toBe(handle.rlm_child_id);
+		expect(byId.results[0]?.status).toBe("done");
+		expect(byId.results[0]?.settled).toBe(true);
+		expect(byId.results[0]?.answer_preview).toContain("child answer");
+
+		const byName = await session.collectRlmChildren(["worker-a"], 0);
+		expect(byName.results[0]?.rlm_child_id).toBe(handle.rlm_child_id);
+
+		const all = await session.collectRlmChildren([], 0);
+		expect(all.results.map((entry) => entry.rlm_child_id)).toContain(handle.rlm_child_id);
+	});
+
 	it("returns current snapshots on timeout without rejecting", async () => {
 		session = makeSession();
 		const handle = await session.runRlmChild("slow task", { name: "worker-a" });
@@ -145,6 +167,9 @@ describe("rlm.collect typed fan-in", () => {
 		await expect(handler({ targets: [""] })).rejects.toThrow("non-empty strings");
 		await expect(handler({ timeout_ms: -1 })).rejects.toThrow("non-negative integer");
 		await expect(handler({ timeout_ms: "soon" })).rejects.toThrow("non-negative integer");
+		// Node clamps setTimeout delays above 2^31-1 to 1ms, so an oversized
+		// timeout must be rejected instead of returning an immediate snapshot.
+		await expect(handler({ timeout_ms: 2_147_483_648 })).rejects.toThrow("2147483647");
 		const ok = await handler({ targets: ["worker-a"], timeout_ms: 5 });
 		expect(ok).toEqual({ results: [] });
 		const defaults = await handler({});

--- a/packages/coding-agent/test/rlm-collect.test.ts
+++ b/packages/coding-agent/test/rlm-collect.test.ts
@@ -1,0 +1,153 @@
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@earendil-works/pi-agent-core";
+import {
+	type AssistantMessage,
+	type Context,
+	createAssistantMessageEventStream,
+	getModel,
+	type TextContent,
+	type Usage,
+} from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AgentSession } from "../src/core/agent-session.js";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { convertToLlm } from "../src/core/messages.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import { createRlmCollectHostHandler } from "../src/core/rlm-runtime.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+import { createTestResourceLoader } from "./utilities.js";
+
+const model = getModel("anthropic", "claude-sonnet-4-5")!;
+
+function userText(context: Context): string {
+	const last = context.messages.at(-1);
+	if (!last || last.role !== "user") return "";
+	if (typeof last.content === "string") return last.content;
+	return last.content
+		.filter((block): block is TextContent => block.type === "text")
+		.map((block) => block.text)
+		.join(" ");
+}
+
+function usage(input = 7, output = 3): Usage {
+	return {
+		input,
+		output,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: input + output,
+		cost: { input, output, cacheRead: 0, cacheWrite: 0, total: input + output },
+	};
+}
+
+function streamAnswer(text: string): ReturnType<typeof createAssistantMessageEventStream> {
+	const stream = createAssistantMessageEventStream();
+	queueMicrotask(() => {
+		const message: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: usage(),
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+		stream.push({ type: "done", reason: "stop", message });
+	});
+	return stream;
+}
+
+describe("rlm.collect typed fan-in", () => {
+	let tempDir: string;
+	let session: AgentSession | undefined;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-rlm-collect-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		session?.dispose();
+		session = undefined;
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	function makeSession(): AgentSession {
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const agent = new Agent({
+			convertToLlm,
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: "", tools: [], thinkingLevel: "off" },
+			streamFn: (_model, context) => streamAnswer(`child answer: ${userText(context)}`),
+		});
+		return new AgentSession({
+			agent,
+			sessionManager: SessionManager.create(tempDir, join(tempDir, "sessions")),
+			settingsManager: SettingsManager.create(tempDir, tempDir),
+			cwd: tempDir,
+			modelRegistry: ModelRegistry.create(authStorage, join(tempDir, "models.json")),
+			resourceLoader: createTestResourceLoader(),
+		});
+	}
+
+	it("returns a typed envelope once the child settles", async () => {
+		session = makeSession();
+		const handle = await session.runRlmChild("compute the answer", { name: "worker-a" });
+
+		const results = await session.collectRlmChildren([handle.rlm_child_id], 10_000);
+		expect(results.results).toHaveLength(1);
+		const entry = results.results[0];
+		expect(entry.rlm_child_id).toBe(handle.rlm_child_id);
+		expect(entry.session_name).toBe("worker-a");
+		expect(entry.status).toBe("done");
+		expect(entry.settled).toBe(true);
+		expect(entry.answer_preview).toContain("child answer");
+		expect(entry.error).toBeUndefined();
+	});
+
+	it("collects every direct child when no targets are given", async () => {
+		session = makeSession();
+		const first = await session.runRlmChild("first task", { name: "worker-a" });
+		const second = await session.runRlmChild("second task", { name: "worker-b" });
+
+		const results = await session.collectRlmChildren([], 10_000);
+		const ids = results.results.map((entry) => entry.rlm_child_id).sort();
+		expect(ids).toEqual([first.rlm_child_id, second.rlm_child_id].sort());
+		expect(results.results.every((entry) => entry.settled && entry.status === "done")).toBe(true);
+	});
+
+	it("returns current snapshots on timeout without rejecting", async () => {
+		session = makeSession();
+		const handle = await session.runRlmChild("slow task", { name: "worker-a" });
+		// The child runs to completion quickly in this stub; a zero timeout is
+		// the guaranteed non-blocking read used for polling.
+		const snapshot = await session.collectRlmChildren([handle.rlm_child_id], 0);
+		expect(snapshot.results).toHaveLength(1);
+		expect(snapshot.results[0].rlm_child_id).toBe(handle.rlm_child_id);
+		expect(["queued", "running", "done"]).toContain(snapshot.results[0].status);
+	});
+
+	it("throws for unknown selectors and keeps ambiguity detection", async () => {
+		session = makeSession();
+		await expect(session.collectRlmChildren(["no-such-child"], 0)).rejects.toThrow(
+			'No direct RLM child matches "no-such-child"',
+		);
+	});
+
+	it("validates host payload shape", async () => {
+		const handler = createRlmCollectHostHandler(async () => ({ results: [] }));
+		await expect(handler({ targets: "worker-a" })).rejects.toThrow("targets must be an array");
+		await expect(handler({ targets: [""] })).rejects.toThrow("non-empty strings");
+		await expect(handler({ timeout_ms: -1 })).rejects.toThrow("non-negative integer");
+		await expect(handler({ timeout_ms: "soon" })).rejects.toThrow("non-negative integer");
+		const ok = await handler({ targets: ["worker-a"], timeout_ms: 5 });
+		expect(ok).toEqual({ results: [] });
+		const defaults = await handler({});
+		expect(defaults).toEqual({ results: [] });
+	});
+});

--- a/packages/coding-agent/test/rlm-collect.test.ts
+++ b/packages/coding-agent/test/rlm-collect.test.ts
@@ -143,6 +143,18 @@ describe("rlm.collect typed fan-in", () => {
 		expect(all.results.map((entry) => entry.rlm_child_id)).toContain(handle.rlm_child_id);
 	});
 
+	it("returns only the selected child from a targeted collect", async () => {
+		session = makeSession();
+		const first = await session.runRlmChild("first task", { name: "worker-a" });
+		const second = await session.runRlmChild("second task", { name: "worker-b" });
+		await session.collectRlmChildren([], 10_000);
+
+		const targeted = await session.collectRlmChildren([first.rlm_child_id], 0);
+		expect(targeted.results.map((entry) => entry.rlm_child_id)).toEqual([first.rlm_child_id]);
+		const byName = await session.collectRlmChildren(["worker-b"], 0);
+		expect(byName.results.map((entry) => entry.rlm_child_id)).toEqual([second.rlm_child_id]);
+	});
+
 	it("returns current snapshots on timeout without rejecting", async () => {
 		session = makeSession();
 		const handle = await session.runRlmChild("slow task", { name: "worker-a" });

--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -50,6 +50,22 @@ class RLMSubagent:
     status: str
 
 
+@dataclass(frozen=True)
+class RLMChildResult:
+    """Terminal or in-progress state of one direct child, from `collect()`."""
+
+    rlm_child_id: str
+    session_name: str | None
+    session_dir: Path | None
+    status: str
+    settled: bool
+    answer_preview: str | None
+    error: str | None
+    duration_ms: int | None
+    tool_use_count: int | None
+    replied_since_task: bool | None
+
+
 def _spawn_handle_from_payload(payload: Any) -> RLMSpawnHandle:
     if not isinstance(payload, dict):
         raise RuntimeError("rlm.spawn returned an invalid spawn handle")
@@ -239,6 +255,103 @@ async def list_subagents() -> list[RLMSubagent]:
     return [_subagent_from_payload(entry) for entry in entries]
 
 
+def _collect_target_selector(target: Any) -> str:
+    """Normalize a collect target: spawn handle, subagent row, or a name/id string."""
+    if isinstance(target, RLMSpawnHandle):
+        return target.rlm_child_id
+    if isinstance(target, RLMSubagent):
+        return target.rlm_child_id
+    if isinstance(target, str) and target.strip():
+        return target.strip()
+    raise TypeError(
+        f"collect target must be RLMSpawnHandle, RLMSubagent, or non-empty str, got {type(target).__name__}"
+    )
+
+
+def _child_result_from_payload(payload: Any) -> RLMChildResult:
+    if not isinstance(payload, dict):
+        raise RuntimeError("rlm.collect returned an invalid result entry")
+    child_id = payload.get("rlm_child_id")
+    if not isinstance(child_id, str) or not child_id:
+        raise RuntimeError("rlm.collect entry is missing rlm_child_id")
+    status = payload.get("status")
+    if status not in {"queued", "running", "done", "error", "cancelled"}:
+        raise RuntimeError("rlm.collect entry has invalid status")
+    settled = payload.get("settled")
+    if not isinstance(settled, bool):
+        raise RuntimeError("rlm.collect entry has invalid settled flag")
+
+    def _optional_str(field: str) -> str | None:
+        value = payload.get(field)
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise RuntimeError(f"rlm.collect entry has invalid {field}")
+        return value
+
+    def _optional_int(field: str) -> int | None:
+        value = payload.get(field)
+        if value is None:
+            return None
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise RuntimeError(f"rlm.collect entry has invalid {field}")
+        return value
+
+    session_dir = _optional_str("session_dir")
+    replied = payload.get("replied_since_task")
+    if replied is not None and not isinstance(replied, bool):
+        raise RuntimeError("rlm.collect entry has invalid replied_since_task")
+    return RLMChildResult(
+        rlm_child_id=child_id,
+        session_name=_optional_str("session_name"),
+        session_dir=Path(session_dir) if session_dir else None,
+        status=status,
+        settled=settled,
+        answer_preview=_optional_str("answer_preview"),
+        error=_optional_str("error"),
+        duration_ms=_optional_int("duration_ms"),
+        tool_use_count=_optional_int("tool_use_count"),
+        replied_since_task=replied,
+    )
+
+
+async def collect(
+    targets: Any = None,
+    *,
+    timeout_ms: int = 0,
+) -> list[RLMChildResult]:
+    """Collect typed results from direct RLM children.
+
+    ``targets`` selects children: spawn handles, subagent rows, name strings,
+    or a list mixing all three. ``None`` (or an empty list) selects every
+    direct child that is not being deleted.
+
+    ``timeout_ms`` bounds the wait for the selected children to settle:
+    0 returns a non-blocking snapshot immediately; a positive value blocks
+    only this kernel call until the runs settle or the timeout elapses —
+    a timeout returns current snapshots, never an error, and the parent
+    session is never steered. Completed children keep their result until
+    deleted, so a later ``collect`` re-reads them without waiting.
+    """
+    if not isinstance(timeout_ms, int) or isinstance(timeout_ms, bool) or timeout_ms < 0:
+        raise TypeError("timeout_ms must be a non-negative int")
+    if targets is None:
+        selectors: list[str] = []
+    elif isinstance(targets, (RLMSpawnHandle, RLMSubagent, str)):
+        selectors = [_collect_target_selector(targets)]
+    elif isinstance(targets, (list, tuple)):
+        selectors = [_collect_target_selector(target) for target in targets]
+    else:
+        raise TypeError(
+            f"targets must be None, a target, or a list of targets, got {type(targets).__name__}"
+        )
+    payload = await host_request("rlm.collect", {"targets": selectors, "timeout_ms": timeout_ms})
+    results = payload.get("results")
+    if not isinstance(results, list):
+        raise RuntimeError("rlm.collect returned an invalid results list")
+    return [_child_result_from_payload(entry) for entry in results]
+
+
 async def delete_subagent(target: str | RLMSubagent) -> RLMSubagent:
     """Delete one running or retained direct child from the current parent session."""
     if isinstance(target, RLMSubagent):
@@ -334,6 +447,9 @@ class _RLMNamespace:
 
     async def delete_subagent(self, target: str | RLMSubagent) -> RLMSubagent:
         return await delete_subagent(target)
+
+    async def collect(self, targets: Any = None, *, timeout_ms: int = 0) -> list[RLMChildResult]:
+        return await collect(targets, timeout_ms=timeout_ms)
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         raise TypeError(_NOT_CALLABLE_MESSAGE)

--- a/prime-agent-runtime/test/test_subagent_registry.py
+++ b/prime-agent-runtime/test/test_subagent_registry.py
@@ -239,3 +239,91 @@ class RlmSubagentRegistryTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class RlmCollectTest(unittest.TestCase):
+    def test_collect_all_children_returns_typed_results(self) -> None:
+        host_request = AsyncMock(
+            return_value={
+                "results": [
+                    {
+                        "rlm_child_id": "sub-a1b2c3d4",
+                        "session_name": "worker-a",
+                        "session_dir": "/tmp/parent/sub-a1b2c3d4",
+                        "status": "done",
+                        "settled": True,
+                        "answer_preview": "task finished cleanly",
+                        "error": None,
+                        "duration_ms": 4321,
+                        "tool_use_count": 3,
+                        "replied_since_task": False,
+                    },
+                    {
+                        "rlm_child_id": "sub-b2c3d4e5",
+                        "session_name": "worker-b",
+                        "session_dir": "/tmp/parent/sub-b2c3d4e5",
+                        "status": "running",
+                        "settled": False,
+                        "answer_preview": None,
+                        "error": None,
+                        "duration_ms": None,
+                        "tool_use_count": None,
+                        "replied_since_task": None,
+                    },
+                ]
+            }
+        )
+
+        with patch.object(rlm_module, "host_request", host_request):
+            results = asyncio.run(rlm_module.rlm.collect())
+
+        self.assertEqual(len(results), 2)
+        done = results[0]
+        self.assertEqual(done.rlm_child_id, "sub-a1b2c3d4")
+        self.assertEqual(done.session_name, "worker-a")
+        self.assertEqual(done.session_dir, Path("/tmp/parent/sub-a1b2c3d4"))
+        self.assertEqual(done.status, "done")
+        self.assertTrue(done.settled)
+        self.assertEqual(done.answer_preview, "task finished cleanly")
+        self.assertIsNone(done.error)
+        self.assertEqual(done.duration_ms, 4321)
+        self.assertEqual(done.tool_use_count, 3)
+        self.assertFalse(done.replied_since_task)
+        running = results[1]
+        self.assertEqual(running.status, "running")
+        self.assertFalse(running.settled)
+        self.assertIsNone(running.answer_preview)
+        host_request.assert_awaited_once_with("rlm.collect", {"targets": [], "timeout_ms": 0})
+
+    def test_collect_normalizes_spawn_handles_and_names(self) -> None:
+        host_request = AsyncMock(return_value={"results": []})
+        handle = rlm_module.RLMSpawnHandle(
+            rlm_child_id="sub-h1",
+            name="worker-h",
+            session_dir=Path("/tmp/parent/sub-h1"),
+            model="anthropic/claude-sonnet-4-5",
+        )
+
+        with patch.object(rlm_module, "host_request", host_request):
+            results = asyncio.run(rlm_module.rlm.collect([handle, "worker-b"], timeout_ms=250))
+
+        self.assertEqual(results, [])
+        host_request.assert_awaited_once_with(
+            "rlm.collect", {"targets": ["sub-h1", "worker-b"], "timeout_ms": 250}
+        )
+
+    def test_collect_validates_arguments(self) -> None:
+        with self.assertRaisesRegex(TypeError, "timeout_ms"):
+            asyncio.run(rlm_module.rlm.collect(timeout_ms=-1))
+        with self.assertRaisesRegex(TypeError, "timeout_ms"):
+            asyncio.run(rlm_module.rlm.collect(timeout_ms="soon"))
+        with self.assertRaisesRegex(TypeError, "targets must be"):
+            asyncio.run(rlm_module.rlm.collect(42))
+        with self.assertRaisesRegex(TypeError, "collect target"):
+            asyncio.run(rlm_module.rlm.collect(["ok", ""]))
+
+    def test_collect_rejects_invalid_payloads(self) -> None:
+        host_request = AsyncMock(return_value={"results": [{"rlm_child_id": "sub-x", "status": "nonsense"}]})
+
+        with patch.object(rlm_module, "host_request", host_request):
+            with self.assertRaisesRegex(RuntimeError, "invalid status"):
+                asyncio.run(rlm_module.rlm.collect())


### PR DESCRIPTION
## What

`rlm.spawn` returns admission data only (`rlm_child_id`, name, session_dir, model). Results come back as free-text steering messages or file conventions, and the parent has no awaitable completion primitive in Python — it must poll `agent_observe`/`list_subagents` (rate-limited reads). A fan-out of N children spends N message-cap slots (16,384 chars each) or N file reads, and completion detection burns roster roundtrips to learn nothing more than "done".

## Change

Add **`rlm.collect`** — typed, non-steering fan-in built on the existing `RlmChildRun.settlement` deferred (which the detached run loop already resolves in its terminal path):

- `collectRlmChildren(targets, timeoutMs)` resolves direct children by child id, session id, or session name (empty list = every direct child not being deleted), awaits their settlement deferreds with a bounded timeout, and returns per-child result envelopes: `{rlm_child_id, session_name, session_dir, status, settled, answer_preview, error, duration_ms, tool_use_count, replied_since_task}` — reusing the existing `RlmChildAgentSnapshot` builder, no new accounting surface.
- **Never steers the parent, never rejects on timeout.** A timeout returns current snapshots so the caller can end its turn, poll, or retry. `timeout_ms=0` is a guaranteed non-blocking read.
- Completed children keep their envelope until deleted, so re-collecting after a compaction is free.
- Host handler `rlm.collect` wired in `_createKernelHostHandlers` with strict payload validation. Python: `await rlm.collect(targets=None, timeout_ms=0)` accepts spawn handles, subagent rows, name strings, or a list mixing all three; `None` selects every direct child.
- Subagent doctrine updated in `core/prompts/rlm.ts`: prefer `collect` for structured fan-in; large child outputs still belong in files (collect previews are compact by design).

## Tests

- `packages/coding-agent/test/rlm-collect.test.ts` (new, 5 tests): real `AgentSession` with a stubbed streamFn — genuine spawn then collect returns a settled typed envelope with the child's answer; collect-all covers every direct child; zero-timeout returns a non-blocking snapshot; unknown selectors throw; host payload validation (bad targets / negative or non-numeric timeout).
- `prime-agent-runtime/test/test_subagent_registry.py` (+4 tests): payload→`RLMChildResult` parsing, selector normalization (handle/name/list), argument validation, invalid payload rejection.
- Adjacent suites (`acp-rlm-subagents`, `rlm-subagent-display`, `slash-commands`) pass; biome + `tsgo --noEmit` clean; the runtime unittest suite passes except two failures that reproduce on stock `main` in this environment (live-kernel interference, unrelated).

Fixes ENG-6088

---
*This PR was authored autonomously as part of a recursive self-improvement program (RSI).*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core RLM parent/child orchestration in `AgentSession`, but the API is read/wait-only (no parent steering) and is covered by new integration tests.
> 
> **Overview**
> Adds **`rlm.collect`**, a typed, non-steering way for the parent to gather direct child outcomes instead of relying on steering messages or file-only fan-in.
> 
> The coding-agent exposes **`collectRlmChildren`** and a kernel **`rlm.collect`** host handler: callers select children by id or session name (empty targets = all non-deleting direct children), optionally wait up to **`timeout_ms`**, and get per-child envelopes (status, settled, answer preview, error, duration, tool count). Timeouts return current snapshots rather than failing; settled runs remain readable from retained child state after terminal cleanup. RLM prompt guidance now recommends **`collect`** for structured fan-in while keeping files for large outputs.
> 
> The Python runtime adds **`RLMChildResult`**, **`collect()`**, and **`rlm.collect`**, with selector normalization for spawn handles, subagent rows, and name strings. New Vitest and unittest coverage exercises settlement, collect-all, re-collect after cleanup, timeout polling, selector errors, and payload validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b65df2e76ccb5ac1f5f6355e51039f01982e0de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add typed `rlm.collect` fan-in for direct-child subagent results
> - Adds `AgentSession.collectRlmChildren` in [agent-session.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2223/files#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448ae), which collects status, settlement state, answer preview, error, duration, tool count, and reply state for selected direct children, including retained terminal children.
> - Adds the `rlm.collect` host handler adapter in [rlm-runtime.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2223/files#diff-e2f3586cb159b174f953a03ce37d872c059275b629a160203d8ef5c8db5d30e7) that validates targets and timeout, then delegates to the session-level collector.
> - Exposes `rlm.collect(...)` on the Python namespace in [__init__.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/2223/files#diff-8f05bb028ac34c9ff421f45f913f35be2a99010ef924da344d7a427869c7ead3), returning validated `RLMChildResult` objects; invalid payloads raise `RuntimeError`.
> - Updates subagent delegation guidance in [rlm.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2223/files#diff-64c77a41480409e73a6d87d381a618f83c44304c3677d755b3ef66d7a5ddce29) to direct the model to use `collect` for fan-in and read large outputs from files rather than treating collection previews as full results.
> - Behavioral Change: `rlm.collect` with a positive timeout waits up to the deadline for unsettled children and returns current snapshots instead of rejecting on timeout; unknown or ambiguous selectors throw errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b65df2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->