### PR TITLE
[RSI] Track kernel-performed file edits in compaction summaries

### DIFF
--- a/packages/coding-agent/.changes/eng-6090-compaction-kernel-file-ops.md
+++ b/packages/coding-agent/.changes/eng-6090-compaction-kernel-file-ops.md
@@ -1,0 +1,1 @@
+- Fixed compaction summaries never recording kernel-performed file edits: ipython tool results now contribute their structured edit diffs to the tracked file operations, so `<modified-files>` reflects the default toolset's edits.

--- a/packages/coding-agent/src/core/compaction/utils.ts
+++ b/packages/coding-agent/src/core/compaction/utils.ts
@@ -19,9 +19,14 @@ export function createFileOps(): FileOperations {
 }
 
 /**
- * Extract file operations from tool calls in an assistant message.
+ * Extract file operations from tool calls in an assistant message and from
+ * structured tool results.
  */
 export function extractFileOpsFromMessage(message: AgentMessage, fileOps: FileOperations): void {
+	if (message.role === "toolResult") {
+		extractFileOpsFromToolResult(message, fileOps);
+		return;
+	}
 	if (message.role !== "assistant") return;
 	if (!("content" in message) || !Array.isArray(message.content)) return;
 
@@ -41,6 +46,30 @@ export function extractFileOpsFromMessage(message: AgentMessage, fileOps: FileOp
 				fileOps.edited.add(path);
 				break;
 		}
+	}
+}
+
+/**
+ * Extract file operations from a tool result message.
+ *
+ * The default toolset routes file edits through the ipython kernel: the
+ * kernel's edit skill reports structured diff displays (path, oldStr, newStr)
+ * that ride on the tool result's details, and no assistant-side tool call
+ * ever carries the path. Without this branch, compaction summaries never
+ * learn about kernel-performed edits and <modified-files> stays empty in the
+ * default configuration.
+ */
+function extractFileOpsFromToolResult(message: AgentMessage, fileOps: FileOperations): void {
+	if (message.role !== "toolResult" || message.toolName !== "ipython") return;
+	const details =
+		typeof message.details === "object" && message.details !== null && !Array.isArray(message.details)
+			? (message.details as Record<string, unknown>)
+			: {};
+	const diffs = Array.isArray(details.diffs) ? details.diffs : [];
+	for (const diff of diffs) {
+		if (typeof diff !== "object" || diff === null || Array.isArray(diff)) continue;
+		const path = (diff as Record<string, unknown>).path;
+		if (typeof path === "string" && path) fileOps.edited.add(path);
 	}
 }
 

--- a/packages/coding-agent/src/core/compaction/utils.ts
+++ b/packages/coding-agent/src/core/compaction/utils.ts
@@ -74,13 +74,23 @@ function extractFileOpsFromToolResult(message: AgentMessage, fileOps: FileOperat
 }
 
 /**
+ * Maximum files kept per summary block, so a single oversized kernel
+ * result cannot produce a file list larger than the model context limit.
+ */
+const FILE_LIST_MAX_ENTRIES = 200;
+
+/**
  * Compute final file lists from file operations.
  * Returns readFiles (files only read, not modified) and modifiedFiles.
+ * Both lists are capped at FILE_LIST_MAX_ENTRIES (sorted, then truncated).
  */
 export function computeFileLists(fileOps: FileOperations): { readFiles: string[]; modifiedFiles: string[] } {
 	const modified = new Set([...fileOps.edited, ...fileOps.written]);
-	const readOnly = [...fileOps.read].filter((f) => !modified.has(f)).sort();
-	const modifiedFiles = [...modified].sort();
+	const readOnly = [...fileOps.read]
+		.filter((f) => !modified.has(f))
+		.sort()
+		.slice(0, FILE_LIST_MAX_ENTRIES);
+	const modifiedFiles = [...modified].sort().slice(0, FILE_LIST_MAX_ENTRIES);
 	return { readFiles: readOnly, modifiedFiles };
 }
 

