### PR TITLE
benchmark compiled agent installations

### DIFF
--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -52,9 +52,10 @@ and other missing tools. Their setup time and disk usage are outside the install
 - **Installation:** the normal installer and Python/tool bootstrap in three new user homes, each
   with empty npm and uv caches. Unpublished candidate release tarballs are served over loopback;
   npm/Python dependencies use the real network. This does not measure public release-CDN latency.
-- **Compressed artifacts:** total bytes of the four tarballs produced by the release packer, using
-  an identical synthetic version and download origin for both sides. External registry dependencies
-  are not included in these tarballs.
+- **Compressed artifacts:** total bytes of the four npm tarballs and, for revisions with compiled
+  release support, the Linux x64 archive. Both sides use the same synthetic version and download
+  origin. This includes the npm fallback packages, but excludes other platforms and external registry
+  dependencies. The result records which formats were built.
 - **Installed footprint:** apparent bytes added after first use in the first fresh home, including stock Python,
   runtime, and tool assets; excluding download caches, session history, and logs. Shared system
   dependencies supplied by the base image and the fixture repository are excluded.
@@ -64,6 +65,11 @@ and other missing tools. Their setup time and disk usage are outside the install
   shared pages.
 
 Startup and memory use 10 trials per revision. Installation uses three; sizes are measured once.
+Compiled revisions provision pinned Bun tooling and build their Linux x64 archive during untimed
+setup. The installer selects its normal default from the available artifacts; the harness does not
+force Node or compiled mode. Loopback downloads use the installer's explicit test exception, while
+external downloads retain normal HTTPS checks. Harness changes must land on `main` before CI uses
+them, including when benchmarking the Bun migration stack.
 Stock tools, skills, daemon, persistence, and Python bootstrap remain enabled. Homes contain no
 credentials, extensions, MCP servers, or personal skills. The onboarding splash is marked as already
 shown before timing, so startup measures the editor rather than waiting for a person to sign in.

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -68,7 +68,8 @@ Startup and memory use 10 trials per revision. Installation uses three; sizes ar
 Compiled revisions provision pinned Bun tooling and build their Linux x64 archive during untimed
 setup. The installer selects its normal default from the available artifacts; the harness does not
 force Node or compiled mode. Loopback downloads use the installer's explicit test exception, while
-external downloads retain normal HTTPS checks. Harness changes must land on `main` before CI uses
+external downloads retain normal HTTPS checks. A compiled candidate that falls back to Node is
+reported as a failed installation, rather than measuring the wrong runtime. Harness changes must land on `main` before CI uses
 them, including when benchmarking the Bun migration stack.
 Stock tools, skills, daemon, persistence, and Python bootstrap remain enabled. Homes contain no
 credentials, extensions, MCP servers, or personal skills. The onboarding splash is marked as already

--- a/scripts/benchmarks/tests/test_benchmarks.py
+++ b/scripts/benchmarks/tests/test_benchmarks.py
@@ -638,6 +638,9 @@ class MeasurementTests(unittest.TestCase):
             home = root / "benchmark1"
             (home / ".prime/agent/kernel-venv/bin").mkdir(parents=True)
             (home / ".prime/agent/kernel-venv/bin/python").touch()
+            command = home / ".local/bin/prime-agent"
+            command.parent.mkdir(parents=True)
+            command.write_text("#!/usr/bin/env node\n")
             side = Side(sha=SHA)
 
             def run_as(_user, command, *_args, **_kwargs):

