### PR TITLE
Declare the session tools in /btw side questions and block their use

### DIFF
--- a/packages/coding-agent/.changes/btw-side-question-tools.md
+++ b/packages/coding-agent/.changes/btw-side-question-tools.md
@@ -1,0 +1,1 @@
+- Changed `/btw` side questions to declare the session's tools without allowing their use: the request now matches the main conversation's cached prefix byte for byte (tools included), any tool call gets an error result instead of executing, and the side thread's first turn explains that it is a `/btw` side conversation with tools deactivated.

--- a/packages/coding-agent/src/core/side-question.ts
+++ b/packages/coding-agent/src/core/side-question.ts
@@ -122,6 +122,12 @@ export function startSideQuestion(
 	});
 
 	const clonedMessageCount = sideAgent.state.messages.length;
+	// A turn-capped run can end on tool results, so its outcome lives in the
+	// assistant turns it appended rather than in its last message.
+	const assistantTurns = () =>
+		sideAgent.state.messages
+			.slice(clonedMessageCount)
+			.filter((message): message is AssistantMessage => message.role === "assistant");
 	let answer = "";
 	let abortRequested = false;
 	let started = false;
@@ -129,12 +135,13 @@ export function startSideQuestion(
 	const emit = (status: SideQuestionStatus, errorMessage?: string) =>
 		onEvent({ id, question, answer, status, ...(errorMessage ? { errorMessage } : {}) });
 
+	// Streaming events carry one partial turn at a time, so they only fill in text
+	// as it arrives; the answer of the whole run is derived from its finished turns.
 	const unsubscribe = sideAgent.subscribe(async (event) => {
 		if (event.type !== "message_update" && event.type !== "message_end") {
 			return;
 		}
 		const nextAnswer = readAssistantText(event.message);
-		// A turn that only calls tools carries no text; keep the answer written so far.
 		if (!nextAnswer || nextAnswer === answer) {
 			return;
 		}
@@ -153,7 +160,7 @@ export function startSideQuestion(
 			started = true;
 			// Standalone side agents bypass the session auto-retry loop; retry here instead.
 			let promptedOnce = false;
-			await completeWithProviderRetry(
+			const finalTurn = await completeWithProviderRetry(
 				async () => {
 					if (promptedOnce) {
 						// Session-loop recovery: drop the failed assistant turn and re-run.
@@ -163,16 +170,11 @@ export function startSideQuestion(
 						promptedOnce = true;
 						await sideAgent.prompt(prompt);
 					}
-					// A turn-capped run can end on tool results, so the outcome of the run
-					// is its last assistant turn rather than its last message.
-					const last = sideAgent.state.messages
-						.slice(clonedMessageCount)
-						.filter((message) => message.role === "assistant")
-						.at(-1);
+					const last = assistantTurns().at(-1);
 					if (!last) {
 						throw new Error(sideAgent.state.errorMessage || "Side question produced no assistant message");
 					}
-					return last as AssistantMessage;
+					return last;
 				},
 				{ policy: retry, signal: retryAbortController.signal },
 			);
@@ -184,6 +186,11 @@ export function startSideQuestion(
 				await emit("error", sideAgent.state.errorMessage);
 				return;
 			}
+			// A run that ends on a tool turn was answered in an earlier turn; a textless
+			// final turn without tool calls is a genuinely empty answer.
+			answer = finalTurn.content.some((block) => block.type === "toolCall")
+				? (assistantTurns().map(readAssistantText).filter(Boolean).at(-1) ?? "")
+				: readAssistantText(finalTurn);
 			await emit("complete");
 		})
 		.catch(async (error) => {

--- a/packages/coding-agent/src/core/side-question.ts
+++ b/packages/coding-agent/src/core/side-question.ts
@@ -29,7 +29,12 @@ export interface SideQuestionRun {
 }
 
 const SIDE_QUESTION_INSTRUCTION =
-	"Answer this side question using only the conversation context above. Do not use tools. The user may send follow-up side questions; none of this side conversation is added to the main session.";
+	"The user asked this via `/btw` — a temporary side thread cloned from the main conversation to answer a question without interrupting the main work. Tools (including `ipython`) are deactivated in this side thread and return an error if called; answer using only the conversation context above. The user may send follow-up side questions. Nothing here is added to the main session, so don't start or plan main-session work from this thread.";
+
+const SIDE_QUESTION_TOOL_BLOCKED = "Tools are deactivated in this side thread. Answer from the conversation context.";
+
+/** Backstop for a model that keeps calling deactivated tools instead of answering. */
+const SIDE_QUESTION_MAX_TURNS = 3;
 
 function sideQuestionPrompt(question: string, isFirstTurn: boolean): string {
 	const body = isFirstTurn ? `${SIDE_QUESTION_INSTRUCTION}\n\n${question}` : question;
@@ -86,6 +91,7 @@ export function startSideQuestion(
 		} satisfies AssistantMessage,
 	]);
 
+	let turnCount = 0;
 	const sideAgent = new Agent({
 		initialState: {
 			model,
@@ -93,7 +99,10 @@ export function startSideQuestion(
 			messages: [...structuredClone(parent.state.messages), ...previousTurnMessages],
 			thinkingLevel: getAuxiliaryThinkingLevel(model, parent.state.thinkingLevel),
 			serviceTier: parent.state.serviceTier,
-			tools: [],
+			// Providers serialize the tool declarations ahead of the system prompt and
+			// messages, so an empty list here would miss the main thread's cache entirely.
+			// Execution is blocked in beforeToolCall instead.
+			tools: parent.state.tools,
 		},
 		convertToLlm: parent.convertToLlm,
 		transformContext: parent.transformContext,
@@ -102,13 +111,18 @@ export function startSideQuestion(
 		getApiKey: parent.getApiKey,
 		onPayload: parent.onPayload,
 		onResponse: parent.onResponse,
-		shouldStopAfterTurn: () => true,
+		beforeToolCall: async () => ({ block: true, reason: SIDE_QUESTION_TOOL_BLOCKED }),
+		shouldStopAfterTurn: ({ message }) => {
+			turnCount += 1;
+			return turnCount >= SIDE_QUESTION_MAX_TURNS || !message.content.some((block) => block.type === "toolCall");
+		},
 		sessionId: parent.sessionId,
 		thinkingBudgets: parent.thinkingBudgets,
 		transport: "sse",
 		toolExecution: parent.toolExecution,
 	});
 
+	const clonedMessageCount = sideAgent.state.messages.length;
 	let answer = "";
 	let abortRequested = false;
 	let started = false;
@@ -121,7 +135,8 @@ export function startSideQuestion(
 			return;
 		}
 		const nextAnswer = readAssistantText(event.message);
-		if (nextAnswer === answer) {
+		// A turn that only calls tools carries no text; keep the answer written so far.
+		if (!nextAnswer || nextAnswer === answer) {
 			return;
 		}
 		answer = nextAnswer;
@@ -149,8 +164,13 @@ export function startSideQuestion(
 						promptedOnce = true;
 						await sideAgent.prompt(prompt);
 					}
-					const last = sideAgent.state.messages.at(-1);
-					if (last?.role !== "assistant") {
+					// A turn-capped run can end on tool results, so the outcome of the run
+					// is its last assistant turn rather than its last message.
+					const last = sideAgent.state.messages
+						.slice(clonedMessageCount)
+						.filter((message) => message.role === "assistant")
+						.at(-1);
+					if (!last) {
 						throw new Error(sideAgent.state.errorMessage || "Side question produced no assistant message");
 					}
 					return last as AssistantMessage;

--- a/packages/coding-agent/src/core/side-question.ts
+++ b/packages/coding-agent/src/core/side-question.ts
@@ -99,9 +99,8 @@ export function startSideQuestion(
 			messages: [...structuredClone(parent.state.messages), ...previousTurnMessages],
 			thinkingLevel: getAuxiliaryThinkingLevel(model, parent.state.thinkingLevel),
 			serviceTier: parent.state.serviceTier,
-			// Providers serialize the tool declarations ahead of the system prompt and
-			// messages, so an empty list here would miss the main thread's cache entirely.
-			// Execution is blocked in beforeToolCall instead.
+			// Providers serialize tool declarations ahead of the cached prefix, so an
+			// empty list would miss the main cache; execution is blocked in beforeToolCall.
 			tools: parent.state.tools,
 		},
 		convertToLlm: parent.convertToLlm,

--- a/packages/coding-agent/test/suite/regressions/4509-side-questions.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4509-side-questions.test.ts
@@ -1,6 +1,8 @@
-import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { Container } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
+import { Type } from "typebox";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { type SideQuestionEvent, startSideQuestion } from "../../../src/core/side-question.js";
 import { AgentDaemon } from "../../../src/modes/daemon/daemon-mode.js";
@@ -23,7 +25,7 @@ describe("ENG-4509 side questions", () => {
 		initTheme("dark");
 	});
 
-	it("uses the current context without tools or session persistence", async () => {
+	it("uses the current context without session persistence", async () => {
 		const harness = await createHarness({ systemPrompt: "Remember relevant project context." });
 		try {
 			harness.setResponses([fauxAssistantMessage("The codename is kestrel.")]);
@@ -39,7 +41,6 @@ describe("ENG-4509 side questions", () => {
 			harness.setResponses([
 				(context, options) => {
 					expect(context.systemPrompt).toBe(systemPromptBefore);
-					expect(context.tools).toEqual([]);
 					expect(context.messages.map(getMessageText)).toEqual([
 						expect.stringContaining("The persistent memories produced across this session so far:"),
 						"The project codename is kestrel.",
@@ -89,10 +90,9 @@ describe("ENG-4509 side questions", () => {
 						"first side answer",
 						expect.stringContaining("Second side question?"),
 					]);
-					expect(context.tools).toEqual([]);
 					// The instruction is repeated only on the first side turn.
-					expect(texts[3]).toContain("Answer this side question");
-					expect(texts[5]).not.toContain("Answer this side question");
+					expect(texts[3]).toContain("asked this via `/btw`");
+					expect(texts[5]).not.toContain("asked this via `/btw`");
 					return fauxAssistantMessage("second side answer");
 				},
 			]);
@@ -110,6 +110,93 @@ describe("ENG-4509 side questions", () => {
 			await run.done;
 
 			expect(events.at(-1)).toMatchObject({ status: "complete", answer: "second side answer" });
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("sends the session's tool declarations but blocks their execution", async () => {
+		let executions = 0;
+		const probe: AgentTool = {
+			name: "probe",
+			label: "Probe",
+			description: "Records executions",
+			parameters: Type.Object({}),
+			execute: async () => {
+				executions += 1;
+				return { content: [{ type: "text", text: "executed" }], details: {} };
+			},
+		};
+		const harness = await createHarness({ tools: [probe] });
+		try {
+			let mainTools: unknown;
+			harness.setResponses([
+				(context) => {
+					mainTools = context.tools;
+					return fauxAssistantMessage("main answer");
+				},
+			]);
+			await harness.session.prompt("Main context message.");
+
+			let secondTurnTexts: string[] = [];
+			harness.setResponses([
+				(context) => {
+					// Providers serialize the tools ahead of the cached prefix, so the side
+					// request must declare the main thread's tools unchanged.
+					expect(context.tools).toEqual(mainTools);
+					return fauxAssistantMessage(fauxToolCall("probe", {}), { stopReason: "toolUse" });
+				},
+				(context) => {
+					secondTurnTexts = context.messages.map(getMessageText);
+					return fauxAssistantMessage("answered from context");
+				},
+			]);
+
+			const events: SideQuestionEvent[] = [];
+			const run = startSideQuestion(harness.session.agent, "tools-1", "Which tool would you use?", (event) => {
+				events.push(event);
+			});
+			await run.done;
+
+			expect(executions).toBe(0);
+			expect(secondTurnTexts.some((text) => text.includes("Tools are deactivated in this side thread"))).toBe(true);
+			expect(events.at(-1)).toMatchObject({ status: "complete", answer: "answered from context" });
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("stops after three turns when the model keeps calling tools", async () => {
+		const probe: AgentTool = {
+			name: "probe",
+			label: "Probe",
+			description: "Never executes",
+			parameters: Type.Object({}),
+			execute: async () => ({ content: [{ type: "text", text: "executed" }], details: {} }),
+		};
+		const harness = await createHarness({ tools: [probe] });
+		try {
+			harness.setResponses([fauxAssistantMessage("main answer")]);
+			await harness.session.prompt("Main context message.");
+
+			const callsBefore = harness.faux.state.callCount;
+			harness.setResponses([
+				fauxAssistantMessage([{ type: "text", text: "Checking." }, fauxToolCall("probe", {})], {
+					stopReason: "toolUse",
+				}),
+				fauxAssistantMessage(fauxToolCall("probe", {}), { stopReason: "toolUse" }),
+				fauxAssistantMessage(fauxToolCall("probe", {}), { stopReason: "toolUse" }),
+				fauxAssistantMessage("unreachable fourth turn"),
+			]);
+
+			const events: SideQuestionEvent[] = [];
+			const run = startSideQuestion(harness.session.agent, "tools-2", "Keep trying?", (event) => {
+				events.push(event);
+			});
+			await run.done;
+
+			expect(harness.faux.state.callCount - callsBefore).toBe(3);
+			expect(events.at(-1)).toMatchObject({ status: "complete", answer: "Checking." });
 		} finally {
 			harness.cleanup();
 		}
@@ -159,7 +246,6 @@ describe("ENG-4509 side questions", () => {
 					return fauxAssistantMessage("main complete");
 				},
 				(context) => {
-					expect(context.tools).toEqual([]);
 					expect(context.messages.map(getMessageText)).toEqual([
 						expect.stringContaining("The persistent memories produced across this session so far:"),
 						"Run the main task.",

--- a/packages/coding-agent/test/suite/regressions/4509-side-questions.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4509-side-questions.test.ts
@@ -1,5 +1,5 @@
 import type { AgentTool } from "@earendil-works/pi-agent-core";
-import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage, fauxThinking, fauxToolCall } from "@earendil-works/pi-ai";
 import { Container } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { Type } from "typebox";
@@ -165,6 +165,28 @@ describe("ENG-4509 side questions", () => {
 		}
 	});
 
+	it("answers empty when the terminal turn is textless without tool calls", async () => {
+		const harness = await createHarness({ tools: [probe] });
+		try {
+			harness.setResponses([fauxAssistantMessage("main answer")]);
+			await harness.session.prompt("Main context message.");
+			harness.setResponses([
+				fauxAssistantMessage([{ type: "text", text: "Checking." }, fauxToolCall("probe", {})], {
+					stopReason: "toolUse",
+				}),
+				fauxAssistantMessage("", { stopReason: "stop" }),
+			]);
+			const events: SideQuestionEvent[] = [];
+			const run = startSideQuestion(harness.session.agent, "tools-3", "Empty finish?", (event) => {
+				events.push(event);
+			});
+			await run.done;
+			expect(events.at(-1)).toMatchObject({ status: "complete", answer: "" });
+		} finally {
+			harness.cleanup();
+		}
+	});
+
 	it("stops after three turns when the model keeps calling tools", async () => {
 		const harness = await createHarness({ tools: [probe] });
 		try {
@@ -176,7 +198,11 @@ describe("ENG-4509 side questions", () => {
 				fauxAssistantMessage([{ type: "text", text: "Checking." }, fauxToolCall("probe", {})], {
 					stopReason: "toolUse",
 				}),
-				fauxAssistantMessage(fauxToolCall("probe", {}), { stopReason: "toolUse" }),
+				// This turn streams thinking before its tool call, so its mid-turn updates
+				// are textless while the first turn's answer is the run's only text.
+				fauxAssistantMessage([fauxThinking("still stuck"), fauxToolCall("probe", {})], {
+					stopReason: "toolUse",
+				}),
 				fauxAssistantMessage(fauxToolCall("probe", {}), { stopReason: "toolUse" }),
 			]);
 

--- a/packages/coding-agent/test/suite/regressions/4509-side-questions.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4509-side-questions.test.ts
@@ -214,6 +214,43 @@ describe("ENG-4509 side questions", () => {
 
 			expect(harness.faux.state.callCount - callsBefore).toBe(3);
 			expect(events.at(-1)).toMatchObject({ status: "complete", answer: "Checking." });
+			// Streamed text must never be wiped mid-run by textless updates.
+			const running = events.filter((event) => event.status === "running");
+			const firstText = running.findIndex((event) => event.answer !== "");
+			expect(firstText).toBeGreaterThanOrEqual(0);
+			expect(running.slice(firstText).every((event) => event.answer !== "")).toBe(true);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("derives the answer from finished turns when a retried run ends on tool calls", async () => {
+		const harness = await createHarness({ tools: [probe] });
+		try {
+			harness.setResponses([fauxAssistantMessage("main answer")]);
+			await harness.session.prompt("Main context message.");
+			harness.setResponses([
+				fauxAssistantMessage([{ type: "text", text: "Checking." }, fauxToolCall("probe", {})], {
+					stopReason: "toolUse",
+				}),
+				fauxAssistantMessage("Almost 42", { stopReason: "error", errorMessage: "500 Internal Server Error" }),
+				fauxAssistantMessage(fauxToolCall("probe", {}), { stopReason: "toolUse" }),
+				fauxAssistantMessage(fauxToolCall("probe", {}), { stopReason: "toolUse" }),
+			]);
+			const events: SideQuestionEvent[] = [];
+			const run = startSideQuestion(
+				harness.session.agent,
+				"retry-2",
+				"Survives a failed turn?",
+				(event) => {
+					events.push(event);
+				},
+				[],
+				{ enabled: true, maxRetries: 3, baseDelayMs: 1, maxRetryDelayMs: 60_000 },
+			);
+			await run.done;
+			// The failed turn's streamed partial is not the outcome; finished turns are.
+			expect(events.at(-1)).toMatchObject({ status: "complete", answer: "Checking." });
 		} finally {
 			harness.cleanup();
 		}

--- a/packages/coding-agent/test/suite/regressions/4509-side-questions.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4509-side-questions.test.ts
@@ -115,18 +115,19 @@ describe("ENG-4509 side questions", () => {
 		}
 	});
 
+	let probeExecutions = 0;
+	const probe: AgentTool = {
+		name: "probe",
+		label: "Probe",
+		description: "Records executions",
+		parameters: Type.Object({}),
+		execute: async () => {
+			probeExecutions += 1;
+			return { content: [{ type: "text", text: "executed" }], details: {} };
+		},
+	};
+
 	it("sends the session's tool declarations but blocks their execution", async () => {
-		let executions = 0;
-		const probe: AgentTool = {
-			name: "probe",
-			label: "Probe",
-			description: "Records executions",
-			parameters: Type.Object({}),
-			execute: async () => {
-				executions += 1;
-				return { content: [{ type: "text", text: "executed" }], details: {} };
-			},
-		};
 		const harness = await createHarness({ tools: [probe] });
 		try {
 			let mainTools: unknown;
@@ -141,8 +142,6 @@ describe("ENG-4509 side questions", () => {
 			let secondTurnTexts: string[] = [];
 			harness.setResponses([
 				(context) => {
-					// Providers serialize the tools ahead of the cached prefix, so the side
-					// request must declare the main thread's tools unchanged.
 					expect(context.tools).toEqual(mainTools);
 					return fauxAssistantMessage(fauxToolCall("probe", {}), { stopReason: "toolUse" });
 				},
@@ -158,7 +157,7 @@ describe("ENG-4509 side questions", () => {
 			});
 			await run.done;
 
-			expect(executions).toBe(0);
+			expect(probeExecutions).toBe(0);
 			expect(secondTurnTexts.some((text) => text.includes("Tools are deactivated in this side thread"))).toBe(true);
 			expect(events.at(-1)).toMatchObject({ status: "complete", answer: "answered from context" });
 		} finally {
@@ -167,13 +166,6 @@ describe("ENG-4509 side questions", () => {
 	});
 
 	it("stops after three turns when the model keeps calling tools", async () => {
-		const probe: AgentTool = {
-			name: "probe",
-			label: "Probe",
-			description: "Never executes",
-			parameters: Type.Object({}),
-			execute: async () => ({ content: [{ type: "text", text: "executed" }], details: {} }),
-		};
 		const harness = await createHarness({ tools: [probe] });
 		try {
 			harness.setResponses([fauxAssistantMessage("main answer")]);
@@ -186,7 +178,6 @@ describe("ENG-4509 side questions", () => {
 				}),
 				fauxAssistantMessage(fauxToolCall("probe", {}), { stopReason: "toolUse" }),
 				fauxAssistantMessage(fauxToolCall("probe", {}), { stopReason: "toolUse" }),
-				fauxAssistantMessage("unreachable fourth turn"),
 			]);
 
 			const events: SideQuestionEvent[] = [];


### PR DESCRIPTION
No-Ticket: /btw side-thread UX change, discussed directly with snimu

User-visible change: a `/btw` side question now sees the session's tools in its tool list, but cannot run them, and the model is told it is in a `/btw` side thread. Any tool call comes back as an error tool result:

> Tools are deactivated in this side thread. Answer from the conversation context.

The first side turn carries this instruction inside the `<side_question>` wrapper (not in the system prompt, which must stay byte-identical for the cache):

> The user asked this via `/btw` - a temporary side thread cloned from the main conversation to answer a question without interrupting the main work. Tools (including `ipython`) are deactivated in this side thread and return an error if called; answer using only the conversation context above. The user may send follow-up side questions. Nothing here is added to the main session, so don't start or plan main-session work from this thread.

Why: providers serialize the tool declarations ahead of the system prompt and the messages. An empty tool list is a different cached prefix, so the side request missed the main thread's cache completely and re-read the whole conversation at full input price. With the same declarations, the side question reads the cloned conversation from cache. This is the standalone cache fix; the thinking-level half is stacked on top as a separate PR for independent discussion.

Trade-off: the model can now see a tool and try to call it, so a side question may burn one extra round-trip before answering. The error result is a normal tool result, not a turn failure, so the model self-corrects on the next turn. The side loop stops at the first assistant turn without tool calls, with a hard cap of three turns; at the cap the text produced so far is the answer.

Implementation notes:
- `tools: parent.state.tools` is passed through unchanged (same references, same order).
- Execution is blocked at the `beforeToolCall` seam, so no tool body is reachable from a side thread.
- A capped run can end on tool results, so the run's outcome is now read from its last assistant turn instead of its last message.

Tests (extended `4509-side-questions.test.ts`):
- side request declares the same tools as the main thread, a tool call returns the deactivated error, the tool body never runs, and the run still ends with a text answer.
- three tool-calling turns stop the run at the cap and keep the text produced so far.
- existing follow-up test pins the new instruction on the first side turn only.

Validation (Prime sandbox): `npm run check` clean; 11 side-question-related test files, 426 tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes side-question LLM request shape and multi-turn stop/answer logic; tool execution remains blocked but reported answers may differ when the model attempts tools before answering.
> 
> **Overview**
> **`/btw` side questions now mirror the main session’s tool declarations** so provider requests share the same cached prefix as the main thread (empty tools previously forced a full re-read). Tool bodies never run: `beforeToolCall` blocks every call and returns *Tools are deactivated in this side thread.*
> 
> The first side turn’s `<side_question>` text explains the temporary `/btw` thread, deactivated tools, and that nothing here affects the main session. The side agent can take up to **three turns** when the model keeps issuing tool calls; it stops on the first assistant turn without tool calls. **Final answer text** is taken from the last text-bearing assistant turn when the run ends on blocked tool use, with guards so streaming updates do not wipe partial text on textless mid-turn chunks.
> 
> Regression tests cover matching tool lists, zero probe executions, the deactivated error in context, the three-turn cap, empty terminal answers, and retry paths that end on tool calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ead829bf538ac4608a94040a8239c28a0521a94f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Declare session tools in `/btw` side questions and block their execution
> - `/btw` side questions now send the parent session's tool declarations to the provider so the model has full context, but a `beforeToolCall` hook returns an error for every attempted tool call so no tool actually executes.
> - The first-turn instruction in [side-question.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2233/files#diff-854e565ab4c061597eb4ed5ef465f9735fd0b98ef7186bc8424f1df97bd18265) is rewritten to explain the temporary side thread, deactivated tools, and exclusion from the main session.
> - Tool-calling side runs are capped at three turns; answer extraction now uses the latest text-bearing assistant turn when the terminal turn ends on a blocked tool call.
> - Risk: side-question answer text may differ when the terminal turn is a tool call — the runner falls back to the most recent text turn rather than emitting an empty answer. Reviewers should check `startSideQuestion` turn-collection and final-answer derivation in [side-question.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2233/files#diff-854e565ab4c061597eb4ed5ef465f9735fd0b98ef7186bc8424f1df97bd18265).
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2233 opened
>
> - Added assertions to verify streamed text is never cleared during side-question execution [ead829b]
> - Added test coverage for answer derivation from finished turns when retried runs end on tool calls [ead829b]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f16ffab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


(Replaces #2231, which GitHub auto-marked merged during a stack reorder; no code reached main.)