### PR TITLE
fix(side-question): keep the session thinking level for /btw

### DIFF
--- a/packages/coding-agent/.changes/btw-side-question-thinking.md
+++ b/packages/coding-agent/.changes/btw-side-question-thinking.md
@@ -1,0 +1,1 @@
+- Fixed `/btw` side questions discarding the main conversation's prompt cache by lowering the reasoning level: side questions now keep the session's thinking level, so providers whose cache keys include thinking parameters reuse the cached conversation.

--- a/packages/coding-agent/.changes/btw-side-question-tools.md
+++ b/packages/coding-agent/.changes/btw-side-question-tools.md
@@ -1,0 +1,1 @@
+- Changed `/btw` side questions to declare the session's tools without allowing their use: the request now matches the main conversation's cached prefix byte for byte (tools included), any tool call gets an error result instead of executing, and the side thread's first turn explains that it is a `/btw` side conversation with tools deactivated.

--- a/packages/coding-agent/src/core/side-question.ts
+++ b/packages/coding-agent/src/core/side-question.ts
@@ -6,7 +6,6 @@ import {
 	type ProviderRetryPolicy,
 } from "./provider-retry.js";
 import { unwrapSemanticEdgeStreamFn } from "./semantic-edges.js";
-import { getAuxiliaryThinkingLevel } from "./thinking-levels.js";
 
 export type SideQuestionStatus = "running" | "complete" | "cancelled" | "error";
 
@@ -97,7 +96,9 @@ export function startSideQuestion(
 			model,
 			systemPrompt: parent.state.systemPrompt,
 			messages: [...structuredClone(parent.state.messages), ...previousTurnMessages],
-			thinkingLevel: getAuxiliaryThinkingLevel(model, parent.state.thinkingLevel),
+			// Anthropic message-level caching keys on the thinking parameters, so a
+			// different level here would re-read the whole cloned conversation.
+			thinkingLevel: parent.state.thinkingLevel,
 			serviceTier: parent.state.serviceTier,
 			// Providers serialize the tool declarations ahead of the system prompt and
 			// messages, so an empty list here would miss the main thread's cache entirely.

--- a/packages/coding-agent/src/core/side-question.ts
+++ b/packages/coding-agent/src/core/side-question.ts
@@ -29,7 +29,12 @@ export interface SideQuestionRun {
 }
 
 const SIDE_QUESTION_INSTRUCTION =
-	"Answer this side question using only the conversation context above. Do not use tools. The user may send follow-up side questions; none of this side conversation is added to the main session.";
+	"The user asked this via `/btw` — a temporary side thread cloned from the main conversation to answer a question without interrupting the main work. Tools (including `ipython`) are deactivated in this side thread and return an error if called; answer using only the conversation context above. The user may send follow-up side questions. Nothing here is added to the main session, so don't start or plan main-session work from this thread.";
+
+const SIDE_QUESTION_TOOL_BLOCKED = "Tools are deactivated in this side thread. Answer from the conversation context.";
+
+/** Backstop for a model that keeps calling deactivated tools instead of answering. */
+const SIDE_QUESTION_MAX_TURNS = 3;
 
 function sideQuestionPrompt(question: string, isFirstTurn: boolean): string {
 	const body = isFirstTurn ? `${SIDE_QUESTION_INSTRUCTION}\n\n${question}` : question;
@@ -86,6 +91,7 @@ export function startSideQuestion(
 		} satisfies AssistantMessage,
 	]);
 
