### PR TITLE
[RSI] swe-fix-loop capability eval harness

### DIFF
--- a/packages/coding-agent/docs/development.md
+++ b/packages/coding-agent/docs/development.md
@@ -81,3 +81,14 @@ npx tsx ../../node_modules/vitest/dist/cli.js --run test/specific.test.ts
 ```
 
 If you create or modify a test file, run that file and iterate until it passes. Coding-agent suite regressions belong under `test/suite/regressions/` and use the suite harness and faux provider rather than live provider credentials.
+
+## Capability Evals
+
+Real-model capability evals live in `scripts/evals/`. The
+`swe-fix-loop` harness measures the end-to-end software-engineering loop:
+a headless agent run on a seeded-bug fixture repo, scored on target-test
+resolution, no regressions, diff containment, and transcript evidence of
+an actual test run. CI validates the harness itself (fixture integrity,
+golden patches, scorer rubric) with model-free self-tests; real-model
+runs are manual and require provider credentials. See
+`scripts/evals/README.md`.

--- a/packages/coding-agent/docs/development.md
+++ b/packages/coding-agent/docs/development.md
@@ -88,7 +88,7 @@ Real-model capability evals live in `scripts/evals/`. The
 `swe-fix-loop` harness measures the end-to-end software-engineering loop:
 a headless agent run on a seeded-bug fixture repo, scored on target-test
 resolution, no regressions, diff containment, and transcript evidence of
-an actual test run. CI validates the harness itself (fixture integrity,
-golden patches, scorer rubric) with model-free self-tests; real-model
-runs are manual and require provider credentials. See
+an actual test run. The harness itself is validated (fixture integrity,
+golden patches, scorer rubric) by model-free self-tests; real-model runs
+are manual and require provider credentials. See
 `scripts/evals/README.md`.

--- a/scripts/evals/README.md
+++ b/scripts/evals/README.md
@@ -16,12 +16,16 @@ Measures the inner software-engineering loop on seeded-bug fixtures:
    prompt names the failing behavior, never the location.
 2. **Runner** (`swe_fix/runner.py`) copies a fixture to a temp dir, runs
    the agent headless (`--mode json`, `--cwd` at the fixture, task prompt
-   from the fixture), then records the post-state.
+   from the fixture), then records the post-state. Fixture tests are
+   restored to pristine before the post-run suites, so an agent that
+   edits tests cannot mask a failed fix.
 3. **Scorer** (`swe_fix/scorer.py`) applies the rubric: target test
    passes; pre-existing tests still pass (no regressions); diff stays
    within the golden patch's file list (30% collateral tolerance); the
-   transcript shows a bash call running the test command (blocks
-   blind-patch guessing); plus token/turn efficiency from the transcript.
+   transcript shows the agent running the test command (a bash tool call
+   or an ipython bash() cell, as a whole shell command, not a substring
+   or comment); plus token/turn efficiency from the transcript, counted
+   once per assistant message.
 
 A fixture counts as resolved only when every rubric element passes.
 
@@ -39,10 +43,10 @@ uv run --locked python runner.py --fixture fixtures/py-budget --model anthropic/
 The runner prints the scored outcome as JSON and exits 0 only when the
 fixture is resolved. `--timeout` (default 1200s) bounds the agent run.
 
-### CI
+### Self-tests
 
-CI runs the harness self-tests only (fixture integrity, golden patches,
-scorer rubric) - never a model call:
+Validate the harness with the model-free self-tests (fixture integrity,
+golden patches, scorer rubric) - never a model call:
 
 ```
 uv run --locked ruff check .
@@ -55,4 +59,5 @@ uv run --locked python -m unittest discover -s tests -v
 Copy an existing fixture directory, keep the shape: sources + tests
 (3 passing, 1 seeded failing), `task.txt` (symptom only), `golden.patch`
 (diff from the buggy tree, generated with `git diff`), and
-`fixture.json` (test command, target test name, allowed files).
+`fixture.json` (test command, target test command, test files,
+allowed files).

--- a/scripts/evals/README.md
+++ b/scripts/evals/README.md
@@ -1,0 +1,58 @@
+# Prime Agent capability evals
+
+These harnesses measure end-to-end agent capability with a real model:
+find a bug, edit code, run the tests, iterate to green. They complement
+the repo's unit tests (which never call a model) and the PR performance
+benchmarks (which measure startup, not capability).
+
+## swe-fix-loop
+
+Measures the inner software-engineering loop on seeded-bug fixtures:
+
+1. **Fixtures** (`swe_fix/fixtures/`) are small self-contained repos
+   (TypeScript via `node --test`, Python via `unittest`, both stdlib-only,
+   nothing to install) with three pre-existing passing tests, one seeded
+   failing test, a golden patch, and a symptom-only task prompt. The
+   prompt names the failing behavior, never the location.
+2. **Runner** (`swe_fix/runner.py`) copies a fixture to a temp dir, runs
+   the agent headless (`--mode json`, `--cwd` at the fixture, task prompt
+   from the fixture), then records the post-state.
+3. **Scorer** (`swe_fix/scorer.py`) applies the rubric: target test
+   passes; pre-existing tests still pass (no regressions); diff stays
+   within the golden patch's file list (30% collateral tolerance); the
+   transcript shows a bash call running the test command (blocks
+   blind-patch guessing); plus token/turn efficiency from the transcript.
+
+A fixture counts as resolved only when every rubric element passes.
+
+### Running a real-model eval
+
+The eval needs a model selector and provider credentials in the
+environment (the agent's normal auth):
+
+```
+cd scripts/evals/swe_fix
+uv run --locked python runner.py --fixture fixtures/ts-date-utils --model anthropic/claude-sonnet-4-5
+uv run --locked python runner.py --fixture fixtures/py-budget --model anthropic/claude-sonnet-4-5
+```
+
+The runner prints the scored outcome as JSON and exits 0 only when the
+fixture is resolved. `--timeout` (default 1200s) bounds the agent run.
+
+### CI
+
+CI runs the harness self-tests only (fixture integrity, golden patches,
+scorer rubric) - never a model call:
+
+```
+uv run --locked ruff check .
+uv run --locked ruff format --check .
+uv run --locked python -m unittest discover -s tests -v
+```
+
+### Adding a fixture
+
+Copy an existing fixture directory, keep the shape: sources + tests
+(3 passing, 1 seeded failing), `task.txt` (symptom only), `golden.patch`
+(diff from the buggy tree, generated with `git diff`), and
+`fixture.json` (test command, target test name, allowed files).

--- a/scripts/evals/README.md
+++ b/scripts/evals/README.md
@@ -16,9 +16,10 @@ Measures the inner software-engineering loop on seeded-bug fixtures:
    prompt names the failing behavior, never the location.
 2. **Runner** (`swe_fix/runner.py`) copies a fixture to a temp dir, runs
    the agent headless (`--mode json`, `--cwd` at the fixture, task prompt
-   from the fixture), then records the post-state. Fixture tests are
-   restored to pristine before the post-run suites, so an agent that
-   edits tests cannot mask a failed fix.
+   from the fixture), then records the post-state. The post-run suites
+   run against pristine fixture files plus the agent's edits inside
+   `allowed_files`, so out-of-scope edits (tests, runners) cannot mask
+   a failed fix.
 3. **Scorer** (`swe_fix/scorer.py`) applies the rubric: target test
    passes; pre-existing tests still pass (no regressions); diff stays
    within the golden patch's file list (30% collateral tolerance); the
@@ -59,5 +60,4 @@ uv run --locked python -m unittest discover -s tests -v
 Copy an existing fixture directory, keep the shape: sources + tests
 (3 passing, 1 seeded failing), `task.txt` (symptom only), `golden.patch`
 (diff from the buggy tree, generated with `git diff`), and
-`fixture.json` (test command, target test command, test files,
-allowed files).
+`fixture.json` (test command, target test command, allowed files).

--- a/scripts/evals/swe_fix/fixtures/py-budget/budget.py
+++ b/scripts/evals/swe_fix/fixtures/py-budget/budget.py
@@ -1,0 +1,16 @@
+"""Budget allocation: split an income across weighted recipients."""
+
+
+def allocate(income, weights):
+    """Split *income* (cents, int) across named weights.
+
+    Each share is a whole cent; the shares must sum back to exactly
+    *income*.
+    """
+    if not weights:
+        raise ValueError("weights must not be empty")
+    if any(w < 0 for w in weights.values()) or sum(weights.values()) == 0:
+        raise ValueError("weights must be positive")
+    total_w = sum(weights.values())
+    shares = {name: round(income * w / total_w) for name, w in weights.items()}
+    return shares

--- a/scripts/evals/swe_fix/fixtures/py-budget/fixture.json
+++ b/scripts/evals/swe_fix/fixtures/py-budget/fixture.json
@@ -5,6 +5,5 @@
   "target_test_command": "python3 -m unittest test_budget.AllocateTests.test_shares_sum_exactly_to_income",
   "pre_passing_tests": 3,
   "golden_patch": "golden.patch",
-  "allowed_files": ["budget.py"],
-  "test_files": ["test_budget.py"]
+  "allowed_files": ["budget.py"]
 }

--- a/scripts/evals/swe_fix/fixtures/py-budget/fixture.json
+++ b/scripts/evals/swe_fix/fixtures/py-budget/fixture.json
@@ -1,0 +1,9 @@
+{
+  "name": "py-budget",
+  "language": "python",
+  "test_command": "python3 -m unittest -v",
+  "target_test": "test_shares_sum_exactly_to_income",
+  "pre_passing_tests": 3,
+  "golden_patch": "golden.patch",
+  "allowed_files": ["budget.py"]
+}

--- a/scripts/evals/swe_fix/fixtures/py-budget/fixture.json
+++ b/scripts/evals/swe_fix/fixtures/py-budget/fixture.json
@@ -2,8 +2,9 @@
   "name": "py-budget",
   "language": "python",
   "test_command": "python3 -m unittest -v",
-  "target_test": "test_shares_sum_exactly_to_income",
+  "target_test_command": "python3 -m unittest test_budget.AllocateTests.test_shares_sum_exactly_to_income",
   "pre_passing_tests": 3,
   "golden_patch": "golden.patch",
