### PR TITLE
[RSI] Fix agent-traces CI flake: flush upload stragglers before temp-dir cleanup

### DIFF
--- a/packages/coding-agent/test/agent-traces.test.ts
+++ b/packages/coding-agent/test/agent-traces.test.ts
@@ -149,7 +149,30 @@ describe("agent trace upload", () => {
 		delete process.env.PRIME_API_BASE_URL;
 	});
 
-	afterEach(() => {
+	// Fire-and-forget trace uploads keep writing under ENV_AGENT_DIR after the
+	// test body observes its effect and returns; a synchronous rmSync in
+	// afterEach races those straggler writes and failed two unrelated PRs'
+	// CI with ENOTEMPTY. Flush the async queue first, then retry the removal
+	// so a straggler window cannot fail the suite.
+	async function flushAsyncWork(): Promise<void> {
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+
+	async function rmTempDirSafely(dir: string): Promise<void> {
+		await flushAsyncWork();
+		for (let attempt = 1; attempt <= 3; attempt++) {
+			try {
+				rmSync(dir, { recursive: true, force: true });
+				return;
+			} catch (error) {
+				if (attempt === 3) throw error;
+				await new Promise<void>((resolve) => setTimeout(resolve, 10 * attempt));
+			}
+		}
+	}
+
+	afterEach(async () => {
 		vi.restoreAllMocks();
 		vi.useRealTimers();
 		if (originalAgentDir === undefined) {
@@ -178,7 +201,7 @@ describe("agent trace upload", () => {
 			process.env.PRIME_API_BASE_URL = originalPrimeBaseUrl;
 		}
 		if (tempDir && existsSync(tempDir)) {
-			rmSync(tempDir, { recursive: true, force: true });
+			await rmTempDirSafely(tempDir);
 		}
 	});
 

--- a/packages/coding-agent/test/agent-traces.test.ts
+++ b/packages/coding-agent/test/agent-traces.test.ts
@@ -149,11 +149,8 @@ describe("agent trace upload", () => {
 		delete process.env.PRIME_API_BASE_URL;
 	});
 
-	// Fire-and-forget trace uploads keep writing under ENV_AGENT_DIR after the
-	// test body observes its effect and returns; a synchronous rmSync in
-	// afterEach races those straggler writes and failed two unrelated PRs'
-	// CI with ENOTEMPTY. Flush the async queue first, then retry the removal
-	// so a straggler window cannot fail the suite.
+	// Fire-and-forget trace uploads can still be writing under ENV_AGENT_DIR
+	// when the test body returns, so cleanup flushes them and retries removal.
 	async function flushAsyncWork(): Promise<void> {
 		await new Promise<void>((resolve) => setImmediate(resolve));
 		await new Promise<void>((resolve) => setImmediate(resolve));
@@ -175,6 +172,11 @@ describe("agent trace upload", () => {
 	afterEach(async () => {
 		vi.restoreAllMocks();
 		vi.useRealTimers();
+		// Flush straggler uploads and remove the temp dir while ENV_AGENT_DIR
+		// still points at it, so late writes land inside the dir being removed.
+		if (tempDir && existsSync(tempDir)) {
+			await rmTempDirSafely(tempDir);
+		}
 		if (originalAgentDir === undefined) {
 			delete process.env[ENV_AGENT_DIR];
 		} else {
@@ -199,9 +201,6 @@ describe("agent trace upload", () => {
 			delete process.env.PRIME_API_BASE_URL;
 		} else {
 			process.env.PRIME_API_BASE_URL = originalPrimeBaseUrl;
-		}
-		if (tempDir && existsSync(tempDir)) {
-			await rmTempDirSafely(tempDir);
 		}
 	});
 

--- a/packages/coding-agent/test/agent-traces.test.ts
+++ b/packages/coding-agent/test/agent-traces.test.ts
@@ -172,35 +172,38 @@ describe("agent trace upload", () => {
 	afterEach(async () => {
 		vi.restoreAllMocks();
 		vi.useRealTimers();
-		// Flush straggler uploads and remove the temp dir while ENV_AGENT_DIR
-		// still points at it, so late writes land inside the dir being removed.
-		if (tempDir && existsSync(tempDir)) {
-			await rmTempDirSafely(tempDir);
-		}
-		if (originalAgentDir === undefined) {
-			delete process.env[ENV_AGENT_DIR];
-		} else {
-			process.env[ENV_AGENT_DIR] = originalAgentDir;
-		}
-		if (originalTraceApiKey === undefined) {
-			delete process.env.PRIME_AGENT_TRACES_API_KEY;
-		} else {
-			process.env.PRIME_AGENT_TRACES_API_KEY = originalTraceApiKey;
-		}
-		if (originalPrimeApiKey === undefined) {
-			delete process.env.PRIME_API_KEY;
-		} else {
-			process.env.PRIME_API_KEY = originalPrimeApiKey;
-		}
-		if (originalTraceBaseUrl === undefined) {
-			delete process.env.PRIME_AGENT_TRACES_BASE_URL;
-		} else {
-			process.env.PRIME_AGENT_TRACES_BASE_URL = originalTraceBaseUrl;
-		}
-		if (originalPrimeBaseUrl === undefined) {
-			delete process.env.PRIME_API_BASE_URL;
-		} else {
-			process.env.PRIME_API_BASE_URL = originalPrimeBaseUrl;
+		try {
+			// Flush straggler uploads and remove the temp dir while ENV_AGENT_DIR
+			// still points at it, so late writes land inside the dir being removed.
+			if (tempDir && existsSync(tempDir)) {
+				await rmTempDirSafely(tempDir);
+			}
+		} finally {
+			if (originalAgentDir === undefined) {
+				delete process.env[ENV_AGENT_DIR];
+			} else {
+				process.env[ENV_AGENT_DIR] = originalAgentDir;
+			}
+			if (originalTraceApiKey === undefined) {
+				delete process.env.PRIME_AGENT_TRACES_API_KEY;
+			} else {
+				process.env.PRIME_AGENT_TRACES_API_KEY = originalTraceApiKey;
+			}
+			if (originalPrimeApiKey === undefined) {
+				delete process.env.PRIME_API_KEY;
+			} else {
+				process.env.PRIME_API_KEY = originalPrimeApiKey;
+			}
+			if (originalTraceBaseUrl === undefined) {
+				delete process.env.PRIME_AGENT_TRACES_BASE_URL;
+			} else {
+				process.env.PRIME_AGENT_TRACES_BASE_URL = originalTraceBaseUrl;
+			}
+			if (originalPrimeBaseUrl === undefined) {
+				delete process.env.PRIME_API_BASE_URL;
+			} else {
+				process.env.PRIME_API_BASE_URL = originalPrimeBaseUrl;
+			}
 		}
 	});
 


### PR DESCRIPTION
## What

The agent-traces suite failed two unrelated PRs' CI on shard 3/3 with `ENOTEMPTY: directory not empty, rmdir '/tmp/agent-traces-test-*'` — PR #2215 and PR #2224, both passing on rerun. Each occurrence taxes an unrelated PR with a failed CI run and a manual rerun.

## Mechanism

`installAgentTraceUpload`'s controller runs uploads fire-and-forget (`void this.runScheduledUpload()`). The async continuation writes outbox/ledger entries under `ENV_AGENT_DIR` — the test's temp dir — *after* the test body has observed its effect (e.g. the mocked fetch call) and returned. The suite's `afterEach` then ran a synchronous `rmSync(tempDir, { recursive: true })` that raced those straggler writes: `rmSync` walks the tree, a straggler recreates a file behind the walk, and the final `rmdir` fails with ENOTEMPTY.

## Change (test-only)

Make the suite's `afterEach` async and harden the cleanup:

- Flush the async queue first (two `setImmediate` turns) so pending upload continuations land before removal.
- Retry `rmSync` up to three times with short waits, so a remaining straggler window cannot fail the suite.

No product behavior change. 43 tests green across three consecutive local runs; biome + `tsgo --noEmit` clean.

Fixes ENG-6091

---
*This PR was authored autonomously as part of a recursive self-improvement program (RSI).*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test teardown in agent-traces.test.ts; no runtime or product code paths are modified.
> 
> **Overview**
> Fixes intermittent CI failures (`ENOTEMPTY` when removing `/tmp/agent-traces-test-*`) caused by **fire-and-forget** trace uploads still writing under `ENV_AGENT_DIR` after the test body finishes.
> 
> The **`agent-traces.test.ts`** suite now uses an **async `afterEach`**: it removes the temp directory **before** restoring env vars (so late writes stay inside the dir being deleted), yields twice via **`flushAsyncWork`** so pending upload continuations can run, and **`rmTempDirSafely`** retries recursive `rmSync` up to three times with short backoff.
> 
> **Test-only** — no production behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9a330d9a95911a91e5169dd2ee38c80abb6c297. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix agent-traces CI flake: flush upload stragglers before temp-dir cleanup
> Test teardown now waits for pending fire-and-forget trace upload work before removing the temporary directory.
>
> - Adds `flushAsyncWork` helper that yields to the event loop twice via `setImmediate` so async uploads can progress.
> - Adds `rmTempDirSafely` helper that attempts recursive forced removal up to three times with increasing delays between retries.
> - Changes suite teardown from synchronous to asynchronous, moving cleanup into a try/finally block with environment restoration after directory removal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9a330d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->