### PR TITLE
fix invalid macos signatures in compiled releases

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,6 +1,8 @@
 name: Release Prime Agent
 
 on:
+  pull_request:
+    branches: [main]
   push:
     branches:
       - main
@@ -14,7 +16,7 @@ on:
         type: string
 
 concurrency:
-  group: release-prime-agent
+  group: ${{ github.event_name == 'pull_request' && format('release-validation-pr-{0}', github.event.pull_request.number) || 'release-prime-agent' }}
   cancel-in-progress: false
   queue: max
 
@@ -22,7 +24,25 @@ permissions:
   contents: read
 
 jobs:
+  trust:
+    name: Contributor trust
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ github.event_name != 'pull_request' || steps.vouch.outputs.vouched == 'true' }}
+    steps:
+      - name: Check pull request author
+        id: vouch
+        if: github.event_name == 'pull_request'
+        uses: mitchellh/vouch/action/check-user@d66fa29a64600490892131ad87597c30c91fcac4 # v1
+        with:
+          user: ${{ github.event.pull_request.user.login }}
+          allow-fail: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   release-context:
+    needs: trust
+    if: needs.trust.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -59,7 +79,14 @@ jobs:
           publish_beta=false
           publish_production=false
 
-          if [ "$EVENT_NAME" = workflow_dispatch ]; then
+          if [ "$EVENT_NAME" = pull_request ]; then
+            # Exercise both real packer paths without release credentials or publication.
+            production_version=$(node -p "require('./package.json').version")
+            build_ref="$GITHUB_SHA_VALUE"
+            beta_version="${production_version}-beta.${RUN_NUMBER}.${RUN_ATTEMPT}.${GITHUB_SHA_VALUE::7}"
+            publish_beta=true
+            publish_production=true
+          elif [ "$EVENT_NAME" = workflow_dispatch ]; then
             if [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
               echo "Manual releases must run from the default branch (${DEFAULT_BRANCH}), not ${REF_NAME}." >&2
               exit 1
@@ -118,6 +145,8 @@ jobs:
   standalone:
     needs: release-context
     uses: ./.github/workflows/standalone-binaries.yml
+    with:
+      build_ref: ${{ needs.release-context.outputs.build_ref }}
 
   build:
     runs-on: ubuntu-latest
@@ -171,7 +200,7 @@ jobs:
       - name: Pack production release
         if: env.PUBLISH_PRODUCTION == 'true'
         env:
-          PRIME_AGENT_DOWNLOAD_BASE_URL: ${{ vars.R2_PUBLIC_BASE_URL }}
+          PRIME_AGENT_DOWNLOAD_BASE_URL: ${{ github.event_name == 'pull_request' && 'https://example.invalid/prime-agent-validation' || vars.R2_PUBLIC_BASE_URL }}
         run: |
           test -n "$PRIME_AGENT_DOWNLOAD_BASE_URL"
           npm run release:pack -- \
@@ -184,7 +213,7 @@ jobs:
       - name: Pack beta release
         if: env.PUBLISH_BETA == 'true'
         env:
-          PRIME_AGENT_DOWNLOAD_BASE_URL: ${{ vars.R2_PUBLIC_BASE_URL }}
+          PRIME_AGENT_DOWNLOAD_BASE_URL: ${{ github.event_name == 'pull_request' && 'https://example.invalid/prime-agent-validation' || vars.R2_PUBLIC_BASE_URL }}
         run: |
           test -n "$PRIME_AGENT_DOWNLOAD_BASE_URL"
           npm run release:pack -- \
@@ -247,9 +276,89 @@ jobs:
           path: packages/coding-agent/release/beta/artifacts/*
           if-no-files-found: error
 
-  publish:
-    runs-on: ubuntu-latest
+  validate-macos:
+    name: Final release (${{ matrix.platform }})
     needs: [release-context, build]
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: darwin-arm64
+            runner: macos-15
+          - platform: darwin-x64
+            runner: macos-15-intel
+    env:
+      BUILD_REF: ${{ needs.release-context.outputs.build_ref }}
+      PUBLISH_PRODUCTION: ${{ needs.release-context.outputs.publish_production }}
+      PUBLISH_BETA: ${{ needs.release-context.outputs.publish_beta }}
+    steps:
+      - name: Checkout validation source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ env.BUILD_REF }}
+          persist-credentials: false
+          path: source
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          package-manager-cache: false
+
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        with:
+          version: '0.11.7'
+          enable-cache: false
+
+      - name: Install validation dependencies
+        working-directory: source
+        run: npm ci
+
+      - name: Download exact final release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: prime-agent-*
+          path: ${{ runner.temp }}/final-artifacts
+
+      - name: Download tested executable identity
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: standalone-${{ matrix.platform }}
+          path: ${{ runner.temp }}/standalone-reference
+
+      - name: Remove the build paths from the test machine
+        run: mv "$GITHUB_WORKSPACE/source" "$RUNNER_TEMP/validation-source"
+
+      - name: Verify and exercise exact final Mac archives
+        working-directory: ${{ runner.temp }}/validation-source
+        env:
+          TARGET_PLATFORM: ${{ matrix.platform }}
+        run: |
+          export PRIME_AGENT_TEST_UV=$(command -v uv)
+          for channel in production beta; do
+            if [ "$channel" = production ] && [ "$PUBLISH_PRODUCTION" != true ]; then continue; fi
+            if [ "$channel" = beta ] && [ "$PUBLISH_BETA" != true ]; then continue; fi
+            artifacts="$RUNNER_TEMP/final-artifacts/prime-agent-$channel"
+            node scripts/validate-macos-release.mjs "$artifacts" "$TARGET_PLATFORM" \
+              "$RUNNER_TEMP/standalone-reference/binaries.json" \
+              "$RUNNER_TEMP/macos-validation/$channel-$TARGET_PLATFORM.json"
+            export PRIME_AGENT_TEST_ARCHIVE=$(find "$artifacts" -maxdepth 1 -name "*-$TARGET_PLATFORM.tar.gz")
+            test -n "$PRIME_AGENT_TEST_ARCHIVE"
+            (cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/compiled-artifact.test.ts test/native-installer.test.ts)
+          done
+
+      - name: Upload native validation receipts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: macos-validation-${{ matrix.platform }}
+          path: ${{ runner.temp }}/macos-validation/*.json
+          if-no-files-found: error
+
+  publish:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: [release-context, build, validate-macos]
     permissions:
       contents: write
     env:
@@ -284,6 +393,22 @@ jobs:
         with:
           name: prime-agent-beta
           path: release-artifacts/beta
+
+      - name: Download native validation receipts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: macos-validation-*
+          path: macos-validation
+          merge-multiple: true
+
+      - name: Match native validation to publication artifacts
+        run: |
+          if [ "$PUBLISH_PRODUCTION" = true ]; then
+            node scripts/verify-macos-validation-receipts.mjs release-artifacts/production macos-validation production
+          fi
+          if [ "$PUBLISH_BETA" = true ]; then
+            node scripts/verify-macos-validation-receipts.mjs release-artifacts/beta macos-validation beta
+          fi
 
       - name: Prepare installer
         run: |

--- a/.github/workflows/standalone-binaries.yml
+++ b/.github/workflows/standalone-binaries.yml
@@ -2,6 +2,11 @@ name: Standalone binaries
 
 on:
   workflow_call:
+    inputs:
+      build_ref:
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -26,6 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ inputs.build_ref || github.sha }}
           persist-credentials: false
           path: source
 
@@ -71,7 +77,7 @@ jobs:
 
       - name: Test extracted application without JavaScript runtimes on PATH
         working-directory: ${{ runner.temp }}/standalone-source/packages/coding-agent
-        run: npx tsx ../../node_modules/vitest/dist/cli.js --run test/compiled-artifact.test.ts test/native-installer.test.ts test/native-probe-timeout.test.ts
+        run: npx tsx ../../node_modules/vitest/dist/cli.js --run test/release-signatures.test.ts test/compiled-artifact.test.ts test/native-installer.test.ts test/native-probe-timeout.test.ts
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -79,4 +85,5 @@ jobs:
           path: |
             ${{ runner.temp }}/standalone/*.tar.gz
             ${{ runner.temp }}/standalone/SHA256SUMS
+            ${{ runner.temp }}/standalone/binaries.json
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Prime Agent combines a persistent Python control environment with durable harnes
 Install the latest stable release on macOS or Linux:
 
 ```bash
-curl --proto '=https' --proto-redir '=https' -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
+curl --proto '=https' -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
 ```
 
 The installer requires HTTPS for release downloads, checks the selected archive against the release origin's SHA-256 inventory, installs the `prime-agent` command, and can prepare the Python runtime used by the agent. The checksum detects corruption or an inconsistent transfer; because the inventory and archive come from the same origin, HTTPS is the authenticity boundary.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Prime Agent combines a persistent Python control environment with durable harnes
 Install the latest stable release on macOS or Linux:
 
 ```bash
-curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
+curl --proto '=https' --proto-redir '=https' -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
 ```
 
 The installer requires HTTPS for release downloads, checks the selected archive against the release origin's SHA-256 inventory, installs the `prime-agent` command, and can prepare the Python runtime used by the agent. The checksum detects corruption or an inconsistent transfer; because the inventory and archive come from the same origin, HTTPS is the authenticity boundary.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Prime Agent combines a persistent Python control environment with durable harnes
 Install the latest stable release on macOS or Linux:
 
 ```bash
-curl --proto '=https' -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
+curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
 ```
 
 The installer requires HTTPS for release downloads, checks the selected archive against the release origin's SHA-256 inventory, installs the `prime-agent` command, and can prepare the Python runtime used by the agent. The checksum detects corruption or an inconsistent transfer; because the inventory and archive come from the same origin, HTTPS is the authenticity boundary.

--- a/packages/coding-agent/.changes/fix-macos-compiled-signatures.md
+++ b/packages/coding-agent/.changes/fix-macos-compiled-signatures.md
@@ -1,0 +1,1 @@
+- Fixed invalid macOS signatures in standalone downloads and blocked releases whose final Mac archives fail signature or runtime checks.

--- a/packages/coding-agent/scripts/build-binary.mjs
+++ b/packages/coding-agent/scripts/build-binary.mjs
@@ -4,6 +4,7 @@ import { mkdirSync, mkdtempSync, renameSync, rmSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { copyBinaryAssets, validateBinaryAssets } from "./copy-binary-assets.mjs";
+import { signMacosBinary } from "./macos-signature.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 const packageDir = join(root, "packages/coding-agent");
@@ -55,6 +56,7 @@ for (const target of platform === "all" ? platforms : [platform]) {
 			],
 			{ cwd: packageDir, stdio: "inherit" },
 		);
+		signMacosBinary(join(staging, "prime-agent"), target);
 		copyBinaryAssets(staging);
 		validateBinaryAssets(staging);
 		const destination = join(outputRoot, target);

--- a/packages/coding-agent/scripts/macos-signature.mjs
+++ b/packages/coding-agent/scripts/macos-signature.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+function requiresMacosSigning(platform) {
+	if (platform === "linux-arm64" || platform === "linux-x64") return false;
+	if (platform !== "darwin-arm64" && platform !== "darwin-x64") throw new Error(`Unsupported binary platform: ${platform}`);
+	if (process.platform !== "darwin") throw new Error("Darwin binaries must be signed and verified on macOS");
+	return true;
+}
+
+export function verifyMacosBinary(binary, platform) {
+	if (!requiresMacosSigning(platform)) return;
+	execFileSync("/usr/bin/codesign", ["--verify", "--deep", "--strict", "--verbose=4", resolve(binary)], { stdio: "inherit" });
+}
+
+export function signMacosBinary(binary, platform) {
+	if (!requiresMacosSigning(platform)) return;
+	// Bun 1.4.0 emits invalid page hashes. Apple must replace its signature, not preserve it.
+	// Preserve Intel hardened runtime and Bun's JSC grants; do not add permissions on arm64.
+	// These are Bun's compatibility grants, not a claim of minimum required permissions.
+	// https://github.com/oven-sh/bun/blob/bun-v1.4.0/entitlements.plist
+	// https://github.com/oven-sh/bun/blob/bun-v1.4.0/docs/guides/runtime/codesign-macos-executable.mdx
+	execFileSync("/usr/bin/codesign", ["--force", "--sign", "-", "--preserve-metadata=entitlements,flags", resolve(binary)], { stdio: "inherit" });
+	verifyMacosBinary(binary, platform);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+	const [command, binary, platform, ...extra] = process.argv.slice(2);
+	if (!binary || !platform || extra.length || !["sign", "verify"].includes(command))
+		throw new Error("Usage: node macos-signature.mjs sign|verify <binary> <platform>");
+	if (command === "sign") signMacosBinary(binary, platform);
+	else verifyMacosBinary(binary, platform);
+}

--- a/packages/coding-agent/test/compiled-artifact.test.ts
+++ b/packages/coding-agent/test/compiled-artifact.test.ts
@@ -1,16 +1,20 @@
 import { type ChildProcess, execFileSync, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
+	closeSync,
 	copyFileSync,
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
+	openSync,
 	readdirSync,
 	readFileSync,
+	readSync,
 	realpathSync,
 	rmSync,
 	symlinkSync,
 	writeFileSync,
+	writeSync,
 } from "node:fs";
 import { createServer } from "node:http2";
 import { tmpdir } from "node:os";
@@ -100,6 +104,9 @@ describe.skipIf(!archive)("extracted standalone archive", () => {
 		mkdirSync(extracted);
 		execFileSync("tar", ["-xzf", resolve(archive!), "-C", extracted]);
 		binary = join(extracted, "prime-agent");
+		if (process.platform === "darwin") {
+			execFileSync("/usr/bin/codesign", ["--verify", "--deep", "--strict", "--verbose=4", binary]);
+		}
 		const bin = join(root, "bin");
 		mkdirSync(bin);
 		for (const command of [
@@ -210,6 +217,47 @@ describe.skipIf(!archive)("extracted standalone archive", () => {
 		const help = await run(["--help"]);
 		expect(help.code, help.stderr).toBe(0);
 		expect(help.stdout).toContain("Python REPL");
+	});
+
+	it.skipIf(process.platform !== "darwin")("rejects a tampered copy without changing the verified executable", () => {
+		const originalHash = createHash("sha256").update(readFileSync(binary)).digest("hex");
+		const tampered = join(home, "tampered-prime-agent");
+		copyFileSync(binary, tampered);
+		const descriptor = openSync(tampered, "r+");
+		try {
+			const byte = Buffer.alloc(1);
+			expect(readSync(descriptor, byte, 0, 1, 4096)).toBe(1);
+			byte[0] ^= 1;
+			writeSync(descriptor, byte, 0, 1, 4096);
+		} finally {
+			closeSync(descriptor);
+		}
+		expect(() =>
+			execFileSync("/usr/bin/codesign", ["--verify", "--deep", "--strict", "--verbose=4", tampered], {
+				stdio: "pipe",
+			}),
+		).toThrow();
+		expect(createHash("sha256").update(readFileSync(binary)).digest("hex")).toBe(originalHash);
+	});
+
+	it("executes hot JavaScript in the extracted runtime, not only help/version startup", async () => {
+		const extensionPath = join(cwd, "extension.ts");
+		writeFileSync(
+			extensionPath,
+			`${readFileSync(extensionPath, "utf8")}
+const hot = new Function("value", "for (let i = 0; i < 128; i++) value = (Math.imul(value, 1664525) + 1013904223) >>> 0; return value;");
+let value = 1;
+for (let i = 0; i < 100000; i++) value = hot(value);
+writeFileSync(join(process.cwd(), "hot-runtime.json"), JSON.stringify({ value, executable: process.execPath }));
+`,
+		);
+		const result = await run([...sessionArgs(), "--no-tools", "-p", "artifact hot runtime"]);
+		expect(result.code, result.stderr).toBe(0);
+		expect(JSON.parse(readFileSync(join(cwd, "hot-runtime.json"), "utf8"))).toEqual({
+			value: 1000067073,
+			executable: binary,
+		});
+		expect(result.stdout.trim()).toBe(`artifact-ok:${"x".repeat(131072)}:complete`);
 	});
 
 	it("loads extensions and skills, flushes piped output, and starts an owned daemon", async () => {

--- a/packages/coding-agent/test/native-installer.test.ts
+++ b/packages/coding-agent/test/native-installer.test.ts
@@ -1052,6 +1052,7 @@ exec /bin/${operation} "$@"
 			const archive = process.env.PRIME_AGENT_TEST_ARCHIVE!;
 			const name = basename(archive);
 			const version = name.slice("prime-agent-".length, -`-${platform}.tar.gz`.length);
+			const manifestPath = /-beta(?:\.|$)/.test(version) ? "/beta.json" : "/latest.json";
 			feed.set(`/releases/v${version}/${name}`, readFileSync(archive));
 			feed.set(`/releases/v${version}/SHA256SUMS`, readFileSync(join(dirname(archive), "SHA256SUMS")));
 			const result = await install(version);
@@ -1061,7 +1062,7 @@ exec /bin/${operation} "$@"
 			).toBe(`${version}\n`);
 			const originalTarget = readlinkSync(command());
 			feed.set(
-				"/latest.json",
+				manifestPath,
 				Buffer.from(
 					JSON.stringify({
 						version,
@@ -1092,10 +1093,10 @@ exec /bin/${operation} "$@"
 			const sha256 = createHash("sha256").update(bytes).digest("hex");
 			feed.set(`/releases/v99.0.0/${nextFile}`, bytes);
 			feed.set("/releases/v99.0.0/SHA256SUMS", Buffer.from(`${sha256}  ${nextFile}\n`));
-			feed.set(
-				"/latest.json",
-				Buffer.from(JSON.stringify({ version: "v99.0.0", binaries: [{ platform, file: nextFile, sha256 }] })),
+			const nextManifest = Buffer.from(
+				JSON.stringify({ version: "v99.0.0", binaries: [{ platform, file: nextFile, sha256 }] }),
 			);
+			feed.set(manifestPath, nextManifest);
 			mkdirSync(join(home, "agent"), { recursive: true });
 			writeFileSync(join(home, "agent/auth.json"), "{}\n");
 			writeFileSync(
@@ -1126,6 +1127,9 @@ exec /bin/${operation} "$@"
 			expect((await run(command(), ["--version"])).output).toBe("99.0.0\n");
 			expect(await daemonExecutable()).toBe(realpathSync(command()));
 			expect(readlinkSync(join(dirname(command()), "previous"))).toBe(previous);
+			// Update discovery follows the now-active stable version, not the original archive's channel.
+			feed.delete(manifestPath);
+			feed.set("/latest.json", nextManifest);
 			const unchanged = await run(command(), ["update"]);
 			expect(unchanged.code, unchanged.output).toBe(0);
 			expect(unchanged.output).toContain("already up to date");

--- a/packages/coding-agent/test/release-signatures.test.ts
+++ b/packages/coding-agent/test/release-signatures.test.ts
@@ -1,0 +1,288 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+	chmodSync,
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const repository = resolve(__dirname, "../../..");
+const signatureScript = join(repository, "packages/coding-agent/scripts/macos-signature.mjs");
+const assemblyScript = join(repository, "scripts/assemble-release-archives.mjs");
+const platform = `${process.platform}-${process.arch}`;
+let root: string;
+let fixture: string;
+
+function signature(command: string, binary: string, target = platform) {
+	return spawnSync(process.execPath, [signatureScript, command, binary, target], { encoding: "utf8" });
+}
+
+function sha256(path: string): string {
+	return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function codesignDetails(binary: string): string {
+	const result = spawnSync("/usr/bin/codesign", ["--display", "--verbose=4", binary], { encoding: "utf8" });
+	expect(result.status, result.stderr).toBe(0);
+	return result.stdout + result.stderr;
+}
+
+function entitlements(binary: string): string {
+	return execFileSync("/usr/bin/codesign", ["--display", "--entitlements", "-", binary], {
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+}
+
+beforeAll(() => {
+	root = mkdtempSync(join(tmpdir(), "prime-release-signatures-"));
+	if (process.platform === "darwin") {
+		fixture = join(root, "native-fixture");
+		const source = join(root, "fixture.c");
+		writeFileSync(
+			source,
+			`#include <stdio.h>
+#include <string.h>
+const char payload[32768] = "signature-page-fixture";
+int main(int argc, char **argv) {
+  if (argc == 2 && strcmp(argv[1], "--version") == 0) puts("1.2.3");
+  else if (argc == 2 && strcmp(argv[1], "--help") == 0) puts("Python REPL");
+  return payload[0] == 0;
+}
+`,
+		);
+		execFileSync("/usr/bin/cc", [source, "-o", fixture]);
+		execFileSync("/usr/bin/codesign", ["--force", "--sign", "-", fixture], { stdio: "pipe" });
+	}
+});
+
+afterAll(() => {
+	if (root) rmSync(root, { recursive: true, force: true });
+});
+
+describe("release signature command", () => {
+	it.each(["linux-arm64", "linux-x64"])("leaves %s binaries untouched", (target) => {
+		const binary = join(root, target);
+		writeFileSync(binary, `Linux fixture ${target}`);
+		const original = sha256(binary);
+		for (const command of ["sign", "verify"]) {
+			const result = signature(command, binary, target);
+			expect(result.status, result.stderr).toBe(0);
+			expect(sha256(binary)).toBe(original);
+		}
+	});
+
+	it("rejects unsupported targets and invalid commands", () => {
+		expect(signature("sign", "unused", "windows-x64").status).not.toBe(0);
+		expect(signature("repair", "unused", "linux-x64").status).not.toBe(0);
+	});
+
+	it.skipIf(process.platform === "darwin")("cannot approve Darwin signatures on a non-macOS host", () => {
+		for (const target of ["darwin-arm64", "darwin-x64"]) {
+			for (const command of ["sign", "verify"]) {
+				const result = signature(command, "unused", target);
+				expect(result.status).not.toBe(0);
+				expect(result.stderr).toContain("macOS");
+			}
+		}
+	});
+
+	it.skipIf(process.platform !== "darwin")(
+		"rejects unsigned and damaged signatures, then repairs signed page hashes",
+		() => {
+			const binary = join(root, "damaged-fixture");
+			copyFileSync(fixture, binary);
+			expect(signature("verify", binary).status).toBe(0);
+			const bytes = readFileSync(binary);
+			bytes[4096] ^= 1;
+			writeFileSync(binary, bytes);
+			const damaged = signature("verify", binary);
+			expect(damaged.status).not.toBe(0);
+			expect(damaged.stderr).toMatch(/invalid|modified/i);
+			const repaired = signature("sign", binary);
+			expect(repaired.status, repaired.stderr).toBe(0);
+			expect(signature("verify", binary).status).toBe(0);
+			execFileSync("/usr/bin/codesign", ["--remove-signature", binary]);
+			expect(signature("verify", binary).status).not.toBe(0);
+		},
+	);
+
+	it.skipIf(process.platform !== "darwin")(
+		"retains JIT entitlements and the hardened runtime flag during replacement",
+		() => {
+			const binary = join(root, "jit-fixture");
+			copyFileSync(fixture, binary);
+			const plist = join(root, "entitlements.plist");
+			writeFileSync(
+				plist,
+				`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>com.apple.security.cs.allow-jit</key><true/>
+<key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/></dict></plist>`,
+			);
+			execFileSync(
+				"/usr/bin/codesign",
+				["--force", "--sign", "-", "--options", "runtime", "--entitlements", plist, binary],
+				{
+					stdio: "pipe",
+				},
+			);
+			const originalEntitlements = entitlements(binary);
+			expect(originalEntitlements).toContain("com.apple.security.cs.allow-jit");
+			expect(codesignDetails(binary)).toMatch(/flags=.*\bruntime\b/);
+			const result = signature("sign", binary);
+			expect(result.status, result.stderr).toBe(0);
+			expect(entitlements(binary)).toBe(originalEntitlements);
+			expect(codesignDetails(binary)).toMatch(/flags=.*\bruntime\b/);
+			expect(signature("verify", binary).status).toBe(0);
+		},
+	);
+
+	it.skipIf(process.platform !== "darwin")(
+		"does not grant entitlements or hardened runtime to a plain ad-hoc binary",
+		() => {
+			const binary = join(root, "plain-fixture");
+			copyFileSync(fixture, binary);
+			const originalEntitlements = entitlements(binary);
+			expect(originalEntitlements).not.toContain("com.apple.security");
+			expect(codesignDetails(binary)).not.toMatch(/flags=.*\bruntime\b/);
+			const result = signature("sign", binary);
+			expect(result.status, result.stderr).toBe(0);
+			expect(entitlements(binary)).toBe(originalEntitlements);
+			expect(codesignDetails(binary)).not.toMatch(/flags=.*\bruntime\b/);
+		},
+	);
+});
+
+function binaryAssets(directory: string, binary: Buffer): void {
+	mkdirSync(directory, { recursive: true });
+	writeFileSync(join(directory, "prime-agent"), binary, { mode: 0o755 });
+	for (const name of [
+		"install.sh",
+		"README.md",
+		"CHANGELOG.md",
+		"LICENSE",
+		"photon_rs_bg.wasm",
+		"prime-agent-runtime/pyproject.toml",
+		"prime-agent-runtime/src/rlm/repl.py",
+		"theme/prime.json",
+		"theme/dark.json",
+		"theme/light.json",
+		"export-html/template.html",
+		"export-html/template.css",
+		"export-html/template.js",
+		"export-html/vendor/marked.min.js",
+		"export-html/vendor/highlight.min.js",
+	]) {
+		mkdirSync(dirname(join(directory, name)), { recursive: true });
+		writeFileSync(join(directory, name), name);
+	}
+	for (const name of ["skills", "assets", "docs", "examples"]) mkdirSync(join(directory, name));
+	writeFileSync(join(directory, "package.json"), JSON.stringify({ name: "fixture", version: "0.0.0" }));
+}
+
+interface BinaryManifest {
+	version: string;
+	binaries: { platform: string; file: string; sha256: string; executableSha256: string }[];
+}
+
+describe.skipIf(process.platform === "win32")("release archive executable identity", () => {
+	it("keeps all four executable bytes identical across stable and beta metadata rewrites", () => {
+		const binaries = join(root, "binaries");
+		const targets = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"];
+		for (const target of targets) binaryAssets(join(binaries, target), Buffer.from(`unchanged ${target} executable`));
+		for (const version of ["1.2.3", "1.2.3-beta.4.1.abcdef0"]) {
+			const output = join(root, version);
+			execFileSync(process.execPath, [assemblyScript, binaries, output, version]);
+			const manifest: BinaryManifest = JSON.parse(readFileSync(join(output, "binaries.json"), "utf8"));
+			expect(manifest.version).toBe(`v${version}`);
+			expect(manifest.binaries.map((entry) => entry.platform)).toEqual(targets);
+			for (const entry of manifest.binaries) {
+				const original = join(binaries, entry.platform, "prime-agent");
+				const archive = join(output, entry.file);
+				const extracted = join(output, entry.platform);
+				mkdirSync(extracted);
+				execFileSync("tar", ["-xzf", archive, "-C", extracted]);
+				expect(sha256(join(extracted, "prime-agent"))).toBe(sha256(original));
+				expect(entry.executableSha256).toBe(sha256(original));
+				expect(entry.sha256).toBe(sha256(archive));
+				expect(readFileSync(join(output, "SHA256SUMS"), "utf8")).toContain(`${entry.sha256}  ${entry.file}\n`);
+				expect(JSON.parse(readFileSync(join(extracted, "package.json"), "utf8")).version).toBe(version);
+				expect(JSON.parse(readFileSync(join(binaries, entry.platform, "package.json"), "utf8")).version).toBe(
+					"0.0.0",
+				);
+			}
+		}
+	});
+
+	it("does not emit an archive inventory when the executable cannot be packaged", () => {
+		const binaries = join(root, "invalid-binaries");
+		binaryAssets(join(binaries, "linux-x64"), Buffer.from("not executable"));
+		chmodSync(join(binaries, "linux-x64/prime-agent"), 0o644);
+		const output = join(root, "invalid-output");
+		const result = spawnSync(process.execPath, [assemblyScript, binaries, output, "1.2.3"], { encoding: "utf8" });
+		expect(result.status).not.toBe(0);
+		expect(existsSync(join(output, "SHA256SUMS"))).toBe(false);
+		expect(existsSync(join(output, "binaries.json"))).toBe(false);
+	});
+});
+
+describe.skipIf(process.platform !== "darwin")("final native macOS validation", () => {
+	function validate(binary: Buffer, name: string, changeReference = false) {
+		const directory = join(root, name);
+		const binaries = join(directory, "binaries");
+		binaryAssets(join(binaries, platform), binary);
+		const artifacts = join(directory, "artifacts");
+		execFileSync(process.execPath, [assemblyScript, binaries, artifacts, "1.2.3"]);
+		const reference = join(directory, "reference.json");
+		const manifest: BinaryManifest = JSON.parse(readFileSync(join(artifacts, "binaries.json"), "utf8"));
+		if (changeReference) manifest.binaries[0]!.executableSha256 = "f".repeat(64);
+		writeFileSync(reference, JSON.stringify(manifest));
+		const receipt = join(directory, "receipt.json");
+		const result = spawnSync(
+			process.execPath,
+			[join(repository, "scripts/validate-macos-release.mjs"), artifacts, platform, reference, receipt],
+			{ encoding: "utf8" },
+		);
+		return { result, receipt, artifacts };
+	}
+
+	it("writes a receipt only after exact packaged executable verification and runtime checks", () => {
+		const { result, receipt, artifacts } = validate(readFileSync(fixture), "valid-final");
+		expect(result.status, result.stderr).toBe(0);
+		const evidence = JSON.parse(readFileSync(receipt, "utf8"));
+		expect(evidence).toMatchObject({
+			schemaVersion: 1,
+			platform,
+			version: "v1.2.3",
+			executableSha256: sha256(fixture),
+		});
+		expect(evidence.signature).toContain("Signature=adhoc");
+		expect(evidence.manifestSha256).toBe(sha256(join(artifacts, "binaries.json")));
+		expect(evidence.inventorySha256).toBe(sha256(join(artifacts, "SHA256SUMS")));
+	});
+
+	it("rejects invalid signed pages even with matching archive and executable digests", () => {
+		const bytes = readFileSync(fixture);
+		bytes[4096] ^= 1;
+		const { result, receipt } = validate(bytes, "tampered-final");
+		expect(result.status).not.toBe(0);
+		expect(result.stderr).toMatch(/invalid|modified/i);
+		expect(existsSync(receipt)).toBe(false);
+	});
+
+	it("does not attest an executable different from the tested standalone build", () => {
+		const { result, receipt } = validate(readFileSync(fixture), "wrong-reference", true);
+		expect(result.status).not.toBe(0);
+		expect(result.stderr).toContain("identity differs");
+		expect(existsSync(receipt)).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/release-validation-receipts.test.ts
+++ b/packages/coding-agent/test/release-validation-receipts.test.ts
@@ -1,0 +1,207 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const script = resolve(__dirname, "../../../scripts/verify-macos-validation-receipts.mjs");
+let root: string;
+
+function sha256(path: string): string {
+	return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+interface ReceiptFixture {
+	artifacts: string;
+	receipts: string;
+	manifestPath: string;
+	inventory: string;
+	archive: string;
+	receipt: string;
+	channel: string;
+}
+
+function fixture(channel = "production"): ReceiptFixture {
+	const directory = mkdtempSync(join(root, "release-"));
+	const artifacts = join(directory, "artifacts");
+	const receipts = join(directory, "receipts");
+	mkdirSync(artifacts);
+	mkdirSync(receipts);
+	const version = channel === "production" ? "1.2.3" : "1.2.3-beta.5.1.abcdef0";
+	const manifestFile = channel === "production" ? "latest.json" : "beta.json";
+	const binaries = ["darwin-arm64", "darwin-x64"].map((platform) => {
+		const file = `prime-agent-${version}-${platform}.tar.gz`;
+		writeFileSync(join(artifacts, file), `receipt fixture for ${platform}`);
+		return { platform, file, sha256: sha256(join(artifacts, file)), executableSha256: "a".repeat(64) };
+	});
+	const manifestPath = join(artifacts, manifestFile);
+	writeFileSync(manifestPath, JSON.stringify({ version: `v${version}`, binaries }));
+	const inventory = join(artifacts, "SHA256SUMS");
+	writeFileSync(inventory, binaries.map((entry) => `${entry.sha256}  ${entry.file}\n`).join(""));
+	for (const entry of binaries) {
+		writeFileSync(
+			join(receipts, `${channel}-${entry.platform}.json`),
+			JSON.stringify({
+				schemaVersion: 1,
+				...entry,
+				version: `v${version}`,
+				manifestFile,
+				manifestSha256: sha256(manifestPath),
+				inventorySha256: sha256(inventory),
+			}),
+		);
+	}
+	return {
+		artifacts,
+		receipts,
+		manifestPath,
+		inventory,
+		channel,
+		archive: join(artifacts, binaries[0]!.file),
+		receipt: join(receipts, `${channel}-darwin-arm64.json`),
+	};
+}
+
+function verify(value: ReceiptFixture, channel = value.channel) {
+	return spawnSync(process.execPath, [script, value.artifacts, value.receipts, channel], { encoding: "utf8" });
+}
+
+beforeAll(() => {
+	root = mkdtempSync(join(tmpdir(), "prime-release-receipts-"));
+});
+afterAll(() => {
+	if (root) rmSync(root, { recursive: true, force: true });
+});
+
+describe("macOS validation receipt publication gate", () => {
+	it.each(["production", "beta"])("accepts matching %s receipts from both architectures", (channel) => {
+		const result = verify(fixture(channel));
+		expect(result.status, result.stderr).toBe(0);
+		expect(result.stdout).toContain("darwin-arm64");
+		expect(result.stdout).toContain("darwin-x64");
+	});
+
+	it.each(["darwin-arm64", "darwin-x64"])("fails closed when %s validation did not produce a receipt", (platform) => {
+		const value = fixture();
+		rmSync(join(value.receipts, `production-${platform}.json`));
+		expect(verify(value).status).not.toBe(0);
+	});
+
+	it.each([
+		["changed archive bytes", (value: ReceiptFixture) => writeFileSync(value.archive, "changed after validation")],
+		[
+			"changed manifest bytes",
+			(value: ReceiptFixture) => writeFileSync(value.manifestPath, `${readFileSync(value.manifestPath, "utf8")}\n`),
+		],
+		[
+			"changed inventory bytes",
+			(value: ReceiptFixture) =>
+				writeFileSync(value.inventory, `${readFileSync(value.inventory, "utf8")}${"b".repeat(64)}  extra.tgz\n`),
+		],
+		[
+			"duplicate inventory entry",
+			(value: ReceiptFixture) => writeFileSync(value.inventory, readFileSync(value.inventory, "utf8").repeat(2)),
+		],
+		[
+			"ambiguous manifests",
+			(value: ReceiptFixture) =>
+				writeFileSync(join(value.artifacts, "binaries.json"), readFileSync(value.manifestPath)),
+		],
+	])("rejects %s after native validation", (_label, mutate) => {
+		const value = fixture();
+		mutate(value);
+		expect(verify(value).status).not.toBe(0);
+	});
+
+	it("rejects a changed executable identity even if the archive and inventory remain consistent", () => {
+		const value = fixture();
+		const manifest = JSON.parse(readFileSync(value.manifestPath, "utf8"));
+		manifest.binaries[0].executableSha256 = "b".repeat(64);
+		writeFileSync(value.manifestPath, JSON.stringify(manifest));
+		const result = verify(value);
+		expect(result.status).not.toBe(0);
+		expect(result.stderr).toContain("executableSha256");
+	});
+
+	it("rejects an archive replaced together with its manifest and checksum inventory", () => {
+		const value = fixture();
+		writeFileSync(value.archive, "replacement archive with internally consistent metadata");
+		const manifest = JSON.parse(readFileSync(value.manifestPath, "utf8"));
+		manifest.binaries[0].sha256 = sha256(value.archive);
+		writeFileSync(value.manifestPath, JSON.stringify(manifest));
+		writeFileSync(
+			value.inventory,
+			manifest.binaries
+				.map((entry: { sha256: string; file: string }) => `${entry.sha256}  ${entry.file}\n`)
+				.join(""),
+		);
+		const result = verify(value);
+		expect(result.status).not.toBe(0);
+		expect(result.stderr).toContain("sha256");
+	});
+
+	it.each([
+		"schemaVersion",
+		"platform",
+		"version",
+		"file",
+		"sha256",
+		"executableSha256",
+		"manifestFile",
+		"manifestSha256",
+		"inventorySha256",
+	])("rejects a mismatched receipt %s", (key) => {
+		const value = fixture();
+		const receipt = JSON.parse(readFileSync(value.receipt, "utf8"));
+		receipt[key] = "changed";
+		writeFileSync(value.receipt, JSON.stringify(receipt));
+		expect(verify(value).status).not.toBe(0);
+	});
+
+	it.skipIf(process.platform === "win32").each(["production", "beta"])(
+		"the actual workflow shell stops before publication when %s validation is missing",
+		(channel) => {
+			const value = fixture(channel);
+			const working = mkdtempSync(join(root, "publication-"));
+			mkdirSync(join(working, "release-artifacts"));
+			symlinkSync(value.artifacts, join(working, "release-artifacts", channel));
+			symlinkSync(value.receipts, join(working, "macos-validation"));
+			mkdirSync(join(working, "scripts"));
+			for (const name of ["verify-macos-validation-receipts.mjs", "release-artifact-integrity.mjs"]) {
+				copyFileSync(resolve(__dirname, "../../../scripts", name), join(working, "scripts", name));
+			}
+			const workflow = parse(
+				readFileSync(resolve(__dirname, "../../../.github/workflows/build-binaries.yml"), "utf8"),
+			);
+			const gate = workflow.jobs.publish.steps.find(
+				(step: { name?: string }) => step.name === "Match native validation to publication artifacts",
+			);
+			expect(gate).toBeDefined();
+			const runGate = () =>
+				spawnSync("bash", ["-e", "-o", "pipefail", "-c", `${gate.run}\nprintf publication-reached`], {
+					cwd: working,
+					env: {
+						...process.env,
+						PUBLISH_PRODUCTION: String(channel === "production"),
+						PUBLISH_BETA: String(channel === "beta"),
+					},
+					encoding: "utf8",
+				});
+			const passed = runGate();
+			expect(passed.status, passed.stderr).toBe(0);
+			expect(passed.stdout).toContain("publication-reached");
+			rmSync(join(value.receipts, `${channel}-darwin-x64.json`));
+			const failed = runGate();
+			expect(failed.status).not.toBe(0);
+			expect(failed.stdout).not.toContain("publication-reached");
+		},
+	);
+
+	it("does not substitute another channel's receipts or accept an unknown channel", () => {
+		const value = fixture();
+		expect(verify(value, "beta").status).not.toBe(0);
+		expect(verify(value, "stable").status).not.toBe(0);
+	});
+});

--- a/packages/coding-agent/test/release-workflow.test.ts
+++ b/packages/coding-agent/test/release-workflow.test.ts
@@ -1,0 +1,157 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+interface Step {
+	name?: string;
+	run?: string;
+	uses?: string;
+	if?: string;
+	"continue-on-error"?: boolean;
+	with?: Record<string, string>;
+}
+interface Job {
+	needs?: string | string[];
+	if?: string;
+	"continue-on-error"?: boolean;
+	"runs-on"?: string;
+	strategy?: { matrix: { include: { platform: string; runner: string }[] } };
+	steps: Step[];
+	with?: Record<string, string>;
+}
+interface Workflow {
+	jobs: Record<string, Job>;
+	on: Record<string, unknown>;
+}
+
+const repository = resolve(__dirname, "../../..");
+const release: Workflow = parse(readFileSync(join(repository, ".github/workflows/build-binaries.yml"), "utf8"));
+const standalone: Workflow = parse(readFileSync(join(repository, ".github/workflows/standalone-binaries.yml"), "utf8"));
+
+function step(job: Job, name: string): Step {
+	const found = job.steps.find((entry) => entry.name === name);
+	expect(found, `Missing workflow step: ${name}`).toBeDefined();
+	return found!;
+}
+
+function requiresSuccess(job: Job): void {
+	expect(job["continue-on-error"]).toBeUndefined();
+	// GitHub adds success() unless a status-check function overrides it.
+	expect(job.if ?? "").not.toMatch(/(?:always|failure|cancelled|success)\s*\(/);
+	for (const entry of job.steps ?? []) {
+		expect(entry["continue-on-error"]).toBeUndefined();
+		expect(entry.if ?? "").not.toMatch(/(?:always|failure|cancelled)\s*\(/);
+	}
+}
+
+describe("release workflow signature gates", () => {
+	it("requires successful build and both native final validation jobs before publication", () => {
+		const validation = release.jobs["validate-macos"]!;
+		expect(validation.needs).toEqual(expect.arrayContaining(["release-context", "build"]));
+		expect(validation["runs-on"]).toBe(`\${{ matrix.runner }}`);
+		expect(validation.strategy?.matrix.include).toEqual([
+			{ platform: "darwin-arm64", runner: "macos-15" },
+			{ platform: "darwin-x64", runner: "macos-15-intel" },
+		]);
+		const publish = release.jobs.publish!;
+		expect(publish.needs).toEqual(expect.arrayContaining(["build", "validate-macos"]));
+		expect(publish.if).toBe("github.event_name != 'pull_request'");
+		requiresSuccess(validation);
+		requiresSuccess(publish);
+	});
+
+	it("tests final channel archives before uploading receipts, then checks receipts before external writes", () => {
+		const validation = release.jobs["validate-macos"]!;
+		const verify = step(validation, "Verify and exercise exact final Mac archives");
+		expect(verify.run).toContain("for channel in production beta");
+		expect(verify.run).toContain("validate-macos-release.mjs");
+		expect(verify.run).toContain("standalone-reference/binaries.json");
+		expect(verify.run).toContain("test/compiled-artifact.test.ts");
+		expect(verify.run).not.toMatch(/\|\|\s*(?:true|:)|continue-on-error/);
+		expect(validation.steps.indexOf(verify)).toBeLessThan(
+			validation.steps.indexOf(step(validation, "Upload native validation receipts")),
+		);
+		const publish = release.jobs.publish!;
+		const gate = step(publish, "Match native validation to publication artifacts");
+		expect(gate.if).toBeUndefined();
+		expect(gate.run).toContain(
+			"verify-macos-validation-receipts.mjs release-artifacts/production macos-validation production",
+		);
+		expect(gate.run).toContain("verify-macos-validation-receipts.mjs release-artifacts/beta macos-validation beta");
+		const writes = publish.steps.filter((entry) =>
+			/aws s3 cp|gh release (?:upload|create|edit)|gh api --method/.test(entry.run ?? ""),
+		);
+		expect(writes.length).toBeGreaterThan(0);
+		for (const write of writes) expect(publish.steps.indexOf(gate)).toBeLessThan(publish.steps.indexOf(write));
+	});
+
+	it("retains all four standalone targets and only uploads tested executable identities", () => {
+		const build = standalone.jobs.build!;
+		expect(build.strategy?.matrix.include.map((entry) => entry.platform)).toEqual([
+			"darwin-arm64",
+			"darwin-x64",
+			"linux-arm64",
+			"linux-x64",
+		]);
+		const test = step(build, "Test extracted application without JavaScript runtimes on PATH");
+		expect(test.run).toContain("test/compiled-artifact.test.ts");
+		expect(test.run).toContain("test/release-signatures.test.ts");
+		const upload = build.steps.find((entry) => entry.uses?.startsWith("actions/upload-artifact@"))!;
+		expect(upload.with?.path).toContain("binaries.json");
+		expect(build.steps.indexOf(test)).toBeLessThan(build.steps.indexOf(upload));
+		requiresSuccess(build);
+		expect(release.jobs.standalone!.with?.build_ref).toBe(`\${{ needs.release-context.outputs.build_ref }}`);
+	});
+
+	it.skipIf(process.platform === "win32")(
+		"selects both real packer paths for PR validation without allowing publication",
+		() => {
+			expect(release.on).toHaveProperty("pull_request");
+			const directory = mkdtempSync(join(tmpdir(), "prime-release-context-"));
+			try {
+				const output = join(directory, "output");
+				const context = step(release.jobs["release-context"]!, "Resolve release context");
+				const result = spawnSync("bash", ["-e", "-o", "pipefail", "-c", context.run!], {
+					cwd: repository,
+					env: {
+						...process.env,
+						EVENT_NAME: "pull_request",
+						GITHUB_SHA_VALUE: "abcdef0123456789",
+						RUN_NUMBER: "5",
+						RUN_ATTEMPT: "1",
+						GITHUB_OUTPUT: output,
+					},
+					encoding: "utf8",
+				});
+				expect(result.status, result.stderr).toBe(0);
+				const values = Object.fromEntries(
+					readFileSync(output, "utf8")
+						.trim()
+						.split("\n")
+						.map((line) => line.split("=")),
+				);
+				expect(values).toMatchObject({
+					publish_beta: "true",
+					publish_production: "true",
+					build_ref: "abcdef0123456789",
+				});
+				expect(values.beta_version).toBe(`${values.production_version}-beta.5.1.abcdef0`);
+				for (const [name, channel] of [
+					["Pack production release", "stable"],
+					["Pack beta release", "beta"],
+				]) {
+					const pack = step(release.jobs.build!, name!);
+					expect(pack.run).toContain("npm run release:pack");
+					expect(pack.run).toContain(`--channel ${channel}`);
+					expect(pack.run).toContain("--binary-dir packages/coding-agent/binaries");
+				}
+				expect(release.jobs.publish!.if).toBe("github.event_name != 'pull_request'");
+			} finally {
+				rmSync(directory, { recursive: true, force: true });
+			}
+		},
+	);
+});

--- a/scripts/assemble-release-archives.mjs
+++ b/scripts/assemble-release-archives.mjs
@@ -49,7 +49,12 @@ export function assembleBinaryArchives({ binaryDir, artifactsDir, version, requi
 			execFileSync("tar", ["-czf", output, "-C", staging, "prime-agent", ...binaryAssets], {
 				env: { ...process.env, COPYFILE_DISABLE: "1" },
 			});
-			archives.push({ platform, file, sha256: createHash("sha256").update(readFileSync(output)).digest("hex") });
+			archives.push({
+				platform,
+				file,
+				sha256: createHash("sha256").update(readFileSync(output)).digest("hex"),
+				executableSha256: createHash("sha256").update(readFileSync(binary)).digest("hex"),
+			});
 		} finally {
 			rmSync(staging, { recursive: true, force: true });
 		}

--- a/scripts/release-artifact-integrity.mjs
+++ b/scripts/release-artifact-integrity.mjs
@@ -1,0 +1,38 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+export function sha256File(path) {
+	return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+export function readReleaseBinary(artifactsDir, platform) {
+	const manifests = ["latest.json", "beta.json", "binaries.json"].filter((file) => existsSync(join(artifactsDir, file)));
+	if (manifests.length !== 1) throw new Error("Expected exactly one release manifest");
+	const manifestFile = manifests[0];
+	const manifest = JSON.parse(readFileSync(join(artifactsDir, manifestFile), "utf8"));
+	const entries = manifest.binaries?.filter((entry) => entry.platform === platform);
+	if (entries?.length !== 1) throw new Error(`Expected one ${platform} binary in ${manifestFile}`);
+	const entry = entries[0];
+	if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(manifest.version)) throw new Error("Invalid manifest version");
+	if (entry.file !== `prime-agent-${manifest.version.slice(1)}-${platform}.tar.gz`)
+		throw new Error("Unexpected archive filename");
+	for (const field of ["sha256", "executableSha256"])
+		if (!/^[a-f0-9]{64}$/.test(entry[field])) throw new Error(`Missing or invalid ${field}`);
+	const inventory = readFileSync(join(artifactsDir, "SHA256SUMS"), "utf8").trim().split("\n");
+	const checksums = new Map();
+	for (const line of inventory) {
+		const match = /^([a-f0-9]{64})  (.+)$/.exec(line);
+		if (!match || basename(match[2]) !== match[2] || checksums.has(match[2])) throw new Error("Invalid checksum inventory");
+		checksums.set(match[2], match[1]);
+	}
+	if (checksums.get(entry.file) !== entry.sha256 || sha256File(join(artifactsDir, entry.file)) !== entry.sha256)
+		throw new Error(`Archive checksum mismatch: ${entry.file}`);
+	return {
+		...entry,
+		version: manifest.version,
+		manifestFile,
+		manifestSha256: sha256File(join(artifactsDir, manifestFile)),
+		inventorySha256: sha256File(join(artifactsDir, "SHA256SUMS")),
+	};
+}

--- a/scripts/validate-macos-release.mjs
+++ b/scripts/validate-macos-release.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { validateBinaryAssets } from "../packages/coding-agent/scripts/copy-binary-assets.mjs";
+import { verifyMacosBinary } from "../packages/coding-agent/scripts/macos-signature.mjs";
+import { readReleaseBinary, sha256File } from "./release-artifact-integrity.mjs";
+
+export function validateMacosRelease(artifactsDir, platform, referenceManifest, evidencePath) {
+	rmSync(evidencePath, { force: true });
+	if (process.platform !== "darwin" || platform !== `darwin-${process.arch}`)
+		throw new Error(`Final ${platform} validation requires a matching native macOS runner`);
+	const release = readReleaseBinary(artifactsDir, platform);
+	const references = JSON.parse(readFileSync(referenceManifest, "utf8")).binaries?.filter((entry) => entry.platform === platform);
+	if (references?.length !== 1 || references[0].executableSha256 !== release.executableSha256)
+		throw new Error("Final executable identity differs from the tested standalone build");
+	const temporary = mkdtempSync(join(tmpdir(), "prime-agent-signature-"));
+	try {
+		const extracted = join(temporary, "extracted app");
+		const home = join(temporary, "home");
+		mkdirSync(extracted);
+		mkdirSync(home);
+		execFileSync("tar", ["-xzf", join(artifactsDir, release.file), "-C", extracted], { env: { ...process.env, COPYFILE_DISABLE: "1" } });
+		validateBinaryAssets(extracted);
+		const binary = join(extracted, "prime-agent");
+		if (sha256File(binary) !== release.executableSha256) throw new Error("Extracted executable checksum mismatch");
+		verifyMacosBinary(binary, platform);
+		const display = spawnSync("/usr/bin/codesign", ["--display", "--verbose=4", binary], { encoding: "utf8" });
+		if (display.status !== 0) throw new Error(`Cannot inspect signature: ${display.stderr}`);
+		const signature = display.stderr;
+		console.log(signature);
+		const options = {
+			cwd: home,
+			env: { HOME: home, PATH: "/usr/bin:/bin", TMPDIR: temporary, DO_NOT_TRACK: "1", PRIME_AGENT_CODING_AGENT_DIR: join(home, "agent") },
+			encoding: "utf8",
+			timeout: 30000,
+		};
+		if (execFileSync(binary, ["--version"], options).trim() !== release.version.slice(1)) throw new Error("Final archive version mismatch");
+		if (!execFileSync(binary, ["--help"], options).includes("Python REPL")) throw new Error("Final archive help failed");
+		mkdirSync(dirname(evidencePath), { recursive: true });
+		const receipt = { schemaVersion: 1, ...release, referenceManifestSha256: sha256File(referenceManifest), signature, macosVersion: execFileSync("/usr/bin/sw_vers", ["-productVersion"], { encoding: "utf8" }).trim() };
+		writeFileSync(evidencePath, `${JSON.stringify(receipt, null, 2)}\n`);
+		console.log(`Verified final ${platform} ${release.version}: ${release.sha256}`);
+		return receipt;
+	} finally {
+		rmSync(temporary, { recursive: true, force: true });
+	}
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+	const [artifactsDir, platform, referenceManifest, evidencePath, ...extra] = process.argv.slice(2);
+	if (!artifactsDir || !platform || !referenceManifest || !evidencePath || extra.length)
+		throw new Error("Usage: node validate-macos-release.mjs <artifacts-dir> <platform> <reference-binaries.json> <receipt-path>");
+	validateMacosRelease(resolve(artifactsDir), platform, resolve(referenceManifest), resolve(evidencePath));
+}

--- a/scripts/verify-macos-validation-receipts.mjs
+++ b/scripts/verify-macos-validation-receipts.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { readReleaseBinary } from "./release-artifact-integrity.mjs";
+
+export function verifyMacosValidationReceipts(artifactsDir, receiptsDir, channel) {
+	if (!["production", "beta"].includes(channel)) throw new Error("Expected production or beta channel");
+	for (const platform of ["darwin-arm64", "darwin-x64"]) {
+		const release = readReleaseBinary(artifactsDir, platform);
+		const receipt = JSON.parse(readFileSync(join(receiptsDir, `${channel}-${platform}.json`), "utf8"));
+		if (receipt.schemaVersion !== 1) throw new Error("Unsupported validation receipt");
+		for (const key of ["platform", "version", "file", "sha256", "executableSha256", "manifestFile", "manifestSha256", "inventorySha256"]) {
+			if (receipt[key] !== release[key]) throw new Error(`macOS validation receipt mismatch: ${platform} ${key}`);
+		}
+		console.log(`Matched native validation receipt: ${channel} ${platform} ${release.sha256}`);
+	}
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+	const [artifactsDir, receiptsDir, channel, ...extra] = process.argv.slice(2);
+	if (!artifactsDir || !receiptsDir || !channel || extra.length)
+		throw new Error("Usage: node verify-macos-validation-receipts.mjs <artifacts-dir> <receipts-dir> <production|beta>");
+	verifyMacosValidationReceipts(resolve(artifactsDir), resolve(receiptsDir), channel);
+}


### PR DESCRIPTION
- replace bun’s invalid signatures with apple ad-hoc signatures while preserving existing runtime permissions.
- block beta and stable publication until matching final archives pass native signature and runtime checks.
- cover damaged signatures, unchanged executables through packaging, and missing or changed validation records.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline to fail closed on missing or mismatched macOS validation receipts; a regression in signing, packing, or manifest fields can block stable/beta publication.
> 
> **Overview**
> Fixes **invalid Bun-produced macOS page hashes** by re-signing Darwin `prime-agent` binaries during `build-binary` with ad-hoc `codesign` (preserving entitlements/flags), then strictly verifying them via new `macos-signature.mjs`.
> 
> Release metadata now records **`executableSha256`** in assembled archives and ships **`binaries.json`** from standalone builds so final stable/beta Mac tarballs can be matched to the tested standalone executable.
> 
> **CI/release workflow changes:** `build-binaries.yml` runs on PRs (trusted authors only) to exercise full pack paths with a dummy download base and **skips publish**; adds **`validate-macos`** jobs on arm64/x64 that verify final artifacts, run native tests, and upload receipts; **`publish` waits on receipt matching** via `verify-macos-validation-receipts.mjs` before any external writes. Standalone builds checkout the resolved **`build_ref`**.
> 
> Tests cover damaged signatures, tampering, receipt integrity, and workflow ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84d6372cee1a9c5176b6b7780f027bf526761fae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix invalid macOS signatures in compiled releases
> - Adds ad-hoc signing and strict verification for Darwin executables during binary assembly in [build-binary.mjs](https://github.com/PrimeIntellect-ai/prime-agent/pull/2265/files#diff-8e73b154fb960515ef79ccbe1eb9f235460d998d32949cb3b819604e3357b42f)
> - Runs arm64 and Intel macOS CI jobs that validate archive signatures, executable identity, and runtime behavior, producing validation receipts
> - Adds a publication gate in [verify-macos-validation-receipts.mjs](https://github.com/PrimeIntellect-ai/prime-agent/pull/2265/files#diff-fe7349616c5105cda77eb1a5cffba346037a6e61407c7333e85c9f0628f4568e) that stops the `publish release` job unless production and beta artifacts match the native validation receipts
> - Adds executable SHA-256 digests to release archive manifests in [assemble-release-archives.mjs](https://github.com/PrimeIntellect-ai/prime-agent/pull/2265/files#diff-46de661e3d695e982dc577c80c500ee01947e15fb5960628d3d9a00b993b8ea0) to track executable identity
> - Behavioral Change: The `publish release` job fails if macOS validation receipts are missing, mismatched, or unverified for either architecture. Pull requests targeting `main` now run the workflow in validation mode without publishing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84d6372.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->