+	let turnCount = 0;
 	const sideAgent = new Agent({
 		initialState: {
 			model,
@@ -93,7 +99,10 @@ export function startSideQuestion(
 			messages: [...structuredClone(parent.state.messages), ...previousTurnMessages],
 			thinkingLevel: getAuxiliaryThinkingLevel(model, parent.state.thinkingLevel),
 			serviceTier: parent.state.serviceTier,
-			tools: [],
+			// Providers serialize the tool declarations ahead of the system prompt and
+			// messages, so an empty list here would miss the main thread's cache entirely.
+			// Execution is blocked in beforeToolCall instead.
+			tools: parent.state.tools,
 		},
 		convertToLlm: parent.convertToLlm,
 		transformContext: parent.transformContext,
@@ -102,13 +111,18 @@ export function startSideQuestion(
 		getApiKey: parent.getApiKey,
 		onPayload: parent.onPayload,
 		onResponse: parent.onResponse,
-		shouldStopAfterTurn: () => true,
+		beforeToolCall: async () => ({ block: true, reason: SIDE_QUESTION_TOOL_BLOCKED }),
+		shouldStopAfterTurn: ({ message }) => {
+			turnCount += 1;
+			return turnCount >= SIDE_QUESTION_MAX_TURNS || !message.content.some((block) => block.type === "toolCall");
+		},
 		sessionId: parent.sessionId,
 		thinkingBudgets: parent.thinkingBudgets,
 		transport: "sse",
 		toolExecution: parent.toolExecution,
 	});
 
+	const clonedMessageCount = sideAgent.state.messages.length;
 	let answer = "";
 	let abortRequested = false;
 	let started = false;
@@ -121,7 +135,8 @@ export function startSideQuestion(
 			return;
 		}
 		const nextAnswer = readAssistantText(event.message);
-		if (nextAnswer === answer) {
+		// A turn that only calls tools carries no text; keep the answer written so far.
+		if (!nextAnswer || nextAnswer === answer) {
 			return;
 		}
 		answer = nextAnswer;
@@ -149,8 +164,13 @@ export function startSideQuestion(
 						promptedOnce = true;
 						await sideAgent.prompt(prompt);
 					}
-					const last = sideAgent.state.messages.at(-1);
-					if (last?.role !== "assistant") {
+					// A turn-capped run can end on tool results, so the outcome of the run
+					// is its last assistant turn rather than its last message.
+					const last = sideAgent.state.messages
+						.slice(clonedMessageCount)
+						.filter((message) => message.role === "assistant")
+						.at(-1);
+					if (!last) {
 						throw new Error(sideAgent.state.errorMessage || "Side question produced no assistant message");
 					}
 					return last as AssistantMessage;

--- a/packages/coding-agent/test/suite/regressions/4509-side-questions.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4509-side-questions.test.ts
@@ -1,6 +1,8 @@
-import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { Container } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
+import { Type } from "typebox";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { type SideQuestionEvent, startSideQuestion } from "../../../src/core/side-question.js";
 import { AgentDaemon } from "../../../src/modes/daemon/daemon-mode.js";
@@ -23,7 +25,7 @@ describe("ENG-4509 side questions", () => {
 		initTheme("dark");
 	});
 
-	it("uses the current context without tools or session persistence", async () => {
+	it("uses the current context without session persistence", async () => {
 		const harness = await createHarness({ systemPrompt: "Remember relevant project context." });
 		try {
 			harness.setResponses([fauxAssistantMessage("The codename is kestrel.")]);
@@ -39,7 +41,6 @@ describe("ENG-4509 side questions", () => {
 			harness.setResponses([
 				(context, options) => {
 					expect(context.systemPrompt).toBe(systemPromptBefore);
-					expect(context.tools).toEqual([]);
 					expect(context.messages.map(getMessageText)).toEqual([
 						expect.stringContaining("The persistent memories produced across this session so far:"),
 						"The project codename is kestrel.",
@@ -89,10 +90,9 @@ describe("ENG-4509 side questions", () => {
 						"first side answer",
 						expect.stringContaining("Second side question?"),
 					]);
-					expect(context.tools).toEqual([]);
 					// The instruction is repeated only on the first side turn.
-					expect(texts[3]).toContain("Answer this side question");
-					expect(texts[5]).not.toContain("Answer this side question");
+					expect(texts[3]).toContain("asked this via `/btw`");
+					expect(texts[5]).not.toContain("asked this via `/btw`");
 					return fauxAssistantMessage("second side answer");
 				},
 			]);
@@ -110,6 +110,93 @@ describe("ENG-4509 side questions", () => {
 			await run.done;
 
 			expect(events.at(-1)).toMatchObject({ status: "complete", answer: "second side answer" });
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("sends the session's tool declarations but blocks their execution", async () => {
+		let executions = 0;
+		const probe: AgentTool = {
+			name: "probe",
+			label: "Probe",
+			description: "Records executions",
+			parameters: Type.Object({}),
+			execute: async () => {
+				executions += 1;
+				return { content: [{ type: "text", text: "executed" }], details: {} };
+			},
+		};
+		const harness = await createHarness({ tools: [probe] });
+		try {
+			let mainTools: unknown;
+			harness.setResponses([
+				(context) => {
+					mainTools = context.tools;
+					return fauxAssistantMessage("main answer");
+				},
+			]);
+			await harness.session.prompt("Main context message.");
+
+			let secondTurnTexts: string[] = [];
+			harness.setResponses([
+				(context) => {
+					// Providers serialize the tools ahead of the cached prefix, so the side
+					// request must declare the main thread's tools unchanged.
+					expect(context.tools).toEqual(mainTools);
+					return fauxAssistantMessage(fauxToolCall("probe", {}), { stopReason: "toolUse" });
+				},
+				(context) => {
+					secondTurnTexts = context.messages.map(getMessageText);
+					return fauxAssistantMessage("answered from context");
+				},
+			]);
+
+			const events: SideQuestionEvent[] = [];
+			const run = startSideQuestion(harness.session.agent, "tools-1", "Which tool would you use?", (event) => {
+				events.push(event);
+			});
+			await run.done;
+
+			expect(executions).toBe(0);
+			expect(secondTurnTexts.some((text) => text.includes("Tools are deactivated in this side thread"))).toBe(true);
+			expect(events.at(-1)).toMatchObject({ status: "complete", answer: "answered from context" });
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("stops after three turns when the model keeps calling tools", async () => {
+		const probe: AgentTool = {
+			name: "probe",
+			label: "Probe",
+			description: "Never executes",
+			parameters: Type.Object({}),
+			execute: async () => ({ content: [{ type: "text", text: "executed" }], details: {} }),
+		};
+		const harness = await createHarness({ tools: [probe] });
+		try {
+			harness.setResponses([fauxAssistantMessage("main answer")]);
+			await harness.session.prompt("Main context message.");
+
+			const callsBefore = harness.faux.state.callCount;
+			harness.setResponses([
+				fauxAssistantMessage([{ type: "text", text: "Checking." }, fauxToolCall("probe", {})], {
+					stopReason: "toolUse",
+				}),
+				fauxAssistantMessage(fauxToolCall("probe", {}), { stopReason: "toolUse" }),
+				fauxAssistantMessage(fauxToolCall("probe", {}), { stopReason: "toolUse" }),
+				fauxAssistantMessage("unreachable fourth turn"),
+			]);
+
+			const events: SideQuestionEvent[] = [];
+			const run = startSideQuestion(harness.session.agent, "tools-2", "Keep trying?", (event) => {
+				events.push(event);
+			});
+			await run.done;
+
+			expect(harness.faux.state.callCount - callsBefore).toBe(3);
+			expect(events.at(-1)).toMatchObject({ status: "complete", answer: "Checking." });
 		} finally {
 			harness.cleanup();
 		}
@@ -159,7 +246,6 @@ describe("ENG-4509 side questions", () => {
 					return fauxAssistantMessage("main complete");
 				},
 				(context) => {
-					expect(context.tools).toEqual([]);
 					expect(context.messages.map(getMessageText)).toEqual([
 						expect.stringContaining("The persistent memories produced across this session so far:"),
 						"Run the main task.",

--- a/packages/coding-agent/test/suite/regressions/6010-auxiliary-reasoning.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6010-auxiliary-reasoning.test.ts
@@ -70,11 +70,14 @@ describe("auxiliary reasoning settings", () => {
 		parent.state.thinkingLevel = testCase.parentLevel;
 		const parentMessages = structuredClone(parent.state.messages);
 		const observed: SimpleStreamOptions[] = [];
+		// Side questions reuse the main thread's prompt cache, so they keep the
+		// session level instead of the auxiliary clamp the first two calls use.
+		const expectedLevels: ThinkingLevel[] = [testCase.expectedLevel, testCase.expectedLevel, testCase.parentLevel];
 		harness.setResponses(
-			[JSON.stringify(proposal), JSON.stringify(review), "Side answer"].map((text) => (_context, options) => {
+			[JSON.stringify(proposal), JSON.stringify(review), "Side answer"].map((text, index) => (_context, options) => {
 				const request = options as SimpleStreamOptions;
 				observed.push(request);
-				if (request.reasoning !== testCase.expectedLevel) {
+				if (request.reasoning !== expectedLevels[index]) {
 					return fauxAssistantMessage("", {
 						stopReason: "error",
 						errorMessage: `Unsupported auxiliary reasoning: ${request.reasoning}`,
@@ -131,7 +134,7 @@ describe("auxiliary reasoning settings", () => {
 			noRetry,
 		).done;
 		expect(events.at(-1)).toMatchObject({ status: "complete", answer: "Side answer" });
-		expect(observed.map((options) => options.reasoning)).toEqual(Array(3).fill(testCase.expectedLevel));
+		expect(observed.map((options) => options.reasoning)).toEqual(expectedLevels);
 		expect(observed[0].maxTokens).toBe(testCase.expectedLevel === "off" ? 32_000 : model.maxTokens);
 		expect(observed[1].maxTokens).toBe(testCase.expectedLevel === "off" ? 4_096 : model.maxTokens);
 		expect(parent.state.thinkingLevel).toBe(testCase.parentLevel);


### PR DESCRIPTION
No-Ticket: side-question cache cost fix, discussed directly with snimu

`/btw` side questions clone the main conversation and send it to the model again. Today the side request also drops the thinking level to the cheap auxiliary level. On Anthropic-style APIs the thinking parameters are part of the message-level cache key, so a different level means the cloned conversation does not hit the cache: the first `/btw` on a long session re-reads the whole conversation at full input price instead of the much cheaper cache-read price.

This change sends the session's own thinking level for side questions, so the cache key for the cloned messages matches the main thread's requests.

Notes:
- No preference clamp is re-added. Providers already clamp the level per model at request time, exactly as they do for the main thread, so an unsupported level cannot be sent.
- `getAuxiliaryThinkingLevel` stays; refinement and auto-refine review still use it.
- Model-invisible change: the side thread still sees the same prompt, messages and (empty) tool list as before.

Test: `6010-auxiliary-reasoning.test.ts` now pins that the side question's request uses the session level while refinement and review keep the auxiliary level.

Validation (Prime sandbox): `npm run check` clean; `4509-side-questions.test.ts`, `6010-auxiliary-reasoning.test.ts`, `daemon-supervisor-side-question.test.ts` - 49 tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change to `/btw` cost and tool handling only; main session tools never execute in side threads, and reasoning may cost more than the old auxiliary level while cache savings offset input on long sessions.
> 
> **Overview**
> **`/btw` side questions now mirror the main session’s reasoning and tool declarations** so provider prompt caches (Anthropic-style keys on thinking params and tool prefixes) hit on the cloned conversation instead of forcing a full re-read at input price.
> 
> Side agents inherit the parent **thinking level** (no auxiliary clamp) and the parent **tool list**, while **`beforeToolCall` blocks every execution** with a fixed error message. The first-turn instruction explains `/btw`, deactivated tools, and that nothing feeds the main session. Runs can continue up to **three turns** when the model keeps attempting tools; completion picks the **last assistant message** in the side thread, and streaming keeps partial text when a turn is tool-only.
> 
> Regression coverage adds tool-declaration/blocking and turn-cap cases in `4509-side-questions.test.ts`, and `6010-auxiliary-reasoning.test.ts` expects auxiliary levels only for refinement/review—not side questions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7289eb3ffac92aa9a105c05b995de45b1fc8fc97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep session thinking level and tool declarations for `/btw` side questions
> - Side questions now use the parent session thinking level instead of an auxiliary lookup, so provider cache keys match the main conversation
> - Side questions receive the parent tool declarations but block every tool call through `beforeToolCall`, returning a fixed blocked-tool reason without executing tools
> - Side runs stop after three consecutive tool-call turns or when the assistant produces a non-tool response, whichever comes first
> - Answer updates now ignore assistant turns that contain no extracted text, so accumulated text is no longer wiped by tool-only updates
> - Behavioral Change: `sideQuestion.startSideQuestion` in [side-question.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2230/files#diff-854e565ab4c061597eb4ed5ef465f9735fd0b98ef7186bc8424f1df97bd18265) sends tool declarations to the provider and blocks execution; first-turn instruction wording is updated; repeated tool-request turns are bounded by a three-turn maximum
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7289eb3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->