--- a/scripts/benchmarks/tests/test_worker_release.py
+++ b/scripts/benchmarks/tests/test_worker_release.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import worker
+from schema import Side
+
+
+class ReleasePreparationTests(unittest.TestCase):
+    def test_packages_the_selected_release_format_and_complete_checksums(self):
+        for native in (False, True):
+            with self.subTest(native=native), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                source = root / "source"
+                agent = source / "packages/coding-agent"
+                artifacts = agent / "release/benchmark/artifacts"
+                artifacts.mkdir(parents=True)
+                if native:
+                    for script in (
+                        agent / "scripts/build-binary.mjs",
+                        source / "scripts/assemble-release-archives.mjs",
+                    ):
+                        script.parent.mkdir(parents=True, exist_ok=True)
+                        script.touch()
+                calls = []
+
+                def run_as(user, command, cwd, calls=calls, artifacts=artifacts, **options):
+                    calls.append((user, command, cwd, options))
+                    if command == ["git", "rev-parse", "HEAD"]:
+                        return "a" * 40
+                    if "scripts/pack-prime-agent-release.mjs" in command:
+                        for name in ("agent", "ai", "core", "tui"):
+                            (artifacts / f"{name}.tgz").write_bytes(name.encode())
+                    if any(arg.endswith("assemble-release-archives.mjs") for arg in command):
+                        (artifacts / f"prime-agent-{worker.VERSION}-linux-x64.tar.gz").write_bytes(b"native")
+                        (artifacts / "SHA256SUMS").write_text("native-only inventory\n")
+                    return "fixture"
+
+                read_text = Path.read_text
+
+                def read(path, *args, original=read_text, **kwargs):
+                    return (
+                        "model name: fixture\n"
+                        if str(path) == "/proc/cpuinfo"
+                        else original(path, *args, **kwargs)
+                    )
+
+                side = Side(sha="a" * 40)
+                with (
+                    patch.object(worker, "SOURCE", source),
+                    patch.object(worker, "ROOT", root),
+                    patch.object(worker, "RESULTS", root),
+                    patch.object(worker, "run_as", side_effect=run_as),
+                    patch("worker.pwd.getpwnam", return_value=SimpleNamespace(pw_uid=1, pw_gid=1)),
+                    patch("worker.os.chown"),
+                    patch(
+                        "worker.os.uname", return_value=SimpleNamespace(release="fixture", machine="x86_64")
+                    ),
+                    patch.object(Path, "read_text", read),
+                ):
+                    worker.prepare(SimpleNamespace(source_repository="owner/repo", sha="a" * 40), side)
+                archives = sorted([*artifacts.glob("*.tgz"), *artifacts.glob("*.tar.gz")])
+                self.assertEqual(len(archives), 5 if native else 4)
+                self.assertEqual(
+                    side.metrics["bundle"][0].value, sum(path.stat().st_size for path in archives)
+                )
+                self.assertEqual(
+                    (artifacts / "SHA256SUMS").read_text(),
+                    "".join(
+                        f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}\n" for path in archives
+                    ),
+                )
+                self.assertEqual(
+                    (root / "www/releases" / f"v{worker.VERSION}").resolve(), artifacts.resolve()
+                )
+                builds = [call for call in calls if "--platform" in call[1]]
+                self.assertEqual(len(builds), int(native))
+                if native:
+                    self.assertEqual(builds[0][1][-2:], ["--platform", "linux-x64"])
+                    self.assertEqual(
+                        builds[0][3]["extra_env"]["BUN_BINARY"],
+                        str(source / ".benchmark-bun/node_modules/.bin/bun"),
+                    )
+                    self.assertEqual(side.runtime["artifact_format"], "npm-tarballs+linux-x64-native")
+                else:
+                    self.assertEqual(side.runtime["artifact_format"], "npm-tarballs")
+                    self.assertFalse(any(any("bun@" in arg for arg in call[1]) for call in calls))
+
+    def test_incomplete_native_build_does_not_silently_benchmark_node(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory)
+            agent = source / "packages/coding-agent"
+            script = agent / "scripts/build-binary.mjs"
+            script.parent.mkdir(parents=True)
+            script.touch()
+            with patch.object(worker, "SOURCE", source), self.assertRaisesRegex(RuntimeError, "incomplete"):
+                worker.prepare_native_artifact(agent, source, source / "log")
+
+    def test_install_enables_only_the_loopback_test_exception(self):
+        with (
+            patch("worker.subprocess.run"),
+            patch("worker.disk_bytes", return_value=0),
+            patch("worker.stop_processes"),
+            patch(
+                "worker.run_as", side_effect=RuntimeError("stop after inspecting installer arguments")
+            ) as run,
+        ):
+            worker.install(SimpleNamespace(), Side(sha="a" * 40), 0)
+        env = run.call_args.kwargs["extra_env"]
+        self.assertEqual(env["PRIME_AGENT_ALLOW_INSECURE_HTTP_FOR_TESTS"], "1")
+        self.assertEqual(env["PRIME_AGENT_DOWNLOAD_BASE_URL"], worker.ORIGIN)
+        self.assertNotIn("PRIME_AGENT_INSTALL_METHOD", env)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmarks/tests/test_worker_release.py
+++ b/scripts/benchmarks/tests/test_worker_release.py
@@ -116,6 +116,24 @@ class ReleasePreparationTests(unittest.TestCase):
         self.assertEqual(env["PRIME_AGENT_DOWNLOAD_BASE_URL"], worker.ORIGIN)
         self.assertNotIn("PRIME_AGENT_INSTALL_METHOD", env)
 
