### PR TITLE
Keep the session thinking level for /btw side questions

### DIFF
--- a/packages/coding-agent/.changes/btw-side-question-thinking.md
+++ b/packages/coding-agent/.changes/btw-side-question-thinking.md
@@ -1,0 +1,1 @@
+- Fixed `/btw` side questions discarding the main conversation's prompt cache by lowering the reasoning level: side questions now keep the session's thinking level, so providers whose cache keys include thinking parameters reuse the cached conversation.

--- a/packages/coding-agent/src/core/side-question.ts
+++ b/packages/coding-agent/src/core/side-question.ts
@@ -6,7 +6,6 @@ import {
 	type ProviderRetryPolicy,
 } from "./provider-retry.js";
 import { unwrapSemanticEdgeStreamFn } from "./semantic-edges.js";
-import { getAuxiliaryThinkingLevel } from "./thinking-levels.js";
 
 export type SideQuestionStatus = "running" | "complete" | "cancelled" | "error";
 
@@ -97,7 +96,9 @@ export function startSideQuestion(
 			model,
 			systemPrompt: parent.state.systemPrompt,
 			messages: [...structuredClone(parent.state.messages), ...previousTurnMessages],
-			thinkingLevel: getAuxiliaryThinkingLevel(model, parent.state.thinkingLevel),
+			// Anthropic message-level caching keys on the thinking parameters, so a
+			// different level here would re-read the whole cloned conversation.
+			thinkingLevel: parent.state.thinkingLevel,
 			serviceTier: parent.state.serviceTier,
 			// Providers serialize tool declarations ahead of the cached prefix, so an
 			// empty list would miss the main cache; execution is blocked in beforeToolCall.

--- a/packages/coding-agent/test/suite/regressions/6010-auxiliary-reasoning.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6010-auxiliary-reasoning.test.ts
@@ -70,11 +70,13 @@ describe("auxiliary reasoning settings", () => {
 		parent.state.thinkingLevel = testCase.parentLevel;
 		const parentMessages = structuredClone(parent.state.messages);
 		const observed: SimpleStreamOptions[] = [];
+		// Side questions keep the session level (cache identity); the first two calls clamp.
+		const expectedLevels: ThinkingLevel[] = [testCase.expectedLevel, testCase.expectedLevel, testCase.parentLevel];
 		harness.setResponses(
-			[JSON.stringify(proposal), JSON.stringify(review), "Side answer"].map((text) => (_context, options) => {
+			[JSON.stringify(proposal), JSON.stringify(review), "Side answer"].map((text, index) => (_context, options) => {
 				const request = options as SimpleStreamOptions;
 				observed.push(request);
-				if (request.reasoning !== testCase.expectedLevel) {
+				if (request.reasoning !== expectedLevels[index]) {
 					return fauxAssistantMessage("", {
 						stopReason: "error",
 						errorMessage: `Unsupported auxiliary reasoning: ${request.reasoning}`,
@@ -131,7 +133,7 @@ describe("auxiliary reasoning settings", () => {
 			noRetry,
 		).done;
 		expect(events.at(-1)).toMatchObject({ status: "complete", answer: "Side answer" });
-		expect(observed.map((options) => options.reasoning)).toEqual(Array(3).fill(testCase.expectedLevel));
+		expect(observed.map((options) => options.reasoning)).toEqual(expectedLevels);
 		expect(observed[0].maxTokens).toBe(testCase.expectedLevel === "off" ? 32_000 : model.maxTokens);
 		expect(observed[1].maxTokens).toBe(testCase.expectedLevel === "off" ? 4_096 : model.maxTokens);
 		expect(parent.state.thinkingLevel).toBe(testCase.parentLevel);


### PR DESCRIPTION
No-Ticket: side-question cache cost fix, discussed directly with snimu

`/btw` side questions clone the main conversation and send it to the model again. Today the side request also drops the thinking level to the cheap auxiliary level. On Anthropic-style APIs the thinking parameters are part of the message-level cache key, so a different level means the cloned conversation does not hit the cache: the first `/btw` on a long session re-reads the whole conversation at full input price instead of the much cheaper cache-read price.

This change sends the session's own thinking level for side questions, so the cache key for the cloned messages matches the main thread's requests.

Notes:
- No preference clamp is re-added. Providers already clamp the level per model at request time, exactly as they do for the main thread, so an unsupported level cannot be sent.
- `getAuxiliaryThinkingLevel` stays; refinement and auto-refine review still use it.
- Model-invisible change: the side thread still sees the same prompt, messages and tool list as its base PR.

Test: `6010-auxiliary-reasoning.test.ts` now pins that the side question's request uses the session level while refinement and review keep the auxiliary level.

Validation (Prime sandbox): `npm run check` clean; `4509-side-questions.test.ts`, `6010-auxiliary-reasoning.test.ts`, `daemon-supervisor-side-question.test.ts` - 49 tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to side-question LLM request parameters and cost/caching; refinement paths and parent session state are untouched aside from test expectations.
> 
> **Overview**
> **`/btw` side questions now use the parent session's thinking level** instead of the cheaper auxiliary level from `getAuxiliaryThinkingLevel`. That aligns cache keys with the main thread on providers (e.g. Anthropic) where thinking parameters are part of message-level cache identity, so cloned conversation context can reuse prompt cache instead of a full-priced re-read.
> 
> Refinement and auto-refine review are unchanged and still clamp to the auxiliary level. The regression test **6010-auxiliary-reasoning** now expects refinement/review at `expectedLevel` and the side-question call at `parentLevel`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7cdd7b1188ad9ef7cd384232055c2429c3cfaf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep parent thinking level and tool declarations for `/btw` side questions
> Side questions previously used a lower auxiliary thinking level and an empty tool list. This caused thinking-sensitive provider cache keys to miss the main conversation's cache. The cloned side-question agent now inherits the parent thinking level and tool declarations but blocks tool execution, returning a fixed `SIDE_QUESTION_TOOL_BLOCKED` reason to the next turn.
> - Tool-call turns continue up to `SIDE_QUESTION_MAX_TURNS` (3) before the run stops, so repeated tool-call attempts don't loop indefinitely.
> - Final answer is derived from completed assistant turns; a tool-ending run uses the latest streamed text, and a textless non-tool terminal turn yields an empty answer. Partial text from failed provider turns is not selected.
> - Risk: `startSideQuestion` in [side-question.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2234/files#diff-854e565ab4c061597eb4ed5ef465f9735fd0b98ef7186bc8424f1df97bd18265) now sends real tool declarations to the provider on side questions; any consumer expecting an empty tool list will see a behavior change.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5ad3c92. 3 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>packages/coding-agent/src/core/side-question.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 192](https://github.com/PrimeIntellect-ai/prime-agent/blob/5ad3c9219d5398276a83766c30211dd33cea23bd/packages/coding-agent/src/core/side-question.ts#L192): When the three-turn cap ends on a tool-call message that also contains text, this branch discards that final turn's text and returns an earlier turn's text (or `""`). A model can provide its actual answer while still emitting a deactivated tool call, so `/btw` reports a stale/incomplete answer instead of the latest answer it produced. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