-  "allowed_files": ["budget.py"]
+  "allowed_files": ["budget.py"],
+  "test_files": ["test_budget.py"]
 }

--- a/scripts/evals/swe_fix/fixtures/py-budget/golden.patch
+++ b/scripts/evals/swe_fix/fixtures/py-budget/golden.patch
@@ -1,0 +1,18 @@
+diff --git a/budget.py b/budget.py
+index a35f788..e356c2a 100644
+--- a/budget.py
++++ b/budget.py
+@@ -12,5 +12,12 @@ def allocate(income, weights):
+     if any(w < 0 for w in weights.values()) or sum(weights.values()) == 0:
+         raise ValueError("weights must be positive")
+     total_w = sum(weights.values())
+-    shares = {name: round(income * w / total_w) for name, w in weights.items()}
++    raw = {name: income * w / total_w for name, w in weights.items()}
++    shares = {name: int(value) for name, value in raw.items()}
++    remainder = income - sum(shares.values())
++    # Largest-remainder distribution: hand leftover cents to the shares
++    # with the largest fractional parts first.
++    order = sorted(raw, key=lambda name: raw[name] - shares[name], reverse=True)
++    for name in order[:remainder] if remainder > 0 else []:
++        shares[name] += 1
+     return shares

--- a/scripts/evals/swe_fix/fixtures/py-budget/task.txt
+++ b/scripts/evals/swe_fix/fixtures/py-budget/task.txt
@@ -1,0 +1,4 @@
+The package's test suite fails one test: when an amount cannot be split
+evenly, the allocated shares do not sum back to the original income. Fix
+the allocation logic, not the tests, so the full suite passes. The fix
+must keep every share a whole cent and never over-allocate.

--- a/scripts/evals/swe_fix/fixtures/py-budget/test_budget.py
+++ b/scripts/evals/swe_fix/fixtures/py-budget/test_budget.py
@@ -1,0 +1,25 @@
+import unittest
+
+from budget import allocate
+
+
+class AllocateTests(unittest.TestCase):
+    def test_shares_sum_exactly_to_income(self):
+        shares = allocate(100_00, {"alpha": 1, "beta": 1, "gamma": 1})
+        self.assertEqual(sum(shares.values()), 100_00)
+
+    def test_rejects_empty_weights(self):
+        with self.assertRaises(ValueError):
+            allocate(100_00, {})
+
+    def test_rejects_zero_total_weight(self):
+        with self.assertRaises(ValueError):
+            allocate(100_00, {"alpha": 0, "beta": 0})
+
+    def test_proportional_shares_for_exact_division(self):
+        shares = allocate(200_00, {"alpha": 3, "beta": 1})
+        self.assertEqual(shares, {"alpha": 150_00, "beta": 50_00})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/evals/swe_fix/fixtures/ts-date-utils/fixture.json
+++ b/scripts/evals/swe_fix/fixtures/ts-date-utils/fixture.json
@@ -2,8 +2,9 @@
   "name": "ts-date-utils",
   "language": "typescript",
   "test_command": "npm test",
-  "target_test": "returns 28 for February in a non-leap century year",
+  "target_test_command": "node --test --test-name-pattern \"returns 28 for February in a non-leap century year\" test/",
   "pre_passing_tests": 3,
   "golden_patch": "golden.patch",
-  "allowed_files": ["src/dates.js"]
+  "allowed_files": ["src/dates.js"],
+  "test_files": ["test/dates.test.js"]
 }

--- a/scripts/evals/swe_fix/fixtures/ts-date-utils/fixture.json
+++ b/scripts/evals/swe_fix/fixtures/ts-date-utils/fixture.json
@@ -1,0 +1,9 @@
+{
+  "name": "ts-date-utils",
+  "language": "typescript",
+  "test_command": "npm test",
+  "target_test": "returns 28 for February in a non-leap century year",
+  "pre_passing_tests": 3,
+  "golden_patch": "golden.patch",
+  "allowed_files": ["src/dates.js"]
+}

--- a/scripts/evals/swe_fix/fixtures/ts-date-utils/fixture.json
+++ b/scripts/evals/swe_fix/fixtures/ts-date-utils/fixture.json
@@ -5,6 +5,5 @@
   "target_test_command": "node --test --test-name-pattern \"returns 28 for February in a non-leap century year\" test/",
   "pre_passing_tests": 3,
   "golden_patch": "golden.patch",
-  "allowed_files": ["src/dates.js"],
-  "test_files": ["test/dates.test.js"]
+  "allowed_files": ["src/dates.js"]
 }

--- a/scripts/evals/swe_fix/fixtures/ts-date-utils/golden.patch
+++ b/scripts/evals/swe_fix/fixtures/ts-date-utils/golden.patch
@@ -1,12 +1,12 @@
 diff --git a/src/dates.js b/src/dates.js
-index 9d5f4fa..61b8b87 100644
+index e4b528a..61b8b87 100644
 --- a/src/dates.js
 +++ b/src/dates.js
 @@ -7,7 +7,7 @@ export function daysInMonth(year, month) {
  		throw new RangeError("month must be between 1 and 12");
  	}
  	if (month === 2) {
--		const leap = year % 4 === 0 && (year % 100 === 0 || year % 400 === 0);
+-		const leap = year % 4 === 0;
 +		const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
  		return leap ? 29 : 28;
  	}

--- a/scripts/evals/swe_fix/fixtures/ts-date-utils/golden.patch
+++ b/scripts/evals/swe_fix/fixtures/ts-date-utils/golden.patch
@@ -1,0 +1,13 @@
+diff --git a/src/dates.js b/src/dates.js
+index 9d5f4fa..61b8b87 100644
+--- a/src/dates.js
++++ b/src/dates.js
+@@ -7,7 +7,7 @@ export function daysInMonth(year, month) {
+ 		throw new RangeError("month must be between 1 and 12");
+ 	}
+ 	if (month === 2) {
+-		const leap = year % 4 === 0 && (year % 100 === 0 || year % 400 === 0);
++		const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+ 		return leap ? 29 : 28;
+ 	}
+ 	return [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];

--- a/scripts/evals/swe_fix/fixtures/ts-date-utils/package.json
+++ b/scripts/evals/swe_fix/fixtures/ts-date-utils/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "date-utils",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test test/"
+  }
+}

--- a/scripts/evals/swe_fix/fixtures/ts-date-utils/src/dates.js
+++ b/scripts/evals/swe_fix/fixtures/ts-date-utils/src/dates.js
@@ -7,7 +7,7 @@ export function daysInMonth(year, month) {
 		throw new RangeError("month must be between 1 and 12");
 	}
 	if (month === 2) {
-		const leap = year % 4 === 0 && (year % 100 === 0 || year % 400 === 0);
+		const leap = year % 4 === 0;
 		return leap ? 29 : 28;
 	}
 	return [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];

--- a/scripts/evals/swe_fix/fixtures/ts-date-utils/src/dates.js
+++ b/scripts/evals/swe_fix/fixtures/ts-date-utils/src/dates.js
@@ -1,0 +1,30 @@
+/**
+ * Calendar helpers. Months are 1-based (January = 1).
+ */
+
+export function daysInMonth(year, month) {
+	if (month < 1 || month > 12) {
+		throw new RangeError("month must be between 1 and 12");
+	}
+	if (month === 2) {
+		const leap = year % 4 === 0 && (year % 100 === 0 || year % 400 === 0);
+		return leap ? 29 : 28;
+	}
+	return [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
+}
+
+export function addDays(year, month, day, delta) {
+	// Walks month boundaries; assumes the input date is valid.
+	let y = year;
+	let m = month;
+	let d = day + delta;
+	while (d > daysInMonth(y, m)) {
+		d -= daysInMonth(y, m);
+		m += 1;
+		if (m > 12) {
+			m = 1;
+			y += 1;
+		}
+	}
+	return { year: y, month: m, day: d };
+}

--- a/scripts/evals/swe_fix/fixtures/ts-date-utils/task.txt
+++ b/scripts/evals/swe_fix/fixtures/ts-date-utils/task.txt
@@ -1,0 +1,4 @@
+The package's test suite fails one test: the day count for February in a
+non-leap century year is wrong. Fix the bug in the library code, not in the
+tests, so the full suite passes. The fix must preserve correct leap-year
+behavior for every other year.

--- a/scripts/evals/swe_fix/fixtures/ts-date-utils/test/dates.test.js
+++ b/scripts/evals/swe_fix/fixtures/ts-date-utils/test/dates.test.js
@@ -1,0 +1,19 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { daysInMonth, addDays } from "../src/dates.js";
+
+test("returns 31 for January", () => {
+	assert.equal(daysInMonth(2024, 1), 31);
+});
+
+test("returns 29 for February in a leap year", () => {
+	assert.equal(daysInMonth(2024, 2), 29);
+});
+
+test("returns 28 for February in a non-leap century year", () => {
+	assert.equal(daysInMonth(1900, 2), 28);
+});
+
+test("addDays rolls over into the next month", () => {
+	assert.deepEqual(addDays(2024, 1, 31, 1), { year: 2024, month: 2, day: 1 });
+});

--- a/scripts/evals/swe_fix/pyproject.toml
+++ b/scripts/evals/swe_fix/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "prime-agent-evals"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = []
+
+[dependency-groups]
+dev = ["ruff==0.16.5"]
+
+[tool.uv]
+package = false
+exclude-newer = "2026-09-02T00:00:00Z"
+
+[tool.ruff]
+line-length = 110
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]

--- a/scripts/evals/swe_fix/runner.py
+++ b/scripts/evals/swe_fix/runner.py
@@ -5,7 +5,7 @@ records the post-state (test results, diff, transcript), and prints the
 scored outcome as JSON.
 
 Real-model runs are manual: pass --model and ensure provider auth is
-configured in the environment. The harness itself is validated in CI by
+configured in the environment. The harness itself is validated by
 model-free self-tests (tests/test_swe_fix.py).
 
 Usage:
@@ -18,6 +18,7 @@ import argparse
 import json
 import os
 import shutil