+    def test_rejects_node_fallback_when_measuring_a_compiled_release(self):
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            command = home / ".local/bin/prime-agent"
+            command.parent.mkdir(parents=True)
+            command.write_bytes(b"#!/usr/bin/env node\n")
+            side = Side(sha="a" * 40, runtime={"artifact_format": "npm-tarballs+linux-x64-native"})
+            with self.assertRaisesRegex(RuntimeError, "selected Node"):
+                worker.verify_installation_format(home, side)
+            self.assertEqual(side.runtime["installation_format"], "npm")
+            command.write_bytes(b"\x7fELFfixture")
+            worker.verify_installation_format(home, side)
+            self.assertEqual(side.runtime["installation_format"], "compiled")
+            command.write_bytes(b"#!/usr/bin/env node\n")
+            side.runtime["artifact_format"] = "npm-tarballs"
+            worker.verify_installation_format(home, side)
+            self.assertEqual(side.runtime["installation_format"], "npm")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/benchmarks/worker.py
+++ b/scripts/benchmarks/worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import pwd
@@ -38,6 +39,7 @@ SOURCE = HOMES / "builder/source"
 RESULTS = ROOT / "results"
 VERSION = "0.0.0-benchmark"
 ORIGIN = "http://127.0.0.1:18741"
+BUN_VERSION = "1.4.0"
 
 
 def clean_error(error: Exception) -> str:
@@ -142,6 +144,41 @@ def memory(uid: int) -> list[ProcessMemory]:
     return processes
 
 
+def prepare_native_artifact(agent: Path, artifacts: Path, log: Path) -> bool:
+    build = agent / "scripts/build-binary.mjs"
+    assemble = SOURCE / "scripts/assemble-release-archives.mjs"
+    if not build.exists() and not assemble.exists():
+        return False
+    if not build.is_file() or not assemble.is_file():
+        raise RuntimeError("Compiled release build scripts are incomplete")
+    tools = SOURCE / ".benchmark-bun"
+    run_as(
+        "builder",
+        ["npm", "install", "--prefix", str(tools), "--no-audit", "--no-fund", f"bun@{BUN_VERSION}"],
+        SOURCE,
+        timeout=180,
+        log=log,
+    )
+    run_as(
+        "builder",
+        ["node", str(build), "--platform", "linux-x64"],
+        SOURCE,
+        timeout=600,
+        log=log,
+        extra_env={"BUN_BINARY": str(tools / "node_modules/.bin/bun")},
+    )
+    run_as(
+        "builder",
+        ["node", str(assemble), str(agent / "binaries"), str(artifacts), VERSION],
+        SOURCE,
+        timeout=180,
+        log=log,
+    )
+    if not (artifacts / f"prime-agent-{VERSION}-linux-x64.tar.gz").is_file():
+        raise RuntimeError("Compiled Linux x64 release archive is missing")
+    return True
+
+
 def prepare(request: Request, side: Side) -> None:
     log = RESULTS / "build.log"
     source_url = f"https://github.com/{request.source_repository}.git"
@@ -187,9 +224,14 @@ def prepare(request: Request, side: Side) -> None:
         log=log,
     )
     artifacts = agent / "release/benchmark/artifacts"
-    side.artifacts = {path.name: path.stat().st_size for path in sorted(artifacts.glob("*.tgz"))}
-    if len(side.artifacts) != 4:
+    if len(list(artifacts.glob("*.tgz"))) != 4:
         raise RuntimeError("Expected the four release package tarballs")
+    native = prepare_native_artifact(agent, artifacts, log)
+    archives = sorted([*artifacts.glob("*.tgz"), *artifacts.glob("*.tar.gz")])
+    side.artifacts = {path.name: path.stat().st_size for path in archives}
+    (artifacts / "SHA256SUMS").write_text(
+        "".join(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}\n" for path in archives)
+    )
     record(side, "bundle", 0, sum(side.artifacts.values()))
     release = ROOT / "www/releases" / f"v{VERSION}"
     release.parent.mkdir(parents=True, exist_ok=True)
@@ -198,7 +240,9 @@ def prepare(request: Request, side: Side) -> None:
         side.runtime[name] = run_as("builder", [name, "--version"], SOURCE).strip()
     side.runtime["kernel"] = os.uname().release
     side.runtime["machine"] = os.uname().machine
