### PR TITLE
[RSI] Usage errors for no-argument slash commands given arguments

### DIFF
--- a/packages/coding-agent/.changes/eng-6103-no-arg-slash-usage-errors.md
+++ b/packages/coding-agent/.changes/eng-6103-no-arg-slash-usage-errors.md
@@ -1,0 +1,1 @@
+- No-argument slash commands now show a `Usage: /<command>` error when given arguments instead of silently sending the text to the model; the input is preserved for editing.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4758,6 +4758,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "settings") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /settings");
 						return;
 					}
@@ -4767,6 +4768,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "scoped-models") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /scoped-models");
 						return;
 					}
@@ -4806,6 +4808,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "share") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /share");
 						return;
 					}
@@ -4815,6 +4818,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "copy") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /copy");
 						return;
 					}
@@ -4834,6 +4838,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "session") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /session");
 						return;
 					}
@@ -4844,6 +4849,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "system-prompt") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /system-prompt");
 						return;
 					}
@@ -4859,6 +4865,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "context") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /context");
 						return;
 					}
@@ -4869,6 +4876,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "logs") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /logs");
 						return;
 					}
@@ -4884,6 +4892,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "heartbeats") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /heartbeats");
 						return;
 					}
@@ -4893,6 +4902,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "changelog") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /changelog");
 						return;
 					}
@@ -4903,6 +4913,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "hotkeys") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /hotkeys");
 						return;
 					}
@@ -4913,6 +4924,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "fork") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /fork");
 						return;
 					}
@@ -4922,6 +4934,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "clone") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /clone");
 						return;
 					}
@@ -4931,6 +4944,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "tree") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /tree");
 						return;
 					}
@@ -4941,6 +4955,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "login") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /login");
 						return;
 					}
@@ -4950,6 +4965,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "logout") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /logout");
 						return;
 					}
@@ -4992,6 +5008,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "reload") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /reload");
 						return;
 					}
