### PR TITLE
[RSI] Persistent SupervisorLink for cross-worker requests

### DIFF
--- a/packages/coding-agent/.changes/eng-6097-supervisor-link.md
+++ b/packages/coding-agent/.changes/eng-6097-supervisor-link.md
@@ -1,0 +1,1 @@
+- Added a persistent supervisor connection for daemon workers: cross-worker requests (agent messages, roster reads, root-session creation, renames) now multiplex over one `SupervisorLink` instead of opening a fresh supervisor connection per call. Requests are never retried in-flight because daemon commands are not idempotent.

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -143,7 +143,6 @@ import {
 	workerRosterEntryFromSummary,
 } from "./agent-roster.js";
 import { createCompactAssistantDelta } from "./compact-session-stream.js";
-import { DaemonClient } from "./daemon-client.js";
 import { filterClientEnv, withClientEnv } from "./daemon-client-env.js";
 import { deserializeDaemonError, serializeDaemonError } from "./daemon-errors.js";
 import { bindActiveSessionState } from "./daemon-extension-binding.js";
@@ -238,6 +237,7 @@ import {
 	SNAPSHOT_TARGET_CHUNK_BYTES,
 	type SnapshotTranscriptChunkSource,
 } from "./snapshot-transcript-cache.js";
+import { SupervisorLink } from "./supervisor-link.js";
 import { WorkerRecoveryJournal } from "./worker-recovery-journal.js";
 
 export interface DaemonModeOptions {
@@ -712,6 +712,15 @@ export class AgentDaemon {
 	private supervisorSocketPathFromEnv(): string | undefined {
 		const raw = process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV];
 		return raw ? normalizeSocketPath(raw) : undefined;
+	}
+
+	/** Persistent supervisor connection for cross-worker requests; one link per daemon process. */
+	private supervisorLinkInstance?: SupervisorLink;
+	private supervisorLink(): SupervisorLink | undefined {
+		const supervisorSocketPath = this.supervisorSocketPathFromEnv();
+		if (!supervisorSocketPath) return undefined;
+		this.supervisorLinkInstance ??= new SupervisorLink({ socketPath: supervisorSocketPath });
+		return this.supervisorLinkInstance;
 	}
 
 	private startSupervisorMonitor(): void {
@@ -2689,16 +2698,14 @@ export class AgentDaemon {
 		parentState: ActiveSessionState,
 		options: CreateRlmRootSessionOptions,
 	): Promise<RlmCreateSessionResult> {
-		const supervisorSocketPath = this.supervisorSocketPathFromEnv();
-		if (!this.options.worker || !supervisorSocketPath) {
+		const link = this.supervisorLink();
+		if (!this.options.worker || !link) {
 			throw new Error("rlm.create_session requires a daemon worker connected to its supervisor");
 		}
 
-		const client = new DaemonClient(supervisorSocketPath);
 		let activeSessionId: string | undefined;
 		try {
-			await client.connect(3000);
-			await client.waitForHello(3000);
+			const client = link;
 			const runtimeConfig = parentState.runtime.runtimeConfig;
 			const inheritsProvider = options.model.provider === parentState.runtime.session.model?.provider;
 			const authSource = parentState.runtime.services.authStorage.getAuthStatus(options.model.provider).source;
@@ -2766,11 +2773,9 @@ export class AgentDaemon {
 			};
 		} catch (error) {
 			if (activeSessionId) {
-				await client.request({ type: "kill", activeSessionId }, 30_000).catch(() => undefined);
+				await link.request({ type: "kill", activeSessionId }, 30_000).catch(() => undefined);
 			}
 			throw error;
-		} finally {
-			client.close();
 		}
 	}
 
@@ -3404,9 +3409,7 @@ export class AgentDaemon {
 			...(entry.repliedSinceTask !== undefined ? { repliedSinceTask: entry.repliedSinceTask } : {}),
 			...(entry.parentSessionId ? { parentSessionId: entry.parentSessionId } : {}),
 			...(entry.rlmChildId ? { rlmChildId: entry.rlmChildId } : {}),
-			...(entry.firstMessage
-				? { firstMessage: entry.firstMessage.slice(0, AGENT_OBSERVE_PREVIEW_MAX_CHARS) }
-				: {}),
+			...(entry.firstMessage ? { firstMessage: entry.firstMessage.slice(0, AGENT_OBSERVE_PREVIEW_MAX_CHARS) } : {}),
 		};
 	}
 
@@ -3482,7 +3485,11 @@ export class AgentDaemon {
 			...(summary.firstMessage ? { firstMessage: summary.firstMessage } : {}),
 			...(latest
 				? {
-						latestMessage: createAgentObserveMessagePreview(latest, messages.length - 1, AGENT_OBSERVE_PREVIEW_MAX_CHARS),
+						latestMessage: createAgentObserveMessagePreview(
+							latest,
+							messages.length - 1,
+							AGENT_OBSERVE_PREVIEW_MAX_CHARS,
+						),
 					}
 				: {}),
 		};
@@ -5713,13 +5720,10 @@ export class AgentDaemon {
 	}
 
 	private async listSupervisorAgentPeers(): Promise<AgentSessionMessageAgentSummary[]> {
-		const supervisorSocketPath = this.supervisorSocketPathFromEnv();
-		if (!this.options.worker || !supervisorSocketPath) return [];
-		const client = new DaemonClient(supervisorSocketPath);
+		const link = this.supervisorLink();
+		if (!this.options.worker || !link) return [];
 		try {
-			await client.connect(1000);
-			await client.waitForHello();
-			const response = await client.request(
+			const response = await link.request(
 				{ type: "list_agent_peers", workerToken: this.options.worker.authenticationToken },
 				5000,
 			);
@@ -5728,8 +5732,6 @@ export class AgentDaemon {
 			return (response.data as { peers: AgentSessionMessageAgentSummary[] }).peers;
 		} catch {
 			return [];
-		} finally {
-			client.close();
 		}
 	}
 
@@ -5925,27 +5927,20 @@ export class AgentDaemon {
 	}
 
 	private async setStateSessionNameViaSupervisor(state: ActiveSessionState, name: string): Promise<void> {
-		const supervisorSocketPath = this.supervisorSocketPathFromEnv();
-		if (!this.options.worker || !supervisorSocketPath) {
+		const link = this.supervisorLink();
+		if (!this.options.worker || !link) {
 			return this.setStateSessionName(state, name);
 		}
-		const client = new DaemonClient(supervisorSocketPath);
-		try {
-			await client.connect(1000);
-			await client.waitForHello();
-			const response = await client.request(
-				{
-					type: "set_session_name",
-					activeSessionId: state.activeSessionId,
-					name,
-					workerToken: this.options.worker.authenticationToken,
-				},
-				30_000,
-			);
-			if (!response.success) throw deserializeDaemonError(response);
-		} finally {
-			client.close();
-		}
+		const response = await link.request(
+			{
+				type: "set_session_name",
+				activeSessionId: state.activeSessionId,
+				name,
+				workerToken: this.options.worker.authenticationToken,
+			},
+			30_000,
+		);
+		if (!response.success) throw deserializeDaemonError(response);
 	}
 
 	private setStateSessionNameForCommand(state: ActiveSessionState, name: string): Promise<void> {
@@ -6221,50 +6216,45 @@ export class AgentDaemon {
 		targetSelector: string,
 		message: string,
 	): Promise<AgentSessionMessageReceipt> {
-		const supervisorSocketPath = this.supervisorSocketPathFromEnv();
-		if (!supervisorSocketPath) {
+		const link = this.supervisorLink();
+		if (!link) {
 			throw new Error(`Unknown active session: ${targetSelector}`);
 		}
 		const deadline = Date.now() + 30_000;
-		let client: DaemonClient | undefined;
 		let lastError: unknown;
+		// Connect-window loop only: the supervisor may still be starting up.
+		// The message itself is sent exactly once - daemon commands are not
+		// idempotent, so a rejected or timed-out send must never be retried.
 		while (Date.now() < deadline && !this.shuttingDown) {
-			const candidate = new DaemonClient(supervisorSocketPath);
 			try {
-				await candidate.connect(1000);
-				await candidate.waitForHello();
-				client = candidate;
+				await link.ensureConnected();
+				lastError = undefined;
 				break;
 			} catch (error) {
 				lastError = error;
-				candidate.close();
+				await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
 			}
-			await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
 		}
-		if (!client) {
+		if (lastError !== undefined) {
 			throw lastError instanceof Error ? lastError : new Error(`Unknown active session: ${targetSelector}`);
 		}
-		try {
-			const response = await client.request(
-				{
-					type: "send_message",
-					targetActiveSessionId: targetSelector,
-					message,
-					fromActiveSessionId: fromState.activeSessionId,
-					agentOrigin: true,
-				},
-				30_000,
-			);
-			if (!response.success) {
-				throw deserializeDaemonError(response);
-			}
-			if (!response.data || typeof response.data !== "object") {
-				throw new Error("Supervisor returned an invalid agent-message receipt");
-			}
-			return response.data as AgentSessionMessageReceipt;
-		} finally {
-			client.close();
+		const response = await link.request(
+			{
+				type: "send_message",
+				targetActiveSessionId: targetSelector,
+				message,
+				fromActiveSessionId: fromState.activeSessionId,
+				agentOrigin: true,
+			},
+			30_000,
+		);
+		if (!response.success) {
+			throw deserializeDaemonError(response);
 		}
+		if (!response.data || typeof response.data !== "object") {
+			throw new Error("Supervisor returned an invalid agent-message receipt");
+		}
+		return response.data as AgentSessionMessageReceipt;
 	}
 
 	private async acceptAgentSessionMessage(
@@ -7600,6 +7590,7 @@ export class AgentDaemon {
 		this.shuttingDown = true;
 		this.peerAdmissionsFenced = true;
 		this.peerGrants.clear();
+		this.supervisorLinkInstance?.close();
 		if (this.supervisorMonitorTimer) {
 			clearTimeout(this.supervisorMonitorTimer);
 			this.supervisorMonitorTimer = undefined;

--- a/packages/coding-agent/src/modes/daemon/supervisor-link.ts
+++ b/packages/coding-agent/src/modes/daemon/supervisor-link.ts
@@ -1,17 +1,16 @@
 import type { DaemonCommandBody } from "./daemon-client.js";
-import { DaemonClient } from "./daemon-client.js";
+import { DaemonClient, DaemonSocketClosedError } from "./daemon-client.js";
 import type { DaemonResponse } from "./daemon-protocol.js";
 
 /**
  * Long-lived supervisor connection for a daemon worker.
  *
- * daemon-mode.ts used to open a fresh DaemonClient - connect, hello,
- * request, close - on every cross-worker interaction (agent messages,
- * roster reads, root-session creation, renames). SupervisorLink holds
- * one persistent connection instead and multiplexes requests over it.
- * Socket death is expected (supervisor restarts): the link tears down
- * on close, the next request reconnects, and one in-flight retry
- * preserves the old per-call-fresh-connection resilience.
+ * Holds one persistent connection and multiplexes cross-worker requests
+ * (agent messages, roster reads, root-session creation, renames) over
+ * it. Socket death is expected during supervisor restarts: teardown
+ * happens on close or handshake failure, and the next request
+ * reconnects. Requests are never retried (daemon commands are not
+ * idempotent).
  */
 
 export interface DaemonClientLike {
@@ -55,7 +54,10 @@ export class SupervisorLink {
 		try {
 			return await client.request(command, timeoutMs);
 		} catch (error) {
-			this.teardown();
+			// A command-level failure (timeout, rejection) leaves a healthy
+			// socket serving other in-flight requests; only socket death
+			// invalidates the shared connection.
+			if (error instanceof DaemonSocketClosedError) this.teardown();
 			throw error;
 		}
 	}
@@ -74,8 +76,17 @@ export class SupervisorLink {
 			)(this.options.socketPath);
 			const detach = client.onClose(() => this.teardown());
 			this.disposers.add(detach);
-			await client.connect(this.options.connectTimeoutMs ?? 1000);
-			await client.waitForHello();
+			try {
+				await client.connect(this.options.connectTimeoutMs ?? 1000);
+				await client.waitForHello();
+			} catch (error) {
+				// DaemonClient fires onClose only after a successful connect,
+				// so a failed handshake must close its own socket here.
+				this.disposers.delete(detach);
+				detach();
+				client.close();
+				throw error;
+			}
 			this.client = client;
 			return client;
 		})();

--- a/packages/coding-agent/src/modes/daemon/supervisor-link.ts
+++ b/packages/coding-agent/src/modes/daemon/supervisor-link.ts
@@ -32,6 +32,8 @@ export interface SupervisorLinkOptions {
 
 export class SupervisorLink {
 	private client?: DaemonClientLike;
+	/** Client mid-handshake; teardown must close it too (close() during connect). */
+	private pendingClient?: DaemonClientLike;
 	private connecting?: Promise<DaemonClientLike>;
 	private closed = false;
 	private readonly disposers = new Set<() => void>();
@@ -74,19 +76,30 @@ export class SupervisorLink {
 			const client = (
 				this.options.factory ?? ((socketPath: string) => new DaemonClient(socketPath) as DaemonClientLike)
 			)(this.options.socketPath);
+			this.pendingClient = client;
 			const detach = client.onClose(() => this.teardown());
 			this.disposers.add(detach);
-			try {
-				await client.connect(this.options.connectTimeoutMs ?? 1000);
-				await client.waitForHello();
-			} catch (error) {
+			const cleanup = () => {
 				// DaemonClient fires onClose only after a successful connect,
 				// so a failed handshake must close its own socket here.
 				this.disposers.delete(detach);
 				detach();
+				if (this.pendingClient === client) this.pendingClient = undefined;
 				client.close();
+			};
+			try {
+				await client.connect(this.options.connectTimeoutMs ?? 1000);
+				await client.waitForHello();
+			} catch (error) {
+				cleanup();
 				throw error;
 			}
+			if (this.closed || this.client !== undefined) {
+				// Teardown ran mid-handshake or another coroutine won the race.
+				cleanup();
+				throw new Error("Supervisor link was closed during handshake");
+			}
+			this.pendingClient = undefined;
 			this.client = client;
 			return client;
 		})();
@@ -99,12 +112,13 @@ export class SupervisorLink {
 
 	/** Drop the cached connection; the next request reconnects. */
 	teardown(): void {
-		const client = this.client;
+		const clients = [this.client, this.pendingClient];
 		this.client = undefined;
+		this.pendingClient = undefined;
 		this.connecting = undefined;
 		for (const detach of this.disposers) detach();
 		this.disposers.clear();
-		client?.close();
+		for (const client of clients) client?.close();
 	}
 
 	/** Stop the link permanently; further requests fail fast without reconnecting. */

--- a/packages/coding-agent/src/modes/daemon/supervisor-link.ts
+++ b/packages/coding-agent/src/modes/daemon/supervisor-link.ts
@@ -1,0 +1,104 @@
+import type { DaemonCommandBody } from "./daemon-client.js";
+import { DaemonClient } from "./daemon-client.js";
+import type { DaemonResponse } from "./daemon-protocol.js";
+
+/**
+ * Long-lived supervisor connection for a daemon worker.
+ *
+ * daemon-mode.ts used to open a fresh DaemonClient - connect, hello,
+ * request, close - on every cross-worker interaction (agent messages,
+ * roster reads, root-session creation, renames). SupervisorLink holds
+ * one persistent connection instead and multiplexes requests over it.
+ * Socket death is expected (supervisor restarts): the link tears down
+ * on close, the next request reconnects, and one in-flight retry
+ * preserves the old per-call-fresh-connection resilience.
+ */
+
+export interface DaemonClientLike {
+	connect(timeoutMs: number): Promise<void>;
+	waitForHello(timeoutMs?: number): Promise<unknown>;
+	request(command: DaemonCommandBody, timeoutMs: number): Promise<DaemonResponse>;
+	onClose(listener: () => void): () => void;
+	close(): void;
+}
+
+export interface SupervisorLinkOptions {
+	socketPath: string;
+	connectTimeoutMs?: number;
+	/** Request-level default; call sites may override per request. */
+	requestTimeoutMs?: number;
+	/** Test seam: client factory. */
+	factory?: (socketPath: string) => DaemonClientLike;
+}
+
+export class SupervisorLink {
+	private client?: DaemonClientLike;
+	private connecting?: Promise<DaemonClientLike>;
+	private closed = false;
+	private readonly disposers = new Set<() => void>();
+
+	constructor(private readonly options: SupervisorLinkOptions) {}
+
+	/**
+	 * Send one request over the persistent link. Never retries: daemon
+	 * commands like create or send_message are not idempotent, so the
+	 * link tears down on failure and the NEXT request reconnects. Call
+	 * sites that need an establishment window use ensureConnected in
+	 * their own retry loop.
+	 */
+	async request(
+		command: DaemonCommandBody,
+		timeoutMs: number = this.options.requestTimeoutMs ?? 30_000,
+	): Promise<DaemonResponse> {
+		if (this.closed) throw new Error("Supervisor link is closed");
+		const client = await this.ensureConnected();
+		try {
+			return await client.request(command, timeoutMs);
+		} catch (error) {
+			this.teardown();
+			throw error;
+		}
+	}
+
+	/** Establish (or reuse) the authenticated connection. */
+	async ensureConnected(): Promise<DaemonClientLike> {
+		if (this.closed) throw new Error("Supervisor link is closed");
+		return this.ensureConnectedInternal();
+	}
+
+	private async ensureConnectedInternal(): Promise<DaemonClientLike> {
+		if (this.client) return this.client;
+		this.connecting ??= (async () => {
+			const client = (
+				this.options.factory ?? ((socketPath: string) => new DaemonClient(socketPath) as DaemonClientLike)
+			)(this.options.socketPath);
+			const detach = client.onClose(() => this.teardown());
+			this.disposers.add(detach);
+			await client.connect(this.options.connectTimeoutMs ?? 1000);
+			await client.waitForHello();
+			this.client = client;
+			return client;
+		})();
+		try {
+			return await this.connecting;
+		} finally {
+			this.connecting = undefined;
+		}
+	}
+
+	/** Drop the cached connection; the next request reconnects. */
+	teardown(): void {
+		const client = this.client;
+		this.client = undefined;
+		this.connecting = undefined;
+		for (const detach of this.disposers) detach();
+		this.disposers.clear();
+		client?.close();
+	}
+
+	/** Stop the link permanently; further requests fail fast without reconnecting. */
+	close(): void {
+		this.closed = true;
+		this.teardown();
+	}
+}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -17,6 +17,15 @@ import {
 import fsPromises from "node:fs/promises";
 import { syncBuiltinESMExports } from "node:module";
 import { createServer, type Server, type Socket } from "node:net";
+
+/** Close a fake supervisor and destroy lingering worker connections (persistent supervisor links keep sockets open). */
+function closeFakeSupervisor(server: Server, sockets: Set<Socket>): Promise<void> {
+	return new Promise<void>((resolveClose) => {
+		server.close(() => resolveClose());
+		for (const socket of sockets) socket.destroy();
+	});
+}
+
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import type { Api, Model } from "@earendil-works/pi-ai";
@@ -1867,7 +1876,10 @@ describe("daemon mode helpers", () => {
 			const tempDir = mkdtempSync(join(tmpdir(), "pa-root-session-"));
 			const socketPath = join(tempDir, "supervisor.sock");
 			const commands: Array<Record<string, unknown>> = [];
+			const sockets = new Set<Socket>();
 			const server: Server = createServer((socket) => {
+				sockets.add(socket);
+				socket.on("close", () => sockets.delete(socket));
 				socket.on("error", () => undefined);
 				socket.write(
 					`${JSON.stringify({
@@ -2022,7 +2034,7 @@ describe("daemon mode helpers", () => {
 				vi.unstubAllEnvs();
 				if (previousSupervisorSocket === undefined) delete process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV];
 				else process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV] = previousSupervisorSocket;
-				await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+				await closeFakeSupervisor(server, sockets);
 				rmSync(tempDir, { recursive: true, force: true });
 			}
 		},
@@ -2032,7 +2044,10 @@ describe("daemon mode helpers", () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "pa-root-timeout-"));
 		const socketPath = join(tempDir, "supervisor.sock");
 		const commands: Array<Record<string, unknown>> = [];
+		const sockets = new Set<Socket>();
 		const server = createServer((socket) => {
+			sockets.add(socket);
+			socket.on("close", () => sockets.delete(socket));
 			socket.on("error", () => {});
 			socket.write(
 				`${JSON.stringify({
@@ -2098,7 +2113,7 @@ describe("daemon mode helpers", () => {
 			requestSpy.mockRestore();
 			if (previousSocket === undefined) delete process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV];
 			else process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV] = previousSocket;
-			await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+			await closeFakeSupervisor(server, sockets);
 			rmSync(tempDir, { recursive: true, force: true });
 		}
 	});
@@ -2279,7 +2294,10 @@ describe("daemon mode helpers", () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "pa-msg-"));
 		const socketPath = join(tempDir, "d.sock");
 		let connectionCount = 0;
+		const sockets = new Set<Socket>();
 		const server: Server = createServer((socket) => {
+			sockets.add(socket);
+			socket.on("close", () => sockets.delete(socket));
 			connectionCount++;
 			socket.on("error", () => undefined);
 			socket.write(
@@ -2345,7 +2363,7 @@ describe("daemon mode helpers", () => {
 			} else {
 				process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV] = previousSupervisorSocket;
 			}
-			await new Promise<void>((resolve) => server.close(() => resolve()));
+			await closeFakeSupervisor(server, sockets);
 			rmSync(tempDir, { recursive: true, force: true });
 		}
 	});
@@ -2354,7 +2372,10 @@ describe("daemon mode helpers", () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "pa-msg-disconnect-"));
 		const socketPath = join(tempDir, "d.sock");
 		let requestCount = 0;
+		const sockets = new Set<Socket>();
 		const server: Server = createServer((socket) => {
+			sockets.add(socket);
+			socket.on("close", () => sockets.delete(socket));
 			socket.on("error", () => undefined);
 			socket.write(
 				`${JSON.stringify({
@@ -2424,7 +2445,7 @@ describe("daemon mode helpers", () => {
 			} else {
 				process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV] = previousSupervisorSocket;
 			}
-			await new Promise<void>((resolve) => server.close(() => resolve()));
+			await closeFakeSupervisor(server, sockets);
 			rmSync(tempDir, { recursive: true, force: true });
 		}
 	});
@@ -2437,7 +2458,10 @@ describe("daemon mode helpers", () => {
 		const responseGate = new Promise<void>((resolve) => {
 			releaseResponse = resolve;
 		});
+		const sockets = new Set<Socket>();
 		const server = createServer((socket) => {
+			sockets.add(socket);
+			socket.on("close", () => sockets.delete(socket));
 			socket.write(
 				`${JSON.stringify({
 					type: "daemon_hello",
@@ -2505,7 +2529,7 @@ describe("daemon mode helpers", () => {
 		} finally {
 			if (previousSocketPath === undefined) delete process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV];
 			else process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV] = previousSocketPath;
-			await new Promise<void>((resolve) => server.close(() => resolve()));
+			await closeFakeSupervisor(server, sockets);
 			rmSync(tempDir, { recursive: true, force: true });
 		}
 	});
@@ -2514,7 +2538,10 @@ describe("daemon mode helpers", () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "pa-ambiguous-"));
 		const socketPath = join(tempDir, "s");
 		let requestCount = 0;
+		const sockets = new Set<Socket>();
 		const server = createServer((socket) => {
+			sockets.add(socket);
+			socket.on("close", () => sockets.delete(socket));
 			socket.write(
 				`${JSON.stringify({
 					type: "daemon_hello",
@@ -2563,7 +2590,7 @@ describe("daemon mode helpers", () => {
 		} finally {
 			if (previousSocketPath === undefined) delete process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV];
 			else process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV] = previousSocketPath;
-			await new Promise<void>((resolve) => server.close(() => resolve()));
+			await closeFakeSupervisor(server, sockets);
 			rmSync(tempDir, { recursive: true, force: true });
 		}
 	});

--- a/packages/coding-agent/test/supervisor-link.test.ts
+++ b/packages/coding-agent/test/supervisor-link.test.ts
@@ -136,6 +136,34 @@ describe("SupervisorLink", () => {
 		link.close();
 	});
 
+	it("closes a client still mid-handshake when close() runs", async () => {
+		const clients: MockClient[] = [];
+		const link = new SupervisorLink({
+			socketPath: "/tmp/unused.sock",
+			factory: () => {
+				const client = makeMockClient();
+				let rejectHello: ((error: Error) => void) | undefined;
+				client.waitForHello = () =>
+					new Promise((_, reject) => {
+						rejectHello = reject;
+					});
+				const closeClient = client.close.bind(client);
+				client.close = () => {
+					// Socket death surfaces the pending handshake as a failure.
+					closeClient();
+					rejectHello?.(new Error("socket closed during handshake"));
+				};
+				clients.push(client);
+				return client;
+			},
+		});
+		const pending = link.ensureConnected();
+		await new Promise((resolveTick) => setTimeout(resolveTick, 0));
+		link.close();
+		expect(clients[0].closeCount).toBe(1);
+		await expect(pending).rejects.toThrow();
+	});
+
 	it("stops reconnecting after close()", async () => {
 		const clients: MockClient[] = [];
 		const link = makeLink(clients);

--- a/packages/coding-agent/test/supervisor-link.test.ts
+++ b/packages/coding-agent/test/supervisor-link.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { DaemonCommandBody } from "../src/modes/daemon/daemon-client.js";
+import { DaemonSocketClosedError } from "../src/modes/daemon/daemon-client.js";
 import type { DaemonResponse } from "../src/modes/daemon/daemon-protocol.js";
 import { type DaemonClientLike, SupervisorLink } from "../src/modes/daemon/supervisor-link.js";
 
@@ -80,7 +81,7 @@ describe("SupervisorLink", () => {
 		link.close();
 	});
 
-	it("does not retry a failed request; the next request reconnects", async () => {
+	it("does not retry a failed request; a healthy socket survives, a dead one reconnects", async () => {
 		const clients: MockClient[] = [];
 		const link = new SupervisorLink({
 			socketPath: "/tmp/unused.sock",
@@ -90,9 +91,45 @@ describe("SupervisorLink", () => {
 				return client;
 			},
 		});
+		// Command-level failure: the shared socket stays up for the next request.
 		await expect(link.request({ type: "send_message" } as DaemonCommandBody)).rejects.toThrow(
 			"socket died mid-request",
 		);
+		const response = await link.request({ type: "send_message" } as DaemonCommandBody);
+		expect(response.success).toBe(true);
+		expect(clients).toHaveLength(1);
+
+		// Socket-level failure: the link tears down, the next request reconnects.
+		const closed = new DaemonSocketClosedError("/tmp/unused.sock", "shutdown");
+		clients[0].request = async () => {
+			throw closed;
+		};
+		await expect(link.request({ type: "send_message" } as DaemonCommandBody)).rejects.toThrow();
+		const response2 = await link.request({ type: "send_message" } as DaemonCommandBody);
+		expect(response2.success).toBe(true);
+		expect(clients).toHaveLength(2);
+		expect(clients[0].closeCount).toBe(1);
+		link.close();
+	});
+
+	it("closes the client when the handshake fails", async () => {
+		const clients: MockClient[] = [];
+		const link = new SupervisorLink({
+			socketPath: "/tmp/unused.sock",
+			factory: () => {
+				const client = makeMockClient();
+				// First candidate fails the hello; the next connects cleanly.
+				if (clients.length === 0) {
+					client.waitForHello = async () => {
+						throw new Error("hello timeout");
+					};
+				}
+				clients.push(client);
+				return client;
+			},
+		});
+		await expect(link.request({ type: "send_message" } as DaemonCommandBody)).rejects.toThrow("hello timeout");
+		expect(clients[0].closeCount).toBe(1);
 		const response = await link.request({ type: "send_message" } as DaemonCommandBody);
 		expect(response.success).toBe(true);
 		expect(clients).toHaveLength(2);

--- a/packages/coding-agent/test/supervisor-link.test.ts
+++ b/packages/coding-agent/test/supervisor-link.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { DaemonCommandBody } from "../src/modes/daemon/daemon-client.js";
+import type { DaemonResponse } from "../src/modes/daemon/daemon-protocol.js";
+import { type DaemonClientLike, SupervisorLink } from "../src/modes/daemon/supervisor-link.js";
+
+interface MockClient extends DaemonClientLike {
+	requests: DaemonCommandBody[];
+	closeCount: number;
+	simulateClose: (() => void) | undefined;
+}
+
+function makeMockClient(failFirstRequest = false): MockClient {
+	const client = {
+		requests: [] as DaemonCommandBody[],
+		closeCount: 0,
+		simulateClose: undefined as (() => void) | undefined,
+		connect: async () => {},
+		waitForHello: async () => ({}),
+		onClose(listener: () => void) {
+			client.simulateClose = listener;
+			return () => {
+				client.simulateClose = undefined;
+			};
+		},
+		close() {
+			client.closeCount += 1;
+		},
+		async request(command: DaemonCommandBody): Promise<DaemonResponse> {
+			client.requests.push(command);
+			if (failFirstRequest && client.requests.length === 1) {
+				throw new Error("socket died mid-request");
+			}
+			return { id: "r", type: "response", command: command.type, success: true, data: { ok: true } };
+		},
+	};
+	return client as MockClient;
+}
+
+function makeLink(clients: MockClient[]) {
+	return new SupervisorLink({
+		socketPath: "/tmp/unused.sock",
+		factory: () => {
+			const client = makeMockClient();
+			clients.push(client);
+			return client;
+		},
+	});
+}
+
+describe("SupervisorLink", () => {
+	it("reuses one connection across requests", async () => {
+		const clients: MockClient[] = [];
+		const link = makeLink(clients);
+		await link.request({ type: "list_agent_peers" } as DaemonCommandBody);
+		await link.request({ type: "agent_messages_status" } as DaemonCommandBody);
+		expect(clients).toHaveLength(1);
+		expect(clients[0].requests).toHaveLength(2);
+		link.close();
+		expect(clients[0].closeCount).toBe(1);
+	});
+
+	it("single-flights concurrent connects", async () => {
+		const clients: MockClient[] = [];
+		const link = makeLink(clients);
+		await Promise.all([
+			link.request({ type: "list_agent_peers" } as DaemonCommandBody),
+			link.request({ type: "list_agent_peers" } as DaemonCommandBody),
+		]);
+		expect(clients).toHaveLength(1);
+		link.close();
+	});
+
+	it("reconnects after the socket closes", async () => {
+		const clients: MockClient[] = [];
+		const link = makeLink(clients);
+		await link.request({ type: "list_agent_peers" } as DaemonCommandBody);
+		clients[0].simulateClose?.();
+		await link.request({ type: "list_agent_peers" } as DaemonCommandBody);
+		expect(clients).toHaveLength(2);
+		link.close();
+	});
+
+	it("does not retry a failed request; the next request reconnects", async () => {
+		const clients: MockClient[] = [];
+		const link = new SupervisorLink({
+			socketPath: "/tmp/unused.sock",
+			factory: () => {
+				const client = makeMockClient(clients.length === 0);
+				clients.push(client);
+				return client;
+			},
+		});
+		await expect(link.request({ type: "send_message" } as DaemonCommandBody)).rejects.toThrow(
+			"socket died mid-request",
+		);
+		const response = await link.request({ type: "send_message" } as DaemonCommandBody);
+		expect(response.success).toBe(true);
+		expect(clients).toHaveLength(2);
+		link.close();
+	});
+
+	it("stops reconnecting after close()", async () => {
+		const clients: MockClient[] = [];
+		const link = makeLink(clients);
+		link.close();
+		await expect(link.request({ type: "list_agent_peers" } as DaemonCommandBody)).rejects.toThrow();
+		expect(clients).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## What

Every cross-worker interaction in `daemon-mode.ts` opened a fresh supervisor connection — connect, hello, request, close — per call: each agent-to-agent message, every roster peer read, every `rlm.create_session`, and every worker-local rename. The supervisor handled N transient connections per worker instead of one.

## Change

- **New `SupervisorLink`** (`modes/daemon/supervisor-link.ts`): one persistent connection per daemon process, multiplexed requests, single-flighted connects, teardown on socket close so the next request reconnects.
- **No in-flight retries, by contract**: daemon commands like `create` and `send_message` are not idempotent, so a rejected or timed-out request must never resend. The link tears down on failure; the next request reconnects.
- `sendRemoteAgentSessionMessage` keeps its 30s supervisor-startup window but only around **connection establishment**; the message itself is sent exactly once. The link does not require a worker token, matching the old anonymous-client path.
- `createRlmRootSession`, `listSupervisorAgentPeers`, and `setStateSessionNameViaSupervisor` route through the link; their error handling and fallbacks are unchanged.
- `AgentDaemon.shutdown` closes the link — no descriptor leak on worker exit.

## Tests

`supervisor-link.test.ts` (5): connection reuse across requests, single-flight under concurrent connects, reconnect after socket close, the no-retry contract (failed request rejects; the next request reconnects), and `close()` fail-fast semantics. `daemon-mode.test.ts`: fake-supervisor cleanups now destroy lingering link sockets — `server.close()` waits for open connections, so the persistent link hung all 12 supervisor-path tests (that is how the no-retry bug was found: an in-flight retry duplicated a `create`). 209 daemon-mode/supervisor-link + 133 daemon-supervisor tests green; `tsgo` + biome clean; rebased on current `main` (`ecd60e3cd`).

Fixes ENG-6097

---
*This PR was authored autonomously as part of a recursive self-improvement program (RSI).*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cross-worker messaging and session creation over the supervisor with explicit no-retry semantics; mis-handled reconnect or duplicate sends would affect multi-worker agent coordination.
> 
> **Overview**
> Replaces **per-call supervisor `DaemonClient` connect/hello/request/close** with a **single lazy `SupervisorLink` per worker**, so cross-worker work (RLM root session creation, peer listing, session renames, remote agent messages) multiplexes on one socket.
> 
> The link **single-flights** concurrent handshakes, **reconnects** after socket death or failed hello, and **never retries an in-flight command**—rejections/timeouts surface once because daemon ops like `create` and `send_message` are not idempotent. **`sendRemoteAgentSessionMessage`** still loops for up to 30s on **`ensureConnected()`** only; the **`send_message`** runs exactly once. **Shutdown** closes the cached link.
> 
> Adds **`supervisor-link.test.ts`** and updates fake-supervisor teardown in **`daemon-mode.test.ts`** so persistent sockets do not hang tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d066b1f4093f58cc078f78bcae08c2b4a8d7de12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add persistent `SupervisorLink` for cross-worker daemon requests
> - Introduces `SupervisorLink` in [supervisor-link.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2242/files#diff-0cc1217f3abf387866aafee572ceaa2841e2924f23114bde2e4c6b888d8d0d3f), which caches one authenticated supervisor connection, single-flights concurrent connection attempts, and reconnects after socket closure or handshake failure.
> - Updates [daemon-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2242/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450) so root-session creation, peer listing, session rename, and remote message delivery all route through the cached link instead of constructing a per-request client.
> - Remote message delivery in `AgentDaemon.sendRemoteAgentSessionMessage` retries connection establishment within a 30-second startup window (250 ms between attempts) but issues the send command exactly once.
> - Daemon shutdown now closes the cached `SupervisorLink` before process exit.
> - Behavioral Change: in-flight daemon commands are no longer retried after they are sent, including rejections and timeouts; only `DaemonSocketClosedError` causes the shared link to be discarded for a later reconnect.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2242 opened
>
> - Fixed race condition in `SupervisorLink.ensureConnected` method where concurrent callers could lose newer in-flight connection promises when older handshakes settled [d066b1f]
> - Added test coverage for concurrent connection attempt race condition in `SupervisorLink` [d066b1f]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized af4060f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->