### PR TITLE
feat(coding-agent): garbage-collect orphaned session workers (ENG-6105)

### DIFF
--- a/packages/coding-agent/.changes/eng-4742-transcript-survives-render-failures.md
+++ b/packages/coding-agent/.changes/eng-4742-transcript-survives-render-failures.md
@@ -1,0 +1,2 @@
+- Fixed re-opened sessions rendering an empty transcript until the next message when a transient control-plane failure interrupted the initial render.
+- Fixed one unrenderable message aborting the whole transcript rebuild during a session resync.

--- a/packages/coding-agent/.changes/orphaned-worker-gc.md
+++ b/packages/coding-agent/.changes/orphaned-worker-gc.md
@@ -1,0 +1,1 @@
+- Fixed orphaned session workers retrying supervisor resurrection forever when no replacement can come up: they now exit gracefully after a bounded supervisor-lost window, closing active sessions first.

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -267,6 +267,18 @@ const structuredLog = getLogger("coding-agent.daemon");
 const WORKER_SNAPSHOT_TERMINAL_DRAIN_TIMEOUT_MS = 1_000;
 const UPDATE_RESTART_PREPARE_TIMEOUT_MS = 90_000;
 const MAX_SESSION_SNAPSHOT_STABILIZATION_RETRIES = 3;
+// Orphaned-worker garbage collection: a session worker whose supervisor stays
+// unreachable (no supervisor claim, no successful replacement launch) exits
+// after this window instead of retrying the resurrection loop forever.
+// Sessions persist on disk, and a later supervisor spawns fresh workers on
+// demand, so an unreachable-supervisor worker serves nothing by lingering.
+const WORKER_SUPERVISOR_LOST_EXIT_MS_ENV = "PRIME_AGENT_INTERNAL_WORKER_SUPERVISOR_LOST_EXIT_MS";
+const DEFAULT_WORKER_SUPERVISOR_LOST_EXIT_MS = 5 * 60_000;
+
+function workerSupervisorLostExitMs(): number {
+	const raw = Number(process.env[WORKER_SUPERVISOR_LOST_EXIT_MS_ENV]);
+	return Number.isFinite(raw) && raw >= 0 ? raw : DEFAULT_WORKER_SUPERVISOR_LOST_EXIT_MS;
+}
 
 const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"ack_result",
