### PR TITLE
restore the newest discussion notifier state

### DIFF
--- a/.github/scripts/discussion-notifier/notify.py
+++ b/.github/scripts/discussion-notifier/notify.py
@@ -86,7 +86,7 @@ def restore_state(directory: Path) -> dict | None:
     ]
     latest = None
     for artifact in sorted(
-        artifacts, key=lambda artifact: artifact["id"], reverse=True
+        artifacts, key=lambda artifact: artifact["created_at"], reverse=True
     ):
         run = json.loads(
             gh(

--- a/.github/scripts/discussion-notifier/test_notify.py
+++ b/.github/scripts/discussion-notifier/test_notify.py
@@ -394,18 +394,23 @@ class NotificationTests(unittest.TestCase):
                         notify.deliver(item, "/services/test")
                 connection.return_value.request.assert_called_once()
 
-    def test_restores_latest_reservation_regardless_of_run_conclusion(self):
+    def test_restores_latest_trusted_reservation_by_creation_time(self):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory)
             saved = state()
             (path / "state.json").write_text(json.dumps(saved))
             artifacts = [
                 {
-                    "id": i,
+                    "id": artifact_id,
                     "expired": False,
-                    "workflow_run": {"id": i * 10, "head_branch": branch},
+                    "created_at": created_at,
+                    "workflow_run": {"id": run_id, "head_branch": branch},
                 }
-                for i, branch in [(1, "main"), (3, "feature/test"), (2, "main")]
+                for artifact_id, run_id, branch, created_at in [
+                    (300, 10, "main", "2026-09-12T01:00:00Z"),
+                    (100, 30, "feature/test", "2026-09-12T03:00:00Z"),
+                    (200, 20, "main", "2026-09-12T02:00:00Z"),
+                ]
             ]
             with patch.object(
                 notify,
@@ -438,6 +443,7 @@ class NotificationTests(unittest.TestCase):
                     {
                         "id": i,
                         "expired": False,
+                        "created_at": f"2026-09-12T00:0{i}:00Z",
                         "workflow_run": {"id": i * 10, "head_branch": "main"},
                     }
                     for i in [1, 2]
@@ -463,6 +469,7 @@ class NotificationTests(unittest.TestCase):
         artifact = {
             "id": 1,
             "expired": True,
+            "created_at": "2026-09-12T00:01:00Z",
             "workflow_run": {"id": 10, "head_branch": "main"},
         }
         with patch.object(


### PR DESCRIPTION
The Slack discussion notifier restored state artifacts by numeric artifact ID, but the live artifacts are not assigned in creation order. Scheduled runs therefore kept loading an older cursor and reservation checkpoint, which reposted discussion #2257 three times.

This changes state restoration to order artifacts by GitHub's creation timestamp while retaining the existing trusted-run checks. The regression test uses deliberately non-monotonic artifact IDs so the stale-state behavior cannot return.

Tested the 25 notifier unit tests and the full `npm run check` suite. A read-only dry run against the live workflow state restored the newest checkpoint and selected no discussions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to CI state-restore ordering in the discussion notifier; trusted-run validation is unchanged.
> 
> **Overview**
> Fixes **stale notification state** when the Slack discussion notifier picks which GitHub Actions artifact to restore. **`restore_state`** now sorts `main` branch artifacts by GitHub’s **`created_at`** (newest first) instead of numeric **`id`**, so scheduled runs load the latest cursor and reservation checkpoint instead of an older one that caused duplicate Slack posts.
> 
> Tests were updated to match: the main regression case uses **non-monotonic artifact IDs** with explicit timestamps and asserts the download targets the run tied to the newest trusted artifact; other fixtures now include **`created_at`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0acde5aac8873f8f450cdb8e6dae79787a918406. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore discussion notifier state by artifact creation timestamp instead of artifact ID
> Changes `restore_state` in notify.py to sort candidate state artifacts by descending creation timestamp rather than descending artifact ID before validating the workflow run. The first qualifying trusted main-branch run is now selected by creation time. Tests are updated to use distinct artifact IDs, workflow-run IDs, branches, and creation timestamps so creation-time ordering differs from artifact-ID ordering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0acde5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->