+import socket
 import subprocess
 import sys
 import tempfile
@@ -25,6 +26,18 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import scorer  # noqa: E402
+
+
+def _captured_text(output: str | bytes | None) -> str:
+    """Decode captured subprocess output.
+
+    TimeoutExpired output arrives as bytes even with text=True.
+    """
+    if output is None:
+        return ""
+    if isinstance(output, bytes):
+        return output.decode(errors="replace")
+    return output
 
 
 def run_command(command: str, cwd: Path, timeout: int = 300) -> dict:
@@ -41,8 +54,8 @@ def run_command(command: str, cwd: Path, timeout: int = 300) -> dict:
         # A hanging command must still score as a failure, not abort the eval.
         return {
             "exit_code": 124,
-            "stdout": exc.stdout or "",
-            "stderr": exc.stderr or "",
+            "stdout": _captured_text(exc.stdout),
+            "stderr": _captured_text(exc.stderr),
         }
     return {
         "exit_code": completed.returncode,
@@ -51,36 +64,52 @@ def run_command(command: str, cwd: Path, timeout: int = 300) -> dict:
     }
 
 
-def repo_changed_files(repo_dir: Path, initial_sha: str) -> list[str]:
-    """Files the agent changed: committed, staged, unstaged, or new."""
-    names: list[str] = []
-    commands = (
+def repo_changes(repo_dir: Path, initial_sha: str) -> tuple[list[str], list[str]]:
+    """Tracked changes against the initial commit, and untracked (new) files."""
+    tracked = subprocess.run(
         ["git", "diff", "--name-only", initial_sha],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    untracked = subprocess.run(
         ["git", "ls-files", "--others", "--exclude-standard"],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return (
+        [line for line in tracked.splitlines() if line],
+        [line for line in untracked.splitlines() if line],
     )
-    for command in commands:
-        output = subprocess.run(command, cwd=repo_dir, capture_output=True, text=True, check=True).stdout
-        names.extend(line for line in output.splitlines() if line)
-    return sorted(set(names))
 
 
-def restore_test_files(fixture: dict, fixture_dir: Path, repo_dir: Path) -> None:
-    """Reset fixture tests to pristine so edited tests cannot mask a failed fix."""
-    for rel_path in fixture.get("test_files", []):
-        source = fixture_dir / rel_path
-        if source.is_file():
-            destination = repo_dir / rel_path
-            # The agent may have deleted the file or its directory.
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(source, destination)
+def restore_scoring_tree(fixture: dict, repo_dir: Path, initial_sha: str) -> None:
+    """Revert every change outside allowed_files, including new files.
+
+    The scored suites then run the fixture's pristine tests and runners
+    plus the agent's allowed edits, so edited tests or agent-added shadow
+    runners (for example a repo-level unittest.py) cannot mask a failed
+    fix.
+    """
+    allowed = set(fixture.get("allowed_files", []))
+    tracked, untracked = repo_changes(repo_dir, initial_sha)
+    reverted = [path for path in tracked if path not in allowed]
+    if reverted:
+        subprocess.run(["git", "checkout", initial_sha, "--", *reverted], cwd=repo_dir, check=True)
+    for path in untracked:
+        if path not in allowed:
+            (repo_dir / path).unlink(missing_ok=True)
 
 
-def fixture_outcome(
-    fixture: dict, fixture_dir: Path, workdir: Path, initial_sha: str, agent_log: str
-) -> dict:
-    # Record the diff before restoring tests so edited tests stay visible.
-    changed_files = repo_changed_files(workdir, initial_sha)
-    restore_test_files(fixture, fixture_dir, workdir)
+def fixture_outcome(fixture: dict, workdir: Path, initial_sha: str, agent_log: str) -> dict:
+    # Record the diff before restoring so out-of-scope edits stay visible
+    # in the containment report even though they are reverted for scoring.
+    tracked, untracked = repo_changes(workdir, initial_sha)
+    changed_files = sorted(set(tracked) | set(untracked))
+    restore_scoring_tree(fixture, workdir, initial_sha)
     suite_result = run_command(fixture["test_command"], workdir)
     target_result = run_command(fixture["target_test_command"], workdir)
     session_text = read_session_text(agent_log)
@@ -129,6 +158,34 @@ def first_stderr_error(stderr: str) -> str | None:
         if stripped:
             return stripped
     return None
+
+
+def shutdown_agent_daemon(socket_path: Path) -> None:
+    """Stop the daemon the agent run leaves listening on the eval socket.
+
+    The CLI spawns a detached daemon per --daemon-socket; without this,
+    repeated evals accumulate orphan daemons and a timed-out run keeps
+    its worker going. Client commands ride in a protocol envelope; the
+    shutdown command closes the daemon's sessions before it exits.
+    """
+    envelope = json.dumps(
+        {
+            "type": "command",
+            "id": "eval-shutdown",
+            "protocol": {"name": "prime-agent.daemon", "version": 7},
+            "command": {"type": "shutdown"},
+        }
+    )
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(10)
+            client.connect(str(socket_path))
+            client.sendall(envelope.encode() + b"\n")
+            while client.recv(4096):
+                pass
+    except OSError:
+        # No daemon on the socket (launch failure or a stub agent): done.
+        pass
 
 
 def agent_env(agent_home: Path) -> dict:
@@ -223,19 +280,21 @@ def main(argv: list[str] | None = None) -> int:
         exit_code = completed.returncode
     except subprocess.TimeoutExpired as exc:
         # A timed-out run still scores; keep whatever transcript exists.
-        agent_log = exc.stdout or ""
-        stderr_text = exc.stderr or ""
+        agent_log = _captured_text(exc.stdout)
+        stderr_text = _captured_text(exc.stderr)
         exit_code = None
     except OSError as exc:
         # A missing or non-executable agent binary still produces a result.
         agent_log = ""
         stderr_text = str(exc)
         exit_code = None
+    finally:
+        shutdown_agent_daemon(workdir / "daemon.sock")
     (workdir / "agent.log").write_text(agent_log)
     # stderr is where launch and auth failures land; keep it with the result.
     (workdir / "agent.stderr").write_text(stderr_text)
 
-    outcome = fixture_outcome(fixture, fixture_dir, repo_dir, initial_sha, agent_log)
+    outcome = fixture_outcome(fixture, repo_dir, initial_sha, agent_log)
     result = scorer.score_fixture(fixture, outcome)
     result["exit_code"] = exit_code
     result["workdir"] = str(workdir)

--- a/scripts/evals/swe_fix/runner.py
+++ b/scripts/evals/swe_fix/runner.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -92,6 +93,30 @@ def first_agent_error(agent_log: str) -> str | None:
     return None
 
 
+def agent_env(agent_home: Path) -> dict:
+    """A clean, isolated environment for the agent subprocess.
+
+    The eval agent must be an independent root session: every PRIME_AGENT_INTERNAL_*
+    variable an embedding session might leak is stripped (a child inheriting
+    them would try to attach to the parent's worker), the agent runs under
+    its own PRIME_AGENT_CODING_AGENT_DIR / PI_CODING_AGENT_DIR (the workspace
+    launcher's env prefix derives from the package config name) so it never
+    touches a production agent dir, and the credential file is copied in so
+    model auth works without sharing any state.
+    """
+    env = {key: value for key, value in os.environ.items() if not key.startswith("PRIME_AGENT_INTERNAL_")}
+    for key in ("PRIME_AGENT_BASH_SHELL", "PRIME_AGENT_BASH_COMMAND_PREFIX"):
+        env.pop(key, None)
+    source_agent_dir = Path(env.get("PRIME_AGENT_CODING_AGENT_DIR") or Path.home() / ".prime" / "agent")
+    source_auth = source_agent_dir / "auth.json"
+    if source_auth.is_file():
+        agent_home.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_auth, agent_home / "auth.json")
+    env["PRIME_AGENT_CODING_AGENT_DIR"] = str(agent_home)
+    env["PI_CODING_AGENT_DIR"] = str(agent_home)
+    return env
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--fixture", required=True, help="Fixture directory (contains fixture.json)")
@@ -129,6 +154,8 @@ def main(argv: list[str] | None = None) -> int:
             args.agent_bin,
             "--mode",
             "json",
+            "--daemon-socket",
+            str(workdir / "daemon.sock"),
             "--cwd",
             str(repo_dir),
             "--session-dir",
@@ -138,6 +165,7 @@ def main(argv: list[str] | None = None) -> int:
             "--",
             prompt,
         ],
+        env=agent_env(workdir / "agent-home"),
         capture_output=True,
         text=True,
         timeout=args.timeout,

--- a/scripts/evals/swe_fix/runner.py
+++ b/scripts/evals/swe_fix/runner.py
@@ -1,0 +1,136 @@
+"""Runner for the swe-fix-loop eval.
+
+Copies a fixture repo to a temp dir, runs the agent headless against it,
+records the post-state (test results, diff, transcript), and prints the
+scored outcome as JSON.
+
+Real-model runs are manual: pass --model and ensure provider auth is
+configured in the environment. The harness itself is validated in CI by
+model-free self-tests (tests/test_swe_fix.py).
+
+Usage:
+    uv run --locked python runner.py --fixture fixtures/ts-date-utils --model anthropic/claude-sonnet-4-5
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import scorer  # noqa: E402
+
+
+def run_command(command: str, cwd: Path) -> dict:
+    completed = subprocess.run(
+        command,
+        shell=True,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    return {
+        "exit_code": completed.returncode,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+    }
+
+
+def fixture_outcome(fixture: dict, workdir: Path, agent_log: str) -> dict:
+    test_result = run_command(fixture["test_command"], workdir)
+    diff_names = subprocess.run(
+        ["git", "diff", "--name-only"],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    changed_files = [name for name in diff_names.splitlines() if name]
+    session_text = read_session_text(agent_log)
+    tests_passing = test_result["exit_code"] == 0
+    return {
+        "changed_files": changed_files,
+        "target_test_passes": tests_passing,
+        "pre_existing_tests_pass": tests_passing,
+        "test_run_evidence": scorer.test_run_evidence(session_text, fixture["test_command"]),
+        "usage": scorer.summarize_usage(session_text),
+    }
+
+
+def read_session_text(agent_log: str) -> str:
+    """Pull the session transcript out of the agent log.
+
+    In --mode json the agent emits transcript events on stdout; the runner
+    captures them to the log file. Scorer helpers accept any JSONL text.
+    """
+    return agent_log
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", required=True, help="Fixture directory (contains fixture.json)")
+    parser.add_argument("--model", required=True, help="Model selector under test, provider/model-id")
+    parser.add_argument("--timeout", type=int, default=1200, help="Agent run timeout in seconds")
+    parser.add_argument("--agent-bin", default="prime-agent", help="Agent binary to invoke")
+    args = parser.parse_args(argv)
+
+    fixture_dir = Path(args.fixture).resolve()
+    fixture = json.loads((fixture_dir / "fixture.json").read_text())
+    task = (fixture_dir / "task.txt").read_text()
+
+    workdir = Path(tempfile.mkdtemp(prefix="swe-fix-"))
+    repo_dir = workdir / "repo"
+    sessions_dir = workdir / "sessions"
+    shutil.copytree(
+        fixture_dir, repo_dir, ignore=shutil.ignore_patterns("fixture.json", "task.txt", "golden.patch")
+    )
+    for command in (
+        ["git", "init", "-q"],
+        ["git", "add", "-A"],
+        ["git", "-c", "commit.gpgsign=false", "commit", "-qm", "fixture"],
+    ):
+        git_env = {
+            "GIT_AUTHOR_NAME": "eval",
+            "GIT_AUTHOR_EMAIL": "eval@eval",
+            "GIT_COMMITTER_NAME": "eval",
+            "GIT_COMMITTER_EMAIL": "eval@eval",
+        }
+        subprocess.run(command, cwd=repo_dir, check=True, env={**git_env})
+
+    prompt = f"{task}\n\nWork in this repository, fix the bug, and make the full test suite pass."
+    completed = subprocess.run(
+        [
+            args.agent_bin,
+            "--mode",
+            "json",
+            "--cwd",
+            str(repo_dir),
+            "--session-dir",
+            str(sessions_dir),
+            "--model",
+            args.model,
+            "--",
+            prompt,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=args.timeout,
+    )
+    agent_log = completed.stdout
+    (workdir / "agent.log").write_text(agent_log)
+
+    outcome = fixture_outcome(fixture, repo_dir, agent_log)
+    result = scorer.score_fixture(fixture, outcome)
+    result["exit_code"] = completed.returncode
+    print(json.dumps(result, indent=2))
+    return 0 if result["resolved"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/evals/swe_fix/runner.py
+++ b/scripts/evals/swe_fix/runner.py
@@ -72,6 +72,26 @@ def read_session_text(agent_log: str) -> str:
     return agent_log
 
 
+def first_agent_error(agent_log: str) -> str | None:
+    """The first error message the agent reported, for quick diagnosis.
+
+    A zero-token unresolved run almost always means a launch or auth
+    failure; surfacing the error in the result JSON saves the
+    workdir-digging this field was created for.
+    """
+    for line in agent_log.splitlines():
+        try:
+            entry = json.loads(line)
+        except ValueError:
+            continue
+        message = entry.get("message") if isinstance(entry, dict) else None
+        if isinstance(message, dict) and message.get("role") == "assistant":
+            error = message.get("errorMessage")
+            if isinstance(error, str) and error:
+                return error
+    return None
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--fixture", required=True, help="Fixture directory (contains fixture.json)")
@@ -124,10 +144,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     agent_log = completed.stdout
     (workdir / "agent.log").write_text(agent_log)
+    # stderr is where launch and auth failures land; keep it with the result.
+    (workdir / "agent.stderr").write_text(completed.stderr)
 
     outcome = fixture_outcome(fixture, repo_dir, agent_log)
     result = scorer.score_fixture(fixture, outcome)
     result["exit_code"] = completed.returncode
+    result["workdir"] = str(workdir)
+    result["agent_error"] = first_agent_error(agent_log)
     print(json.dumps(result, indent=2))
     return 0 if result["resolved"] else 1
 

--- a/scripts/evals/swe_fix/runner.py
+++ b/scripts/evals/swe_fix/runner.py
@@ -27,15 +27,23 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import scorer  # noqa: E402
 
 
-def run_command(command: str, cwd: Path) -> dict:
-    completed = subprocess.run(
-        command,
-        shell=True,
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        timeout=300,
-    )
+def run_command(command: str, cwd: Path, timeout: int = 300) -> dict:
+    try:
+        completed = subprocess.run(
+            command,
+            shell=True,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        # A hanging command must still score as a failure, not abort the eval.
+        return {
+            "exit_code": 124,
+            "stdout": exc.stdout or "",
+            "stderr": exc.stderr or "",
+        }
     return {
         "exit_code": completed.returncode,
         "stdout": completed.stdout,
@@ -43,22 +51,40 @@ def run_command(command: str, cwd: Path) -> dict:
     }
 
 
-def fixture_outcome(fixture: dict, workdir: Path, agent_log: str) -> dict:
-    test_result = run_command(fixture["test_command"], workdir)
-    diff_names = subprocess.run(
-        ["git", "diff", "--name-only"],
-        cwd=workdir,
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout
-    changed_files = [name for name in diff_names.splitlines() if name]
+def repo_changed_files(repo_dir: Path, initial_sha: str) -> list[str]:
+    """Files the agent changed: committed, staged, unstaged, or new."""
+    names: list[str] = []
+    commands = (
+        ["git", "diff", "--name-only", initial_sha],
+        ["git", "ls-files", "--others", "--exclude-standard"],
+    )
+    for command in commands:
+        output = subprocess.run(command, cwd=repo_dir, capture_output=True, text=True, check=True).stdout
+        names.extend(line for line in output.splitlines() if line)
+    return sorted(set(names))
+
+
+def restore_test_files(fixture: dict, fixture_dir: Path, repo_dir: Path) -> None:
+    """Reset fixture tests to pristine so edited tests cannot mask a failed fix."""
+    for rel_path in fixture.get("test_files", []):
+        source = fixture_dir / rel_path
+        if source.is_file():
+            shutil.copy2(source, repo_dir / rel_path)
+
+
+def fixture_outcome(
+    fixture: dict, fixture_dir: Path, workdir: Path, initial_sha: str, agent_log: str
+) -> dict:
+    # Record the diff before restoring tests so edited tests stay visible.
+    changed_files = repo_changed_files(workdir, initial_sha)
+    restore_test_files(fixture, fixture_dir, workdir)
+    suite_result = run_command(fixture["test_command"], workdir)
+    target_result = run_command(fixture["target_test_command"], workdir)
     session_text = read_session_text(agent_log)
-    tests_passing = test_result["exit_code"] == 0
     return {
         "changed_files": changed_files,
-        "target_test_passes": tests_passing,
-        "pre_existing_tests_pass": tests_passing,
+        "target_test_passes": target_result["exit_code"] == 0,
+        "pre_existing_tests_pass": suite_result["exit_code"] == 0,
         "test_run_evidence": scorer.test_run_evidence(session_text, fixture["test_command"]),
         "usage": scorer.summarize_usage(session_text),
     }
@@ -90,6 +116,15 @@ def first_agent_error(agent_log: str) -> str | None:
             error = message.get("errorMessage")
             if isinstance(error, str) and error:
                 return error
+    return None
+
+
+def first_stderr_error(stderr: str) -> str | None:
+    """The first stderr line, where launch and auth failures surface."""
+    for line in stderr.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
     return None
 
 
@@ -135,51 +170,73 @@ def main(argv: list[str] | None = None) -> int:
     shutil.copytree(
         fixture_dir, repo_dir, ignore=shutil.ignore_patterns("fixture.json", "task.txt", "golden.patch")
     )
+    git_env = {
+        "GIT_AUTHOR_NAME": "eval",
+        "GIT_AUTHOR_EMAIL": "eval@eval",
+        "GIT_COMMITTER_NAME": "eval",
+        "GIT_COMMITTER_EMAIL": "eval@eval",
+    }
     for command in (
         ["git", "init", "-q"],
         ["git", "add", "-A"],
         ["git", "-c", "commit.gpgsign=false", "commit", "-qm", "fixture"],
     ):
-        git_env = {
-            "GIT_AUTHOR_NAME": "eval",
-            "GIT_AUTHOR_EMAIL": "eval@eval",
-            "GIT_COMMITTER_NAME": "eval",
-            "GIT_COMMITTER_EMAIL": "eval@eval",
-        }
-        subprocess.run(command, cwd=repo_dir, check=True, env={**git_env})
-
-    prompt = f"{task}\n\nWork in this repository, fix the bug, and make the full test suite pass."
-    completed = subprocess.run(
-        [
-            args.agent_bin,
-            "--mode",
-            "json",
-            "--daemon-socket",
-            str(workdir / "daemon.sock"),
-            "--cwd",
-            str(repo_dir),
-            "--session-dir",
-            str(sessions_dir),
-            "--model",
-            args.model,
-            "--",
-            prompt,
-        ],
-        env=agent_env(workdir / "agent-home"),
+        # Extend the ambient environment rather than replacing it: the git
+        # identity vars describe the commit author, not a new environment.
+        subprocess.run(command, cwd=repo_dir, check=True, env={**os.environ, **git_env})
+    initial_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_dir,
         capture_output=True,
         text=True,
-        timeout=args.timeout,
-    )
-    agent_log = completed.stdout
+        check=True,
+    ).stdout.strip()
+
+    prompt = f"{task}\n\nWork in this repository, fix the bug, and make the full test suite pass."
+    try:
+        completed = subprocess.run(
+            [
+                args.agent_bin,
+                "--mode",
+                "json",
+                "--daemon-socket",
+                str(workdir / "daemon.sock"),
+                "--cwd",
+                str(repo_dir),
+                "--session-dir",
+                str(sessions_dir),
+                "--model",
+                args.model,
+                "--",
+                prompt,
+            ],
+            env=agent_env(workdir / "agent-home"),
+            capture_output=True,
+            text=True,
+            timeout=args.timeout,
+        )
+        agent_log = completed.stdout
+        stderr_text = completed.stderr
+        exit_code = completed.returncode
+    except subprocess.TimeoutExpired as exc:
+        # A timed-out run still scores; keep whatever transcript exists.
+        agent_log = exc.stdout or ""
+        stderr_text = exc.stderr or ""
+        exit_code = None
+    except OSError as exc:
+        # A missing or non-executable agent binary still produces a result.
+        agent_log = ""
+        stderr_text = str(exc)
+        exit_code = None
     (workdir / "agent.log").write_text(agent_log)
     # stderr is where launch and auth failures land; keep it with the result.
-    (workdir / "agent.stderr").write_text(completed.stderr)
+    (workdir / "agent.stderr").write_text(stderr_text)
 
-    outcome = fixture_outcome(fixture, repo_dir, agent_log)
+    outcome = fixture_outcome(fixture, fixture_dir, repo_dir, initial_sha, agent_log)
     result = scorer.score_fixture(fixture, outcome)
-    result["exit_code"] = completed.returncode
+    result["exit_code"] = exit_code
     result["workdir"] = str(workdir)
-    result["agent_error"] = first_agent_error(agent_log)
+    result["agent_error"] = first_agent_error(agent_log) or first_stderr_error(stderr_text)
     print(json.dumps(result, indent=2))
     return 0 if result["resolved"] else 1
 

--- a/scripts/evals/swe_fix/runner.py
+++ b/scripts/evals/swe_fix/runner.py
@@ -69,7 +69,10 @@ def restore_test_files(fixture: dict, fixture_dir: Path, repo_dir: Path) -> None
     for rel_path in fixture.get("test_files", []):
         source = fixture_dir / rel_path
         if source.is_file():
-            shutil.copy2(source, repo_dir / rel_path)
+            destination = repo_dir / rel_path
+            # The agent may have deleted the file or its directory.
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, destination)
 
 
 def fixture_outcome(

--- a/scripts/evals/swe_fix/scorer.py
+++ b/scripts/evals/swe_fix/scorer.py
@@ -1,0 +1,106 @@
+"""Pure scorer for the swe-fix-loop eval.
+
+The scorer consumes a fixture manifest plus a recorded outcome dict and
+produces the rubric verdict. It never runs the agent; the runner records
+the outcome and calls in here, so every rule below is unit-testable
+without a model or network.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def score_fixture(fixture: dict, outcome: dict) -> dict:
+    """Apply the swe-fix-loop rubric to one recorded outcome.
+
+    Rubric:
+      - target test passes after the run
+      - every pre-existing test still passes (no regressions)
+      - diff containment: changed files stay within the golden patch's file
+        list, with a tolerance of 30% of the allowed set (min 1) for
+        legitimate collateral changes
+      - test-run evidence: the session transcript contains at least one bash
+        tool call running the fixture's test command (blocks blind-patch
+        guessing)
+    ``resolved`` requires every rubric element.
+    """
+    allowed = list(fixture.get("allowed_files", []))
+    changed = list(outcome.get("changed_files", []))
+    extras = [path for path in changed if path not in allowed]
+    tolerance = max(1, int(len(allowed) * 0.3))
+    diff_contained = len(extras) <= tolerance
+    evidence = bool(outcome.get("test_run_evidence", False))
+    target_passes = bool(outcome.get("target_test_passes", False))
+    pre_pass = bool(outcome.get("pre_existing_tests_pass", False))
+    usage = outcome.get("usage") or {}
+    resolved = target_passes and pre_pass and diff_contained and evidence
+    return {
+        "fixture": fixture.get("name"),
+        "resolved": resolved,
+        "target_test_passes": target_passes,
+        "pre_existing_tests_pass": pre_pass,
+        "diff_contained": diff_contained,
+        "extra_changed_files": extras,
+        "test_run_evidence": evidence,
+        "tokens_used": int(usage.get("tokens", 0)),
+        "turns": int(usage.get("turns", 0)),
+    }
+
+
+def test_run_evidence(session_text: str, test_command: str) -> bool:
+    """True when the session transcript shows a bash call running the tests.
+
+    Matches a bash toolCall whose command contains the test command (the
+    command may be prefixed or wrapped, so a substring test is used).
+    """
+    probe = _evidence_probe(test_command)
+    for line in session_text.splitlines():
+        try:
+            entry = json.loads(line)
+        except ValueError:
+            continue
+        message = entry.get("message") if isinstance(entry, dict) else None
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "toolCall":
+                continue
+            if block.get("name") != "bash":
+                continue
+            command = (block.get("arguments") or {}).get("command", "")
+            if isinstance(command, str) and probe in command:
+                return True
+    return False
+
+
+def _evidence_probe(test_command: str) -> str:
+    """The distinctive tail of the test command (e.g. 'npm test').
+
+    Strip leading runner prefixes so wrapped invocations still match.
+    """
+    return test_command.strip()
+
+
+def summarize_usage(session_text: str) -> dict:
+    """Sum assistant tokens and assistant turns from the session JSONL."""
+    tokens = 0
+    turns = 0
+    for line in session_text.splitlines():
+        try:
+            entry = json.loads(line)
+        except ValueError:
+            continue
+        message = entry.get("message") if isinstance(entry, dict) else None
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        usage = message.get("usage") or {}
+        total = usage.get("totalTokens", 0)
+        if not isinstance(total, int) or total <= 0:
+            continue
+        tokens += total
+        turns += 1
+    return {"tokens": tokens, "turns": turns}

--- a/scripts/evals/swe_fix/scorer.py
+++ b/scripts/evals/swe_fix/scorer.py
@@ -9,6 +9,10 @@ without a model or network.
 from __future__ import annotations
 
 import json
+import re
+
+# One double- or single-quoted Python string literal per match.
+STRING_LITERAL = re.compile("\"((?:[^\"\\\\\\n]|\\\\.)*)\"|'((?:[^'\\\\\\n]|\\\\.)*)'")
 
 
 def score_fixture(fixture: dict, outcome: dict) -> dict:
@@ -20,9 +24,9 @@ def score_fixture(fixture: dict, outcome: dict) -> dict:
       - diff containment: changed files stay within the golden patch's file
         list, with a tolerance of 30% of the allowed set (min 1) for
         legitimate collateral changes
-      - test-run evidence: the session transcript contains at least one bash
-        tool call running the fixture's test command (blocks blind-patch
-        guessing)
+      - test-run evidence: the session transcript shows the agent running
+        the fixture's test command, via a bash tool call or an ipython
+        bash() cell (blocks blind-patch guessing)
     ``resolved`` requires every rubric element.
     """
     allowed = list(fixture.get("allowed_files", []))
@@ -49,12 +53,14 @@ def score_fixture(fixture: dict, outcome: dict) -> dict:
 
 
 def test_run_evidence(session_text: str, test_command: str) -> bool:
-    """True when the session transcript shows a bash call running the tests.
+    """True when the transcript shows the agent running the test command.
 
-    Matches a bash toolCall whose command contains the test command (the
-    command may be prefixed or wrapped, so a substring test is used).
+    The agent's only built-in tool is the ipython kernel, so shell work
+    goes through a bash(...) call inside a cell; both a raw bash tool call
+    and an ipython bash() cell count. The test command must appear as a
+    whole shell command, so echoes and comments naming it do not.
     """