@@ -556,6 +568,7 @@ export class AgentDaemon {
 	private supervisorMonitorTimer?: ReturnType<typeof setTimeout>;
 	private supervisorFenceTimer?: ReturnType<typeof setTimeout>;
 	private supervisorLaunchInProgress = false;
+	private supervisorAbsentSince?: number;
 	private readonly supervisorClaims = new Map<DaemonSocketClient, BoundSupervisorGenerationClaim>();
 	private readonly peerGrants = new Map<string, DaemonWorkerPeerGrant>();
 	private readonly peerClaims = new Map<DaemonSocketClient, DaemonWorkerPeerGrant>();
@@ -741,19 +754,62 @@ export class AgentDaemon {
 
 	private async checkSupervisorAvailability(supervisorSocketPath: string): Promise<void> {
 		if (this.shuttingDown || this.hasAuthenticatedSupervisorConnection()) {
+			this.supervisorAbsentSince = undefined;
 			return;
 		}
 		if (await isDaemonShutdownAdmissionActive()) {
+			this.supervisorAbsentSince = undefined;
 			this.scheduleSupervisorAvailabilityCheck(supervisorSocketPath, 5000);
 			return;
 		}
 		if (await this.canConnectToSupervisor(supervisorSocketPath)) {
+			this.supervisorAbsentSince = undefined;
 			return;
 		}
+		// The supervisor socket is unreachable; remember when the worker last
+		// saw it so the orphan window below stays bounded.
+		this.supervisorAbsentSince ??= Date.now();
 		await this.launchReplacementSupervisor(supervisorSocketPath);
+		await this.exitIfSupervisorOrphanedForTooLong(supervisorSocketPath);
 		if (!this.shuttingDown && !this.hasAuthenticatedSupervisorConnection()) {
 			this.scheduleSupervisorAvailabilityCheck(supervisorSocketPath, 5000);
 		}
+	}
+
+	/**
+	 * Garbage-collect orphaned workers. If the supervisor has been unreachable
+	 * for the whole bounded window — no supervisor claim, no successful
+	 * replacement launch — the worker exits: retrying the resurrection loop
+	 * forever only accumulates garbage. Sessions persist on disk, so the next
+	 * supervisor to claim the socket spawns fresh workers on demand.
+	 */
+	private async exitIfSupervisorOrphanedForTooLong(supervisorSocketPath: string): Promise<void> {
+		const absentSince = this.supervisorAbsentSince;
+		if (absentSince === undefined || Date.now() - absentSince < workerSupervisorLostExitMs()) {
+			return;
+		}
+		if (this.hasAuthenticatedSupervisorConnection()) {
+			this.supervisorAbsentSince = undefined;
+			return;
+		}
+		if (this.hasOngoingSessionWork()) {
+			// An active run owns the worker a little longer; its turn end
+			// lets the next availability check reconsider.
+			return;
+		}
+		this.log(
+			`supervisor ${supervisorSocketPath} unreachable for ${Math.round((Date.now() - absentSince) / 1000)}s; exiting orphaned worker`,
+		);
+		await this.shutdown(0);
+	}
+
+	private hasOngoingSessionWork(): boolean {
+		for (const state of this.sessions.values()) {
+			if (state.runtime.session.isStreaming || state.runtime.session.isCompacting) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private hasAuthenticatedSupervisorConnection(): boolean {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -805,7 +805,10 @@ export class AgentDaemon {
 
 	private hasOngoingSessionWork(): boolean {
 		for (const state of this.sessions.values()) {
-			if (state.runtime.session.isStreaming || state.runtime.session.isCompacting) {
+			// Same predicate the daemon reports as isSessionActive: retrying,
+			// bash/kernel background work, refinement, compaction settlement,
+			// and queued actions must all keep holding the worker.
+			if (state.runtime.session.isSessionActive) {
 				return true;
 			}
 		}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -770,6 +770,12 @@ export class AgentDaemon {
 		// saw it so the orphan window below stays bounded.
 		this.supervisorAbsentSince ??= Date.now();
 		await this.launchReplacementSupervisor(supervisorSocketPath);
+		if (await this.canConnectToSupervisor(supervisorSocketPath)) {
+			// A replacement came up during the launch: recovery succeeded, so
+			// the orphan window must restart instead of exiting the worker.
+			this.supervisorAbsentSince = undefined;
+			return;
+		}
 		await this.exitIfSupervisorOrphanedForTooLong(supervisorSocketPath);
 		if (!this.shuttingDown && !this.hasAuthenticatedSupervisorConnection()) {
 			this.scheduleSupervisorAvailabilityCheck(supervisorSocketPath, 5000);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -771,10 +771,13 @@ export class AgentDaemon {
 		this.supervisorAbsentSince ??= Date.now();
 		await this.launchReplacementSupervisor(supervisorSocketPath);
 		if (await this.canConnectToSupervisor(supervisorSocketPath)) {
-			// A replacement came up during the launch: recovery succeeded, so
-			// the orphan window must restart instead of exiting the worker.
+			// A replacement came up during the launch: the orphan window must
+			// restart instead of exiting the worker. The monitor must stay
+			// armed, though — a replacement can bind and then exit before it
+			// ever claims the worker, and only an authenticated claim (or its
+			// later close) re-arms the monitor. Falling through reschedules
+			// the next availability check below.
 			this.supervisorAbsentSince = undefined;
-			return;
 		}
 		await this.exitIfSupervisorOrphanedForTooLong(supervisorSocketPath);
 		if (!this.shuttingDown && !this.hasAuthenticatedSupervisorConnection()) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -578,6 +578,9 @@ const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);
 // evicted past the cap to keep a long session bounded.
 const MAX_PASTED_IMAGE_BYTES = 64 * 1024 * 1024;
 const INITIAL_TRANSCRIPT_RENDER_MESSAGE_LIMIT = 400;
+// Coalesce at most this many heartbeats_changed refreshes into one refresh
+// promise; sustained churn must not hold rebindCurrentSession in a drain loop.
+const HEARTBEAT_REFRESH_DRAIN_LIMIT = 25;
 
 function initialRenderMessages(messages: AgentMessage[]): AgentMessage[] {
 	if (messages.length <= INITIAL_TRANSCRIPT_RENDER_MESSAGE_LIMIT) {
@@ -2580,12 +2583,16 @@ export class InteractiveMode {
 		}
 		const connection = this.agentConnection;
 		const refresh = (async () => {
-			do {
+			// Bound the drain loop: sustained heartbeats_changed churn must not
+			// starve an awaiting rebind (and its transcript render) indefinitely.
+			for (let drain = 0; drain <= HEARTBEAT_REFRESH_DRAIN_LIMIT; drain++) {
 				this.heartbeatRefreshRequested = false;
 				const heartbeats = await connection.listHeartbeats();
 				if (this.agentConnection !== connection) return;
 				this.applyHeartbeatCatalog(heartbeats);
-			} while (this.heartbeatRefreshRequested);
+				if (!this.heartbeatRefreshRequested) return;
+			}
+			// A further heartbeats_changed event starts the next refresh.
 		})().finally(() => {
 			if (this.heartbeatRefreshPromise === refresh) {
 				this.heartbeatRefreshPromise = undefined;
@@ -2840,14 +2847,28 @@ export class InteractiveMode {
 			await this.bindCurrentSessionExtensions();
 		} else {
 			setRegisteredThemes(this.uiServices.getThemes());
-			await this.refreshConnectionCatalog();
+			// Best-effort: the catalog enriches the composer (commands, models,
+			// resources). A transient control-plane failure must not abort the
+			// rebind and leave the transcript unrendered.
+			try {
+				await this.refreshConnectionCatalog();
+			} catch {
+				// Keep the previous catalog; reconnects re-fetch it.
+			}
 			this.setupAutocompleteProvider();
 			this.showLoadedResources({ force: false, showDiagnosticsWhenQuiet: true });
 		}
 		this.subscribeToAgent();
 		await this.subscribeToRosterBar();
 		// A session_action_update in the unsubscribed gap above is lost; re-sync the queue post-subscription.
-		this.patchConnectionState({ sessionActions: (await this.agentConnection.getState()).sessionActions });
+		// Best-effort: a transient control-plane failure must not abort the
+		// rebind and leave the transcript unrendered.
+		try {
+			this.patchConnectionState({ sessionActions: (await this.agentConnection.getState()).sessionActions });
+		} catch {
+			// Keep the attached snapshot's session actions; the next connection
+			// state update re-syncs them.
+		}
 		this.refreshQueueSelectionFromState();
 		this.updatePendingMessagesDisplay();
 		await this.refreshHeartbeatCatalog().catch(() => undefined);
@@ -6407,7 +6428,14 @@ export class InteractiveMode {
 				}
 			}
 		}
-		await this.preloadToolDefinitions(toolNames);
+		// Tool definitions only enrich rendering: components fall back to
+		// cached or missing definitions. A transient control-plane failure here
+		// must not abort the render (a resync render aborts into an empty chat).
+		try {
+			await this.preloadToolDefinitions(toolNames);
+		} catch (error) {
+			this.showWarning(`Could not load tool definitions: ${error instanceof Error ? error.message : String(error)}`);
+		}
 
 		if (options.clearChat) {
 			this.chatContainer.clear();
@@ -6441,61 +6469,79 @@ export class InteractiveMode {
 		}
 
 		for (const message of messagesToRender) {
-			// Assistant messages need special handling for tool calls
-			if (message.role === "assistant") {
-				this.addMessageToChat(message);
-				// Render tool call components
-				for (const content of message.content) {
-					if (content.type === "toolCall") {
-						const spacing = createConversationSpacing(this.chatContainer.children);
-						const component = new ToolExecutionComponent(
-							content.name,
-							content.id,
-							content.arguments,
-							{
-								showImages: this.settingsManager.getShowImages(),
-								includeImageDimensions: false,
-								shouldAddLeadingSpace: () => spacing.shouldAddLeadingSpace(true),
-							},
-							this.getCachedToolDefinition(content.name),
-							this.ui,
-							this.getCurrentCwd(),
-						);
-						component.setExpanded(this.toolOutputExpanded);
-						component.setEditDiffsExpanded(this.editDiffsExpanded);
-						selectLatestToolExpandHint(this.chatContainer.children, component);
-						this.chatContainer.addChild(component);
-						this.registerIpythonToolComponent(content.name, content.id, component);
+			// One unrenderable message must not abort the whole transcript:
+			// the chat container may already be cleared for this render.
+			try {
+				// Assistant messages need special handling for tool calls
+				if (message.role === "assistant") {
+					this.addMessageToChat(message);
+					// Render tool call components
+					for (const content of message.content) {
+						if (content.type === "toolCall") {
+							const spacing = createConversationSpacing(this.chatContainer.children);
+							const component = new ToolExecutionComponent(
+								content.name,
+								content.id,
+								content.arguments,
+								{
+									showImages: this.settingsManager.getShowImages(),
+									includeImageDimensions: false,
+									shouldAddLeadingSpace: () => spacing.shouldAddLeadingSpace(true),
+								},
+								this.getCachedToolDefinition(content.name),
+								this.ui,
+								this.getCurrentCwd(),
+							);
+							component.setExpanded(this.toolOutputExpanded);
+							component.setEditDiffsExpanded(this.editDiffsExpanded);
+							selectLatestToolExpandHint(this.chatContainer.children, component);
+							this.chatContainer.addChild(component);
+							this.registerIpythonToolComponent(content.name, content.id, component);
 
-						if (message.stopReason === "aborted" || message.stopReason === "error") {
-							let errorMessage: string;
-							if (message.stopReason === "aborted") {
-								const retryAttempt = this.getRetryAttempt();
-								errorMessage =
-									retryAttempt > 0
-										? `Aborted after ${retryAttempt} retry attempt${retryAttempt > 1 ? "s" : ""}`
-										: message.errorMessage && message.errorMessage !== "Request was aborted"
-											? message.errorMessage
-											: "Operation aborted";
+							if (message.stopReason === "aborted" || message.stopReason === "error") {
+								let errorMessage: string;
+								if (message.stopReason === "aborted") {
+									const retryAttempt = this.getRetryAttempt();
+									errorMessage =
+										retryAttempt > 0
+											? `Aborted after ${retryAttempt} retry attempt${retryAttempt > 1 ? "s" : ""}`
+											: message.errorMessage && message.errorMessage !== "Request was aborted"
+												? message.errorMessage
+												: "Operation aborted";
+								} else {
+									errorMessage = message.errorMessage || "Error";
+								}
+								component.updateResult({ content: [{ type: "text", text: errorMessage }], isError: true });
 							} else {
-								errorMessage = message.errorMessage || "Error";
+								renderedPendingTools.set(content.id, component);
 							}
-							component.updateResult({ content: [{ type: "text", text: errorMessage }], isError: true });
-						} else {
-							renderedPendingTools.set(content.id, component);
 						}
 					}
+				} else if (message.role === "toolResult") {
+					// Match tool results to pending tool components
+					const component = renderedPendingTools.get(message.toolCallId);
+					if (component) {
+						component.updateResult(message);
+						renderedPendingTools.delete(message.toolCallId);
+					}
+				} else {
+					// All other messages use standard rendering
+					this.addMessageToChat(message, renderOptions);
 				}
-			} else if (message.role === "toolResult") {
-				// Match tool results to pending tool components
-				const component = renderedPendingTools.get(message.toolCallId);
-				if (component) {
-					component.updateResult(message);
-					renderedPendingTools.delete(message.toolCallId);
-				}
-			} else {
-				// All other messages use standard rendering
-				this.addMessageToChat(message, renderOptions);
+			} catch (error) {
+				// Render an inline placeholder instead of losing the transcript.
+				this.chatContainer.addChild(
+					new Text(
+						theme.fg(
+							"warning",
+							`Failed to render a ${message.role} message: ${
+								error instanceof Error ? error.message : String(error)
+							}`,
+						),
+						1,
+						0,
+					),
+				);
 			}
 		}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2592,10 +2592,15 @@ export class InteractiveMode {
 				this.applyHeartbeatCatalog(heartbeats);
 				if (!this.heartbeatRefreshRequested) return;
 			}
-			// A further heartbeats_changed event starts the next refresh.
 		})().finally(() => {
 			if (this.heartbeatRefreshPromise === refresh) {
 				this.heartbeatRefreshPromise = undefined;
+				// The drain bound was hit with a newer heartbeats_changed
+				// pending: schedule the follow-up refresh so the catalog
+				// converges instead of staying stale until the next event.
+				if (this.heartbeatRefreshRequested) {
+					void this.refreshHeartbeatCatalog().catch(() => undefined);
+				}
 			}
 		});
 		this.heartbeatRefreshPromise = refresh;
@@ -6431,14 +6436,22 @@ export class InteractiveMode {
 		// Tool definitions only enrich rendering: components fall back to
 		// cached or missing definitions. A transient control-plane failure here
 		// must not abort the render (a resync render aborts into an empty chat).
+		let toolDefinitionWarning: string | undefined;
 		try {
 			await this.preloadToolDefinitions(toolNames);
 		} catch (error) {
-			this.showWarning(`Could not load tool definitions: ${error instanceof Error ? error.message : String(error)}`);
+			toolDefinitionWarning = `Could not load tool definitions: ${
+				error instanceof Error ? error.message : String(error)
+			}`;
 		}
 
 		if (options.clearChat) {
 			this.chatContainer.clear();
+		}
+
+		// Shown after clearChat so rebuild/resync renders keep the warning.
+		if (toolDefinitionWarning) {
+			this.showWarning(toolDefinitionWarning);
 		}
 
 		if (options.updateFooter) {
@@ -6521,8 +6534,10 @@ export class InteractiveMode {
 					// Match tool results to pending tool components
 					const component = renderedPendingTools.get(message.toolCallId);
 					if (component) {
-						component.updateResult(message);
+						// Delete first: a throwing updateResult must not leave the
+						// completed result reported as still pending.
 						renderedPendingTools.delete(message.toolCallId);
+						component.updateResult(message);
 					}
 				} else {
 					// All other messages use standard rendering

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -150,6 +150,7 @@ interface SupervisorMonitorHarness {
 	clients: Set<{ authenticated: boolean }>;
 	supervisorClaims: Map<object, object>;
 	shuttingDown: boolean;
+	supervisorAbsentSince?: number;
 	supervisorMonitorTimer?: ReturnType<typeof setTimeout>;
 	canConnectToSupervisor: (socketPath: string) => Promise<boolean>;
 	launchReplacementSupervisor: (socketPath: string) => Promise<void>;
@@ -1221,6 +1222,41 @@ describe("daemon worker supervisor monitoring", () => {
 		await vi.runAllTimersAsync();
 
 		expect(daemon.canConnectToSupervisor).not.toHaveBeenCalled();
+	});
+
+	it("keeps the supervisor monitor armed after a replacement binds but exits before claiming", async () => {
+		vi.useFakeTimers();
+		// The supervisor socket is dead, comes up with the replacement launch,
+		// then dies again before the replacement ever claims the worker.
+		const probeResults = [false, true, false, false];
+		let probeCount = 0;
+		const daemon = createHarness(async () => {
+			const result = probeResults[Math.min(probeCount, probeResults.length - 1)];
+			probeCount += 1;
+			return result ?? false;
+		});
+		// Drive the fake clock until the expected number of probes have run;
+		// one advance alone does not flush the availability check chain.
+		const advanceUntilProbes = async (expected: number) => {
+			for (let step = 0; probeCount < expected && step < 200; step++) {
+				await vi.advanceTimersByTimeAsync(100);
+			}
+			expect(probeCount).toBe(expected);
+		};
+
+		daemon.scheduleSupervisorAvailabilityCheck("/tmp/supervisor.sock", 1500);
+		await advanceUntilProbes(2);
+		expect(daemon.launchReplacementSupervisor).toHaveBeenCalledOnce();
+		// The replacement binding mid-launch restarts the orphan window...
+		expect(daemon.supervisorAbsentSince).toBeUndefined();
+		// ...but a bind is not an authenticated claim: the monitor must stay armed
+		// instead of orphaning the worker if the replacement exits unclaimed.
+		expect(daemon.supervisorMonitorTimer).toBeDefined();
+
+		await advanceUntilProbes(4);
+		expect(daemon.launchReplacementSupervisor).toHaveBeenCalledTimes(2);
+		expect(daemon.canConnectToSupervisor).toHaveBeenCalledTimes(4);
+		expect(daemon.supervisorMonitorTimer).toBeDefined();
 	});
 
 	it("retries when shutdown admission lookup fails", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -1,6 +1,15 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -1723,5 +1732,96 @@ describe("daemon supervisor resident workers", () => {
 		await waitForSocketGone(socketPath);
 		await waitForProcessGone(summary.workerPid);
 		workerPids.delete(summary.workerPid);
+	});
+
+	it("exits an orphaned session worker when no replacement supervisor can come up", { timeout: 120_000 }, async () => {
+		const root = tempDir();
+		const agentDir = join(root, "agent");
+		const projectDir = join(root, "project");
+		const registryDir = join(root, "supervisor-registry");
+		// The socket path must stay short: macOS rejects listen() with EINVAL
+		// past the sun_path limit, and the per-test temp dir nests too deep.
+		const socketDir = mkdtempSync(join(tmpdir(), "prime-orphan-gc-"));
+		tempDirs.push(socketDir);
+		const sessionDir = join(agentDir, "sessions");
+		const socketPath = join(socketDir, "supervisor.sock");
+		mkdirSync(projectDir, { recursive: true });
+
+		const manager = SessionManager.create(projectDir, sessionDir);
+		manager.appendMessage({ role: "user", content: "orphan gc fixture", timestamp: 1 });
+		manager.flushNow();
+		const sessionFile = manager.getSessionFile();
+		if (!sessionFile) throw new Error("Missing fixture session path");
+
+		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir, [], {
+			PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR: registryDir,
+			PRIME_AGENT_INTERNAL_WORKER_SUPERVISOR_LOST_EXIT_MS: "3000",
+		});
+		// Cold tsx startup can exceed the shared helper's 15s readiness deadline.
+		let client: DaemonClient | undefined;
+		const readyDeadline = Date.now() + 60_000;
+		while (client === undefined && Date.now() < readyDeadline) {
+			if (supervisor.exitCode !== null || supervisor.signalCode !== null) {
+				const diagnostics = childDiagnostics.get(supervisor);
+				throw new Error(
+					`Supervisor exited before becoming ready\nstdout:\n${diagnostics?.stdout ?? ""}\nstderr:\n${diagnostics?.stderr ?? ""}`,
+				);
+			}
+			const candidate = new DaemonClient(socketPath);
+			try {
+				await candidate.connect(250);
+				await candidate.waitForHello(1000);
+				client = candidate;
+			} catch {
+				candidate.close();
+				await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
+			}
+		}
+		if (!client) throw new Error("Supervisor did not become ready in time");
+		const created = await client.request({
+			type: "create",
+			sessionPath: sessionFile,
+			config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
+		});
+		if (!created.success) throw new Error(created.error);
+		const summary = requireSummary(created.data);
+		if (!summary.workerPid) throw new Error("Session worker did not spawn");
+		workerPids.add(summary.workerPid);
+
+		// SIGKILL the registry-recorded supervisor pid: the spawned child can be
+		// a tsx wrapper, and killing the wrapper alone leaves the supervisor
+		// listening on its socket, so the worker would never orphan.
+		const ownerDirectories = readdirSync(registryDir).filter((name) => name.endsWith(".owner"));
+		expect(ownerDirectories).toHaveLength(1);
+		const owner = JSON.parse(readFileSync(join(registryDir, ownerDirectories[0], "owner.json"), "utf8")) as {
+			pid?: number;
+		};
+		if (!owner.pid) throw new Error("Supervisor owner record is missing its pid");
+		const supervisorPid = owner.pid;
+		const workerPid = summary.workerPid;
+		client.close();
+
+		// A read-only socket directory makes every replacement-launch attempt
+		// fail (lock/bind EACCES): the real-world orphan precondition where a
+		// worker cannot bring its supervisor back.
+		chmodSync(socketDir, 0o555);
+		try {
+			process.kill(supervisorPid, "SIGKILL");
+			await waitForCondition(
+				() => {
+					try {
+						process.kill(workerPid, 0);
+						return false;
+					} catch (error) {
+						return (error as NodeJS.ErrnoException).code === "ESRCH";
+					}
+				},
+				"Orphaned session worker did not exit after the supervisor-lost window",
+				60_000,
+			);
+		} finally {
+			chmodSync(socketDir, 0o755);
+		}
+		workerPids.delete(workerPid);
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -224,6 +224,7 @@ type RenderSessionContextHarness = {
 	getRetryAttempt: () => number;
 	ui: { requestRender: () => void };
 	addMessageToChat: (message: AgentMessage, options?: { populateHistory?: boolean }) => void;
+	showWarning: (warningMessage: string) => void;
 	connectionState?: AgentConnectionState;
 };
 
@@ -272,6 +273,7 @@ function createRenderSessionContextHarness(overrides: Partial<RenderSessionConte
 		getRetryAttempt: () => 0,
 		ui: { requestRender: vi.fn() },
 		addMessageToChat,
+		showWarning: vi.fn(),
 		...overrides,
 	};
 	Object.setPrototypeOf(harness, InteractiveMode.prototype);
@@ -482,6 +484,43 @@ describe("InteractiveMode.renderSessionContext", () => {
 		expect(addMessageToChat.mock.calls[0]?.[0]).toMatchObject({ content: "message 0" });
 		expect(renderAll(chatContainer)).not.toContain("old transcript");
 		expect(renderAll(chatContainer)).not.toContain("for faster open");
+	});
+
+	test("still renders the transcript when tool definition preloading fails", async () => {
+		const showWarning = vi.fn();
+		const { harness, chatContainer, addMessageToChat } = createRenderSessionContextHarness({
+			preloadToolDefinitions: vi.fn(async () => {
+				throw new Error("daemon transport unavailable");
+			}),
+			showWarning,
+		});
+		const messages = [userMessage("message 0", 0), userMessage("message 1", 1)];
+
+		await renderMessages(harness, messages, { clearChat: true });
+
+		expect(showWarning).toHaveBeenCalledWith(expect.stringContaining("daemon transport unavailable"));
+		expect(addMessageToChat).toHaveBeenCalledTimes(2);
+		expect(chatContainer.children).toHaveLength(2);
+	});
+
+	test("keeps rendering later messages when one message fails to render", async () => {
+		const chatContainer = new Container();
+		const addMessageToChat = vi.fn((message: AgentMessage) => {
+			if (message.role === "user" && message.content === "broken") {
+				throw new Error("render boom");
+			}
+			chatContainer.addChild({ render: () => ["assistant"], invalidate: () => {} });
+		});
+		const { harness } = createRenderSessionContextHarness({ chatContainer, addMessageToChat });
+
+		await renderMessages(harness, [userMessage("first", 0), userMessage("broken", 1), userMessage("last", 2)], {
+			clearChat: true,
+		});
+
+		expect(addMessageToChat).toHaveBeenCalledTimes(3);
+		// Two rendered messages plus the inline failure placeholder.
+		expect(chatContainer.children).toHaveLength(3);
+		expect(renderAll(chatContainer)).toContain("Failed to render a user message");
 	});
 
 	test("populates editor history from the full transcript when initial rendering is capped", async () => {


### PR DESCRIPTION
## Problem

When a supervisor dies, its session workers try to resurrect it by launching a replacement supervisor and retrying every 5 seconds. When the replacement cannot come up, the worker retries **forever** and becomes garbage: it keeps running indefinitely and holds its session kernels (e.g. Python REPLs) alive. These orphans accumulate — observed repeatedly during local daemon testing today, including workers that stayed alive for an hour after their supervisor died.

## Persistent failure modes (observed in real logs)

- `spawn <node> ENOENT`: the worker's launch spec resolved a node path that vanished after a Homebrew node upgrade.
- Lock/bind failures (`EACCES` / `EADDRINUSE`) on the supervisor socket or its launch lock.
- Denied registry claims for scratch daemons.

## Fix

`AgentDaemon.checkSupervisorAvailability` (worker role) now tracks when the supervisor was last reachable. If no supervisor has been reachable for `PRIME_AGENT_INTERNAL_WORKER_SUPERVISOR_LOST_EXIT_MS` (default 5 minutes, env-overridable for tests), and no session is streaming or compacting, the worker exits gracefully — closing active sessions first. Sessions persist on disk; a later supervisor spawns fresh workers on demand.

The legitimate resilience path is untouched: any successful reconnect or replacement launch resets the clock, so a supervisor crash that can be recovered still is.

## Testing

- New integration test in `test/daemon-supervisor-process.test.ts`: spawns a scratch supervisor (isolated registry, 3s window), creates a session so its worker comes up, then SIGKILLs the registry-recorded supervisor pid with a read-only socket directory forcing every replacement launch to fail — the orphaned worker must exit itself.
- Live A/B validation of the same scenario: shipped code leaves the worker alive past 90s (retrying resurrection); this change exits it right after the window elapses, logging `exiting orphaned worker; shutting down (exit 0); closing 1 active session(s)`.
- `npm run check` passes.

Fixes ENG-6105.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Daemon workers may stay alive until `isSessionActive` clears if orphan GC defers on session work; invalid supervisor-lost env values silently use the 5-minute default.
> 
> **Overview**
> Session workers no longer spin forever trying to resurrect a dead supervisor when replacement launch keeps failing. They track how long the supervisor has been unreachable and **exit after a bounded window** (default 5 minutes, overridable via `PRIME_AGENT_INTERNAL_WORKER_SUPERVISOR_LOST_EXIT_MS`), unless an authenticated supervisor claim appears or **ongoing session work** is still active; sessions stay on disk for a later supervisor to pick up.
> 
> Interactive **re-open/rebind** is hardened against transient control-plane errors: connection catalog refresh, session-action resync, and tool-definition preload are **best-effort** (warnings instead of aborting), heartbeat catalog refresh is **capped** with a follow-up refresh if events keep arriving, and **each transcript message** renders inside its own error boundary so one bad message shows an inline placeholder instead of leaving an empty chat after `clearChat`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd84a7f04746f111927afa152cc00128a8971cde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Garbage-collect orphaned session workers after 5 minutes
> - Adds orphan worker garbage collection to the daemon. If a worker loses supervisor connectivity for the configured window (default 5 minutes via `workerSupervisorLostExitMs`) and has no active session work, the daemon exits cleanly.
> - Bounds the heartbeat catalog refresh loop in interactive mode to prevent indefinite waits under sustained events.
> - Makes session rebind best-effort, retaining prior state if transient refresh or sync failures occur.
> - Isolates transcript rendering failures per-message so a single bad message shows an inline warning instead of breaking the entire chat view.
> - Risk: Orphan GC may terminate the daemon process if the supervisor is unreachable for 5 minutes. Adjust `workerSupervisorLostExitMs` to change this window.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd84a7f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->