### PR TITLE
[RSI] Stat-guarded edge cache for spawn-ledger reads

### DIFF
--- a/packages/coding-agent/.changes/eng-6093-rlm-ledger-edge-cache.md
+++ b/packages/coding-agent/.changes/eng-6093-rlm-ledger-edge-cache.md
@@ -1,0 +1,1 @@
+- Sped up roster and family resolution by caching the RLM spawn ledger's replayed edges behind a file-stat guard: unchanged files reuse the cached edges instead of re-reading and re-parsing the whole ledger, while any writer's append (this process or another daemon) still forces a fresh replay.

--- a/packages/coding-agent/src/modes/daemon/rlm-ledger.ts
+++ b/packages/coding-agent/src/modes/daemon/rlm-ledger.ts
@@ -732,14 +732,12 @@ export class RlmSpawnLedger {
 	}
 
 	/**
-	 * Replay the ledger behind a stat-guarded edge cache. Every roster and
-	 * family resolution replays, and each replay re-reads and re-parses the
-	 * whole file; reads outnumber writes by orders of magnitude. The
-	 * multi-writer contract is preserved: any writer's append changes the
-	 * file's size, mtime, or inode, forcing a fresh replay, so cross-process
-	 * staleness stays bounded to in-flight appends exactly as before - minus
-	 * the re-parse cost on the unchanged-file fast path. A missing file skips
-	 * the cache: replaySync owns that decision and returns empty.
+	 * Replay the ledger behind a stat-guarded edge cache: a file whose size,
+	 * mtime, and inode are unchanged reuses the cached edges instead of
+	 * re-parsing. Any append forces a fresh replay - appendRecord drops the
+	 * cache for our own writes, and another process's append changes the
+	 * stat - so staleness stays bounded to in-flight appends. A missing file
+	 * bypasses the cache and replays to an empty edge set.
 	 */
 	private replaySyncCached(): Map<string, RlmLedgerEdge> {
 		let snapshot: { size: number; mtimeMs: number; ino: number } | undefined;

--- a/packages/coding-agent/src/modes/daemon/rlm-ledger.ts
+++ b/packages/coding-agent/src/modes/daemon/rlm-ledger.ts
@@ -8,6 +8,7 @@ import {
 	openSync,
 	realpathSync,
 	rmSync,
+	statSync,
 	writeSync,
 } from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
@@ -301,6 +302,11 @@ export class RlmSpawnLedger {
 	private readonly canonicalSessionsDir: string;
 	private queue: Promise<unknown> = Promise.resolve();
 	private seedAttempted = false;
+	/** Last replay guarded by a file stat snapshot; see replaySyncCached(). */
+	private edgeCache?: {
+		stat: { size: number; mtimeMs: number; ino: number };
+		edges: Map<string, RlmLedgerEdge>;
+	};
 
 	constructor(
 		agentDir: string,
@@ -342,7 +348,7 @@ export class RlmSpawnLedger {
 	appendRenameByChildPath(child: string, name: string): Promise<void> {
 		return this.enqueue(() => {
 			const target = canonicalSessionPath(child);
-			for (const edge of this.replaySync().values()) {
+			for (const edge of this.replaySyncCached().values()) {
 				if (!edge.deleted && canonicalSessionPath(edge.child) === target) {
 					this.appendRecord({ v: 1, op: "rename", at: nowIso(), childId: edge.childId, child: target, name });
 				}
@@ -375,7 +381,9 @@ export class RlmSpawnLedger {
 	 * as cleanup retries.
 	 */
 	edges(includeDeleted = false): Promise<RlmLedgerEdge[]> {
-		return this.enqueue(() => [...this.replaySync().values()].filter((edge) => includeDeleted || !edge.deleted));
+		return this.enqueue(() =>
+			[...this.replaySyncCached().values()].filter((edge) => includeDeleted || !edge.deleted),
+		);
 	}
 
 	/**
@@ -394,7 +402,7 @@ export class RlmSpawnLedger {
 		return this.enqueue(async () => {
 			const target = canonicalSessionPath(sessionPath);
 			const family = await this.familyUnlocked();
-			const edges = [...this.replaySync().values()].filter((edge) => !edge.deleted);
+			const edges = [...this.replaySyncCached().values()].filter((edge) => !edge.deleted);
 			const parentByChild = new Map(
 				edges.map((edge) => [canonicalSessionPath(edge.child), canonicalSessionPath(edge.parent)]),
 			);
@@ -466,7 +474,7 @@ export class RlmSpawnLedger {
 		// Advisory, per-process: catches double-admission mistakes inside this
 		// daemon. It is NOT a global uniqueness guarantee — other processes
 		// append to the same file between our read and write.
-		for (const edge of this.replaySync().values()) {
+		for (const edge of this.replaySyncCached().values()) {
 			if (!edge.deleted && canonicalSessionPath(edge.child) === childPath && edge.childId !== input.childId) {
 				throw new Error(`RLM ledger: duplicate child session path ${childPath} (already ${edge.childId})`);
 			}
@@ -489,7 +497,7 @@ export class RlmSpawnLedger {
 	}
 
 	private async liveEdgesUnlocked(
-		edges = [...this.replaySync().values()].filter((edge) => !edge.deleted),
+		edges = [...this.replaySyncCached().values()].filter((edge) => !edge.deleted),
 	): Promise<RlmLedgerEdge[]> {
 		const statCache = new Map<string, boolean>();
 		const exists = async (path: string): Promise<boolean> => {
@@ -517,7 +525,7 @@ export class RlmSpawnLedger {
 		// One replay, one stat snapshot: byChild comes from the same alive set that emits child rows,
 		// so a child whose dead edge was reconciled away degrades to a root row instead of vanishing.
 		let alive: RlmLedgerEdge[] = await this.liveEdgesUnlocked(
-			[...this.replaySync().values()].filter((candidate) => !candidate.deleted),
+			[...this.replaySyncCached().values()].filter((candidate) => !candidate.deleted),
 		);
 		const byChild = new Map<string, RlmLedgerEdge>();
 		for (const edge of alive) {
@@ -718,6 +726,44 @@ export class RlmSpawnLedger {
 				{ v: 1, op: "meta", at: nowIso(), sessionsDir: this.canonicalSessionsDir } satisfies RlmLedgerMetaRecord,
 			],
 		});
+		// Our own writes must not be served stale from the stat-guarded cache;
+		// other processes' appends are caught by the stat guard itself.
+		this.edgeCache = undefined;
+	}
+
+	/**
+	 * Replay the ledger behind a stat-guarded edge cache. Every roster and
+	 * family resolution replays, and each replay re-reads and re-parses the
+	 * whole file; reads outnumber writes by orders of magnitude. The
+	 * multi-writer contract is preserved: any writer's append changes the
+	 * file's size, mtime, or inode, forcing a fresh replay, so cross-process
+	 * staleness stays bounded to in-flight appends exactly as before - minus
+	 * the re-parse cost on the unchanged-file fast path. A missing file skips
+	 * the cache: replaySync owns that decision and returns empty.
+	 */
+	private replaySyncCached(): Map<string, RlmLedgerEdge> {
+		let snapshot: { size: number; mtimeMs: number; ino: number } | undefined;
+		try {
+			const current = statSync(this.path);
+			snapshot = { size: current.size, mtimeMs: current.mtimeMs, ino: current.ino };
+		} catch {
+			snapshot = undefined;
+		}
+		const cache = this.edgeCache;
+		if (
+			snapshot !== undefined &&
+			cache !== undefined &&
+			cache.stat.size === snapshot.size &&
+			cache.stat.mtimeMs === snapshot.mtimeMs &&
+			cache.stat.ino === snapshot.ino
+		) {
+			return cache.edges;
+		}
+		const edges = this.replaySync();
+		if (snapshot !== undefined) {
+			this.edgeCache = { stat: snapshot, edges };
+		}
+		return edges;
 	}
 
 	private replaySync(): Map<string, RlmLedgerEdge> {

--- a/packages/coding-agent/test/rlm-ledger.test.ts
+++ b/packages/coding-agent/test/rlm-ledger.test.ts
@@ -108,6 +108,48 @@ describe("rlm spawn ledger", () => {
 		}
 	});
 
+	it("serves repeated reads through the stat-guarded cache without missing a rival writer's append", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-rlm-ledger-"));
+		try {
+			const { sessionsDir, parentFile } = makeRoots(root);
+			const ledger = new RlmSpawnLedger(root, sessionsDir);
+			await ledger.appendSpawn({
+				childId: "sub-11111111",
+				parent: parentFile,
+				child: join(root, "a.jsonl"),
+				depth: 1,
+				name: "worker-a",
+			});
+
+			// Prime the cache: a read, then an unchanged-file read.
+			const first = await ledger.edges();
+			expect(first).toHaveLength(1);
+			const cached = await ledger.edges();
+			expect(cached).toHaveLength(1);
+
+			// A rival daemon process appends to the same file directly; the
+			// stat guard must notice and force a fresh replay.
+			const rivalLine = `${JSON.stringify({
+				v: 1,
+				op: "spawn",
+				at: new Date().toISOString(),
+				childId: "sub-22222222",
+				parent: parentFile,
+				child: join(root, "b.jsonl"),
+				depth: 1,
+				name: "worker-b",
+			})}\n`;
+			const { appendFileSync } = await import("node:fs");
+			appendFileSync(ledger.ledgerPath, rivalLine, "utf8");
+
+			const afterRival = await ledger.edges();
+			expect(afterRival).toHaveLength(2);
+			expect(afterRival.map((edge) => edge.childId).sort()).toEqual(["sub-11111111", "sub-22222222"]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("rejects a duplicate canonical child path at append", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-rlm-ledger-dup-"));
 		try {


### PR DESCRIPTION
## What

`RlmSpawnLedger.replaySync` re-reads and re-parses the **entire** append-only ledger file on every read — and a single `family()` resolution calls it multiple times (edges, family, siblings, passive-descendant merge, seeding each replay). Reads outnumber writes by orders of magnitude: every roster read, family resolution, and name-uniqueness check replays. The ledger fails closed at 32 MiB / 100,000 records, so long-lived installations pay a full-file read + parse on every agent listing.

## Change

Add `replaySyncCached()`: stat the ledger file first; an unchanged `(size, mtimeMs, inode)` snapshot returns the cached edge map, any change forces a fresh replay. All six read-side call sites now use it.

The multi-writer contract is preserved by construction: the supervisor and each worker hold their own ledger instance over the same file, and **any** writer's append — ours or another process's — changes the file's stat, so cross-process staleness stays bounded to in-flight appends exactly as before, minus the re-parse cost on the unchanged-file fast path.

- Own appends invalidate directly in `appendRecord` (the single mutation choke point).
- A missing file bypasses the cache; `replaySync` owns that decision.
- Bounds checking stays a function of file content, so an unchanged stat cannot serve an out-of-bounds ledger.

## Tests

`rlm-ledger.test.ts` (+1, 29 total): a rival writer appends directly to the ledger file between two reads — the next read must see the new edge, proving the stat guard notices external writers (the critical multi-writer case). Full ledger suite plus `daemon-agent-roster` (53 tests) green; biome + `tsgo --noEmit` clean.

Fixes ENG-6093

---
*This PR was authored autonomously as part of a recursive self-improvement program (RSI).*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes how spawn topology is loaded on a hot multi-writer ledger path; correctness depends on stat-based invalidation and local cache clears staying aligned with external appends.
> 
> **Overview**
> **Speeds up roster and family resolution** by avoiding a full ledger re-read and re-parse on every edge lookup when the spawn ledger file has not changed.
> 
> `RlmSpawnLedger` now keeps an in-memory **stat-guarded edge cache** (`size`, `mtimeMs`, `inode`). The new `replaySyncCached()` returns the cached edge map when those stats match; otherwise it replays and refreshes the cache. **Local appends** clear the cache in `appendRecord`; **another process’s append** is detected when the file stat changes.
> 
> All read paths that previously called `replaySync()` directly—`edges`, `siblings`, rename/spawn validation, `liveEdges`, and `family`—now go through the cache. A regression test asserts that a rival daemon’s direct append is visible on the next read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e57b3c257d30f300999b30665abf7be48ad15f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add stat-guarded edge cache to `RlmSpawnLedger` for replayed ledger reads
> - Adds `replaySyncCached()` to [rlm-ledger.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2229/files#diff-9a37d17b18302358b04d20a1e73f03e0cca1588155de12c6d2cafd1b7f3c32b3), which snapshots the ledger file's size, modification time, and inode via `statSync()` and returns cached replayed edges when all three match.
> - Routes all edge-reading paths (`edges`, `siblings`, `appendSpawn` validator, `liveEdgesUnlocked`, `familyUnlocked`, `appendRenameByChildPath`) through the cache instead of calling `replaySync()` directly.
> - Clears `edgeCache` after every successful `appendRecord` so the next read performs a fresh replay.
> - Adds a test that primes the cache, simulates a rival daemon appending directly to the ledger file, and verifies the subsequent read detects the change and returns both child edges.
> - Behavioral Change: ledger reads now depend on `statSync()` accuracy to detect external appends; a stat that fails to update (e.g., network filesystem with coarse mtime/inode granularity) could serve stale edges.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e57b3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->