### PR TITLE
fix(coding-agent): preserve session consent environment

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Fixed daemon sessions and nested workers losing an explicitly configured Slack consent mode, without inheriting consent from the daemon environment.
+
 ## [0.9.4] - 2026-09-08
 
 - A Python kernel that dies after a successful startup is restarted on the next use instead of every call being handed the dead kernel forever, and skill-MCP tools advertise their real input schemas again under mcp>=2 (the SDK renamed the field to input_schema).

--- a/packages/coding-agent/docs/daemon.md
+++ b/packages/coding-agent/docs/daemon.md
@@ -164,3 +164,35 @@ PRIME_AGENT_STRESS_WORKERS=50 npx tsx ../../node_modules/vitest/dist/cli.js --ru
 ```
 
 The benchmark compares fanout and attach paths, including serialization count, throughput, elapsed time, and sampled RSS. The stress case starts many resident roots and verifies that their schedules advance independently while sessions are busy.
+
+
+## Session consent environment
+
+The local daemon client forwards the explicitly configured `PI_SLACK_CONSENT_MODE`
+through the existing allowlisted `create.env` payload. Prime transports this string;
+it does not interpret it or enable an approval mode by default. Unknown environment
+keys and non-string values are not accepted by this allowlist.
+
+The session captures its client environment. Active nested workers and hydrated
+children inherit their parent's captured environment. Extension loading and reloads
+run under that session environment; `pi.exec` receives an explicit per-session
+overlay. An absent consent value is never filled from the daemon's launch environment.
+
+Extension callbacks do not have exclusive ownership of `process.env`. Extensions
+that use this setting must capture it **inside their per-session factory**, then use
+the captured value in later tool or command callbacks. Reading it dynamically in a
+callback can see daemon ambient state or another extension-load window. Prime does
+not serialize long-running callbacks or consent waits to fake process isolation.
+
+Existing client-environment adoption rules are unchanged: an existing session with
+a captured environment does not refresh it on reconnect. To revoke an old mode,
+stop the old session and its children, then create a session with the desired mode.
+Creating a new session alone does not revoke the old session. Installing this change
+does not refresh already running code or existing session captures.
+
+The local daemon socket is an owner-level command interface, not an untrusted-client
+security sandbox. An authorized socket client can explicitly supply the consent
+string, just as it can create sessions and run commands. Filtering rejects malformed
+or unrelated environment fields; it does not authenticate an owner decision. Do not
+expose the socket to untrusted users. Extension approval policy remains the authority
+for interpreting a supplied mode.

--- a/packages/coding-agent/src/modes/daemon/daemon-client-env.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-client-env.ts
@@ -7,7 +7,7 @@ export function filterClientEnv(env?: Record<string, string>): Record<string, st
 	}
 	const filtered: Record<string, string> = {};
 	for (const key of DAEMON_CLIENT_ENV_KEYS) {
-		if (env[key] !== undefined) {
+		if (Object.hasOwn(env, key) && typeof env[key] === "string") {
 			filtered[key] = env[key];
 		}
 	}
@@ -18,7 +18,7 @@ export function filterClientEnv(env?: Record<string, string>): Record<string, st
 // can mutate process.env.
 const baseClientEnv: Record<string, string | undefined> = {};
 for (const key of DAEMON_CLIENT_ENV_KEYS) {
-	baseClientEnv[key] = process.env[key];
+	baseClientEnv[key] = key === "PI_SLACK_CONSENT_MODE" ? undefined : process.env[key];
 }
 
 /**
@@ -49,6 +49,15 @@ const activeShared = new Set<Promise<unknown>>();
  * this window the session's exec env covers subprocess reads.
  */
 export async function withClientEnv<T>(env: Record<string, string> | undefined, fn: () => Promise<T>): Promise<T> {
+	// Consent is session-owned, never inherited from the daemon. Use an exclusive
+	// window when ambient consent must be cleared; ordinary env-less loads stay shared.
+	if (!env && process.env.PI_SLACK_CONSENT_MODE !== undefined) {
+		env = {};
+		for (const key of DAEMON_CLIENT_ENV_KEYS) {
+			const value = baseClientEnv[key];
+			if (value !== undefined) env[key] = value;
+		}
+	}
 	if (!env) {
 		const gate = lastExclusive;
 		const run = (async () => {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -232,6 +232,7 @@ export const DAEMON_CLIENT_ENV_KEYS = [
 	"HERDR_SOCKET_PATH",
 	"HERDR_TAB_ID",
 	"HERDR_WORKSPACE_ID",
+	"PI_SLACK_CONSENT_MODE",
 ] as const;
 
 /** Collect the allowlisted env vars from the client process for the create command. */

--- a/packages/coding-agent/test/daemon-client-env.test.ts
+++ b/packages/coding-agent/test/daemon-client-env.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { execEnvForSession, filterClientEnv, withClientEnv } from "../src/modes/daemon/daemon-client-env.js";
+import { collectDaemonClientEnv } from "../src/modes/daemon/daemon-protocol.js";
 
 describe("filterClientEnv", () => {
 	it("keeps only allowlisted keys", () => {
@@ -96,6 +98,7 @@ describe("withClientEnv", () => {
 				HERDR_SOCKET_PATH: undefined,
 				HERDR_TAB_ID: undefined,
 				HERDR_WORKSPACE_ID: undefined,
+				PI_SLACK_CONSENT_MODE: undefined,
 			});
 		});
 	});
@@ -113,5 +116,59 @@ describe("withClientEnv", () => {
 		await Promise.all([envless, windowed]);
 		expect(order).toEqual(["envless:undefined", "windowed:b"]);
 		expect(process.env.HERDR_PANE_ID).toBeUndefined();
+	});
+});
+
+describe("session consent environment", () => {
+	afterEach(() => vi.unstubAllEnvs());
+
+	it.each(["local-auto-approve", "slack", "", undefined])(
+		"transports explicit mode %s without a default",
+		async (mode) => {
+			const source = mode === undefined ? {} : { PI_SLACK_CONSENT_MODE: mode };
+			const env = filterClientEnv(collectDaemonClientEnv(source));
+			vi.stubEnv("PI_SLACK_CONSENT_MODE", "daemon-ambient");
+			await withClientEnv(env, async () => {
+				expect(process.env.PI_SLACK_CONSENT_MODE).toBe(mode);
+				const output = execFileSync(
+					process.execPath,
+					["-e", "console.log(JSON.stringify(process.env.PI_SLACK_CONSENT_MODE ?? null))"],
+					{
+						env: { ...process.env, ...execEnvForSession(env) },
+						encoding: "utf8",
+					},
+				);
+				expect(JSON.parse(output)).toBe(mode ?? null);
+			});
+			expect(process.env.PI_SLACK_CONSENT_MODE).toBe("daemon-ambient");
+			expect(execEnvForSession().PI_SLACK_CONSENT_MODE).toBeUndefined();
+		},
+	);
+
+	it("isolates concurrent explicit and absent sessions and restores failures", async () => {
+		vi.stubEnv("PI_SLACK_CONSENT_MODE", "daemon-ambient");
+		const modes = ["local-auto-approve", undefined, "slack"];
+		await Promise.all(
+			modes.map((mode) =>
+				withClientEnv(mode === undefined ? undefined : { PI_SLACK_CONSENT_MODE: mode }, async () => {
+					await new Promise((resolve) => setTimeout(resolve, 5));
+					expect(process.env.PI_SLACK_CONSENT_MODE).toBe(mode);
+				}),
+			),
+		);
+		await expect(
+			withClientEnv({ PI_SLACK_CONSENT_MODE: "local-auto-approve" }, async () => {
+				throw new Error("fail");
+			}),
+		).rejects.toThrow("fail");
+		expect(process.env.PI_SLACK_CONSENT_MODE).toBe("daemon-ambient");
+	});
+
+	it("rejects unrelated, malformed and inherited socket environment fields", () => {
+		expect(
+			filterClientEnv(JSON.parse('{"PI_SLACK_CONSENT_MODE":true,"NODE_OPTIONS":"--inspect","PATH":"/evil"}')),
+		).toBeUndefined();
+		const inherited = Object.create({ PI_SLACK_CONSENT_MODE: "local-auto-approve" });
+		expect(filterClientEnv(inherited)).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/daemon-extension-binding.test.ts
+++ b/packages/coding-agent/test/daemon-extension-binding.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
 import type { AgentSession } from "../src/core/agent-session.js";
 import {
@@ -13,9 +14,10 @@ import {
 import { AuthStorage } from "../src/core/auth-storage.js";
 import type { AgentCronJob } from "../src/core/cron-jobs.js";
 import { SessionManager } from "../src/core/session-manager.js";
-import type { ExtensionAPI, ExtensionFactory } from "../src/index.js";
+import type { ExtensionAPI, ExtensionFactory, ToolDefinition } from "../src/index.js";
 import { createAgentConnectionState } from "../src/modes/agent-connection/snapshot.js";
 import type { ActiveSessionState } from "../src/modes/daemon/active-session-state.js";
+import { withClientEnv } from "../src/modes/daemon/daemon-client-env.js";
 import { bindActiveSessionState } from "../src/modes/daemon/daemon-extension-binding.js";
 import type { DaemonOutbound } from "../src/modes/daemon/daemon-protocol.js";
 import { conversationMessages } from "./suite/harness.js";
@@ -112,6 +114,65 @@ describe("daemon extension binding", () => {
 
 		return runtime;
 	}
+
+	it.each(["local-auto-approve", "slack", undefined])(
+		"preserves load-captured consent %s through extension commands and subprocesses",
+		async (mode) => {
+			const original = process.env.PI_SLACK_CONSENT_MODE;
+			process.env.PI_SLACK_CONSENT_MODE = "daemon-ambient";
+			try {
+				const seen: Array<string | undefined> = [];
+				const env = mode === undefined ? undefined : { PI_SLACK_CONSENT_MODE: mode };
+				const runtime = await withClientEnv(env, () =>
+					createRuntimeForTest((pi) => {
+						const capturedMode = process.env.PI_SLACK_CONSENT_MODE;
+						const tool = {
+							name: "consent_probe",
+							label: "Consent probe",
+							description: "test consent scope",
+							parameters: Type.Object({}),
+							execute: async () => {
+								seen.push(capturedMode);
+								// Callbacks do not own process.env: session-specific values must be captured at load.
+								expect(process.env.PI_SLACK_CONSENT_MODE).toBe("daemon-ambient");
+								const result = await pi.exec(process.execPath, [
+									"-e",
+									"console.log(JSON.stringify(process.env.PI_SLACK_CONSENT_MODE ?? null))",
+								]);
+								expect(result.code).toBe(0);
+								expect(JSON.parse(result.stdout)).toBe(mode ?? null);
+								return { content: [{ type: "text", text: "checked" }], details: {} };
+							},
+						} satisfies ToolDefinition;
+						pi.registerTool(tool);
+						pi.registerCommand("consent-probe", {
+							description: "run the registered tool without a model",
+							handler: async () => {
+								await tool.execute();
+							},
+						});
+					}, []),
+				);
+				const state: ActiveSessionState = {
+					activeSessionId: "consent-test",
+					runtime,
+					clients: new Set(),
+					pendingAttaches: 0,
+					extensionUiRequests: new Map(),
+					eventGeneration: "consent-generation",
+					lastEventSequence: 0,
+					clientEnv: mode === undefined ? undefined : { PI_SLACK_CONSENT_MODE: mode },
+				};
+				await bindActiveSessionState(state, { broadcast: () => {}, shutdown: () => {} });
+				await runtime.session.prompt("/consent-probe");
+				expect(seen).toEqual([mode]);
+				expect(process.env.PI_SLACK_CONSENT_MODE).toBe("daemon-ambient");
+			} finally {
+				if (original === undefined) delete process.env.PI_SLACK_CONSENT_MODE;
+				else process.env.PI_SLACK_CONSENT_MODE = original;
+			}
+		},
+	);
 
 	it("strips the duplicated partial message from broadcast message_update events", async () => {
 		const runtime = await createRuntimeForTest(() => {}, ["streamed reply"]);

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1082,67 +1082,79 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
-	it("plumbs semantic-edge ancestry into daemon-hosted child session options", async () => {
-		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-lineage-ancestry-"));
-		try {
-			const sessionDir = join(tempDir, "sessions");
-			const parentManager = SessionManager.create(tempDir, sessionDir);
-			parentManager.newSession();
-			parentManager.appendSessionInfo("parent");
-			const parentSessionFile = parentManager.getSessionFile();
-			if (!parentSessionFile) throw new Error("Missing parent session file");
-			const createRuntime = vi.fn(async (options: Parameters<CreateAgentSessionRuntimeFactory>[0]) => ({
-				session: makeRuntimeSession(options.sessionManager),
-				extensionsResult: { extensions: [], errors: [], runtime: {} } as unknown as Awaited<
-					ReturnType<CreateAgentSessionRuntimeFactory>
-				>["extensionsResult"],
-				services: { cwd: options.cwd, agentDir: options.agentDir } as Awaited<
-					ReturnType<CreateAgentSessionRuntimeFactory>
-				>["services"],
-				diagnostics: [],
-			}));
-			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
-				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir },
-				createRuntime,
-			});
-			const internals = daemon as unknown as {
-				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
-				createRlmSubagentRuntime(
-					parentState: ActiveSessionState,
-					options: CreateRlmSubagentRuntimeOptions,
-				): Promise<ActiveSessionState["runtime"]>;
-			};
-			const parentState = await internals.createRuntime({ type: "create", sessionPath: parentSessionFile });
-			const spawnedByRequestId = "b".repeat(32);
-			await internals.createRlmSubagentRuntime(parentState, {
-				parentSession: parentState.runtime.session,
-				id: "lineage-child",
-				prompt: "carry ancestry",
-				sessionName: "lineage-worker",
-				sessionDir: join(parentManager.getSessionArtifactDir()!, "lineage-child"),
-				model: { provider: "test", id: "model" } as Model<Api>,
-				thinkingLevel: "off",
-				serviceTier: null,
-				scopedModels: [],
-				activeToolNames: [],
-				customTools: [],
-				includeGoals: false,
-				includeCompactSkill: false,
-				rlmDepth: 1,
-				rlmMaxDepth: 4,
-				rlmParentNodeId: "lineage-child",
-				spawnedByRequestId,
-			});
+	it.each(["local-auto-approve", "slack", undefined])(
+		"plumbs ancestry and consent %s into daemon-hosted child session options",
+		async (mode) => {
+			const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-lineage-ancestry-"));
+			try {
+				const sessionDir = join(tempDir, "sessions");
+				const parentManager = SessionManager.create(tempDir, sessionDir);
+				parentManager.newSession();
+				parentManager.appendSessionInfo("parent");
+				const parentSessionFile = parentManager.getSessionFile();
+				if (!parentSessionFile) throw new Error("Missing parent session file");
+				const seen: Array<string | undefined> = [];
+				const createRuntime = vi.fn(async (options: Parameters<CreateAgentSessionRuntimeFactory>[0]) => {
+					seen.push(process.env.PI_SLACK_CONSENT_MODE);
+					return {
+						session: makeRuntimeSession(options.sessionManager),
+						extensionsResult: { extensions: [], errors: [], runtime: {} } as unknown as Awaited<
+							ReturnType<CreateAgentSessionRuntimeFactory>
+						>["extensionsResult"],
+						services: { cwd: options.cwd, agentDir: options.agentDir } as Awaited<
+							ReturnType<CreateAgentSessionRuntimeFactory>
+						>["services"],
+						diagnostics: [],
+					};
+				});
+				const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+					defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir },
+					createRuntime,
+				});
+				const internals = daemon as unknown as {
+					createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+					createRlmSubagentRuntime(
+						parentState: ActiveSessionState,
+						options: CreateRlmSubagentRuntimeOptions,
+					): Promise<ActiveSessionState["runtime"]>;
+				};
+				const parentState = await internals.createRuntime({
+					type: "create",
+					sessionPath: parentSessionFile,
+					env: mode === undefined ? undefined : { PI_SLACK_CONSENT_MODE: mode },
+				});
+				const spawnedByRequestId = "b".repeat(32);
+				await internals.createRlmSubagentRuntime(parentState, {
+					parentSession: parentState.runtime.session,
+					id: "lineage-child",
+					prompt: "carry ancestry",
+					sessionName: "lineage-worker",
+					sessionDir: join(parentManager.getSessionArtifactDir()!, "lineage-child"),
+					model: { provider: "test", id: "model" } as Model<Api>,
+					thinkingLevel: "off",
+					serviceTier: null,
+					scopedModels: [],
+					activeToolNames: [],
+					customTools: [],
+					includeGoals: false,
+					includeCompactSkill: false,
+					rlmDepth: 1,
+					rlmMaxDepth: 4,
+					rlmParentNodeId: "lineage-child",
+					spawnedByRequestId,
+				});
 
-			const childCreate = createRuntime.mock.calls.at(-1)?.[0];
-			expect(childCreate?.sessionOptions).toMatchObject({
-				semanticParentSessionId: parentState.runtime.session.sessionId,
-				semanticSpawnedByRequestId: spawnedByRequestId,
-			});
-		} finally {
-			rmSync(tempDir, { recursive: true, force: true });
-		}
-	});
+				expect(seen).toEqual([mode, mode]);
+				const childCreate = createRuntime.mock.calls.at(-1)?.[0];
+				expect(childCreate?.sessionOptions).toMatchObject({
+					semanticParentSessionId: parentState.runtime.session.sessionId,
+					semanticSpawnedByRequestId: spawnedByRequestId,
+				});
+			} finally {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		},
+	);
 	it("discovers a non-resident child left running in the persisted registry", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-orphan-running-child-"));
 		try {
@@ -5907,6 +5919,42 @@ describe("daemon mode helpers", () => {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
 	});
+
+	it.each(["local-auto-approve", "slack", undefined])(
+		"inherits session consent %s when hydrating a nested worker",
+		async (mode) => {
+			const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-consent-"));
+			const original = process.env.PI_SLACK_CONSENT_MODE;
+			process.env.PI_SLACK_CONSENT_MODE = "daemon-ambient";
+			try {
+				const fixture = makePersistedRlmDaemonFixture(tempDir);
+				const seen: Array<string | undefined> = [];
+				const factory = fixture.createRuntime.getMockImplementation();
+				if (!factory) throw new Error("Missing fixture runtime factory");
+				fixture.createRuntime.mockImplementation(async (options) => {
+					seen.push(process.env.PI_SLACK_CONSENT_MODE);
+					return factory(options);
+				});
+				const internals = fixture.daemon as unknown as {
+					createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				};
+				const parent = await internals.createRuntime({
+					type: "create",
+					sessionPath: fixture.parentSessionFile,
+					env: mode === undefined ? undefined : { PI_SLACK_CONSENT_MODE: mode },
+				});
+				const child = await internals.createRuntime({ type: "create", sessionPath: fixture.childSessionFile });
+				expect(parent.clientEnv?.PI_SLACK_CONSENT_MODE).toBe(mode);
+				expect(child.clientEnv?.PI_SLACK_CONSENT_MODE).toBe(mode);
+				expect(seen).toEqual([mode, mode]);
+				expect(process.env.PI_SLACK_CONSENT_MODE).toBe("daemon-ambient");
+			} finally {
+				if (original === undefined) delete process.env.PI_SLACK_CONSENT_MODE;
+				else process.env.PI_SLACK_CONSENT_MODE = original;
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		},
+	);
 
 	it("loads a passive child under the create command client env", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-passive-create-env-"));


### PR DESCRIPTION
## Summary
- Forward explicit `PI_SLACK_CONSENT_MODE` through the existing local client allowlist and parent/child environment capture.
- Exclude daemon-ambient consent from env-less extension loads and subprocess overlays; retain normal shared env-less loading.
- Reject inherited/non-string allowlisted client payload fields. No consent default, arbitrary env forwarding, or callback-wide serialization.

## Boundaries
Extensions must capture this value inside their per-session factory, then use the captured value in tool callbacks. Dynamic callback `process.env` reads are not session-isolated; a deterministic probe confirmed that boundary. The companion bridge fix is Eleiris-Pi-Ecosystem/pi-slack#147. The local socket remains an owner-level command interface, not an untrusted-client sandbox.

Existing adoption semantics are unchanged. Reconnecting does not refresh a captured environment. Revocation requires stopping the old session and children, then creating a session with the desired mode. This PR does not install/restart anything or refresh existing sessions.

## Prior art
#1439 is closed, not merged; its existing `tamikomssi:feat/slack-session-env` branch forwards Slack path fields, not consent. This PR does not include those path changes or claim per-session path transport.

## Validation
- `npm run check` passes (Biome, typecheck, Linear-ticket/installer/browser-smoke checks).
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/daemon-client-env.test.ts test/daemon-extension-binding.test.ts`: 20 passed.
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/daemon-mode.test.ts -t "consent|client env|client-env"`: 8 passed, 201 skipped.
- `PI_SLACK_CONSENT_MODE=local-auto-approve npx tsx ../../node_modules/vitest/dist/cli.js --run test/daemon-client-env.test.ts`: 15 passed.

Tests cover explicit autoapprove, other/empty/absent values, daemon-ambient exclusion including startup, concurrent sessions, active child creation, passive hydration, real extension factory capture and registered tool callback plus actual `pi.exec` subprocesses. No model, live Slack, live daemon or customer-data action. Full daemon-mode suite was stopped when the initial dynamic-callback probe failed; no full-suite pass claimed.


## Subprocess-path follow-up
The initial exact-risk review passed at 9faed51a96bddbd54157bbdabe25d930bd6dd5ea but identified another spawn path to inspect. Default daemon tools use the lazy Python kernel, not the exported legacy bash tool. The follow-up reuses the existing per-session exec provider at kernel spawn, after runtime binding; RLM identity/runtime paths take precedence over the overlay. No global process.env mutation and no new consent semantics.

- Unit/integration cohort including `test/ipython-provisioner.test.ts`: **42 passed**.
- Actual existing Python kernel (`~/.prime/agent/kernel-venv/bin/python`) with temporary isolated cwd, then actual `rlm.bash()` subprocess: **3/3 passed** for local-auto-approve/slack/absence under daemon ambient consent. Each kernel disposed. No dependency install/model/live daemon action. This is a bounded local runtime smoke, not installed-release activation.
- Paired real bridge factory/tool callbacks against pi-slack147 head59be9aa935c96169be686468674b152c370cc0d3 plus these unchanged upstream env/protocol source hashes: **6/6 passed**. Synthetic config/state only. No remote daemon transport claim from the paired helper layer.