-    probe = _evidence_probe(test_command)
+    probe = test_command.strip()
     for line in session_text.splitlines():
         try:
             entry = json.loads(line)
@@ -69,24 +75,45 @@ def test_run_evidence(session_text: str, test_command: str) -> bool:
         for block in content:
             if not isinstance(block, dict) or block.get("type") != "toolCall":
                 continue
-            if block.get("name") != "bash":
-                continue
-            command = (block.get("arguments") or {}).get("command", "")
-            if isinstance(command, str) and probe in command:
-                return True
+            arguments = block.get("arguments") or {}
+            if block.get("name") == "bash":
+                command = arguments.get("command")
+                if isinstance(command, str) and _runs_command(command, probe):
+                    return True
+            elif block.get("name") == "ipython":
+                code = arguments.get("code")
+                if isinstance(code, str) and "bash(" in code:
+                    if any(_runs_command(literal, probe) for literal in _string_literals(code)):
+                        return True
     return False
 
 
-def _evidence_probe(test_command: str) -> str:
-    """The distinctive tail of the test command (e.g. 'npm test').
+def _string_literals(code: str) -> list[str]:
+    """The string literals in Python cell code, skipping comment lines."""
+    code = "\n".join(line for line in code.splitlines() if not line.lstrip().startswith("#"))
+    literals = []
+    for match in STRING_LITERAL.finditer(code):
+        literals.append(next(group for group in match.groups() if group is not None))
+    return literals
 
-    Strip leading runner prefixes so wrapped invocations still match.
-    """
-    return test_command.strip()
+
+def _runs_command(command: str, probe: str) -> bool:
+    """True when the probe runs as a whole shell command, not a substring."""
+    parts = command.replace("&&", ";").replace("||", ";").replace("|", ";").replace("&", ";")
+    for part in parts.replace("\n", ";").split(";"):
+        stripped = part.strip()
+        if stripped == probe or stripped.startswith(f"{probe} "):
+            return True
+    return False
 
 
 def summarize_usage(session_text: str) -> dict:
-    """Sum assistant tokens and assistant turns from the session JSONL."""
+    """Sum assistant tokens and assistant turns from the session JSONL.
+
+    In --mode json each completed assistant message is emitted once on
+    message_end; turn_end repeats the same message, so only message_end
+    events are counted.
+    """
     tokens = 0
     turns = 0
     for line in session_text.splitlines():
@@ -94,7 +121,9 @@ def summarize_usage(session_text: str) -> dict:
             entry = json.loads(line)
         except ValueError:
             continue
-        message = entry.get("message") if isinstance(entry, dict) else None
+        if not isinstance(entry, dict) or entry.get("type") != "message_end":
+            continue
+        message = entry.get("message")
         if not isinstance(message, dict) or message.get("role") != "assistant":
             continue
         usage = message.get("usage") or {}

--- a/scripts/evals/swe_fix/tests/test_swe_fix.py
+++ b/scripts/evals/swe_fix/tests/test_swe_fix.py
@@ -298,6 +298,22 @@ class RunnerTests(unittest.TestCase):
         # budget.py is allowed; only the untracked scratch file is extra.
         self.assertEqual(result["extra_changed_files"], ["newfile.txt"])
 
+    def test_deleted_test_directory_still_scores(self):
+        script = self.write_agent_script('cd "$6"\nrm -rf test\n')
+        argv = [
+            "--fixture",
+            str(FIXTURES / "ts-date-utils"),
+            "--model",
+            "test/fake",
+            "--agent-bin",
+            str(script),
+        ]
+        exit_code, result = self.run_runner(argv)
+        self.assertEqual(exit_code, 1)
+        self.assertFalse(result["resolved"])
+        self.assertFalse(result["target_test_passes"])
+        self.assertIn("test/dates.test.js", result["extra_changed_files"])
+
     def test_run_command_timeout_returns_failure_result(self):
         workdir = Path(tempfile.mkdtemp(prefix="swe-fix-cmd-"))
         result = runner.run_command("sleep 30", workdir, timeout=1)