--- a/packages/coding-agent/test/compaction-file-ops.test.ts
+++ b/packages/coding-agent/test/compaction-file-ops.test.ts
@@ -68,6 +68,23 @@ describe("compaction file-op extraction", () => {
 		expect(fileOps.edited.size).toBe(0);
 	});
 
+	it("caps kernel file lists to keep summary blocks bounded", () => {
+		const fileOps = createFileOps();
+		const diffs = Array.from({ length: 250 }, (_, i) => ({
+			path: `pkg/file-${String(i).padStart(3, "0")}.ts`,
+			oldStr: "a",
+			newStr: "b",
+		}));
+		extractFileOpsFromMessage(toolResult({ diffs }) as never, fileOps);
+		const { readFiles, modifiedFiles } = computeFileLists(fileOps);
+		expect(modifiedFiles).toHaveLength(200);
+		expect(modifiedFiles[0]).toBe("pkg/file-000.ts");
+		expect(modifiedFiles[199]).toBe("pkg/file-199.ts");
+		expect(modifiedFiles).not.toContain("pkg/file-249.ts");
+		const summary = formatFileOperations(readFiles, modifiedFiles);
+		expect(summary).not.toContain("pkg/file-249.ts");
+	});
+
 	it("feeds kernel edits into modified-files for summaries", () => {
 		const fileOps = createFileOps();
 		extractFileOpsFromMessage(

--- a/packages/coding-agent/test/compaction-file-ops.test.ts
+++ b/packages/coding-agent/test/compaction-file-ops.test.ts
@@ -1,0 +1,84 @@
+import type { AssistantMessage, ToolResultMessage, Usage } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import {
+	computeFileLists,
+	createFileOps,
+	extractFileOpsFromMessage,
+	formatFileOperations,
+} from "../src/core/compaction/utils.js";
+
+const usage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function assistant(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "test",
+		provider: "test",
+		model: "test",
+		usage,
+		stopReason: "toolUse",
+		timestamp: 0,
+	};
+}
+
+function toolResult(details: unknown, toolName = "ipython"): ToolResultMessage {
+	return { role: "toolResult", toolCallId: "call-1", toolName, content: [], details, isError: false, timestamp: 0 };
+}
+
+function toolCall(name: string, args: Record<string, unknown>) {
+	return { type: "toolCall", id: "call-1", name, arguments: args } as const;
+}
+
+describe("compaction file-op extraction", () => {
+	it("records native edit tool calls", () => {
+		const fileOps = createFileOps();
+		extractFileOpsFromMessage(assistant([toolCall("edit", { path: "src/native-edit.ts" })]) as never, fileOps);
+		expect([...fileOps.edited]).toEqual(["src/native-edit.ts"]);
+	});
+
+	it("records kernel-reported edits from ipython tool results", () => {
+		const fileOps = createFileOps();
+		extractFileOpsFromMessage(
+			toolResult({
+				status: "ok",
+				diffs: [
+					{ path: "pkg/a.ts", oldStr: "x", newStr: "y" },
+					{ path: "pkg/b.ts", oldStr: "x", newStr: "y" },
+				],
+			}) as never,
+			fileOps,
+		);
+		expect([...fileOps.edited]).toEqual(["pkg/a.ts", "pkg/b.ts"]);
+	});
+
+	it("ignores non-ipython tool results and malformed diff payloads", () => {
+		const fileOps = createFileOps();
+		extractFileOpsFromMessage(toolResult({ diffs: [{ path: "pkg/c.ts" }] }, "bash") as never, fileOps);
+		extractFileOpsFromMessage(toolResult({ diffs: "not-an-array" }) as never, fileOps);
+		extractFileOpsFromMessage(toolResult({ diffs: [{ noPath: true }, { path: 42 }, null] }) as never, fileOps);
+		extractFileOpsFromMessage(toolResult(undefined) as never, fileOps);
+		expect(fileOps.edited.size).toBe(0);
+	});
+
+	it("feeds kernel edits into modified-files for summaries", () => {
+		const fileOps = createFileOps();
+		extractFileOpsFromMessage(
+			toolResult({ diffs: [{ path: "src/kernel-edit.ts", oldStr: "a", newStr: "b" }] }) as never,
+			fileOps,
+		);
+		const { readFiles, modifiedFiles } = computeFileLists(fileOps);
+		expect(readFiles).toEqual([]);
+		expect(modifiedFiles).toEqual(["src/kernel-edit.ts"]);
+		expect(formatFileOperations(readFiles, modifiedFiles)).toContain(
+			"<modified-files>\nsrc/kernel-edit.ts\n</modified-files>",
+		);
+	});
+});


### PR DESCRIPTION
## What

`extractFileOpsFromMessage` only scanned assistant-side tool calls matching the native `edit` tool (`name === "edit"` + `args.path`). The default toolset routes file work through the **ipython kernel**: the kernel's edit skill reports structured diff displays (`path`, `oldStr`, `newStr`) that ride on the ipython tool *result's* `details`, and no assistant-side tool call ever carries the path.

Consequence: in default sessions, the `read`/`written`/`edited` sets were only ever seeded from prior compaction details — which themselves start empty — so `<read-files>` and `<modified-files>` never rendered in compaction summaries. The summarizer lost the file-orientation context these blocks exist to provide, across every compaction of every default session.

## Change

`extractFileOpsFromMessage` now also consumes `toolResult` messages: for ipython results, `details.diffs[].path` is recorded into `fileOps.edited`. The existing cumulative chain (compaction details → next compaction) then preserves kernel edits across compactions.

- Native `edit` tool scanning unchanged.
- Live file reads remain intentionally uncaptured: parsing arbitrary Python for reads is brittle; the structured diff channel is the only kernel signal that can be trusted. `<read-files>` stays structurally supported for other sources.

## Tests

`compaction-file-ops.test.ts` (new, 4 tests): native edit calls still recorded; kernel diffs recorded from ipython results; malformed payloads (non-array diffs, missing/non-string paths, wrong tool, missing details) ignored without crashing; kernel edits flow end-to-end into `<modified-files>` via `computeFileLists` + `formatFileOperations`. Adjacent compaction suites (serialization, compaction, edit-summary) pass; biome + `tsgo --noEmit` clean.

Fixes ENG-6090

---
*This PR was authored autonomously as part of a recursive self-improvement program (RSI).*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to compaction summary metadata; wrong ipython diff paths could appear in modified-files lists but do not change file I/O or auth.
> 
> **Overview**
> Fixes compaction summaries omitting file edits when the default toolset routes edits through the **ipython** kernel instead of native `edit` tool calls.
> 
> **`extractFileOpsFromMessage`** now handles `toolResult` messages: for ipython results, paths from **`details.diffs`** are added to **`fileOps.edited`**, so **`<modified-files>`** is populated in default sessions. Native **`edit`** tool-call scanning is unchanged; malformed or non-ipython payloads are ignored safely.
> 
> **`computeFileLists`** caps read and modified file lists at **200** entries (sorted, then truncated) so huge kernel diff batches cannot blow the summarizer context.
> 
> New **`compaction-file-ops.test.ts`** covers native edits, kernel diffs, bad payloads, the cap, and end-to-end **`<modified-files>`** formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c3e53104b33416cbfc19daacbbf39d1ec761a93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track kernel file edits in compaction summaries and cap file lists at 200
> - Compaction now records edited file paths reported in ipython tool-result `details.diffs` arrays, in addition to paths from assistant native edit tool calls
> - Adds `extractFileOpsFromToolResult` in [utils.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2226/files#diff-11c0972a69b3843658c696c91bf76df9af12c08d058c42b47205f1d9e218226e) to parse ipython results; malformed entries (non-array diffs, non-string paths, null) are ignored
> - Both read-only and modified file lists are truncated to `FILE_LIST_MAX_ENTRIES` (200) after sorting in `computeFileLists`
> - Behavioral Change: compaction summaries now include kernel-edited files and will never list more than 200 entries per category; consumers that relied on unbounded lists or kernel edits being absent will see different output
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c3e531.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->