### PR TITLE
[RSI] Hard-error invalid --thinking; stop referencing nonexistent --no-daemon

### DIFF
--- a/packages/coding-agent/.changes/eng-6095-thinking-and-agents-view-messages.md
+++ b/packages/coding-agent/.changes/eng-6095-thinking-and-agents-view-messages.md
@@ -1,0 +1,2 @@
+- Fixed an invalid `--thinking` level being only a warning while the launch continued with the default level; it is now a hard error listing the valid values, matching `--mode` strictness.
+- Fixed the agents-view hint telling users to start "without --no-daemon" - a flag the CLI does not recognize; the hint now names the real condition (a daemon-hosted session; start normally without `--no-session`).

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -171,7 +171,7 @@ export function parseArgs(args: string[]): Args {
 				result.thinking = level;
 			} else {
 				result.diagnostics.push({
-					type: "warning",
+					type: "error",
 					message: `Invalid thinking level "${level}". Valid values: ${THINKING_LEVELS.join(", ")}`,
 				});
 			}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6092,7 +6092,9 @@ export class InteractiveMode {
 	private async openScopedAgentsView(): Promise<void> {
 		if (!this.options.returnToAgentsView) {
 			this.focusEditor();
-			this.showStatus("The agents view needs the daemon; start without --no-daemon to browse sessions");
+			this.showStatus(
+				"The agents view needs a daemon-hosted session; start normally (without --no-session) to browse sessions",
+			);
 			return;
 		}
 		await this.returnToAgentsView("scoped_agents_view");
@@ -6924,7 +6926,9 @@ export class InteractiveMode {
 
 	private async requestAgentsView(): Promise<void> {
 		if (!this.options.returnToAgentsView) {
-			this.showStatus("The agents view needs the daemon; start without --no-daemon to browse sessions");
+			this.showStatus(
+				"The agents view needs a daemon-hosted session; start normally (without --no-session) to browse sessions",
+			);
 			return;
 		}
 		await this.returnToAgentsView();

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -231,6 +231,15 @@ describe("parseArgs", () => {
 			expect(result.thinking).toBe("high");
 		});
 
+		test("rejects an invalid --thinking level as a hard error", () => {
+			const result = parseArgs(["--thinking", "hig"]);
+			expect(result.thinking).toBeUndefined();
+			expect(result.diagnostics).toContainEqual({
+				type: "error",
+				message: 'Invalid thinking level "hig". Valid values: off, minimal, low, medium, high, xhigh, max',
+			});
+		});
+
 		test("parses --models as comma-separated list", () => {
 			const result = parseArgs(["--models", "gpt-4o,claude-sonnet,gemini-pro"]);
 			expect(result.models).toEqual(["gpt-4o", "claude-sonnet", "gemini-pro"]);

--- a/packages/coding-agent/test/interactive-mode-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup.test.ts
@@ -224,7 +224,9 @@ describe("InteractiveMode startup hints", () => {
 
 		await Reflect.get(InteractiveMode.prototype, "requestAgentsView").call(mode);
 
-		expect(showStatus).toHaveBeenCalledWith(expect.stringContaining("needs the daemon"));
+		expect(showStatus).toHaveBeenCalledWith(
+			expect.stringContaining("needs a daemon-hosted session"),
+		);
 		expect(shutdown).not.toHaveBeenCalled();
 	});
 


### PR DESCRIPTION
## What

Two small correctness gaps from the RSI program's UX friction inventory:

### 1. Invalid `--thinking` is only a warning

`--thinking hig` produced a warning and the launch continued with the default level, while invalid `--mode` is already a hard error (PR #2216's strictness). A mistyped reasoning level was silently dropped — the user asked for more reasoning and got the default. It is now an error diagnostic listing the valid values.

The model-resolver's `pattern:level` fallback is deliberately permissive (strict for `--model` so a bad level cannot silently resolve to a different model; tolerant for `--models` scoping) and is untouched.

### 2. Error messages reference a flag that does not exist

`interactive-mode.ts` told users *"start without --no-daemon to browse sessions"* in two places — there is no `--no-daemon` flag in `args.ts`. The advice now names the real condition: a daemon-hosted session, started normally (without `--no-session`).

## Tests

`args.test.ts` gains the hard-error case (invalid level → error diagnostic with the valid values, `thinking` stays undefined). 103/103 args tests pass; `tsgo --noEmit` + biome clean.

Fixes ENG-6095

---
*This PR was authored autonomously as part of a recursive self-improvement program (RSI).*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI validation and user-facing message fixes with no auth, data, or core runtime behavior changes beyond failing fast on bad `--thinking` input.
> 
> **Overview**
> **Invalid `--thinking` values now fail launch** instead of emitting a warning and continuing with the default reasoning level. `parseArgs` records an **error** diagnostic listing valid levels (aligned with strict `--mode` handling), and tests assert the level stays unset.
> 
> **Agents-view status copy** in interactive mode no longer mentions the nonexistent `--no-daemon` flag. When `returnToAgentsView` is unavailable, users are told the view needs a **daemon-hosted session** and to start normally **without `--no-session`**; startup tests expect the updated wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 182c4e6b959b77b0c469d19654419d83f5e15c2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make invalid `--thinking` a hard error and fix agents-view `--no-daemon` references
> - Changes `parseArgs` in [args.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2240/files#diff-3b284fa108abd7559ef709f343eddfe521198102aa818df139fbff7dec918924) so an invalid `--thinking` level produces an error diagnostic instead of a warning; the parsed `thinking` field is left unset.
> - Replaces agents-view status messages in [interactive-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2240/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316) that referenced the nonexistent `--no-daemon` flag with guidance about daemon-hosted sessions and the `--no-session` condition.
> - Behavioral Change: invalid `--thinking` values now fail argument parsing instead of continuing with a warning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 182c4e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->