@@ -5025,6 +5042,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "debug") {
 					if (commandArgs) {
+						this.editor.setText(text);
 						this.showError("Usage: /debug");
 						return;
 					}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4756,12 +4756,20 @@ export class InteractiveMode {
 					await this.handleSideQuestion(commandArgs);
 					return;
 				}
-				if (commandName === "settings" && !commandArgs) {
+				if (commandName === "settings") {
+					if (commandArgs) {
+						this.showError("Usage: /settings");
+						return;
+					}
 					await this.showSettingsSelector();
 					this.editor.setText("");
 					return;
 				}
-				if (commandName === "scoped-models" && !commandArgs) {
+				if (commandName === "scoped-models") {
+					if (commandArgs) {
+						this.showError("Usage: /scoped-models");
+						return;
+					}
 					this.editor.setText("");
 					await this.showModelsSelector();
 					return;
@@ -4796,12 +4804,20 @@ export class InteractiveMode {
 					this.editor.setText("");
 					return;
 				}
-				if (commandName === "share" && !commandArgs) {
+				if (commandName === "share") {
+					if (commandArgs) {
+						this.showError("Usage: /share");
+						return;
+					}
 					await this.handleShareCommand();
 					this.editor.setText("");
 					return;
 				}
-				if (commandName === "copy" && !commandArgs) {
+				if (commandName === "copy") {
+					if (commandArgs) {
+						this.showError("Usage: /copy");
+						return;
+					}
 					await this.handleCopyCommand();
 					this.editor.setText("");
 					return;
@@ -4816,13 +4832,21 @@ export class InteractiveMode {
 					await this.handleRlmMaxDepthCommand(commandArgs);
 					return;
 				}
-				if (commandName === "session" && !commandArgs) {
+				if (commandName === "session") {
+					if (commandArgs) {
+						this.showError("Usage: /session");
+						return;
+					}
 					this.echoLocalCommand(text);
 					await this.handleSessionCommand();
 					this.editor.setText("");
 					return;
 				}
-				if (commandName === "system-prompt" && !commandArgs) {
+				if (commandName === "system-prompt") {
+					if (commandArgs) {
+						this.showError("Usage: /system-prompt");
+						return;
+					}
 					this.echoLocalCommand(text);
 					await this.handleSystemPromptCommand();
 					this.editor.setText("");
@@ -4833,13 +4857,21 @@ export class InteractiveMode {
 					this.editor.setText("");
 					return;
 				}
-				if (commandName === "context" && !commandArgs) {
+				if (commandName === "context") {
+					if (commandArgs) {
+						this.showError("Usage: /context");
+						return;
+					}
 					this.echoLocalCommand(text);
 					await this.handleContextCommand();
 					this.editor.setText("");
 					return;
 				}
-				if (commandName === "logs" && !commandArgs) {
+				if (commandName === "logs") {
+					if (commandArgs) {
+						this.showError("Usage: /logs");
+						return;
+					}
 					this.echoLocalCommand(text);
 					this.handleLogsCommand();
 					this.editor.setText("");
@@ -4851,44 +4883,76 @@ export class InteractiveMode {
 					return;
 				}
 				if (commandName === "heartbeats") {
+					if (commandArgs) {
+						this.showError("Usage: /heartbeats");
+						return;
+					}
 					this.editor.setText("");
 					await this.showHeartbeatManager();
 					return;
 				}
-				if (commandName === "changelog" && !commandArgs) {
+				if (commandName === "changelog") {
+					if (commandArgs) {
+						this.showError("Usage: /changelog");
+						return;
+					}
 					this.echoLocalCommand(text);
 					this.handleChangelogCommand();
 					this.editor.setText("");
 					return;
 				}
-				if (commandName === "hotkeys" && !commandArgs) {
+				if (commandName === "hotkeys") {
+					if (commandArgs) {
+						this.showError("Usage: /hotkeys");
+						return;
+					}
 					this.echoLocalCommand(text);
 					this.handleHotkeysCommand();
 					this.editor.setText("");
 					return;
 				}
-				if (commandName === "fork" && !commandArgs) {
+				if (commandName === "fork") {
+					if (commandArgs) {
+						this.showError("Usage: /fork");
+						return;
+					}
 					this.editor.setText("");
 					await this.showUserMessageSelector();
 					return;
 				}
-				if (commandName === "clone" && !commandArgs) {
+				if (commandName === "clone") {
+					if (commandArgs) {
+						this.showError("Usage: /clone");
+						return;
+					}
 					this.editor.setText("");
 					await this.handleCloneCommand();
 					return;
 				}
-				if (commandName === "tree" && !commandArgs) {
+				if (commandName === "tree") {
+					if (commandArgs) {
+						this.showError("Usage: /tree");
+						return;
+					}
 					this.editor.setText("");
 					restorePromptStashAfterSubmit = false;
 					await this.showTreeSelector();
 					return;
 				}
-				if (commandName === "login" && !commandArgs) {
+				if (commandName === "login") {
+					if (commandArgs) {
+						this.showError("Usage: /login");
+						return;
+					}
 					this.editor.setText("");
 					await this.showConfigurationMenu("providers");
 					return;
 				}
-				if (commandName === "logout" && !commandArgs) {
+				if (commandName === "logout") {
+					if (commandArgs) {
+						this.showError("Usage: /logout");
+						return;
+					}
 					this.editor.setText("");
 					await this.showLogoutSelector();
 					return;
@@ -4926,7 +4990,11 @@ export class InteractiveMode {
 					await this.handleResumeCommand(commandArgs);
 					return;
 				}
-				if (commandName === "reload" && !commandArgs) {
+				if (commandName === "reload") {
+					if (commandArgs) {
+						this.showError("Usage: /reload");
+						return;
+					}
 					this.editor.setText("");
 					await this.handleReloadCommand();
 					return;
@@ -4955,7 +5023,11 @@ export class InteractiveMode {
 					this.setFullscreenMode(enable);
 					return;
 				}
-				if (commandName === "debug" && !commandArgs) {
+				if (commandName === "debug") {
+					if (commandArgs) {
+						this.showError("Usage: /debug");
+						return;
+					}
 					await this.handleDebugCommand();
 					this.editor.setText("");
 					return;

--- a/packages/coding-agent/test/interactive-mode-command-usage.test.ts
+++ b/packages/coding-agent/test/interactive-mode-command-usage.test.ts
@@ -55,13 +55,14 @@ describe("InteractiveMode no-argument command usage errors", () => {
 		const context = makeSubmitContext();
 		const prompt = (context.agentConnection as { prompt: ReturnType<typeof vi.fn> }).prompt;
 		prototype.setupEditorSubmitHandler.call(context);
-		// The real editor holds the submitted text; the usage error must preserve it.
-		context.editor.setText("/tree fix the bug");
+		// The real editor clears its buffer before onSubmit runs; the usage
+		// error must put the draft back for editing (as /clear does).
+		// The real editor clears its buffer BEFORE invoking onSubmit.
+		context.editor.setText("");
 		await context.defaultEditor.onSubmit?.("/tree fix the bug");
 		expect(context.showError).toHaveBeenCalledWith("Usage: /tree");
 		expect(prompt).not.toHaveBeenCalled();
 		expect(context.showTreeSelector).not.toHaveBeenCalled();
-		// The submit chain preserves the editor text when a usage error shows.
 		expect(context.editor.getText()).toBe("/tree fix the bug");
 	});
 

--- a/packages/coding-agent/test/interactive-mode-command-usage.test.ts
+++ b/packages/coding-agent/test/interactive-mode-command-usage.test.ts
@@ -1,0 +1,84 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+type SubmitContext = {
+	defaultEditor: { onSubmit?: (text: string) => Promise<void> };
+	editor: { getText: () => string; setText: (text: string) => void };
+	[key: string]: unknown;
+};
+
+type Prototype = {
+	setupEditorSubmitHandler(this: SubmitContext): void;
+};
+
+const prototype = InteractiveMode.prototype as unknown as Prototype;
+
+function makeSubmitContext() {
+	const prompt = vi.fn(async () => undefined);
+	let editorText = "";
+	const context: SubmitContext = {
+		defaultEditor: {},
+		editor: {
+			getText: () => editorText,
+			setText: (text: string) => {
+				editorText = text;
+			},
+		},
+		agentConnection: { prompt },
+		showError: vi.fn(),
+		showStatus: vi.fn(),
+		echoLocalCommand: vi.fn(),
+		handleSessionCommand: vi.fn(async () => undefined),
+		showTreeSelector: vi.fn(async () => undefined),
+		showSettingsSelector: vi.fn(async () => undefined),
+		showHeartbeatManager: vi.fn(async () => undefined),
+		submittedInputBehavior: "steer",
+		inputSubmissionGeneration: 0,
+		inputSubmissionsPending: 0,
+		pendingPromptStashReleases: [],
+		promptStashState: {},
+		pendingSubmittedPromptStash: undefined,
+		snapshotPromptStash: vi.fn(() => ({ text: "" })),
+		promptStash: undefined,
+		promptStashSessionId: "session-1",
+		sessionId: "session-1",
+		clearShortcutGuide: vi.fn(),
+	};
+	return context;
+}
+
+describe("InteractiveMode no-argument command usage errors", () => {
+	beforeAll(() => initTheme("dark"));
+
+	it("rejects arguments to /tree with a usage error instead of prompting", async () => {
+		const context = makeSubmitContext();
+		const prompt = (context.agentConnection as { prompt: ReturnType<typeof vi.fn> }).prompt;
+		prototype.setupEditorSubmitHandler.call(context);
+		// The real editor holds the submitted text; the usage error must preserve it.
+		context.editor.setText("/tree fix the bug");
+		await context.defaultEditor.onSubmit?.("/tree fix the bug");
+		expect(context.showError).toHaveBeenCalledWith("Usage: /tree");
+		expect(prompt).not.toHaveBeenCalled();
+		expect(context.showTreeSelector).not.toHaveBeenCalled();
+		// The submit chain preserves the editor text when a usage error shows.
+		expect(context.editor.getText()).toBe("/tree fix the bug");
+	});
+
+	it("still opens the tree selector without arguments", async () => {
+		const context = makeSubmitContext();
+		prototype.setupEditorSubmitHandler.call(context);
+		await context.defaultEditor.onSubmit?.("/tree");
+		expect(context.showTreeSelector).toHaveBeenCalledTimes(1);
+		expect(context.showError).not.toHaveBeenCalled();
+	});
+
+	it.each(["settings", "session", "heartbeats"])("rejects arguments to /%s", async (command) => {
+		const context = makeSubmitContext();
+		const prompt = (context.agentConnection as { prompt: ReturnType<typeof vi.fn> }).prompt;
+		prototype.setupEditorSubmitHandler.call(context);
+		await context.defaultEditor.onSubmit?.(`/${command} stray argument`);
+		expect(context.showError).toHaveBeenCalledWith(`Usage: /${command}`);
+		expect(prompt).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## What

Fifteen no-argument built-in slash commands guard with `&& !commandArgs`, so `/tree fix the bug` neither opened the tree nor errored — the literal string was sent to the model as a user turn: the same burned-round-trip, polluted-transcript failure as unknown commands (#2243 fixes that half server-side). Three behaviors coexisted:
- `/fast`, `/clear`, `/fullscreen`, `/effort` validate and show `Usage:` errors;
- the 15 guard commands (`settings`, `scoped-models`, `share`, `copy`, `session`, `system-prompt`, `context`, `logs`, `changelog`, `hotkeys`, `fork`, `clone`, `tree`, `login`, `logout`, `reload`, `debug`) fall through to the model when given arguments;
- `/heartbeats` silently ignores arguments.

## Change

Unify on the `Usage:`-error behavior. Each guard becomes a two-level check: `commandArgs` present → `showError("Usage: /<cmd>")` and return **before any editor clear**, so the user keeps their input to edit; no args → the existing handler unchanged. 17 guard sites plus `/heartbeats`.

No command gains or loses functionality: the argument-present case previously went to the model, so routing it to a usage error can only remove a failure mode.

## Tests

`interactive-mode-command-usage.test.ts` (+5, full submit-chain harness): `/tree fix the bug` shows the usage error, never prompts, never opens the selector, and preserves the editor text; no-arg `/tree` still opens the selector; `/settings`, `/session`, `/heartbeats` with stray arguments all show their usage errors. 48 tests across the touched interactive-mode suites green; tsgo + biome clean.

Fixes ENG-6103

---
*This PR was authored autonomously as part of a recursive self-improvement program (RSI).*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local interactive-mode dispatch only; narrows mistaken input to explicit errors without changing successful command paths.
> 
> **Overview**
> No-argument built-in slash commands (e.g. `/tree`, `/settings`, `/session`, `/heartbeats`, and similar) now **reject extra text** with `Usage: /<command>` instead of letting the line fall through to the model as a normal prompt.
> 
> On that path the submit handler **restores the draft in the editor** (`setText(text)`) before showing the error, matching commands like `/clear` so users can fix typos without losing input. Valid no-arg invocations behave as before; commands that already accept arguments (`/model`, `/fullscreen`, etc.) are unchanged.
> 
> Adds **`interactive-mode-command-usage.test.ts`** to cover usage errors, no prompt/selector side effects, and preserved editor text for representative commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd73ad7249a15e4c099964c7db91848c8b1f6ed8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show usage errors for no-argument slash commands given arguments
> Updates the slash-command handler in `InteractiveMode.setupEditorSubmitHandler` to reject non-empty arguments for commands that take none. When arguments are present, the handler restores the submitted text to the editor and displays `Usage: /<command>` without invoking the command action.
>
> - Covers `/settings`, `/scoped-models`, `/share`, `/copy`, `/session`, `/system-prompt`, `/context`, `/logs`, `/heartbeats`, `/changelog`, `/hotkeys`, `/fork`, `/clone`, `/tree`, `/login`, `/logout`, `/reload`, and `/debug`
> - Adds tests in [interactive-mode-command-usage.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2244/files#diff-7cc5f053cc5f7d6c302aa7935da3c9c33d88737177a32faa8863aac07dcb6088) verifying argument rejection, input restoration, and that valid no-argument invocations still work
> - Behavioral Change: no-argument commands previously fell through to further handling (and could prompt the model) when given arguments; they now stop with a usage error and preserve the input
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd73ad7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->