### PR TITLE
[RSI] chore: biome-format daemon-mode.ts to stop pre-commit drift

### DIFF
--- a/packages/coding-agent/.changes/eng-6107-biome-format-daemon-mode.md
+++ b/packages/coding-agent/.changes/eng-6107-biome-format-daemon-mode.md
@@ -1,0 +1,1 @@
+- Formatting-only: applied biome's line-wrapping to `daemon-mode.ts` so the pre-commit hook no longer leaves working-tree drift after every commit.

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -3404,9 +3404,7 @@ export class AgentDaemon {
 			...(entry.repliedSinceTask !== undefined ? { repliedSinceTask: entry.repliedSinceTask } : {}),
 			...(entry.parentSessionId ? { parentSessionId: entry.parentSessionId } : {}),
 			...(entry.rlmChildId ? { rlmChildId: entry.rlmChildId } : {}),
-			...(entry.firstMessage
-				? { firstMessage: entry.firstMessage.slice(0, AGENT_OBSERVE_PREVIEW_MAX_CHARS) }
-				: {}),
+			...(entry.firstMessage ? { firstMessage: entry.firstMessage.slice(0, AGENT_OBSERVE_PREVIEW_MAX_CHARS) } : {}),
 		};
 	}
 
@@ -3482,7 +3480,11 @@ export class AgentDaemon {
 			...(summary.firstMessage ? { firstMessage: summary.firstMessage } : {}),
 			...(latest
 				? {
-						latestMessage: createAgentObserveMessagePreview(latest, messages.length - 1, AGENT_OBSERVE_PREVIEW_MAX_CHARS),
+						latestMessage: createAgentObserveMessagePreview(
+							latest,
+							messages.length - 1,
+							AGENT_OBSERVE_PREVIEW_MAX_CHARS,
+						),
 					}
 				: {}),
 		};


### PR DESCRIPTION
## What

`packages/coding-agent/src/modes/daemon/daemon-mode.ts` fails `npx biome check` on current `main`, so the biome pre-commit hook rewrites it on **every commit** — leaving uncommitted working-tree drift in every checkout. The drift recurs on each branch switch, shows up as "uncommitted changes" warnings on every PR create, and is a standing risk of contributors discarding what look like stray edits while the file actually contains their formatting delta.

## Change

Apply biome's own formatting to the file: a line-rewrap of two spread expressions (10 diff lines, zero semantic change). After this merges, the hook has nothing to rewrite and the drift class disappears for everyone.

## Validation

`tsgo --noEmit` clean; the full `daemon-mode.test.ts` suite (204 tests) passes on the formatted file.

Fixes ENG-6107

---
*This PR was authored autonomously as part of a recursive self-improvement program (RSI).*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatting-only edits with no logic or runtime changes; validated by typecheck and existing daemon-mode tests.
> 
> **Overview**
> Applies **Biome formatting** to `daemon-mode.ts` so the pre-commit hook stops rewriting the file after every commit and eliminating persistent working-tree drift.
> 
> The diff is line-wrapping only: a conditional spread for `firstMessage` is collapsed to one line, and a `createAgentObserveMessagePreview(...)` call is broken across multiple lines. **No behavior change.**
> 
> A changelog entry under `.changes/` documents ENG-6107.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3632f9c21fc528d73ee67e4ecbf34c2ab2eda8a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Biome-format `daemon-mode.ts` to stop pre-commit drift
> Applies Biome line-wrapping to [daemon-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2247/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450), including the `firstMessage` snapshot property expression and the `createAgentObserveMessagePreview` call. Arguments and logic are unchanged. A change note was added for visibility.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3632f9c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->