### PR TITLE
[RSI] Mark onboarding shown only after the flow completes

### DIFF
--- a/packages/coding-agent/.changes/eng-6104-onboarding-completion-gate.md
+++ b/packages/coding-agent/.changes/eng-6104-onboarding-completion-gate.md
@@ -1,0 +1,1 @@
+- Escaping the onboarding splash or failing its login no longer permanently skips onboarding; the guide reruns on the next launch until a model is configured.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1808,10 +1808,15 @@ export class InteractiveMode {
 		const showPrimeCliSplash = this.shouldRunPrimeCliOnboardingSplash();
 		let outcome: TelemetryOnboardingOutcome = "aborted";
 		try {
-			this.markOnboardingShown();
-			await this.settingsManager.flush();
 			await this.runOnboardingFlow(showPrimeCliSplash);
 			outcome = isOnboardingModelReady(this.getOnboardingState()) ? "success" : "aborted";
+			if (outcome === "success") {
+				// Only a completed onboarding counts as seen: an escaped splash or a
+				// failed login leaves the flag unset so the next launch retries, and
+				// shouldRunOnboarding already skips users who configured a model.
+				this.markOnboardingShown();
+				await this.settingsManager.flush();
+			}
 			return true;
 		} catch (error) {
 			outcome = "error";

--- a/packages/coding-agent/test/interactive-mode-onboarding-completion.test.ts
+++ b/packages/coding-agent/test/interactive-mode-onboarding-completion.test.ts
@@ -1,0 +1,73 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
+import type { OnboardingStartupState } from "../src/modes/interactive/onboarding.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+type Context = Record<string, unknown> & {
+	settingsManager: {
+		getOnboardingShown: () => boolean;
+		setOnboardingShown: (shown: boolean) => void;
+		flush: () => Promise<void>;
+	};
+};
+
+type Prototype = {
+	runStartupOnboarding(this: Context): Promise<boolean>;
+};
+
+const prototype = InteractiveMode.prototype as unknown as Prototype;
+
+function makeContext(options: { modelReady: boolean }): Context {
+	const shown = { value: false };
+	const context: Context = {
+		settingsManager: {
+			getOnboardingShown: () => shown.value,
+			setOnboardingShown: (value: boolean) => {
+				shown.value = value;
+			},
+			flush: vi.fn(async () => {}),
+		},
+		shouldRunOnboarding: () => true,
+		shouldRunPrimeCliOnboardingSplash: () => false,
+		runOnboardingFlow: vi.fn(async () => {}),
+		markOnboardingShown: InteractiveMode.prototype[
+			"markOnboardingShown" as keyof typeof InteractiveMode.prototype
+		] as (this: Context) => void,
+		getOnboardingState: (): OnboardingStartupState =>
+			({
+				settingsManager: context.settingsManager,
+				modelRegistry: {
+					refresh: () => {},
+					hasConfiguredAuth: () => options.modelReady,
+					getProviderAuthStatus: () => ({
+						configured: options.modelReady,
+						source: options.modelReady ? "runtime" : undefined,
+					}),
+					authStorage: { get: () => undefined },
+				},
+				model: options.modelReady ? { id: "m", provider: "anthropic" } : undefined,
+			}) as unknown as OnboardingStartupState,
+		getCurrentModel: () => (options.modelReady ? { id: "m", provider: "anthropic" } : undefined),
+		modelRegistry: {
+			getProviderAuthStatus: () => ({ configured: options.modelReady, source: "runtime" }),
+			authStorage: { get: () => undefined },
+		},
+	};
+	return context;
+}
+
+describe("InteractiveMode startup onboarding completion", () => {
+	beforeAll(() => initTheme("dark"));
+
+	it("does not mark onboarding shown when the flow ends without a ready model", async () => {
+		const context = makeContext({ modelReady: false });
+		await prototype.runStartupOnboarding.call(context);
+		expect(context.settingsManager.getOnboardingShown()).toBe(false);
+	});
+
+	it("marks onboarding shown only after a completed flow", async () => {
+		const context = makeContext({ modelReady: true });
+		await prototype.runStartupOnboarding.call(context);
+		expect(context.settingsManager.getOnboardingShown()).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -3988,7 +3988,7 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		expect(fakeThis.uiServices.settingsManager.setOnboardingShown).toHaveBeenCalledWith(true);
 	});
 
-	test("persists onboarding before opening the one-shot flow", async () => {
+	test("persists onboarding only after the one-shot flow completes", async () => {
 		let shown = false;
 		let flushed = false;
 		const fakeThis = createPrimeCliHarness(false);
@@ -4001,8 +4001,9 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		});
 		fakeThis.runOnboardingFlow = vi.fn(async (showPrimeCliSplash?: boolean) => {
 			expect(showPrimeCliSplash).toBe(true);
-			expect(shown).toBe(true);
-			expect(flushed).toBe(true);
+			// The flag persists only after the flow completes with a ready model.
+			expect(shown).toBe(false);
+			expect(flushed).toBe(false);
 		});
 
 		await expect(runStartupOnboarding.call(fakeThis)).resolves.toBe(true);


### PR DESCRIPTION
## What

`runStartupOnboarding` persisted `markOnboardingShown()` **before** `runOnboardingFlow`, so escaping the splash — or a failed/cancelled Prime Inference login — permanently marked onboarding shown. The next launch skipped the flow and the user landed in a chat with `No models available. Use /login to log into a provider…`: a stranded first-run user with no way back into the guided flow.

## Change

Mark the flag only when the flow ends with a ready model (the existing `"success"` telemetry outcome). Escaped or failed flows leave it unset so the next launch retries.

This is nag-proof: `shouldRunOnboarding` already returns `false` whenever the current model has configured auth, so anyone who configured a model by **any** path (including `/login` + `/model` outside onboarding) never sees the flow again. Only genuinely model-less users get the retry they need — and they are exactly the users the flow exists for.

## Tests

`interactive-mode-onboarding-completion.test.ts` (+2, prototype-call harness on `runStartupOnboarding` with an in-memory settings manager): a flow ending without a ready model leaves `onboardingShown` unset; a completed flow sets it and flushes. 27 tests across the onboarding/interactive startup suites green; tsgo + biome clean.

Fixes ENG-6104

---
*This PR was authored autonomously as part of a recursive self-improvement program (RSI).*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change to first-run settings persistence with targeted tests; no auth or data-path changes beyond when a boolean is saved.
> 
> **Overview**
> **Fixes stranded first-run users** who escaped the splash or failed login and were never prompted again.
> 
> `runStartupOnboarding` used to call `markOnboardingShown()` and flush settings **before** the onboarding UI ran, so aborting the flow still marked onboarding complete. The marker and flush now run **only** when the flow finishes with a ready model (`isOnboardingModelReady` / telemetry `"success"`). Incomplete runs leave the flag unset so the next launch retries the guide; users who already configured auth via any path still skip onboarding via `shouldRunOnboarding`.
> 
> Tests cover both outcomes in a new completion test file and update the existing startup onboarding persistence test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 952dce40cc7b622fec2d469561043e91f7909ca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate `onboarding-shown` persistence on model-ready completion in `InteractiveMode.runStartupOnboarding`
> - Moves the `onboarding-shown` flag write and settings flush from before the onboarding flow to after it, so the flag is set only when the resulting state reports a ready model
> - If the user escapes the splash or login fails, the flag stays unset and onboarding reruns on the next launch
> - Adds a test harness and tests covering both the incomplete-flow (flag unchanged) and ready-model (flag set) outcomes; updates the existing persistence test to assert the flag is unset while the flow runs
> - Risk: any code path in `runStartupOnboarding` that returns early before reaching the model-ready check will leave `onboarding-shown` unset, causing onboarding to rerun — verify early-return branches in [interactive-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2245/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316) all produce the intended behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 952dce4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->