### PR TITLE
fix opencode compaction and refinement session routing

### DIFF
--- a/packages/coding-agent/.changes/eng-6009-opencode-maintenance-session.md
+++ b/packages/coding-agent/.changes/eng-6009-opencode-maintenance-session.md
@@ -1,0 +1,1 @@
+- Fixed OpenCode compaction, refinement, and branch summaries failing because requests omitted the conversation identity.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -7916,6 +7916,7 @@ export class AgentSession {
 					this.thinkingLevel,
 					summaryCall,
 					providerRetryPolicy(this.settingsManager),
+					this.sessionId,
 				));
 			}
 
@@ -8438,6 +8439,7 @@ export class AgentSession {
 			signal,
 			this.thinkingLevel,
 			providerRetryPolicy(this.settingsManager),
+			this.sessionId,
 		);
 	}
 
@@ -8740,6 +8742,7 @@ export class AgentSession {
 			headers,
 			signal,
 			this.thinkingLevel,
+			this.sessionId,
 		);
 		if (this._disposed || signal.aborted) {
 			throw new Error("Refinement cancelled because the session was disposed.");
@@ -12262,6 +12265,7 @@ export class AgentSession {
 					apiKey,
 					headers,
 					signal: this._branchSummaryAbortController.signal,
+					sessionId: this.sessionId,
 					customInstructions,
 					replaceInstructions,
 					reserveTokens: branchSummarySettings.reserveTokens,

--- a/packages/coding-agent/src/core/compaction/branch-summarization.ts
+++ b/packages/coding-agent/src/core/compaction/branch-summarization.ts
@@ -67,6 +67,8 @@ export interface GenerateBranchSummaryOptions {
 	apiKey: string;
 	/** Request headers for the model */
 	headers?: Record<string, string>;
+	/** Owning conversation identity for provider routing and caching. */
+	sessionId?: string;
 	/** Abort signal for cancellation */
 	signal: AbortSignal;
 	/** Optional custom instructions for summarization */
@@ -259,6 +261,7 @@ export async function generateBranchSummary(
 		model,
 		apiKey,
 		headers,
+		sessionId,
 		signal,
 		customInstructions,
 		replaceInstructions,
@@ -299,7 +302,7 @@ export async function generateBranchSummary(
 			completeSimple(
 				model,
 				{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
-				{ apiKey, headers, signal, maxTokens: 2048 },
+				{ apiKey, headers, sessionId, signal, maxTokens: 2048 },
 			),
 		{ policy: retry, signal },
 	);

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -532,6 +532,7 @@ export async function generateSummary(
 	previousSummary?: string,
 	thinkingLevel?: ThinkingLevel,
 	retry?: ProviderRetryPolicy,
+	sessionId?: string,
 ): Promise<SummarySlice> {
 	const maxTokens = Math.floor(0.8 * reserveTokens);
 
@@ -555,8 +556,8 @@ export async function generateSummary(
 
 	const completionOptions =
 		model.reasoning && thinkingLevel && thinkingLevel !== "off"
-			? { maxTokens, signal, apiKey, headers, reasoning: thinkingLevel }
-			: { maxTokens, signal, apiKey, headers };
+			? { maxTokens, signal, apiKey, headers, sessionId, reasoning: thinkingLevel }
+			: { maxTokens, signal, apiKey, headers, sessionId };
 
 	const response = await completeWithProviderRetry(
 		() =>
@@ -706,6 +707,7 @@ export async function compact(
 	thinkingLevel?: ThinkingLevel,
 	summaryCall: SummaryCallRunner = (call) => call(headers),
 	retry?: ProviderRetryPolicy,
+	sessionId?: string,
 ): Promise<CompactionResult> {
 	const {
 		firstKeptEntryId,
@@ -736,6 +738,7 @@ export async function compact(
 							previousSummary,
 							thinkingLevel,
 							retry,
+							sessionId,
 						),
 					)
 				: Promise.resolve<SummarySlice>({ summary: "No prior history." }),
@@ -749,6 +752,7 @@ export async function compact(
 					signal,
 					thinkingLevel,
 					retry,
+					sessionId,
 				),
 			),
 		]);
@@ -767,6 +771,7 @@ export async function compact(
 				previousSummary,
 				thinkingLevel,
 				retry,
+				sessionId,
 			),
 		);
 		slices.push(result);
@@ -806,6 +811,7 @@ async function generateTurnPrefixSummary(
 	signal?: AbortSignal,
 	thinkingLevel?: ThinkingLevel,
 	retry?: ProviderRetryPolicy,
+	sessionId?: string,
 ): Promise<SummarySlice> {
 	const maxTokens = Math.floor(0.5 * reserveTokens); // Smaller budget for turn prefix
 	const llmMessages = convertToLlm(messages);
@@ -825,8 +831,8 @@ async function generateTurnPrefixSummary(
 				model,
 				{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
 				model.reasoning && thinkingLevel && thinkingLevel !== "off"
-					? { maxTokens, signal, apiKey, headers, reasoning: thinkingLevel }
-					: { maxTokens, signal, apiKey, headers },
+					? { maxTokens, signal, apiKey, headers, sessionId, reasoning: thinkingLevel }
+					: { maxTokens, signal, apiKey, headers, sessionId },
 			),
 		{ policy: retry, signal },
 	);

--- a/packages/coding-agent/src/core/refinement/refinement.ts
+++ b/packages/coding-agent/src/core/refinement/refinement.ts
@@ -926,6 +926,7 @@ export async function planRefinement(
 	headers?: Record<string, string>,
 	signal?: AbortSignal,
 	thinkingLevel?: ThinkingLevel,
+	sessionId?: string,
 ): Promise<RefinementPlan> {
 	const id = generateRefinementId();
 	if (options.rollbackId) {
@@ -982,6 +983,7 @@ export async function planRefinement(
 					signal,
 					apiKey,
 					headers,
+					sessionId,
 				},
 			),
 		{ policy: options.retry, signal },
@@ -1025,6 +1027,7 @@ export async function reviewAutoRefine(
 	signal?: AbortSignal,
 	thinkingLevel?: ThinkingLevel,
 	retry?: ProviderRetryPolicy,
+	sessionId?: string,
 ): Promise<AutoRefineReview> {
 	const conversationText = serializeConversation(convertToLlm(messages)).slice(-40_000);
 	const buildPrompt = (conversation: string): string =>
@@ -1069,6 +1072,7 @@ ${conversation}
 					signal,
 					apiKey,
 					headers,
+					sessionId,
 				},
 			),
 		{ policy: retry, signal },
@@ -1096,8 +1100,20 @@ export async function refineHarness(
 	headers?: Record<string, string>,
 	signal?: AbortSignal,
 	thinkingLevel?: ThinkingLevel,
+	sessionId?: string,
 ): Promise<RefinementResult> {
-	const plan = await planRefinement(messages, state, history, model, apiKey, options, headers, signal, thinkingLevel);
+	const plan = await planRefinement(
+		messages,
+		state,
+		history,
+		model,
+		apiKey,
+		options,
+		headers,
+		signal,
+		thinkingLevel,
+		sessionId,
+	);
 	return applyRefinementProposal(state, plan.proposal, {
 		id: plan.id,
 		rollbackOf: plan.rollbackOf,

--- a/packages/coding-agent/test/suite/regressions/6009-opencode-maintenance-session.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6009-opencode-maintenance-session.test.ts
@@ -1,0 +1,262 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { completeSimple, type FauxResponseFactory } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ENV_AGENT_DIR } from "../../../src/config.js";
+import { type AutoRefineReview, type HarnessState, refineHarness } from "../../../src/core/refinement/refinement.js";
+import { createHarness, type Harness } from "../harness.js";
+
+const proposal = { summary: "No change", rationale: "Fixture", expectedOutcome: "No change", edits: [] };
+const missingSession =
+	"Error from provider (Console Go): Request is missing x-opencode-session and cannot be routed efficiently.";
+let server: Server;
+let baseUrl: string;
+let agentDir: string;
+let responseText: string;
+let transientFailures: number;
+let operation: string;
+let requests: { operation: string; headers: IncomingHttpHeaders; body: Record<string, unknown> }[];
+const harnesses: Harness[] = [];
+
+beforeEach(async () => {
+	agentDir = mkdtempSync(join(tmpdir(), "6009-agent-"));
+	vi.stubEnv(ENV_AGENT_DIR, agentDir);
+	requests = [];
+	responseText = "OK";
+	transientFailures = 0;
+	operation = "ordinary";
+	server = createServer(async (req, res) => {
+		let raw = "";
+		for await (const chunk of req) raw += chunk.toString();
+		const body = JSON.parse(raw) as Record<string, unknown>;
+		requests.push({ operation, headers: req.headers, body });
+		if (!req.headers["x-opencode-session"]) {
+			res.writeHead(400, { "content-type": "application/json" });
+			res.end(JSON.stringify({ error: { message: missingSession, type: "invalid_request_error" } }));
+			return;
+		}
+		if (transientFailures > 0) {
+			transientFailures--;
+			res.writeHead(503, { "content-type": "application/json" });
+			res.end(JSON.stringify({ error: { message: "Temporarily unavailable" } }));
+			return;
+		}
+		res.writeHead(200, { "content-type": "text/event-stream" });
+		res.write(
+			`data: ${JSON.stringify({ id: "fixture", choices: [{ index: 0, delta: { role: "assistant", content: responseText }, finish_reason: "stop" }] })}\n\n`,
+		);
+		res.end("data: [DONE]\n\n");
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}/v1`;
+});
+
+afterEach(async () => {
+	while (harnesses.length) harnesses.pop()!.cleanup();
+	server.closeAllConnections();
+	await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+	vi.unstubAllEnvs();
+	rmSync(agentDir, { recursive: true, force: true });
+});
+
+async function setup(provider: string, existingSessionFile?: string, reasoning = false) {
+	const harness = await createHarness({
+		provider,
+		models: [{ id: "routing-fixture", reasoning }],
+		persistSession: true,
+		existingSessionFile,
+		settings: {
+			compaction: { enabled: false, keepRecentTokens: 1 },
+			autoRefine: { enabled: false },
+			retry: { enabled: true, maxRetries: 1, baseDelayMs: 1 },
+		},
+	});
+	harnesses.push(harness);
+	// Match createAgentSession: the low-level suite harness does not bind the Agent's ID.
+	harness.session.agent.sessionId = harness.sessionManager.getSessionId();
+	// Keep the faux provider as the suite boundary, but serialize its actual options
+	// through the real OpenAI-compatible adapter to an entirely local faux endpoint.
+	const forward: FauxResponseFactory = (context, options, _state, model) =>
+		completeSimple({ ...model, api: "openai-completions", baseUrl }, context, {
+			...options,
+			apiKey: "fixture-not-a-real-key",
+			signal: AbortSignal.any([...(options?.signal ? [options.signal] : []), AbortSignal.timeout(5000)]),
+		});
+	harness.setResponses(Array.from({ length: 20 }, () => forward));
+	return harness;
+}
+
+async function ordinary(harness: Harness, text = "remember this request") {
+	operation = "ordinary";
+	await harness.session.prompt(text);
+	expect(harness.session.messages.at(-1)).toMatchObject({ role: "assistant", stopReason: "stop" });
+	expect(requests.at(-1)?.headers["x-opencode-session"]).toBe(harness.sessionManager.getSessionId());
+}
+
+function expectIdentity(harness: Harness, count: number) {
+	const calls = requests.filter((request) => request.operation !== "ordinary");
+	expect(calls).toHaveLength(count);
+	for (const call of calls) {
+		expect(call.headers["x-opencode-session"]).toBe(harness.sessionManager.getSessionId());
+		expect(call.headers["user-agent"]).toMatch(/^prime-agent(?:\/|$)/);
+	}
+}
+
+describe.each(["opencode", "opencode-go"])("ENG-6009 %s maintenance identity", (provider) => {
+	it("ordinary request control", async () => {
+		await ordinary(await setup(provider));
+	});
+	it("routes turn-prefix compaction", async () => {
+		const harness = await setup(provider);
+		await ordinary(harness);
+		operation = "turn-prefix";
+		await expect(harness.session.compact()).resolves.toMatchObject({ summary: expect.stringContaining("OK") });
+		expectIdentity(harness, 1);
+	});
+	it.each(["off", "high"] as const)("routes both split-turn summaries with thinking %s", async (thinking) => {
+		const harness = await setup(provider, undefined, true);
+		harness.session.setThinkingLevel(thinking);
+		await ordinary(harness);
+		await ordinary(harness, "second request");
+		operation = "split-compaction";
+		await expect(harness.session.compact()).resolves.toMatchObject({ summary: expect.stringContaining("OK") });
+		expectIdentity(harness, 2);
+		const summaries = requests.filter((request) => request.operation === "split-compaction");
+		expect(new Set(summaries.map((request) => request.headers["idempotency-key"])).size).toBe(2);
+		expect(summaries.every((request) => request.headers["idempotency-key"])).toBe(true);
+	});
+	it("routes a history-only summary", async () => {
+		const harness = await setup(provider);
+		await ordinary(harness);
+		harness.sessionManager.appendMessage({ role: "user", content: "retained request", timestamp: Date.now() });
+		operation = "history";
+		await expect(harness.session.compact()).resolves.toMatchObject({ summary: "OK" });
+		expectIdentity(harness, 1);
+	});
+	it("routes refinement planning", async () => {
+		const harness = await setup(provider);
+		await ordinary(harness);
+		operation = "refinement-plan";
+		responseText = JSON.stringify(proposal);
+		await expect(harness.session.refine()).resolves.toMatchObject({ summary: "No change" });
+		expectIdentity(harness, 1);
+	});
+	it("routes the auto-refine review gate", async () => {
+		const harness = await setup(provider);
+		await ordinary(harness);
+		operation = "refinement-review";
+		responseText = JSON.stringify({ shouldRefine: false, rationale: "No lesson" });
+		const internal = harness.session as unknown as {
+			_reviewAutoRefine(context: {
+				reason: "turn_interval";
+				turnsSinceLastReview: number;
+			}): Promise<AutoRefineReview>;
+		};
+		await expect(
+			internal._reviewAutoRefine({ reason: "turn_interval", turnsSinceLastReview: 5 }),
+		).resolves.toMatchObject({ shouldRefine: false });
+		expectIdentity(harness, 1);
+	});
+	it("routes a tree branch summary", async () => {
+		const harness = await setup(provider);
+		await ordinary(harness);
+		const target = harness.sessionManager.getLeafId()!;
+		await ordinary(harness, "explore a branch");
+		operation = "branch-summary";
+		await expect(harness.session.navigateTree(target, { summarize: true })).resolves.toMatchObject({
+			cancelled: false,
+			summaryEntry: { summary: expect.stringContaining("OK") },
+		});
+		expectIdentity(harness, 1);
+	});
+	it("keeps the owning session identity across a resume", async () => {
+		const original = await setup(provider);
+		await ordinary(original);
+		const resumed = await setup(provider, original.sessionManager.getSessionFile());
+		expect(resumed.session.sessionId).toBe(original.session.sessionId);
+		await ordinary(resumed, "continue resumed session");
+		operation = "resumed-compaction";
+		await resumed.session.compact();
+		expectIdentity(resumed, 2);
+		operation = "resumed-refinement";
+		responseText = JSON.stringify(proposal);
+		await resumed.session.refine();
+		expectIdentity(resumed, 3);
+	});
+	it("does not reuse another session's routing identity", async () => {
+		const first = await setup(provider);
+		await ordinary(first);
+		operation = "first-compaction";
+		await first.session.compact();
+		expectIdentity(first, 1);
+		const firstId = first.session.sessionId;
+		requests = [];
+		const second = await setup(provider);
+		expect(second.session.sessionId).not.toBe(firstId);
+		await ordinary(second);
+		operation = "second-compaction";
+		await second.session.compact();
+		expectIdentity(second, 1);
+	});
+	it("retains session and request identity when retrying a summary", async () => {
+		const harness = await setup(provider);
+		await ordinary(harness);
+		operation = "retry-compaction";
+		transientFailures = 1;
+		await harness.session.compact();
+		expectIdentity(harness, 2);
+		const calls = requests.filter((request) => request.operation === "retry-compaction");
+		expect(calls[0].headers["idempotency-key"]).toBeTruthy();
+		expect(calls[1].headers["idempotency-key"]).toBe(calls[0].headers["idempotency-key"]);
+		expect(calls[1].body).toEqual(calls[0].body);
+	});
+	it("routes automatic compaction through the same owning session", async () => {
+		const harness = await setup(provider);
+		await ordinary(harness);
+		operation = "automatic-compaction";
+		const internal = harness.session as unknown as {
+			_runAutoCompaction(reason: "threshold", willRetry: boolean): Promise<void>;
+		};
+		await internal._runAutoCompaction("threshold", false);
+		expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({
+			result: { summary: expect.stringContaining("OK") },
+		});
+		expectIdentity(harness, 1);
+	});
+	it.each([false, true])("forwards refineHarness identity with explicit headers=%s", async (explicit) => {
+		const harness = await setup(provider);
+		await ordinary(harness);
+		operation = "refineHarness";
+		responseText = JSON.stringify(proposal);
+		const state: HarnessState = {
+			schema: 1,
+			entries: { prompt: {}, memory: {}, skill: {}, subagent: {} },
+			refinements: [],
+		};
+		const headers: Record<string, string> = { "X-Fixture": "retained" };
+		if (explicit) headers["X-OpenCode-Session"] = "explicit-conversation";
+		const originalHeaders = { ...headers };
+		await expect(
+			refineHarness(
+				harness.session.messages,
+				state,
+				[],
+				harness.getModel(),
+				"faux-key",
+				{},
+				headers,
+				undefined,
+				undefined,
+				harness.session.sessionId,
+			),
+		).resolves.toMatchObject({ summary: "No change" });
+		expect(requests.at(-1)?.headers["x-opencode-session"]).toBe(
+			explicit ? "explicit-conversation" : harness.session.sessionId,
+		);
+		expect(requests.at(-1)?.headers["x-fixture"]).toBe("retained");
+		expect(headers).toEqual(originalHeaders);
+	});
+});


### PR DESCRIPTION
- preserve session routing for compaction, refinement, and branch summaries.
- local http regressions reproduce missing headers on main and verify the fix; live provider and reporter binary remain unverified.
- follows [eng-6009](https://linear.app/primeintellect/issue/ENG-6009/opencode-adapters-omit-conversation-and-application-identification) and [#2131](https://github.com/PrimeIntellect-ai/prime-agent/pull/2131); related reports: [#2072](https://github.com/PrimeIntellect-ai/prime-agent/discussions/2072), [#2110](https://github.com/PrimeIntellect-ai/prime-agent/discussions/2110).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OpenCode maintenance session routing by passing `AgentSession` identity through compaction and refinement
> - `AgentSession` now passes its identifier to compaction, refinement planning, automatic-refinement review, and branch-summary generation in [agent-session.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2266/files#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448ae)
> - Each downstream flow forwards the session identity into its provider completion request: `compact` and `generateTurnPrefixSummary` in [compaction.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2266/files#diff-ad4b3f096b732189266e944cde055f0e15abda3e3e2244b029909b9a89cee11f), `planRefinement` and `reviewAutoRefine` in [refinement.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2266/files#diff-17b614d876315ad8ac0165562a8f07a5c4ada3b28928eb02d90f6b93a96ea91d), and `generateBranchSummary` in [branch-summarization.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2266/files#diff-c2d1f105994c8db37c55a3f9321844ad381eeff24d6f8a62d2c1629ac19903b0)
> - The session identity is optional and additive; rollback refinement and early-return branch summaries still make no provider request
> - Adds a regression suite in [6009-opencode-maintenance-session.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/2266/files#diff-c551583ed00747b25b6a9fcad35ef50545649878d0bdc347033cc73192720e3f) that asserts every maintenance request carries the owning session header, verifies retry identity and body stability, and covers both OpenCode providers
> - Risk: providers or downstream consumers that do not expect the new session identity header on maintenance completions may need updating; the regression test rejects any maintenance request missing the header
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4fd0017.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider request headers on all maintenance LLM paths for OpenCode; incorrect session wiring could mis-route traffic, though the change is additive and covered by regression tests.
> 
> **Overview**
> Fixes **OpenCode / OpenCode Go** failures during **compaction**, **refinement**, and **branch summarization** when the provider rejects requests missing **`x-opencode-session`**.
> 
> **AgentSession** now forwards **`this.sessionId`** into **`compact`**, refinement planning / auto-refine review, and **`generateBranchSummary`**. Those paths thread the optional **`sessionId`** through to **`completeSimple`**, matching ordinary chat routing and provider caching behavior.
> 
> Adds a **local HTTP regression suite** (ENG-6009) for both OpenCode providers: maintenance calls must carry the owning session header, split-turn compaction uses distinct idempotency keys, retries reuse the same identity/body, and resumed vs separate sessions stay isolated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fd0017e62cb1671ddd3e56dfb00318ffeee72c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->