-    side.runtime["artifact_format"] = "npm-tarballs"
+    side.runtime["artifact_format"] = "npm-tarballs+linux-x64-native" if native else "npm-tarballs"
+    if native:
+        side.runtime["bun"] = BUN_VERSION
     cpu = Path("/proc/cpuinfo").read_text()
     side.runtime["cpu"] = next(
         (line.partition(":")[2].strip() for line in cpu.splitlines() if line.startswith("model name")),
@@ -244,6 +288,7 @@ def install(request: Request, side: Side, trial: int) -> None:
             timeout=240,
             log=RESULTS / f"install-{trial}.log",
             extra_env={
+                "PRIME_AGENT_ALLOW_INSECURE_HTTP_FOR_TESTS": "1",
                 "PRIME_AGENT_DOWNLOAD_BASE_URL": ORIGIN,
                 "PRIME_AGENT_INSTALLER_PLAIN": "1",
                 "PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL": "1",

--- a/scripts/benchmarks/worker.py
+++ b/scripts/benchmarks/worker.py
@@ -272,6 +272,14 @@ def disk_bytes(home: Path) -> int:
     return int(output.split()[0])
 
 
+def verify_installation_format(home: Path, side: Side) -> None:
+    with (home / ".local/bin/prime-agent").open("rb") as executable:
+        compiled = executable.read(4) == b"\x7fELF"
+    side.runtime["installation_format"] = "compiled" if compiled else "npm"
+    if side.runtime.get("artifact_format") == "npm-tarballs+linux-x64-native" and not compiled:
+        raise RuntimeError("Expected the compiled installation, but the installer selected Node")
+
+
 def install(request: Request, side: Side, trial: int) -> None:
     user = f"benchmark{trial + 1}"
     subprocess.run(
@@ -300,6 +308,7 @@ def install(request: Request, side: Side, trial: int) -> None:
         version = run_as(user, ["prime-agent", "--version"], home, merge_output=True).strip()
         if VERSION not in version:
             raise RuntimeError(f"Installed version does not match the packed release: {version[:100]}")
+        verify_installation_format(home, side)
         if not (home / ".prime/agent/kernel-venv/bin/python").exists():
             raise RuntimeError("The installer's Python bootstrap did not complete")
         record(side, "install", trial, elapsed)


### PR DESCRIPTION
The Bun migration benchmarks currently finish with incomplete results because the harness builds only npm packages and the new installer rejects its local HTTP downloads.

This PR builds a Linux x64 compiled archive alongside the npm fallback packages when the tested revision supports it, then lets the installer choose its normal default. It preserves checksums for both formats, enables the installer's existing loopback test exception, and rejects a compiled candidate that falls back to Node. This must land on main before rerunning the Bun stack's benchmarks, because those jobs use the trusted default-branch harness.

Tested the build and install changes in two fresh Prime sandboxes: main used Node, while the Bun candidate used the compiled executable. Both completed installation, three cold/warm startup trials, memory measurements, and three Python runtime trials without failed samples. All 41 harness tests, Python lint/format checks, and npm run check passed, including the final guard against Node fallback.

[ENG-6119](https://linear.app/primeintellect/issue/ENG-6119) · Related Bun stack: #2140 → #2165 → #2166.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Benchmark compiled agent installations with native Linux x64 release archives
> - `worker.prepare` now validates the four npm tarballs, optionally builds a Linux x64 native archive via a pinned Bun 1.4.0 toolchain, and reports combined archive size with SHA256SUMS
> - `prepare_native_artifact` detects compiled-release support from the presence of both build scripts; incomplete support or a missing output archive raises an error
> - `verify_installation_format` reads the installed launcher's ELF header and rejects Node-script launchers when native artifacts were selected, while npm-only trials still record npm format
> - `install` passes the loopback insecure-download test flag to the installer environment without overriding the installer's default artifact-format selection
> - Risk: `verify_installation_format` raises when a compiled candidate installs through Node — any benchmark trial expecting native execution must ensure the native build succeeds or it will fail rather than silently benchmark Node
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e561a39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the benchmark harness and documentation; they do not alter the product installer or runtime outside CI/sandbox measurement paths.
> 
> **Overview**
> Extends the PR benchmark harness so revisions with compiled release support are measured with a **Linux x64 native archive** in addition to the four npm tarballs, instead of npm-only artifacts that made Bun migration comparisons incomplete.
> 
> During untimed `prepare`, the worker optionally installs pinned Bun, runs the binary build and archive assembly, writes **SHA256SUMS** over all packaged archives, and records **`artifact_format`** (`npm-tarballs` vs `npm-tarballs+linux-x64-native`). Partial native toolchains now **fail preparation** rather than silently benchmarking npm-only.
> 
> Install trials set **`PRIME_AGENT_ALLOW_INSECURE_HTTP_FOR_TESTS`** for loopback release downloads (without forcing install method), then **`verify_installation_format`** checks whether `prime-agent` is an ELF binary; compiled candidates that still install the Node shim are treated as **failed installs**. README and new **`test_worker_release.py`** tests document and lock in this behavior; an existing install test now stubs a `prime-agent` binary so format verification does not break.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e561a39915ca3516759c2e7d96346c72ea98e027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->