### PR TITLE
fix(coding-agent): prevent heartbeat catalog timeouts

### DIFF
--- a/packages/coding-agent/.changes/res-1343-heartbeat-catalog-timeouts.md
+++ b/packages/coding-agent/.changes/res-1343-heartbeat-catalog-timeouts.md
@@ -1,0 +1,1 @@
+- Fixed heartbeat listing timeouts when multiple clients refresh large saved-session catalogs.

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -743,6 +743,7 @@ export class DaemonSupervisor {
 	private scheduledWakeTimer?: ReturnType<typeof setTimeout>;
 	private scheduledWakeRecompute?: Promise<void>;
 	private scheduledWakeRecomputeQueued = false;
+	private heartbeatRefresh?: Promise<DaemonResponse>;
 	private readonly scheduledWakeFailures = new Map<string, number>();
 
 	constructor(
@@ -938,7 +939,7 @@ export class DaemonSupervisor {
 				pendingCancelRoots.add(canonicalSessionPath(context.sessionFile));
 			}
 		}
-		const infos = await this.rlmSpawnLedger().family();
+		const infos = await this.rlmSpawnLedger().family(SESSION_SCHEDULED_JOBS_FILENAME);
 		const infoByPath = new Map(infos.map((info) => [canonicalSessionPath(info.path), info] as const));
 		const storeBySessionId = new Map<string, AgentCronJobStore>();
 		const infoBySessionId = new Map<string, SessionInfo>();
@@ -2289,56 +2290,68 @@ export class DaemonSupervisor {
 					const match = await this.findWorkerForClient(client, command.activeSessionId);
 					return this.forwardToWorker(match.worker, command);
 				}
-				const workers = [...this.workers.values()].filter(
-					(worker) => this.isLiveWorker(worker) && worker.descriptor.lifecycle !== "failed",
-				);
-				const heartbeats = new Map<string, AgentConnectionHeartbeat>();
-				const snapshots: Array<{ heartbeats?: AgentConnectionHeartbeat[]; response?: DaemonResponse }> =
-					await Promise.all(
-						workers.map(async (worker) => {
-							if (worker.client && worker.descriptor.lifecycle === "ready") {
-								const response = await this.forwardToWorker(worker, command, 5000).catch((error: unknown) =>
-									failure(command.id, command.type, error, serializeDaemonError(error)),
-								);
-								if (response.success) {
-									const snapshot = heartbeatsFromResponse(response);
-									worker.heartbeatSnapshot = snapshot;
-									worker.heartbeatSnapshotStale = false;
-									return { heartbeats: snapshot };
-								}
-								this.log(`Could not list heartbeats from a worker: ${response.error}`);
-								if (worker.heartbeatSnapshot === undefined || worker.heartbeatSnapshotStale === true) {
-									return { response };
-								}
+				// Clients share the in-flight refresh; settled results are never cached.
+				if (!this.heartbeatRefresh) {
+					const refresh = (async (): Promise<DaemonResponse> => {
+						const workers = [...this.workers.values()].filter(
+							(worker) => this.isLiveWorker(worker) && worker.descriptor.lifecycle !== "failed",
+						);
+						const heartbeats = new Map<string, AgentConnectionHeartbeat>();
+						const snapshots: Array<{ heartbeats?: AgentConnectionHeartbeat[]; response?: DaemonResponse }> =
+							await Promise.all(
+								workers.map(async (worker) => {
+									if (worker.client && worker.descriptor.lifecycle === "ready") {
+										const response = await this.forwardToWorker(worker, command, 5000).catch(
+											(error: unknown) =>
+												failure(command.id, command.type, error, serializeDaemonError(error)),
+										);
+										if (response.success) {
+											const snapshot = heartbeatsFromResponse(response);
+											if (this.heartbeatRefresh === refresh) {
+												worker.heartbeatSnapshot = snapshot;
+												worker.heartbeatSnapshotStale = false;
+											}
+											return { heartbeats: snapshot };
+										}
+										this.log(`Could not list heartbeats from a worker: ${response.error}`);
+										if (worker.heartbeatSnapshot === undefined || worker.heartbeatSnapshotStale === true) {
+											return { response };
+										}
+									}
+									if (worker.heartbeatSnapshot !== undefined && worker.heartbeatSnapshotStale !== true) {
+										return { heartbeats: worker.heartbeatSnapshot };
+									}
+									const state =
+										worker.descriptor.lifecycle === "ready" ? "disconnected" : worker.descriptor.lifecycle;
+									const error = new Error(`Cannot list heartbeats while session worker is ${state}`);
+									return { response: failure(command.id, command.type, error, serializeDaemonError(error)) };
+								}),
+							);
+						const failed = snapshots.find((snapshot) => snapshot.response)?.response;
+						if (failed) {
+							return failed;
+						}
+						for (const snapshot of snapshots) {
+							for (const heartbeat of snapshot.heartbeats ?? []) {
+								heartbeats.set(heartbeat.job.id, heartbeat);
 							}
-							if (worker.heartbeatSnapshot !== undefined && worker.heartbeatSnapshotStale !== true) {
-								return { heartbeats: worker.heartbeatSnapshot };
-							}
-							const state =
-								worker.descriptor.lifecycle === "ready" ? "disconnected" : worker.descriptor.lifecycle;
-							const error = new Error(`Cannot list heartbeats while session worker is ${state}`);
-							return { response: failure(command.id, command.type, error, serializeDaemonError(error)) };
-						}),
-					);
-				const failed = snapshots.find((snapshot) => snapshot.response)?.response;
-				if (failed) {
-					return failed;
-				}
-				for (const snapshot of snapshots) {
-					for (const heartbeat of snapshot.heartbeats ?? []) {
-						heartbeats.set(heartbeat.job.id, heartbeat);
-					}
-				}
-				// Passivated sessions keep their armed heartbeats; no worker can list them.
-				for (const { job, info } of await this.collectPassiveScheduledJobs()) {
-					if (!isHeartbeatCronJob(job) || heartbeats.has(job.id)) continue;
-					heartbeats.set(job.id, {
-						job,
-						...(info.name !== undefined ? { sessionName: info.name } : {}),
-						...(info.firstMessage !== undefined ? { firstMessage: info.firstMessage } : {}),
+						}
+						// Passivated sessions keep their armed heartbeats; no worker can list them.
+						for (const { job, info } of await this.collectPassiveScheduledJobs()) {
+							if (!isHeartbeatCronJob(job) || heartbeats.has(job.id)) continue;
+							heartbeats.set(job.id, {
+								job,
+								...(info.name !== undefined ? { sessionName: info.name } : {}),
+								...(info.firstMessage !== undefined ? { firstMessage: info.firstMessage } : {}),
+							});
+						}
+						return success(command.id, "heartbeats_list", { heartbeats: [...heartbeats.values()] });
+					})().finally(() => {
+						if (this.heartbeatRefresh === refresh) this.heartbeatRefresh = undefined;
 					});
+					this.heartbeatRefresh = refresh;
 				}
-				return success(command.id, "heartbeats_list", { heartbeats: [...heartbeats.values()] });
+				return responseWithId(await this.heartbeatRefresh, command.id);
 			}
 			case "heartbeat_manage": {
 				const cachedWorker = [...this.workers.values()].find((worker) =>
@@ -6733,6 +6746,7 @@ export class DaemonSupervisor {
 	}
 
 	private broadcastHeartbeatsChanged(): void {
+		this.heartbeatRefresh = undefined;
 		this.scheduleScheduledSessionWakeRecompute();
 		for (const client of this.clients) {
 			this.write(client, { type: "heartbeats_changed" });

--- a/packages/coding-agent/src/modes/daemon/rlm-ledger.ts
+++ b/packages/coding-agent/src/modes/daemon/rlm-ledger.ts
@@ -15,7 +15,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import { EventLog } from "../../core/event-log.js";
 import { canonicalSessionPath } from "../../core/session-lease.js";
 import { getSessionArtifactPathForFile, readSessionInfo, type SessionInfo } from "../../core/session-manager.js";
-import { readFirstLineSync } from "../../utils/file-lines.js";
+import { readFirstLineSync, readLinesAsBuffers } from "../../utils/file-lines.js";
 
 /**
  * Daemon-owned RLM spawn ledger.
@@ -589,19 +589,26 @@ export class RlmSpawnLedger {
 		// name, so the name comes from this read — writer-owned display data,
 		// not authority.
 		let id = basename(path, ".jsonl");
+		let loadMetadata = metadataArtifact === undefined;
 		if (metadataArtifact !== undefined) {
 			// Imported transcripts can have a filename different from their session id.
 			try {
-				const header = JSON.parse(readFirstLineSync(path) ?? "null") as { id?: unknown } | null;
-				if (typeof header?.id === "string") id = header.id;
+				for await (const line of readLinesAsBuffers(path)) {
+					const text = line.toString("utf8").trim();
+					if (!text) continue;
+					const header = JSON.parse(text) as { id?: unknown } | null;
+					if (typeof header?.id === "string") id = header.id;
+					break;
+				}
 			} catch {
 				// Unreadable headers retain the filename-based fallback below.
 			}
+			loadMetadata = await stat(join(getSessionArtifactPathForFile(path, id), metadataArtifact)).then(
+				() => true,
+				() => false,
+			);
 		}
-		const info =
-			metadataArtifact === undefined || existsSync(join(getSessionArtifactPathForFile(path, id), metadataArtifact))
-				? await readSessionInfo(path).catch(() => null)
-				: null;
+		const info = loadMetadata ? await readSessionInfo(path).catch(() => null) : null;
 		if (info) {
 			const { parentSessionPath: _headerParent, rlmDepth: _headerDepth, ...display } = info;
 			return {

--- a/packages/coding-agent/src/modes/daemon/rlm-ledger.ts
+++ b/packages/coding-agent/src/modes/daemon/rlm-ledger.ts
@@ -40,6 +40,8 @@ export const RLM_LEDGER_DIR = "rlm-ledger";
 export const RLM_LEDGER_MAX_BYTES = 32 * 1024 * 1024;
 export const RLM_LEDGER_MAX_RECORDS = 100_000;
 
+const SESSION_HEADER_PROBE_MAX_BYTES = 1024 * 1024;
+
 export type RlmLedgerDeleteReason = "user" | "parent-teardown" | "revoked" | "gc";
 
 interface RlmLedgerMetaRecord {
@@ -592,16 +594,28 @@ export class RlmSpawnLedger {
 		let loadMetadata = metadataArtifact === undefined;
 		if (metadataArtifact !== undefined) {
 			// Imported transcripts can have a filename different from their session id.
+			let bytesRead = 0;
 			try {
-				for await (const line of readLinesAsBuffers(path)) {
+				for await (const line of readLinesAsBuffers(path, { end: SESSION_HEADER_PROBE_MAX_BYTES - 1 })) {
+					bytesRead += line.length + 1;
+					if (bytesRead >= SESSION_HEADER_PROBE_MAX_BYTES) break;
 					const text = line.toString("utf8").trim();
 					if (!text) continue;
-					const header = JSON.parse(text) as { id?: unknown } | null;
-					if (typeof header?.id === "string") id = header.id;
+					let header: { type?: unknown; id?: unknown } | null;
+					try {
+						header = JSON.parse(text);
+					} catch {
+						continue;
+					}
+					if (header?.type === "session" && typeof header.id === "string") id = header.id;
 					break;
 				}
 			} catch {
 				// Unreadable headers retain the filename-based fallback below.
+			}
+			// A truncated probe cannot establish artifact ownership; fail instead of hiding scheduled jobs.
+			if (bytesRead >= SESSION_HEADER_PROBE_MAX_BYTES) {
+				throw new Error(`Session header exceeds ${SESSION_HEADER_PROBE_MAX_BYTES} byte probe limit: ${path}`);
 			}
 			loadMetadata = await stat(join(getSessionArtifactPathForFile(path, id), metadataArtifact)).then(
 				() => true,

--- a/packages/coding-agent/src/modes/daemon/rlm-ledger.ts
+++ b/packages/coding-agent/src/modes/daemon/rlm-ledger.ts
@@ -384,9 +384,11 @@ export class RlmSpawnLedger {
 	 * reconciled by stat (a dead parent or child drops the edge). Depths are
 	 * verified parent+1 between ledger-known depths; a contradictory edge is
 	 * dropped and logged, never fails the whole family.
+	 * When metadataArtifact is set, only sessions with that artifact load
+	 * transcript metadata; every topology row is still returned.
 	 */
-	family(): Promise<SessionInfo[]> {
-		return this.enqueue(() => this.familyUnlocked());
+	family(metadataArtifact?: string): Promise<SessionInfo[]> {
+		return this.enqueue(() => this.familyUnlocked(metadataArtifact));
 	}
 
 	/** Same-parent rows for a child session path, including the child itself. */
@@ -513,7 +515,7 @@ export class RlmSpawnLedger {
 		return alive;
 	}
 
-	private async familyUnlocked(): Promise<SessionInfo[]> {
+	private async familyUnlocked(metadataArtifact?: string): Promise<SessionInfo[]> {
 		// One replay, one stat snapshot: byChild comes from the same alive set that emits child rows,
 		// so a child whose dead edge was reconciled away degrades to a root row instead of vanishing.
 		let alive: RlmLedgerEdge[] = await this.liveEdgesUnlocked(
@@ -557,7 +559,7 @@ export class RlmSpawnLedger {
 		});
 		const rows: SessionInfo[] = [];
 		for (const rootPath of rootPaths) {
-			rows.push(await this.sessionRow(rootPath, 0, undefined, undefined));
+			rows.push(await this.sessionRow(rootPath, 0, undefined, undefined, metadataArtifact));
 		}
 		for (const edge of alive) {
 			rows.push(
@@ -566,6 +568,7 @@ export class RlmSpawnLedger {
 					edge.depth,
 					canonicalSessionPath(edge.parent),
 					edge.name,
+					metadataArtifact,
 				),
 			);
 		}
@@ -577,6 +580,7 @@ export class RlmSpawnLedger {
 		depth: number,
 		parentPath: string | undefined,
 		name: string | undefined,
+		metadataArtifact?: string,
 	): Promise<SessionInfo> {
 		// Display-grade fields are best-effort from the ordinary session-info
 		// read; topology (path, depth, parent) comes EXCLUSIVELY from the
@@ -584,7 +588,20 @@ export class RlmSpawnLedger {
 		// are stripped, never passed through. For roots the ledger carries no
 		// name, so the name comes from this read — writer-owned display data,
 		// not authority.
-		const info = await readSessionInfo(path).catch(() => null);
+		let id = basename(path, ".jsonl");
+		if (metadataArtifact !== undefined) {
+			// Imported transcripts can have a filename different from their session id.
+			try {
+				const header = JSON.parse(readFirstLineSync(path) ?? "null") as { id?: unknown } | null;
+				if (typeof header?.id === "string") id = header.id;
+			} catch {
+				// Unreadable headers retain the filename-based fallback below.
+			}
+		}
+		const info =
+			metadataArtifact === undefined || existsSync(join(getSessionArtifactPathForFile(path, id), metadataArtifact))
+				? await readSessionInfo(path).catch(() => null)
+				: null;
 		if (info) {
 			const { parentSessionPath: _headerParent, rlmDepth: _headerDepth, ...display } = info;
 			return {
@@ -596,7 +613,7 @@ export class RlmSpawnLedger {
 		}
 		return {
 			path,
-			id: basename(path, ".jsonl"),
+			id,
 			cwd: "",
 			...(name ? { name } : {}),
 			...(parentPath ? { parentSessionPath: parentPath } : {}),

--- a/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
@@ -1,13 +1,22 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, realpathSync, renameSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { type AgentCronJob, AgentCronJobStore } from "../src/core/cron-jobs.js";
+import * as sessionManager from "../src/core/session-manager.js";
 import type { DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
 import { type DaemonCommand, type DaemonResponse, failure, success } from "../src/modes/daemon/daemon-protocol.js";
 import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
+import type { RlmSpawnLedger } from "../src/modes/daemon/rlm-ledger.js";
 
 interface SupervisorHarness {
+	defaultSessionConfig: { agentDir: string };
 	workers: Map<string, unknown>;
+	rlmSpawnLedger(): RlmSpawnLedger;
+	collectPassiveScheduledJobs(): Promise<
+		Array<{ rootSessionFile: string; job: AgentCronJob; info: sessionManager.SessionInfo }>
+	>;
+	findWorkerBySessionFile(path: string): unknown;
 	forwardToWorker(worker: unknown, command: DaemonCommand, timeoutMs?: number): Promise<DaemonResponse>;
 	handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<DaemonResponse | undefined>;
 	handleWorkerFrame(worker: unknown, frame: unknown): void;
@@ -16,6 +25,7 @@ interface SupervisorHarness {
 const tempDirs: string[] = [];
 
 afterEach(() => {
+	vi.restoreAllMocks();
 	for (const directory of tempDirs.splice(0)) {
 		rmSync(directory, { recursive: true, force: true });
 	}
@@ -38,6 +48,138 @@ function worker(lifecycle: "ready" | "recovering" | "failed", connected = true) 
 }
 
 describe("daemon supervisor heartbeat aggregation", () => {
+	it("shares concurrent refreshes across clients while preserving response ids", async () => {
+		const supervisor = createSupervisorHarness();
+		supervisor.workers.set("ready", worker("ready"));
+		supervisor.forwardToWorker = vi.fn(async (_worker, command) =>
+			success(command.id, command.type, { heartbeats: [] }),
+		);
+		let release!: () => void;
+		const blocked = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const scan = vi.spyOn(supervisor, "collectPassiveScheduledJobs").mockImplementation(async () => {
+			await blocked;
+			return [];
+		});
+		const requests = Array.from({ length: 10 }, (_, index) =>
+			supervisor.handleCommand({ id: `client-${index}` } as DaemonSocketClient, {
+				id: `list-${index}`,
+				type: "heartbeats_list",
+			}),
+		);
+		await vi.waitFor(() => expect(scan).toHaveBeenCalledOnce());
+		expect(supervisor.forwardToWorker).toHaveBeenCalledOnce();
+		release();
+		const responses = await Promise.all(requests);
+		for (const [index, response] of responses.entries()) {
+			expect(response).toMatchObject({ id: `list-${index}`, success: true, data: { heartbeats: [] } });
+		}
+		await supervisor.handleCommand({} as DaemonSocketClient, { type: "heartbeats_list" });
+		expect(scan).toHaveBeenCalledTimes(2);
+		expect(supervisor.forwardToWorker).toHaveBeenCalledTimes(2);
+	});
+
+	it("clears a rejected refresh so the next request can recover", async () => {
+		const supervisor = createSupervisorHarness();
+		const scan = vi
+			.spyOn(supervisor, "collectPassiveScheduledJobs")
+			.mockRejectedValueOnce(new Error("unreadable ledger"))
+			.mockResolvedValue([]);
+		await expect(supervisor.handleCommand({} as DaemonSocketClient, { type: "heartbeats_list" })).rejects.toThrow(
+			"unreadable ledger",
+		);
+		await expect(
+			supervisor.handleCommand({} as DaemonSocketClient, { type: "heartbeats_list" }),
+		).resolves.toMatchObject({ success: true, data: { heartbeats: [] } });
+		expect(scan).toHaveBeenCalledTimes(2);
+	});
+
+	it("starts a fresh read after changes without letting the older read overwrite its snapshot", async () => {
+		const supervisor = createSupervisorHarness();
+		const target = { ...worker("ready"), heartbeatSnapshot: [], heartbeatSnapshotStale: false };
+		supervisor.workers.set("ready", target);
+		vi.spyOn(supervisor, "collectPassiveScheduledJobs").mockResolvedValue([]);
+		const replies: Array<(response: DaemonResponse) => void> = [];
+		supervisor.forwardToWorker = vi.fn(() => new Promise<DaemonResponse>((resolve) => replies.push(resolve)));
+		const old = supervisor.handleCommand({} as DaemonSocketClient, { id: "old", type: "heartbeats_list" });
+		supervisor.handleWorkerFrame(target, {
+			header: { kind: "outbound", outboundType: "heartbeats_changed" },
+			payload: Buffer.alloc(0),
+		});
+		const current = supervisor.handleCommand({} as DaemonSocketClient, { id: "current", type: "heartbeats_list" });
+		expect(replies).toHaveLength(2);
+		replies[0]!(success("old", "heartbeats_list", { heartbeats: [{ job: { id: "old-job" } }] }));
+		await old;
+		expect(target.heartbeatSnapshotStale).toBe(true);
+		const joined = supervisor.handleCommand({} as DaemonSocketClient, { id: "joined", type: "heartbeats_list" });
+		expect(replies).toHaveLength(2);
+		replies[1]!(success("current", "heartbeats_list", { heartbeats: [{ job: { id: "new-job" } }] }));
+		await expect(current).resolves.toMatchObject({
+			id: "current",
+			data: { heartbeats: [{ job: { id: "new-job" } }] },
+		});
+		await expect(joined).resolves.toMatchObject({ id: "joined", data: { heartbeats: [{ job: { id: "new-job" } }] } });
+		expect(target.heartbeatSnapshot).toEqual([{ job: { id: "new-job" } }]);
+		expect(target.heartbeatSnapshotStale).toBe(false);
+	});
+
+	it("only scans scheduled transcripts while retaining ancestry, session ids, and archived filtering", async () => {
+		const supervisor = createSupervisorHarness();
+		const directory = realpathSync(supervisor.defaultSessionConfig.agentDir);
+		const [parent, child, archived, unrelated] = ["parent", "child", "archived", "unrelated"].map((name) => {
+			const manager = sessionManager.SessionManager.create(directory, join(directory, "sessions"));
+			manager.newSession({ parentSession: join(directory, "stale-parent.jsonl"), rlmDepth: 9 });
+			manager.appendSessionInfo(name);
+			manager.appendMessage({ role: "user", content: name, timestamp: 1 });
+			if (name === "archived") manager.appendSessionState({ status: "archived" });
+			manager.flushNow();
+			return manager;
+		});
+		const parentFile = parent!.getSessionFile()!;
+		const childFile = join(directory, "sessions", "imported-child.jsonl");
+		renameSync(child!.getSessionFile()!, childFile);
+		await supervisor.rlmSpawnLedger().appendSpawn({
+			childId: "sub-11111111",
+			parent: parentFile,
+			child: childFile,
+			depth: 1,
+			name: "ledger-child",
+		});
+		const store = AgentCronJobStore.forSessionArtifacts();
+		for (const manager of [child!, archived!]) {
+			store.registerSessionArtifact(manager.getSessionId(), manager.getSessionArtifactDir()!);
+			store.createHeartbeat({
+				activeSessionId: manager.getSessionId(),
+				sessionId: manager.getSessionId(),
+				sessionFile: manager === child ? childFile : manager.getSessionFile()!,
+				cwd: directory,
+				scheduleText: "every 1h",
+				prompt: "continue",
+			});
+		}
+		const readInfo = vi.spyOn(sessionManager, "readSessionInfo");
+		const jobs = await supervisor.collectPassiveScheduledJobs();
+		expect(jobs).toHaveLength(1);
+		expect(jobs[0]).toMatchObject({
+			rootSessionFile: parentFile,
+			info: {
+				id: child!.getSessionId(),
+				name: "ledger-child",
+				firstMessage: "child",
+				parentSessionPath: parentFile,
+				rlmDepth: 1,
+			},
+		});
+		expect(readInfo).toHaveBeenCalledTimes(2);
+		expect(readInfo).not.toHaveBeenCalledWith(parentFile);
+		expect(readInfo).not.toHaveBeenCalledWith(unrelated!.getSessionFile());
+		vi.spyOn(supervisor, "findWorkerBySessionFile").mockImplementation((path) =>
+			path === parentFile ? {} : undefined,
+		);
+		await expect(supervisor.collectPassiveScheduledJobs()).resolves.toEqual([]);
+	});
+
 	it("uses the last complete worker snapshot during recovery", async () => {
 		const supervisor = createSupervisorHarness();
 		const first = worker("ready");

--- a/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, realpathSync, renameSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -124,61 +124,65 @@ describe("daemon supervisor heartbeat aggregation", () => {
 		expect(target.heartbeatSnapshotStale).toBe(false);
 	});
 
-	it("only scans scheduled transcripts while retaining ancestry, session ids, and archived filtering", async () => {
-		const supervisor = createSupervisorHarness();
-		const directory = realpathSync(supervisor.defaultSessionConfig.agentDir);
-		const [parent, child, archived, unrelated] = ["parent", "child", "archived", "unrelated"].map((name) => {
-			const manager = sessionManager.SessionManager.create(directory, join(directory, "sessions"));
-			manager.newSession({ parentSession: join(directory, "stale-parent.jsonl"), rlmDepth: 9 });
-			manager.appendSessionInfo(name);
-			manager.appendMessage({ role: "user", content: name, timestamp: 1 });
-			if (name === "archived") manager.appendSessionState({ status: "archived" });
-			manager.flushNow();
-			return manager;
-		});
-		const parentFile = parent!.getSessionFile()!;
-		const childFile = join(directory, "sessions", "imported-child.jsonl");
-		renameSync(child!.getSessionFile()!, childFile);
-		await supervisor.rlmSpawnLedger().appendSpawn({
-			childId: "sub-11111111",
-			parent: parentFile,
-			child: childFile,
-			depth: 1,
-			name: "ledger-child",
-		});
-		const store = AgentCronJobStore.forSessionArtifacts();
-		for (const manager of [child!, archived!]) {
-			store.registerSessionArtifact(manager.getSessionId(), manager.getSessionArtifactDir()!);
-			store.createHeartbeat({
-				activeSessionId: manager.getSessionId(),
-				sessionId: manager.getSessionId(),
-				sessionFile: manager === child ? childFile : manager.getSessionFile()!,
-				cwd: directory,
-				scheduleText: "every 1h",
-				prompt: "continue",
+	it.each(["", "\n \t\r\n", "\n".repeat(65_536)])(
+		"only scans scheduled transcripts while retaining ancestry, imported session ids, and archived filtering (case %#)",
+		async (prefix) => {
+			const supervisor = createSupervisorHarness();
+			const directory = realpathSync(supervisor.defaultSessionConfig.agentDir);
+			const [parent, child, archived, unrelated] = ["parent", "child", "archived", "unrelated"].map((name) => {
+				const manager = sessionManager.SessionManager.create(directory, join(directory, "sessions"));
+				manager.newSession({ parentSession: join(directory, "stale-parent.jsonl"), rlmDepth: 9 });
+				manager.appendSessionInfo(name);
+				manager.appendMessage({ role: "user", content: name, timestamp: 1 });
+				if (name === "archived") manager.appendSessionState({ status: "archived" });
+				manager.flushNow();
+				return manager;
 			});
-		}
-		const readInfo = vi.spyOn(sessionManager, "readSessionInfo");
-		const jobs = await supervisor.collectPassiveScheduledJobs();
-		expect(jobs).toHaveLength(1);
-		expect(jobs[0]).toMatchObject({
-			rootSessionFile: parentFile,
-			info: {
-				id: child!.getSessionId(),
+			const parentFile = parent!.getSessionFile()!;
+			const childFile = join(directory, "sessions", "imported-child.jsonl");
+			renameSync(child!.getSessionFile()!, childFile);
+			writeFileSync(childFile, prefix + readFileSync(childFile, "utf8"));
+			await supervisor.rlmSpawnLedger().appendSpawn({
+				childId: "sub-11111111",
+				parent: parentFile,
+				child: childFile,
+				depth: 1,
 				name: "ledger-child",
-				firstMessage: "child",
-				parentSessionPath: parentFile,
-				rlmDepth: 1,
-			},
-		});
-		expect(readInfo).toHaveBeenCalledTimes(2);
-		expect(readInfo).not.toHaveBeenCalledWith(parentFile);
-		expect(readInfo).not.toHaveBeenCalledWith(unrelated!.getSessionFile());
-		vi.spyOn(supervisor, "findWorkerBySessionFile").mockImplementation((path) =>
-			path === parentFile ? {} : undefined,
-		);
-		await expect(supervisor.collectPassiveScheduledJobs()).resolves.toEqual([]);
-	});
+			});
+			const store = AgentCronJobStore.forSessionArtifacts();
+			for (const manager of [child!, archived!]) {
+				store.registerSessionArtifact(manager.getSessionId(), manager.getSessionArtifactDir()!);
+				store.createHeartbeat({
+					activeSessionId: manager.getSessionId(),
+					sessionId: manager.getSessionId(),
+					sessionFile: manager === child ? childFile : manager.getSessionFile()!,
+					cwd: directory,
+					scheduleText: "every 1h",
+					prompt: "continue",
+				});
+			}
+			const readInfo = vi.spyOn(sessionManager, "readSessionInfo");
+			const jobs = await supervisor.collectPassiveScheduledJobs();
+			expect(jobs).toHaveLength(1);
+			expect(jobs[0]).toMatchObject({
+				rootSessionFile: parentFile,
+				info: {
+					id: child!.getSessionId(),
+					name: "ledger-child",
+					firstMessage: "child",
+					parentSessionPath: parentFile,
+					rlmDepth: 1,
+				},
+			});
+			expect(readInfo).toHaveBeenCalledTimes(2);
+			expect(readInfo).not.toHaveBeenCalledWith(parentFile);
+			expect(readInfo).not.toHaveBeenCalledWith(unrelated!.getSessionFile());
+			vi.spyOn(supervisor, "findWorkerBySessionFile").mockImplementation((path) =>
+				path === parentFile ? {} : undefined,
+			);
+			await expect(supervisor.collectPassiveScheduledJobs()).resolves.toEqual([]);
+		},
+	);
 
 	it("uses the last complete worker snapshot during recovery", async () => {
 		const supervisor = createSupervisorHarness();

--- a/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
@@ -124,7 +124,7 @@ describe("daemon supervisor heartbeat aggregation", () => {
 		expect(target.heartbeatSnapshotStale).toBe(false);
 	});
 
-	it.each(["", "\n \t\r\n", "\n".repeat(65_536)])(
+	it.each(["", "\n \t\r\n", "\n".repeat(65_536), "malformed JSON\n", "\n{broken\n \t\n"])(
 		"only scans scheduled transcripts while retaining ancestry, imported session ids, and archived filtering (case %#)",
 		async (prefix) => {
 			const supervisor = createSupervisorHarness();
@@ -181,6 +181,22 @@ describe("daemon supervisor heartbeat aggregation", () => {
 				path === parentFile ? {} : undefined,
 			);
 			await expect(supervisor.collectPassiveScheduledJobs()).resolves.toEqual([]);
+		},
+	);
+
+	it.each(["\n", "x"])(
+		"rejects oversized header probes instead of returning a partial catalog (case %#)",
+		async (prefix) => {
+			const supervisor = createSupervisorHarness();
+			const directory = realpathSync(supervisor.defaultSessionConfig.agentDir);
+			const manager = sessionManager.SessionManager.create(directory, join(directory, "sessions"));
+			manager.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+			manager.flushNow();
+			const file = manager.getSessionFile()!;
+			writeFileSync(file, `${prefix.repeat(2 * 1024 * 1024)}\n${readFileSync(file, "utf8")}`);
+			const readInfo = vi.spyOn(sessionManager, "readSessionInfo");
+			await expect(supervisor.collectPassiveScheduledJobs()).rejects.toThrow("1048576 byte probe limit");
+			expect(readInfo).not.toHaveBeenCalled();
 		},
 	);
 

--- a/packages/coding-agent/test/suite/regressions/1343-heartbeat-catalog-timeouts.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1343-heartbeat-catalog-timeouts.test.ts
@@ -1,13 +1,19 @@
-import { mkdtempSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readFileSync, realpathSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { type AgentCronJob, AgentCronJobStore } from "../src/core/cron-jobs.js";
-import * as sessionManager from "../src/core/session-manager.js";
-import type { DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
-import { type DaemonCommand, type DaemonResponse, failure, success } from "../src/modes/daemon/daemon-protocol.js";
-import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
-import type { RlmSpawnLedger } from "../src/modes/daemon/rlm-ledger.js";
+import { type AgentCronJob, AgentCronJobStore } from "../../../src/core/cron-jobs.js";
+import * as sessionManager from "../../../src/core/session-manager.js";
+import type { DaemonSocketClient } from "../../../src/modes/daemon/active-session-state.js";
+import {
+	type DaemonCommand,
+	type DaemonResponse,
+	failure,
+	success,
+} from "../../../src/modes/daemon/daemon-protocol.js";
+import { DaemonSupervisor } from "../../../src/modes/daemon/daemon-supervisor.js";
+import type { RlmSpawnLedger } from "../../../src/modes/daemon/rlm-ledger.js";
+
+import { createHarness, type Harness } from "../harness.js";
 
 interface SupervisorHarness {
 	defaultSessionConfig: { agentDir: string };
@@ -22,18 +28,17 @@ interface SupervisorHarness {
 	handleWorkerFrame(worker: unknown, frame: unknown): void;
 }
 
-const tempDirs: string[] = [];
+const harnesses: Harness[] = [];
 
 afterEach(() => {
 	vi.restoreAllMocks();
-	for (const directory of tempDirs.splice(0)) {
-		rmSync(directory, { recursive: true, force: true });
-	}
+	for (const harness of harnesses.splice(0)) harness.cleanup();
 });
 
-function createSupervisorHarness(): SupervisorHarness {
-	const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-heartbeats-"));
-	tempDirs.push(directory);
+async function createSupervisorHarness(): Promise<SupervisorHarness> {
+	const harness = await createHarness();
+	harnesses.push(harness);
+	const directory = harness.tempDir;
 	return new DaemonSupervisor(join(directory, "daemon.sock"), {
 		defaultSessionConfig: { agentDir: directory, cwd: directory },
 		descriptorDir: join(directory, "workers"),
@@ -47,9 +52,9 @@ function worker(lifecycle: "ready" | "recovering" | "failed", connected = true) 
 	};
 }
 
-describe("daemon supervisor heartbeat aggregation", () => {
+describe("RES-1343 heartbeat catalog timeouts", () => {
 	it("shares concurrent refreshes across clients while preserving response ids", async () => {
-		const supervisor = createSupervisorHarness();
+		const supervisor = await createSupervisorHarness();
 		supervisor.workers.set("ready", worker("ready"));
 		supervisor.forwardToWorker = vi.fn(async (_worker, command) =>
 			success(command.id, command.type, { heartbeats: [] }),
@@ -81,7 +86,7 @@ describe("daemon supervisor heartbeat aggregation", () => {
 	});
 
 	it("clears a rejected refresh so the next request can recover", async () => {
-		const supervisor = createSupervisorHarness();
+		const supervisor = await createSupervisorHarness();
 		const scan = vi
 			.spyOn(supervisor, "collectPassiveScheduledJobs")
 			.mockRejectedValueOnce(new Error("unreadable ledger"))
@@ -96,7 +101,7 @@ describe("daemon supervisor heartbeat aggregation", () => {
 	});
 
 	it("starts a fresh read after changes without letting the older read overwrite its snapshot", async () => {
-		const supervisor = createSupervisorHarness();
+		const supervisor = await createSupervisorHarness();
 		const target = { ...worker("ready"), heartbeatSnapshot: [], heartbeatSnapshotStale: false };
 		supervisor.workers.set("ready", target);
 		vi.spyOn(supervisor, "collectPassiveScheduledJobs").mockResolvedValue([]);
@@ -127,7 +132,7 @@ describe("daemon supervisor heartbeat aggregation", () => {
 	it.each(["", "\n \t\r\n", "\n".repeat(65_536), "malformed JSON\n", "\n{broken\n \t\n"])(
 		"only scans scheduled transcripts while retaining ancestry, imported session ids, and archived filtering (case %#)",
 		async (prefix) => {
-			const supervisor = createSupervisorHarness();
+			const supervisor = await createSupervisorHarness();
 			const directory = realpathSync(supervisor.defaultSessionConfig.agentDir);
 			const [parent, child, archived, unrelated] = ["parent", "child", "archived", "unrelated"].map((name) => {
 				const manager = sessionManager.SessionManager.create(directory, join(directory, "sessions"));
@@ -187,7 +192,7 @@ describe("daemon supervisor heartbeat aggregation", () => {
 	it.each(["\n", "x"])(
 		"rejects oversized header probes instead of returning a partial catalog (case %#)",
 		async (prefix) => {
-			const supervisor = createSupervisorHarness();
+			const supervisor = await createSupervisorHarness();
 			const directory = realpathSync(supervisor.defaultSessionConfig.agentDir);
 			const manager = sessionManager.SessionManager.create(directory, join(directory, "sessions"));
 			manager.appendMessage({ role: "user", content: "hello", timestamp: 1 });
@@ -201,7 +206,7 @@ describe("daemon supervisor heartbeat aggregation", () => {
 	);
 
 	it("uses the last complete worker snapshot during recovery", async () => {
-		const supervisor = createSupervisorHarness();
+		const supervisor = await createSupervisorHarness();
 		const first = worker("ready");
 		const second = worker("ready");
 		supervisor.workers.set("first", first);
@@ -236,7 +241,7 @@ describe("daemon supervisor heartbeat aggregation", () => {
 	});
 
 	it("returns a worker failure instead of a partial catalog", async () => {
-		const supervisor = createSupervisorHarness();
+		const supervisor = await createSupervisorHarness();
 		const first = worker("ready");
 		const second = worker("ready");
 		supervisor.workers.set("first", first);
@@ -257,7 +262,7 @@ describe("daemon supervisor heartbeat aggregation", () => {
 	});
 
 	it("does not fall back to a snapshot after the worker reports heartbeat changes", async () => {
-		const supervisor = createSupervisorHarness();
+		const supervisor = await createSupervisorHarness();
 		const target = {
 			...worker("ready"),
 			heartbeatSnapshot: [{ job: { id: "heartbeat-1" } }],
@@ -282,7 +287,7 @@ describe("daemon supervisor heartbeat aggregation", () => {
 	});
 
 	it("fails rather than returning a partial catalog without a cached snapshot", async () => {
-		const supervisor = createSupervisorHarness();
+		const supervisor = await createSupervisorHarness();
 		supervisor.workers.set("ready", worker("ready"));
 		supervisor.workers.set("recovering", worker("recovering", false));
 		supervisor.forwardToWorker = vi.fn(async (_target, command) =>
@@ -302,7 +307,7 @@ describe("daemon supervisor heartbeat aggregation", () => {
 	});
 
 	it("skips terminally failed workers without blocking healthy heartbeats", async () => {
-		const supervisor = createSupervisorHarness();
+		const supervisor = await createSupervisorHarness();
 		supervisor.workers.set("healthy", worker("ready"));
 		supervisor.workers.set("failed", worker("failed", false));
 		supervisor.forwardToWorker = vi.fn(async (_target, command) =>
@@ -322,7 +327,7 @@ describe("daemon supervisor heartbeat aggregation", () => {
 	});
 
 	it("routes management by cached job ownership after a session unloads", async () => {
-		const supervisor = createSupervisorHarness();
+		const supervisor = await createSupervisorHarness();
 		const target = {
 			...worker("ready"),
 			heartbeatSnapshot: [{ job: { id: "heartbeat-1", activeSessionId: "unloaded-session" } }],


### PR DESCRIPTION
## Context

Fixes [RES-1343](https://linear.app/primeintellect/issue/RES-1343/prevent-heartbeat-catalog-timeouts-from-queued-saved-session-scans).

Concurrent global heartbeat requests each enqueue a full saved-session metadata scan. With 1,673 saved sessions, ten queued scans reproduced waits of 30.7 and 33.6 seconds for the last two requests, exceeding the 30-second client deadline. The original incident's queue depth was not recorded.

## Changes

- Share each in-flight global heartbeat refresh across clients while preserving response IDs. Clear it on completion or heartbeat changes, and prevent older refreshes from overwriting newer worker snapshots.
- Load transcript metadata only for sessions with a scheduled-jobs artifact, retaining the full ledger topology, imported session IDs, archived-session filtering, and resident-worker ownership.
- Add regression coverage and a changelog fragment. No daemon wire protocol changes.

## Validation

- `npm run check` passed.
- 71 tests passed: `daemon-supervisor-heartbeats.test.ts`, `daemon-supervisor-eviction.test.ts`, and `rlm-ledger.test.ts`.
- Read-only measurements on a 1,679-session catalog: full scan 4,040 ms; filtered scan 285 ms. Ten concurrent global heartbeat requests in an isolated supervisor completed in 384 ms, all successful.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share `heartbeats_list` refreshes and scope catalog metadata to prevent timeouts
> - Concurrent `heartbeats_list` requests share a single in-flight refresh promise, preventing redundant worker queries and catalog scans.
> - `RlmSpawnLedger.family` accepts an optional artifact selector in [rlm-ledger.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2259/files#diff-9a37d17b18302358b04d20a1e73f03e0cca1588155de12c6d2cafd1b7f3c32b3), loading session metadata only when the `scheduled-jobs` artifact exists.
> - `broadcastHeartbeatsChanged` in [daemon-supervisor.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2259/files#diff-18f2d5ec391785bebc6ddf3c1bd3b795e4ed6e02d0aa3852f5bf247d61d012f8) invalidates any active refresh promise before notifying clients.
> - Risk: `broadcastHeartbeatsChanged` discards in-flight aggregate listing refreshes; concurrent callers join a new refresh instead of receiving the invalidated result.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2259 opened
>
> - Modified session info loading in `RlmSpawnLedger` to parse the first non-empty JSON line from transcript files and use asynchronous file operations for metadata checks [ac48cc7]
> - Added parameterized test cases covering transcript files with varying leading content patterns [ac48cc7]
> - Added 1 MiB size limit to session header probing in `RlmSpawnLedger` with stricter validation and error handling [5cc4ade]
> - Added test coverage for malformed JSON prefixes and oversized header probes in daemon supervisor heartbeat tests [5cc4ade]
> - Replaced manual temporary directory management with `createHarness` and `Harness` abstraction in the regression test suite [9021dd5]
> - Updated all test cases within the heartbeat catalog timeouts regression suite to await the asynchronous `createSupervisorHarness` factory [9021dd5]
> - Adjusted relative import paths throughout the test file to account for relocation into the `suite/regressions` directory structure [9021dd5]
> - Renamed the top-level test suite describe block to reference `RES-1343` [9021dd5]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ac48cc7. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes heartbeat aggregation concurrency and how passive scheduled jobs are discovered from large session catalogs; incorrect coalescing or filtering could hide heartbeats or serve stale lists, but behavior is heavily regression-tested.
> 
> **Overview**
> Fixes **RES-1343** by stopping concurrent global `heartbeats_list` calls from each running a full worker fan-out and saved-session catalog scan.
> 
> **Daemon supervisor:** Global heartbeat listing now shares one in-flight refresh (`heartbeatRefresh`); callers await the same work and get responses with their own command IDs via `responseWithId`. The refresh is cleared when it finishes, when it fails, and when `broadcastHeartbeatsChanged` runs. Worker snapshot updates from a refresh are applied only if that refresh is still current, so an older in-flight read cannot overwrite newer state after heartbeats change.
> 
> **RLM spawn ledger:** `family()` accepts an optional artifact name (used with the scheduled-jobs artifact). Topology rows are unchanged, but full transcript metadata via `readSessionInfo` runs only for sessions that own that artifact—after a bounded header probe resolves session id (including imported filenames) and rejects probes past 1 MiB instead of silently omitting jobs.
> 
> Regression tests replace the old heartbeat unit file and cover coalescing, recovery after errors, stale refresh behavior, filtered catalog scans, and oversized headers. Changelog fragment added; no wire protocol changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9021dd53097efd527bf62ac8061433b328209e6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->