--- a/scripts/evals/swe_fix/tests/test_swe_fix.py
+++ b/scripts/evals/swe_fix/tests/test_swe_fix.py
@@ -1,0 +1,160 @@
+"""Model-free self-tests for the swe-fix-loop eval harness.
+
+Validates fixture integrity (the seeded bug fails exactly one test, the
+golden patch makes the suite pass, and the patch applies cleanly) and the
+scorer rubric with synthetic outcomes and transcripts. No agent or model
+is invoked.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HARNESS = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(HARNESS))
+import scorer  # noqa: E402
+
+FIXTURES = HARNESS / "fixtures"
+
+
+class TempCopy:
+    def __init__(self, fixture_name: str):
+        self.source = FIXTURES / fixture_name
+        self.workdir = Path(tempfile.mkdtemp(prefix="swe-fix-test-"))
+        self.repo = self.workdir / "repo"
+
+    def __enter__(self) -> Path:
+        shutil.copytree(self.source, self.repo)
+        return self.repo
+
+    def __exit__(self, *_exc) -> None:
+        shutil.rmtree(self.workdir, ignore_errors=True)
+
+
+def run_tests(cwd: Path, command: str) -> int:
+    completed = subprocess.run(command, shell=True, cwd=cwd, capture_output=True, text=True, timeout=120)
+    return completed.returncode
+
+
+def fixture_manifest(name: str) -> dict:
+    return json.loads((FIXTURES / name / "fixture.json").read_text())
+
+
+class FixtureIntegrity(unittest.TestCase):
+    def test_ts_fixture_seed_fails_and_golden_patch_passes(self):
+        manifest = fixture_manifest("ts-date-utils")
+        with TempCopy("ts-date-utils") as repo:
+            self.assertNotEqual(run_tests(repo, manifest["test_command"]), 0)
+            subprocess.run(["git", "apply", manifest["golden_patch"]], cwd=repo, check=True)
+            self.assertEqual(run_tests(repo, manifest["test_command"]), 0)
+
+    def test_py_fixture_seed_fails_and_golden_patch_passes(self):
+        manifest = fixture_manifest("py-budget")
+        with TempCopy("py-budget") as repo:
+            self.assertNotEqual(run_tests(repo, manifest["test_command"]), 0)
+            subprocess.run(["git", "apply", manifest["golden_patch"]], cwd=repo, check=True)
+            self.assertEqual(run_tests(repo, manifest["test_command"]), 0)
+
+
+class ScorerTests(unittest.TestCase):
+    def setUp(self):
+        self.fixture = fixture_manifest("ts-date-utils")
+
+    def passing_outcome(self) -> dict:
+        return {
+            "changed_files": ["src/dates.js"],
+            "target_test_passes": True,
+            "pre_existing_tests_pass": True,
+            "test_run_evidence": True,
+            "usage": {"tokens": 12_000, "turns": 4},
+        }
+
+    def test_full_resolution(self):
+        result = scorer.score_fixture(self.fixture, self.passing_outcome())
+        self.assertTrue(result["resolved"])
+        self.assertEqual(result["tokens_used"], 12_000)
+        self.assertEqual(result["turns"], 4)
+
+    def test_missing_evidence_blocks_resolution(self):
+        outcome = self.passing_outcome()
+        outcome["test_run_evidence"] = False
+        self.assertFalse(scorer.score_fixture(self.fixture, outcome)["resolved"])
+
+    def test_regression_blocks_resolution(self):
+        outcome = self.passing_outcome()
+        outcome["pre_existing_tests_pass"] = False
+        self.assertFalse(scorer.score_fixture(self.fixture, outcome)["resolved"])
+
+    def test_diff_containment_tolerance(self):
+        outcome = self.passing_outcome()
+        # One allowed file: tolerance max(1, 0.3) = 1 extra file is contained.
+        outcome["changed_files"] = ["src/dates.js", "README.md"]
+        result = scorer.score_fixture(self.fixture, outcome)
+        self.assertTrue(result["diff_contained"])
+        # Two extras exceed the tolerance.
+        outcome["changed_files"] = ["src/dates.js", "README.md", "package.json"]
+        result = scorer.score_fixture(self.fixture, outcome)
+        self.assertFalse(result["diff_contained"])
+        self.assertEqual(result["extra_changed_files"], ["README.md", "package.json"])
+
+    def test_test_run_evidence_detects_bash_call(self):
+        transcript = json.dumps(
+            {
+                "type": "message",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "toolCall", "id": "c1", "name": "bash", "arguments": {"command": "npm test"}}
+                    ],
+                },
+            }
+        )
+        self.assertTrue(scorer.test_run_evidence(transcript, "npm test"))
+
+    def test_test_run_evidence_ignores_other_tools(self):
+        transcript = json.dumps(
+            {
+                "type": "message",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "toolCall",
+                            "id": "c1",
+                            "name": "ipython",
+                            "arguments": {"command": "npm test"},
+                        }
+                    ],
+                },
+            }
+        )
+        self.assertFalse(scorer.test_run_evidence(transcript, "npm test"))
+
+    def test_test_run_evidence_ignores_malformed_lines(self):
+        transcript = "not json\n" + json.dumps({"type": "message", "message": {"role": "user"}})
+        self.assertFalse(scorer.test_run_evidence(transcript, "npm test"))
+
+    def test_summarize_usage(self):
+        def assistant(tokens: int) -> str:
+            return json.dumps(
+                {
+                    "type": "message",
+                    "message": {
+                        "role": "assistant",
+                        "usage": {"input": 10, "output": tokens - 10, "totalTokens": tokens},
+                    },
+                }
+            )
+
+        session = assistant(100) + "\n" + assistant(50) + "\n" + json.dumps({"type": "message"})
+        self.assertEqual(scorer.summarize_usage(session), {"tokens": 150, "turns": 2})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/evals/swe_fix/tests/test_swe_fix.py
+++ b/scripts/evals/swe_fix/tests/test_swe_fix.py
@@ -12,9 +12,11 @@ import contextlib
 import io
 import json
 import shutil
+import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 
@@ -297,6 +299,90 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual(exit_code, 1)
         # budget.py is allowed; only the untracked scratch file is extra.
         self.assertEqual(result["extra_changed_files"], ["newfile.txt"])
+
+    def test_agent_timeout_with_partial_output_still_scores(self):
+        # TimeoutExpired output arrives as bytes even with text=True; the
+        # partial transcript must still decode, save, and count.
+        event = json.dumps(
+            {
+                "type": "message_end",
+                "message": {"role": "assistant", "usage": {"totalTokens": 42}},
+            }
+        )
+        script = self.write_agent_script(f"cat <<'EVENTS'\n{event}\nEVENTS\nexec sleep 30\n")
+        argv = [
+            "--fixture",
+            str(FIXTURES / "py-budget"),
+            "--model",
+            "test/fake",
+            "--agent-bin",
+            str(script),
+            "--timeout",
+            "1",
+        ]
+        exit_code, result = self.run_runner(argv)
+        self.assertEqual(exit_code, 1)
+        self.assertFalse(result["resolved"])
+        self.assertIsNone(result["exit_code"])
+        self.assertEqual(result["tokens_used"], 42)
+
+    def test_shadow_runner_cannot_fake_resolution(self):
+        # An agent-added repo-level unittest.py would shadow the stdlib
+        # runner and fake a passing suite; it is reverted before scoring.
+        script = self.write_agent_script(
+            'cd "$6"\n'
+            "cat > unittest.py <<'EOF'\n"
+            "import sys\n"
+            "sys.exit(0)\n"
+            "EOF\n"
+            "cat <<'EVENTS'\n"
+            + json.dumps(
+                {
+                    "type": "message_end",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "toolCall",
+                                "id": "c1",
+                                "name": "ipython",
+                                "arguments": {"code": "await bash('python3 -m unittest -v')"},
+                            }
+                        ],
+                    },
+                }
+            )
+            + "\nEVENTS\n"
+        )
+        argv = ["--fixture", str(FIXTURES / "py-budget"), "--model", "test/fake", "--agent-bin", str(script)]
+        exit_code, result = self.run_runner(argv)
+        self.assertEqual(exit_code, 1)
+        self.assertFalse(result["resolved"])
+        self.assertFalse(result["target_test_passes"])
+        self.assertIn("unittest.py", result["extra_changed_files"])
+
+    def test_shutdown_agent_daemon_sends_shutdown_command(self):
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        socket_dir = Path(tempfile.mkdtemp(prefix="swe-fix-sock-"))
+        socket_path = socket_dir / "daemon.sock"
+        server.bind(str(socket_path))
+        server.listen(1)
+        received = []
+
+        def serve() -> None:
+            connection, _ = server.accept()
+            received.append(connection.recv(1024).decode())
+            connection.close()
+
+        thread = threading.Thread(target=serve)
+        thread.start()
+        runner.shutdown_agent_daemon(socket_path)
+        thread.join(timeout=5)
+        server.close()
+        self.assertEqual(len(received), 1)
+        envelope = json.loads(received[0])
+        self.assertEqual(envelope["type"], "command")
+        self.assertEqual(envelope["command"]["type"], "shutdown")
 
     def test_deleted_test_directory_still_scores(self):
         script = self.write_agent_script('cd "$6"\nrm -rf test\n')

--- a/scripts/evals/swe_fix/tests/test_swe_fix.py
+++ b/scripts/evals/swe_fix/tests/test_swe_fix.py
@@ -8,6 +8,8 @@ is invoked.
 
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import shutil
 import subprocess
@@ -18,6 +20,7 @@ from pathlib import Path
 
 HARNESS = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(HARNESS))
+import runner  # noqa: E402
 import scorer  # noqa: E402
 
 FIXTURES = HARNESS / "fixtures"
@@ -42,6 +45,25 @@ def run_tests(cwd: Path, command: str) -> int:
     return completed.returncode
 
 
+def seeded_failure_count(repo: Path, manifest: dict) -> int:
+    """Failing tests in the seeded fixture; exactly one is the contract."""
+    if manifest["language"] == "typescript":
+        completed = subprocess.run(
+            "node --test --test-reporter=tap test/",
+            shell=True,
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        return sum(1 for line in completed.stdout.splitlines() if line.startswith("not ok"))
+    completed = subprocess.run(
+        manifest["test_command"], shell=True, cwd=repo, capture_output=True, text=True, timeout=120
+    )
+    output = completed.stdout + completed.stderr
+    return output.count("FAIL: ") + output.count("ERROR: ")
+
+
 def fixture_manifest(name: str) -> dict:
     return json.loads((FIXTURES / name / "fixture.json").read_text())
 
@@ -50,16 +72,20 @@ class FixtureIntegrity(unittest.TestCase):
     def test_ts_fixture_seed_fails_and_golden_patch_passes(self):
         manifest = fixture_manifest("ts-date-utils")
         with TempCopy("ts-date-utils") as repo:
-            self.assertNotEqual(run_tests(repo, manifest["test_command"]), 0)
+            self.assertEqual(seeded_failure_count(repo, manifest), 1)
+            self.assertNotEqual(run_tests(repo, manifest["target_test_command"]), 0)
             subprocess.run(["git", "apply", manifest["golden_patch"]], cwd=repo, check=True)
             self.assertEqual(run_tests(repo, manifest["test_command"]), 0)
+            self.assertEqual(run_tests(repo, manifest["target_test_command"]), 0)
 
     def test_py_fixture_seed_fails_and_golden_patch_passes(self):
         manifest = fixture_manifest("py-budget")
         with TempCopy("py-budget") as repo:
-            self.assertNotEqual(run_tests(repo, manifest["test_command"]), 0)
+            self.assertEqual(seeded_failure_count(repo, manifest), 1)
+            self.assertNotEqual(run_tests(repo, manifest["target_test_command"]), 0)
             subprocess.run(["git", "apply", manifest["golden_patch"]], cwd=repo, check=True)
             self.assertEqual(run_tests(repo, manifest["test_command"]), 0)
+            self.assertEqual(run_tests(repo, manifest["target_test_command"]), 0)
 
 
 class ScorerTests(unittest.TestCase):
@@ -117,6 +143,41 @@ class ScorerTests(unittest.TestCase):
         )
         self.assertTrue(scorer.test_run_evidence(transcript, "npm test"))
 
+    def test_test_run_evidence_detects_ipython_bash_call(self):
+        # The agent's only built-in tool is the ipython kernel; shell work
+        # goes through its bash() helper.
+        for code in ('await bash("npm test")', "h = bash('cd repo && npm test')"):
+            transcript = json.dumps(
+                {
+                    "type": "message_end",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "toolCall",
+                                "id": "c1",
+                                "name": "ipython",
+                                "arguments": {"code": code},
+                            }
+                        ],
+                    },
+                }
+            )
+            self.assertTrue(scorer.test_run_evidence(transcript, "npm test"))
+
+    def test_test_run_evidence_ignores_echo_and_comments(self):
+        def block(call_id: str, name: str, key: str, value: str) -> dict:
+            return {"type": "toolCall", "id": call_id, "name": name, "arguments": {key: value}}
+
+        blocks = [
+            block("c1", "bash", "command", "echo npm test"),
+            block("c2", "bash", "command", "# npm test"),
+            block("c3", "ipython", "code", "# bash('npm test')"),
+            block("c4", "ipython", "code", 'print("npm test")'),
+        ]
+        transcript = json.dumps({"type": "message_end", "message": {"role": "assistant", "content": blocks}})
+        self.assertFalse(scorer.test_run_evidence(transcript, "npm test"))
+
     def test_test_run_evidence_ignores_other_tools(self):
         transcript = json.dumps(
             {
@@ -144,7 +205,7 @@ class ScorerTests(unittest.TestCase):
         def assistant(tokens: int) -> str:
             return json.dumps(
                 {
-                    "type": "message",
+                    "type": "message_end",
                     "message": {
                         "role": "assistant",
                         "usage": {"input": 10, "output": tokens - 10, "totalTokens": tokens},
@@ -152,8 +213,95 @@ class ScorerTests(unittest.TestCase):
                 }
             )
 
-        session = assistant(100) + "\n" + assistant(50) + "\n" + json.dumps({"type": "message"})
+        session = assistant(100) + "\n" + assistant(50) + "\n" + json.dumps({"type": "message_end"})
         self.assertEqual(scorer.summarize_usage(session), {"tokens": 150, "turns": 2})
+
+    def test_summarize_usage_counts_each_assistant_message_once(self):
+        # --mode json repeats the assistant message on turn_end; the repeat
+        # must not double the token or turn count.
+        message = {"role": "assistant", "usage": {"input": 60, "output": 40, "totalTokens": 100}}
+        session = (
+            json.dumps({"type": "message_end", "message": message})
+            + "\n"
+            + json.dumps({"type": "turn_end", "message": message, "toolResults": []})
+        )
+        self.assertEqual(scorer.summarize_usage(session), {"tokens": 100, "turns": 1})
+
+
+class RunnerTests(unittest.TestCase):
+    """The runner must emit a scored result even when the agent cannot run."""
+
+    def run_runner(self, argv: list[str]) -> tuple[int, dict]:
+        captured = io.StringIO()
+        with contextlib.redirect_stdout(captured):
+            exit_code = runner.main(argv)
+        return exit_code, json.loads(captured.getvalue())
+
+    def write_agent_script(self, body: str) -> Path:
+        script = Path(tempfile.mkdtemp(prefix="swe-fix-agent-")) / "agent"
+        script.write_text(f"#!/bin/sh\n{body}")
+        script.chmod(0o755)
+        return script
+
+    def test_missing_agent_bin_scores_unresolved(self):
+        argv = [
+            "--fixture",
+            str(FIXTURES / "py-budget"),
+            "--model",
+            "test/fake",
+            "--agent-bin",
+            "/nonexistent-agent",
+        ]
+        exit_code, result = self.run_runner(argv)
+        self.assertEqual(exit_code, 1)
+        self.assertFalse(result["resolved"])
+        self.assertFalse(result["target_test_passes"])
+        self.assertTrue(result["agent_error"])
+
+    def test_agent_timeout_still_scores(self):
+        script = self.write_agent_script("exec sleep 30\n")
+        argv = [
+            "--fixture",
+            str(FIXTURES / "py-budget"),
+            "--model",
+            "test/fake",
+            "--agent-bin",
+            str(script),
+            "--timeout",
+            "1",
+        ]
+        exit_code, result = self.run_runner(argv)
+        self.assertEqual(exit_code, 1)
+        self.assertFalse(result["resolved"])
+        self.assertIsNone(result["exit_code"])
+
+    def test_changed_files_include_committed_and_new_files(self):
+        # The agent commits one edit and leaves a new file behind; both must
+        # appear in changed_files, not just unstaged edits.
+        script = self.write_agent_script(
+            'cd "$6"\n'
+            'echo "# agent edit" >> budget.py\n'
+            "git add budget.py\n"
+            "git -c commit.gpgsign=false -c user.email=agent@e -c user.name=agent commit -qm agent\n"
+            "echo scratch > newfile.txt\n"
+        )
+        argv = [
+            "--fixture",
+            str(FIXTURES / "py-budget"),
+            "--model",
+            "test/fake",
+            "--agent-bin",
+            str(script),
+        ]
+        exit_code, result = self.run_runner(argv)
+        self.assertEqual(exit_code, 1)
+        # budget.py is allowed; only the untracked scratch file is extra.
+        self.assertEqual(result["extra_changed_files"], ["newfile.txt"])
+
+    def test_run_command_timeout_returns_failure_result(self):
+        workdir = Path(tempfile.mkdtemp(prefix="swe-fix-cmd-"))
+        result = runner.run_command("sleep 30", workdir, timeout=1)
+        self.assertNotEqual(result["exit_code"], 0)
 
 
 if __name__ == "__main__":

--- a/scripts/evals/swe_fix/uv.lock
+++ b/scripts/evals/swe_fix/uv.lock
@@ -1,0 +1,46 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[options]
+exclude-newer = "2026-09-02T00:00:00Z"
+
+[[package]]
+name = "prime-agent-evals"
+version = "0.1.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = "==0.16.5" }]
+
+[[package]]
+name = "ruff"
+version = "0.16.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/85/c8e12473c93018f92d19dd988a294202e1c27426c47ec4de53ffb847b8d8/ruff-0.16.5.tar.gz", hash = "sha256:1b88500f9ffbcab3dedb0082c9f9492e91ec3d618aac1236a3e0189938f7040b", size = 4912003, upload-time = "2026-08-27T16:34:18.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/b6/77c90a970fe2dae17a723acbd011043ea97c98d7deacccefdc4ba74ec512/ruff-0.16.5-py3-none-linux_armv6l.whl", hash = "sha256:12e5f673e774c35fbb62f288809c7653b73445f8ecec6b6063fd6ea3521aa14b", size = 10011941, upload-time = "2026-08-27T16:33:41.287Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/46/6cf67cf6411885a1d6f7f6d801682f155536a85176d10b605e2ceffed8bd/ruff-0.16.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:eda58a5802de40e7ed5b32b64e0b32539338cc6fcd2c78f61e3ad6a0d79f51c3", size = 10204049, upload-time = "2026-08-27T16:33:44.056Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fd/c8720ca7a090abf0c2fef4abe8a5ef6e5127ed15196d8886ff75a2b370e2/ruff-0.16.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5ae9a7b9a8875131f40f8fe967cc86abf899779efd663cb7ce3d572d01da7eb", size = 9809037, upload-time = "2026-08-27T16:33:46.257Z" },
+    { url = "https://files.pythonhosted.org/packages/43/45/a684caacdedaca180f52bacccc40bf0789d2c5a7c75f25324853e9eaedb5/ruff-0.16.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b719b0a1f4d59710d283ab2965f621684a108a9e41da622e3b23f0326cd0025", size = 9964129, upload-time = "2026-08-27T16:33:48.352Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/5d2bcdaca6b5b93d1b4dfc166cd2aebf7680143a1b38a28759df13a94d31/ruff-0.16.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2298f2780ed1be0c5cb1361e32ab7b1467f3cce7dabe101d2210a314f2fe42e9", size = 9821518, upload-time = "2026-08-27T16:33:50.57Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ff/011cce29accf9257d5974145b733fc653a37985ed6825413a3987cefbfe0/ruff-0.16.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:258f29035a2dd021e7861e631b227a5b3f14e50c1184c9a6a122c5f4576154d7", size = 10534835, upload-time = "2026-08-27T16:33:52.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/5a/f0cf109bada9bba0e96c90c21c9f9251803f57225c32d293327a03c710d6/ruff-0.16.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9a4f0432966834019c74d1b7e5c51224305d7713f3d7faf3e7451f1a3be3cde", size = 11252550, upload-time = "2026-08-27T16:33:54.521Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4d/1d481aaea2046c6a7ed7c291f9004c669cce3c087b6b376ed5b08271e3fe/ruff-0.16.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b5eb3a8c3d0ade9cea42b591fd530368e8798380e30e0a308b85a5cf718f09ea", size = 10777949, upload-time = "2026-08-27T16:33:56.88Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/34/ee245ca55f64443233034b3d02b03236b19242004281247c079390b7facd/ruff-0.16.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef0f69e191a13a3c9816f63163c88790cb12cd157bbbb384e9c44745702ab105", size = 10311656, upload-time = "2026-08-27T16:33:59.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/4d/c33a333e341c0a2b96c715b52d89a606f5a34cd4ac493cd9b8d0187186b8/ruff-0.16.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0eeab41fbea2c42f98dfb9822cdccda9d24ba38d49f6dc945b5c236d48f0ef29", size = 10532125, upload-time = "2026-08-27T16:34:01.166Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/a64cef78b40192497bb98a27a8aa8f2c98ee9ee15bc97f7712d94ef32937/ruff-0.16.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f0768e9df4300713fff30733c87575f68b6f1d8de41184e505b7fdd9c0c95eaf", size = 10097648, upload-time = "2026-08-27T16:34:03.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4e/4cdc9ed3c3e109d2f71e62572a37457298d7bc7501ec3138babb7ed32bbd/ruff-0.16.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:95cc70cdc7aa80c338de356279d2adbeb2de0f520b9ecd8aba75b94e95e02f91", size = 9829344, upload-time = "2026-08-27T16:34:05.134Z" },
+    { url = "https://files.pythonhosted.org/packages/39/4a/31ed35ce31729955fc583ee0d176d6e784c1290cb0b0a75cb2134c1ab72a/ruff-0.16.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d185c8398ded1bfd91c0c2cb258346307571eccc473a8490af8c3977399c384a", size = 10277117, upload-time = "2026-08-27T16:34:07.425Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a0/60356d86687b4b666d593df213f4dc3041750d024cb7bf2cfa81cfd65c2e/ruff-0.16.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fb8e3a3c4c6a784150a7ced53b015f4b253fc2bf97a610886419ead64b4756ef", size = 10711653, upload-time = "2026-08-27T16:34:09.712Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/20/656d67f5b25ca9bda4e02b1de25867b2954e1d19e03648060f167ad0f4cc/ruff-0.16.5-py3-none-win32.whl", hash = "sha256:288b0a5f080492fe5635db849f9e2e84aa3cce7b7f0e955997d416c507c76a26", size = 10034250, upload-time = "2026-08-27T16:34:11.8Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/42/ee8e68a207b9127fcde6c3d7e197def432f346cb1af159e1fa14ca0d1cdc/ruff-0.16.5-py3-none-win_amd64.whl", hash = "sha256:ddc6385fb2137f616357ca03d6c74f4be987f80fed4008566b754f6032b8546f", size = 10516714, upload-time = "2026-08-27T16:34:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e3/7df5a396e445b9ba49ce9a9437439a4d80042c61c0ade199abf8d16de1ac/ruff-0.16.5-py3-none-win_arm64.whl", hash = "sha256:a64abe90968719b851bb7cedffaa8753fbdbdadab483089682db623f3edc587e", size = 10391564, upload-time = "2026-08-27T16:34:16.064Z" },
+]


### PR DESCRIPTION
## What

The repo has ~5,300 unit tests and **zero capability evaluation** — no test anywhere measures whether the agent can actually find a bug, edit code, run the tests, and iterate to green. The 22 gated real-model tests in `packages/ai` verify provider payload shapes; the benchmark harness measures startup performance. This ships eval #1 from the RSI program's eval gap matrix: **swe-fix-loop**.

## The harness

- **Two stdlib-only fixture repos** (TypeScript via `node --test`, Python via `unittest` — nothing to install, nothing to network): each ships 3 pre-existing passing tests, 1 seeded failing test, a `golden.patch`, and a symptom-only `task.txt` that names the failing behavior, never the location.
- **`runner.py`** copies a fixture to a temp dir, runs the agent headless (`--mode json`, `--cwd` at the fixture, task prompt, timeout), records the post-state, scores, prints JSON. Exits 0 only on a resolved fixture. Real-model runs are manual (`--model` + provider credentials); the runner never runs in CI.
- **`scorer.py`** (pure, unit-testable): target test passes; pre-existing tests still pass; diff containment vs the golden file list (30% collateral tolerance); **transcript evidence of a bash call running the test command** (blocks blind-patch guessing); tokens/turns from the transcript.
- **10 model-free self-tests**: fixture integrity (the seed fails exactly one test; the golden patch flips the suite to green and applies cleanly) and every scorer rule with synthetic outcomes and transcripts.

## Validation

Self-tests green locally (`uv run --locked python -m unittest discover -s tests` — 10/10); `ruff check` and `ruff format --check` clean; both fixtures verified end to end (buggy → 1 failure, patched → all pass). `development.md` documents the harness.

## Follow-up for a maintainer

Adding a CI step requires `workflow` scope this token lacks; the intended addition (mirroring the existing benchmark-harness step, after the `Test benchmark harness` step in ci.yml):

```yaml
      - name: Test eval harness
        if: matrix.name == 'runtime python'
        working-directory: scripts/evals/swe_fix
        run: |
          uv run --locked ruff check .
          uv run --locked ruff format --check .
          uv run --locked python -m unittest discover -s tests -v
```

Fixes ENG-6094

---
*This PR was authored autonomously as part of a recursive self-improvement program (RSI).*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Python eval tooling under `scripts/evals/` with no changes to production agent runtime paths except optional manual `prime-agent` invocations.
> 
> **Overview**
> Introduces **real-model capability evals** under `scripts/evals/`, starting with the **swe-fix-loop** harness that scores whether a headless agent can fix a seeded bug, run tests, and stay within scope.
> 
> The **runner** copies a fixture into a temp git repo, invokes `prime-agent` in JSON mode with an isolated agent home (stripped internal env, copied `auth.json`), shuts down the eval daemon afterward, restores pristine tests/runners before scoring so cheats like shadow `unittest.py` or edited tests cannot pass, then prints JSON and exits 0 only when **resolved**. The **scorer** requires target + full suite green, diff containment vs `allowed_files` (30% extra-file tolerance), and transcript proof the fixture test command ran via bash or ipython `bash()`.
> 
> Two stdlib-only fixtures ship (**py-budget** rounding, **ts-date-utils** leap-century rule), each with symptom-only `task.txt` and `golden.patch`. A large **model-free** unittest suite validates fixtures, rubric edge cases, and runner hardening (git index flags, symlinks, bytecode caches, timeouts). `packages/coding-agent/docs/development.md` and `scripts/evals/README.md` document usage; real-model runs stay manual and out of CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8da71c8cc12b58ef4aa70a04b74ed59fba7c086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `swe-fix-loop` capability evaluation harness with seeded-bug fixtures and scorer
> - Adds a headless runner in [runner.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/2237/files#diff-687d5d9476b91fa79e917dcaa66de7d65539c430807ef5d4b2ae46974ca8e594) that copies a fixture into an isolated git repo, invokes an agent, restores out-of-scope edits, runs the configured tests, and emits a scored JSON result.
> - Adds a rubric scorer in [scorer.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/2237/files#diff-49407c30ea92ba3fc15f1479e5bc515a9f9daf89f14c2d53ef668500b8657b5f) that marks a fixture resolved only when the target test passes, the full suite passes, changed files stay within a one-file tolerance, and the transcript proves the configured test command was run.
> - Adds two seeded-bug fixtures: `py-budget` (share rounding) and `ts-date-utils` (leap-year century rule), each with a golden patch, target tests, and a symptom-only task prompt.
> - Adds self-tests in [test_swe_fix.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/2237/files#diff-b4973d7aeab1c49857d754c5562d929feabc774a4abe65d75bb2d44300687b05) covering fixture integrity, scorer behavior, and runner failure paths (timeouts, missing agent, shadow tests, daemon shutdown).
> - Risk: the runner excludes selected internal environment variables and copies auth into a temporary agent directory via `agent_env`; verify that real agent runs still authenticate correctly under this isolated environment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 063ded2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->